### PR TITLE
Add periodic GitHub PR sync to Gubernator.

### DIFF
--- a/gubernator/github/admin.py
+++ b/gubernator/github/admin.py
@@ -17,11 +17,12 @@ import cPickle as pickle
 import logging
 import os
 
+import webapp2
+
 from google.appengine.api import urlfetch
 from google.appengine.ext import deferred
 from google.appengine.ext import ndb
 
-import webapp2
 import models
 import handlers
 

--- a/gubernator/github/admin.py
+++ b/gubernator/github/admin.py
@@ -91,7 +91,6 @@ class AdminDash(webapp2.RequestHandler):
         #     #Checking_The_Referer_Header
         origin = self.request.headers.get('origin') + '/'
         expected = self.request.host_url + '/'
-        print expected
         if not (origin and origin == expected):
             logging.error('csrf check failed for %s, origin: %r', self.request.url, origin)
             self.abort(403)

--- a/gubernator/github/app.yaml
+++ b/gubernator/github/app.yaml
@@ -16,6 +16,9 @@ handlers:
 - url: /admin.*
   script: admin.app
   login: admin
+- url: /sync
+  script: periodic_sync.app
+  login: admin
 - url: .*
   script: main.app
 

--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -40,12 +40,12 @@ def classify_issue(repo, number):
         last_event_timestamp: the timestamp of the most recent event.
     """
     ancestor = models.GithubResource.make_key(repo, number)
-    logging.debug('finding webhooks for %s %s', repo, number)
+    logging.info('finding webhooks for %s %s', repo, number)
     event_keys = list(models.GithubWebhookRaw.query(ancestor=ancestor)
         .order(models.GithubWebhookRaw.timestamp)
         .fetch(keys_only=True))
 
-    logging.debug('classifying %s %s (%d events)', repo, number, len(event_keys))
+    logging.info('classifying %s %s (%d events)', repo, number, len(event_keys))
     last_event_timestamp = [datetime.datetime(2000, 1, 1)]
 
     def events_iterator():
@@ -200,7 +200,6 @@ def classify_from_iterator(events_iterator, status_fetcher=None):
 
 
 def _classify_internal(merged, labels, comments, reviewers, distilled_events, status_fetcher):
-
     approvers = get_approvers(comments)
 
     is_pr = 'head' in merged or 'pull_request' in merged

--- a/gubernator/github/cron.yaml
+++ b/gubernator/github/cron.yaml
@@ -1,0 +1,7 @@
+# These URLs will be fetched by AppEngine on the given schedule.
+# Only the default (currently serving) version's URL will be fetched.
+# docs: https://cloud.google.com/appengine/docs/standard/python/config/cron
+cron:
+- description: sync PR state
+  url: /sync
+  schedule: every 8 hours

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -159,6 +159,18 @@ class GHIssueDigest(ndb.Model):
     def find_xrefs(xref):
         return GHIssueDigest.query(GHIssueDigest.xref == xref)
 
+    @staticmethod
+    def find_open_prs():
+        # pylint: disable=singleton-comparison
+        return GHIssueDigest.query(GHIssueDigest.is_pr == True,
+                                   GHIssueDigest.is_open == True)
+
+    @staticmethod
+    def find_open_prs_for_repo(repo):
+        return (GHIssueDigest.find_open_prs()
+            .filter(GHIssueDigest.key > GHIssueDigest.make_key(repo, ''),
+                    GHIssueDigest.key < GHIssueDigest.make_key(repo, '~')))
+
 
 class GHUserState(ndb.Model):
     # Key: {github username}

--- a/gubernator/github/periodic_sync.py
+++ b/gubernator/github/periodic_sync.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Periodically synchronize our Datastore view of PRs with Github.
+
+Various things can cause the local status of a PR to diverge from upstream:
+dropped hooks from bugs in the app, upstream GitHub bugs (webhooks aren't
+guaranteed!), or a repo *just* starting sending hooks to Gubernator.
+
+Divergent PR state make the PR dashboard less useful, since old PRs accumulate
+and clutter out real items, decreasing signal-to-noise ratio and user trust.
+
+To handle these, on a regular schedule we perform a reconciliation step:
+- for each repository that we're tracking:
+  - A = all open PRs from Datastore
+  - B = all open PRs from Github
+  - A-B is the set of improperly open PRs. For each PR, add a synthetic
+    webhook event to Datastore with state=closed, and reprocess.
+  - B-A is the set of improperly closed or missing PRs. Again, inject a
+    synthetic webhook with the details received from GitHub and reprocess.
+
+This requires a Github token set like other secrets with /config in the root.
+Total token usage is low: number of open PRs / 100 PRs per list call.
+As of 2018-01-10, 1666 open PRs in the k8s org translates into ~56 list calls.
+"""
+
+import json
+import logging
+import re
+
+import webapp2
+
+from google.appengine.api import urlfetch
+from google.appengine.ext import deferred
+
+import handlers
+import models
+import secrets
+
+PULL_API = 'https://api.github.com/repos/%s/pulls?state=open&per_page=100'
+
+
+def get_prs_from_github(token, repo):
+    headers = {'Authorization': 'token %s' % token}
+    url = PULL_API % repo
+    prs = []
+    while True:
+        logging.info('fetching %s', url)
+        response = urlfetch.fetch(url, headers=headers)
+        if response.status_code != 200:
+            raise urlfetch.Error('status code %s' % response.status_code)
+        prs += json.loads(response.content)
+        m = re.search(r'<([^>]+)>; rel="next"', response.headers.get('Link', ''))
+        if m:
+            url = m.group(1)
+        else:
+            break
+    logging.info('pr count: %d, github tokens left: %s',
+                 len(prs), response.headers.get('x-ratelimit-remaining'))
+    return prs
+
+
+def inject_event_and_reclassify(repo, number, action, body):
+    # this follows similar code as handlers.GithubHandler
+    parent = models.GithubResource.make_key(repo, number)
+    hook = models.GithubWebhookRaw(
+        parent=parent, repo=repo, number=number, event='pull_request',
+        body=json.dumps({'action': action, 'pull_request': body}, sort_keys=True))
+    hook.put()
+    deferred.defer(handlers.update_issue_digest, repo, number)
+
+
+def sync_repo(token, repo, write_html=None):
+    if write_html is None:
+        write_html = lambda x: None
+
+    logging.info('syncing repo %s', repo)
+    write_html('<h1>%s</h1>' % repo)
+
+    # There is a race condition here:
+    # We can't atomically get a list of PRs from the database and GitHub,
+    # so a PR might falsely be in stale_open_prs if it is opened after
+    # we scan GitHub, or falsely be in missing_prs if a PR is made after we
+    # got the list from GitHub, and before we get the list from the database.
+    #
+    # These cases will both be fixed the next time this code runs, so we don't
+    # try to prevent it here.
+    prs_gh = get_prs_from_github(token, repo)
+    prs_gh_by_number = {pr['number']: pr for pr in prs_gh}
+
+    prs_db = list(models.GHIssueDigest.find_open_prs_for_repo(repo))
+    prs_db_by_number = {pr.number: pr for pr in prs_db}
+
+    numbers_datastore = set(prs_db_by_number)
+    numbers_github = set(prs_gh_by_number)
+
+    stale_open_prs = sorted(numbers_datastore - numbers_github)
+    missing_prs = sorted(numbers_github - numbers_datastore)
+
+    if not stale_open_prs and not missing_prs:
+        write_html('matched, no further work needed')
+        logging.info('matched, no further work needed')
+        return
+
+    logging.info('PRs to close: %s', stale_open_prs)
+    logging.info('PRs to open: %s', missing_prs)
+
+    write_html('<br>')
+    write_html('PRs that should be closed: %s<br>' % stale_open_prs)
+
+    for number in stale_open_prs:
+        pr = prs_db_by_number[number]
+        write_html('<b>%d</b><br>%s<br>' % (number, pr))
+        inject_event_and_reclassify(repo, number, 'gh-sync-close',
+            {'state': 'closed',
+             # These other 3 keys are injected because the classifier expects them.
+             # This simplifies the testing code, and means we don't have to inject
+             # fake webhooks.
+             'user': {'login': pr.payload['author']},
+             'assignees': [{'login': u} for u in pr.payload['assignees']],
+             'title': pr.payload['title']})
+
+    write_html('PRs that should be opened: %s<br>' % missing_prs)
+
+    for number in missing_prs:
+        pr = models.shrink(prs_gh_by_number[number])
+        write_html('<br>%d</br><pre>%s</pre><br>' %
+            (number, json.dumps(pr, indent=4, sort_keys=True)))
+        inject_event_and_reclassify(repo, number, 'gh-sync-open', pr)
+
+
+class PRSync(webapp2.RequestHandler):
+    def get(self):
+        # This is called automatically by the periodic cron scheduler.
+        # For debugging, visit something like /sync?repo=kubernetes/test-infra
+        token = secrets.get('github_token', per_host=False)
+        if not token:
+            logging.warning('no github token, skipping sync')
+            self.abort(200)
+
+        # first, determine which repositories we need to sync
+        open_prs = list(
+            models.GHIssueDigest.find_open_prs().fetch(keys_only=True))
+        open_repos = sorted({models.GHIssueDigest(key=pr).repo for pr in open_prs})
+
+        self.response.write('open repos:')
+        self.response.write(', '.join(open_repos))
+
+        repo = self.request.get('repo')
+        if repo:
+            # debugging case
+            sync_repo(token, repo, self.response.write)
+        else:
+            for repo in open_repos:
+                deferred.defer(sync_repo, token, repo)
+
+
+app = webapp2.WSGIApplication([
+    (r'/sync', PRSync),
+], debug=True)

--- a/gubernator/github/periodic_sync_test.py
+++ b/gubernator/github/periodic_sync_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=no-self-use
+
+import cPickle as pickle
+import json
+
+import webtest
+
+from google.appengine.ext import deferred
+from google.appengine.ext import testbed
+
+import main_test
+import models
+import periodic_sync
+import secrets
+
+app = webtest.TestApp(periodic_sync.app)
+
+TOKEN = 'gh_auth_secret'
+
+def pr_data(number):
+    return {
+        'number': number,
+        'state': 'open',
+        'user': {'login': 'a'},
+        'assignees': [{'login': 'b'}],
+        'title': 'some fix %d' % number,
+        'head': {'sha': 'abcdef'},
+    }
+
+class SyncTest(main_test.TestBase):
+    def setUp(self):
+        self.init_stubs()
+        self.taskqueue = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
+        secrets.put('github_token', TOKEN, per_host=False)
+        self.gh_data = {}
+
+    def inject_pr(self, repo, number):
+        models.GHIssueDigest.make(
+            repo, number, True, True, [],
+            {'author': 'someone', 'assignees': [], 'title': '#%d' % number},
+            None).put()
+
+    def get_deferred_funcs(self):
+        out = []
+        for task in self.taskqueue.get_filtered_tasks():
+            func, args, _kwargs = pickle.loads(task.payload)
+            out.append((func.__name__, args))
+        return out
+
+    def test_repo_dispatch(self):
+        self.inject_pr('a/b', 3)
+        self.inject_pr('a/b', 4)
+        self.inject_pr('k/t', 90)
+
+        app.get('/sync')
+
+        self.assertEqual(self.get_deferred_funcs(),
+            [('sync_repo', (TOKEN, 'a/b')),
+             ('sync_repo', (TOKEN, 'k/t'))])
+
+    def urlfetch_github_stub(self, url, _payload, method,
+                             headers, _request, response, **_kwargs):
+        assert method == 'GET'
+        assert headers[0].key() == 'Authorization'
+        assert headers[0].value() == 'token ' + TOKEN
+        path = url[url.find('.com')+4:]
+        content, response_headers = self.gh_data[path]
+        response.set_content(json.dumps(content))
+        response.set_statuscode(200)
+        for k, v in response_headers.iteritems():
+            header = response.add_header()
+            header.set_key(k)
+            header.set_value(v)
+
+    def init_github_fake(self):
+        # Theoretically, I should be able to pass this to init_urlfetch_stub.
+        # Practically, that doesn't work for unknown reasons, and this is fine.
+        uf = self.testbed.get_stub('urlfetch')
+        uf._urlmatchers_to_fetch_functions.append(  # pylint: disable=protected-access
+            (lambda u: u.startswith('https://api.github.com'), self.urlfetch_github_stub))
+
+    def test_get_prs_from_github(self):
+        self.init_github_fake()
+
+        base_url = '/repos/a/b/pulls?state=open&per_page=100'
+        def make_headers(page):
+            frag = '<https://api.github.com%s' % base_url
+            link = '%s&page=4>; rel="last"' % frag
+            if page < 4:
+                link = '%s&page=%d>; rel="next", %s' % (frag, page + 1, link)
+            if page > 1:
+                link = '%s&page=%d>; rel="prev", %s' % (frag, page - 1, link)
+            print link
+            return {'Link': link}
+
+        prs = [pr_data(n) for n in range(400)]
+        self.gh_data = {
+            base_url:             (prs[:100], make_headers(1)),
+            base_url + '&page=2': (prs[100:200], make_headers(2)),
+            base_url + '&page=3': (prs[200:300], make_headers(3)),
+            base_url + '&page=4': (prs[300:], make_headers(4)),
+        }
+
+        got_prs = periodic_sync.get_prs_from_github(TOKEN, 'a/b')
+        got_pr_nos = [pr['number'] for pr in got_prs]
+        expected_pr_nos = [pr['number'] for pr in prs]
+
+        self.assertEqual(got_pr_nos, expected_pr_nos)
+
+    def test_sync_repo(self):
+        self.init_github_fake()
+        self.gh_data = {
+            '/repos/a/b/pulls?state=open&per_page=100':
+                ([pr_data(11), pr_data(12), pr_data(13)], {}),
+        }
+
+        # PRs <10 are closed
+        # PRs >10 are open
+        self.inject_pr('a/b', 1)
+        self.inject_pr('a/b', 2)
+        self.inject_pr('a/b', 3)
+        self.inject_pr('a/b', 11)
+        self.inject_pr('a/b', 12)
+
+        periodic_sync.sync_repo(TOKEN, 'a/b')
+
+        for task in self.taskqueue.get_filtered_tasks():
+            deferred.run(task.payload)
+
+        open_prs = models.GHIssueDigest.find_open_prs().fetch()
+        open_prs = [pr.number for pr in open_prs]
+
+        self.assertEqual(open_prs, [11, 12, 13])

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -67,9 +67,11 @@ class ConfigHandler(view_base.BaseHandler):
         if users.is_current_user_admin():
             oauth_set = False
             webhook_set = False
+            token_set = False
 
             github_id = self.request.get('github_id')
             github_secret = self.request.get('github_secret')
+            github_token = self.request.get('github_token')
             if github_id and github_secret:
                 value = {'id': github_id, 'secret': github_secret}
                 secrets.put('github_client', value)
@@ -81,8 +83,14 @@ class ConfigHandler(view_base.BaseHandler):
                             github_webhook_secret,
                             per_host=False)
                 webhook_set = True
+            if github_token:
+                secrets.put('github_token', github_token, per_host=False)
+                token_set = True
             self.render('config.html',
-                        {'hostname': hostname, 'oauth_set': oauth_set, 'webhook_set': webhook_set})
+                        dict(hostname=hostname,
+                             oauth_set=oauth_set,
+                             webhook_set=webhook_set,
+                             token_set=token_set))
         else:
             self.abort(403)
 

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -64,6 +64,7 @@ class ConfigHandler(view_base.BaseHandler):
         self.render('config.html', {'hostname': hostname})
 
     def post(self):
+        self.check_csrf()
         if users.is_current_user_admin():
             oauth_set = False
             webhook_set = False

--- a/gubernator/templates/config.html
+++ b/gubernator/templates/config.html
@@ -11,6 +11,10 @@ GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
 <hr>
 <p>This value must match whatever is entered on GitHub when registering hooks to receive.
 <p>GitHub Webhook Secret: <input type="text" name="github_webhook_secret"><br>
+<hr>
+<p>This Token is used to periodically synchronize PR status stored in the database with GitHub.
+<p>This prevents dropped hooks and other bugs from causing stale PRs to linger in users' dashboards.
+<p>GitHub Token: <input type="text" name="github_token"><br>
 <input type="submit" value="Submit">
 </form>
 % if oauth_set
@@ -18,5 +22,8 @@ GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
 % endif
 % if webhook_set
 <h2>Github Webhook secret set!</h2>
+% endif
+% if token_set
+<h2>Github Token set!</h2>
 % endif
 % endblock

--- a/gubernator/view_base.py
+++ b/gubernator/view_base.py
@@ -58,6 +58,15 @@ class BaseHandler(webapp2.RequestHandler):
         # directory listing operations.
         urlfetch.set_default_fetch_deadline(60)
 
+    def check_csrf(self):
+        # https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+        #     #Checking_The_Referer_Header
+        origin = self.request.headers.get('origin') + '/'
+        expected = self.request.host_url + '/'
+        if not (origin and origin == expected):
+            logging.error('csrf check failed for %s, origin: %r', self.request.url, origin)
+            self.abort(403)
+
     # This example code is from:
     # http://webapp2.readthedocs.io/en/latest/api/webapp2_extras/sessions.html
     def dispatch(self):


### PR DESCRIPTION
This will reconcile GitHub state with Datastore state, avoiding
stale PRs from remaining for too long.

See the comment in gubernator/github/cron.py for more details.

Fixes #5473, #4298.