### PR TITLE
Introducting an upgrade and downgrade job for ingress-gce

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -170,10 +170,19 @@
       "sig-multicluster"
     ]
   },
+  "ci-ingress-gce-downgrade-e2e": {
+    "args": [
+      "true"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-ingress-gce-e2e": {
     "args": [
-      "--build-ingressgce",
       "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/e2e-ingress-gce/ingress-gce-e2e-glbc-amd64:latest",
       "--extract=ci/latest",
       "--gcp-project=e2e-ingress-gce",
       "--gcp-zone=us-central1-f",
@@ -183,6 +192,25 @@
       "--timeout=320m"
     ],
     "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-ingress-gce-image-push": {
+    "args": [
+      "make",
+      "push-e2e"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-ingress-gce-upgrade-e2e": {
+    "args": [
+      "true"
+    ],
+    "scenario": "execute",
     "sigOwners": [
       "sig-network"
     ]

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 )
 
@@ -118,32 +117,4 @@ func (b *buildFederationStrategy) Build() error {
 	}
 
 	return finishRunning(exec.Command("make", "-C", k8s("federation"), target))
-}
-
-func (b *buildIngressGCEStrategy) Build() error {
-	// Currently, this is the only strategy.
-	target := "push-e2e"
-
-	// Make sure we are in the ingress-gce repo before getting the image tag.
-	err := os.Chdir(k8s("ingress-gce"))
-	if err != nil {
-		return fmt.Errorf("error during ingress-gce build: %v", err)
-	}
-	// Get image tag (git command is how ingress-gce Makefile generates the tag).
-	c := exec.Command("git", "describe", "--tags", "--always", "--dirty")
-	o, err := c.Output()
-	if err != nil {
-		return fmt.Errorf("error during ingress-gce build: %v", err)
-	}
-	// Make sure that kube-up uses the correct glbc image by exporting as
-	// environment variable
-	e := fmt.Sprintf("gcr.io/e2e-ingress-gce/ingress-gce-e2e-glbc-amd64:%s", o)
-	os.Setenv("GCE_GLBC_IMAGE", e)
-	// Ensure we are back in /go/src/k8s.io so that k8s binaries are acquired properly.
-	err = os.Chdir(k8s())
-	if err != nil {
-		return fmt.Errorf("error during ingress-gce build: %v", err)
-	}
-
-	return finishRunning(exec.Command("make", "-C", k8s("ingress-gce"), target))
 }

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -53,7 +53,6 @@ var (
 type options struct {
 	build               buildStrategy
 	buildFederation     buildFederationStrategy
-	buildIngressGCE     buildIngressGCEStrategy
 	charts              bool
 	checkLeaks          bool
 	checkSkew           bool
@@ -111,7 +110,6 @@ type options struct {
 func defineFlags() *options {
 	o := options{}
 	flag.Var(&o.build, "build", "Rebuild k8s binaries, optionally forcing (release|quick|bazel) strategy")
-	flag.Var(&o.buildIngressGCE, "build-ingressgce", "Build ingress-gce binaries")
 	flag.Var(&o.buildFederation, "build-federation", "Rebuild federation binaries, optionally forcing (release|quick|bazel) strategy")
 	flag.BoolVar(&o.charts, "charts", false, "If true, run charts tests")
 	flag.BoolVar(&o.checkSkew, "check-version-skew", true, "Verify client and server versions match")
@@ -369,9 +367,6 @@ func complete(o *options) error {
 		}
 	}
 
-	if err := acquireIngressGCE(o); err != nil {
-		return fmt.Errorf("failed to acquire ingress-gce binaries: %v", err)
-	}
 	if err := acquireKubernetes(o); err != nil {
 		return fmt.Errorf("failed to acquire k8s binaries: %v", err)
 	}
@@ -509,20 +504,6 @@ func acquireFederation(o *options) error {
 			return o.extractFederation.Extract(o.gcpProject, o.gcpZone)
 		})
 		return err
-	}
-	return nil
-}
-
-func acquireIngressGCE(o *options) error {
-	// Potentially build ingress-GCE
-	if o.buildIngressGCE.Enabled() {
-		err := xmlWrap("BuildIngressGCE", o.buildIngressGCE.Build)
-		if o.flushMemAfterBuild {
-			flushMem()
-		}
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -200,29 +200,16 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: docker-graph
-          mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
   GoogleCloudPlatform/k8s-multicluster-ingress:
   - name: pull-kubernetes-multicluster-ingress-test
     agent: kubernetes
@@ -6828,9 +6815,71 @@ periodics:
         secretName: ssh-key-secret
     - name: var-lib-docker
       emptyDir: {}
+  # TODO(rramkumar): Job does nothing yet.
+- name: ci-ingress-gce-downgrade-e2e
+  agent: kubernetes
+  interval: 24h
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
+      args:
+      - "--timeout=320"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
 - name: ci-ingress-gce-e2e
   agent: kubernetes
   interval: 60m
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
+      args:
+      - "--timeout=320"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+  # Pushes new image of ingress-gce from HEAD for use by other CI jobs.
+- name: ci-ingress-gce-image-push
+  agent: kubernetes
+  interval: 45m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
@@ -6844,19 +6893,12 @@ periodics:
         value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
         readOnly: true
       - name: docker-graph
         mountPath: /docker-graph
@@ -6867,13 +6909,40 @@ periodics:
     - name: service
       secret:
         secretName: service-account
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
+  # TODO(rramkumar): Job does nothing yet.
+- name: ci-ingress-gce-upgrade-e2e
+  agent: kubernetes
+  interval: 24h
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
+      args:
+      - "--timeout=320"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 - name: ci-kubernetes-bazel-build
   interval: 6h
   agent: kubernetes
@@ -16418,7 +16487,7 @@ periodics:
 
 - interval: 2h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-cos-oldetcd-default # TODO(krzyzacy) this job is temporary, remove once we verify it works 
+  name: ci-kubernetes-e2e-gke-cos-oldetcd-default # TODO(krzyzacy) this job is temporary, remove once we verify it works
   spec:
     containers:
     - args:
@@ -16452,7 +16521,7 @@ periodics:
 
 - interval: 2h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-cos-oldetcd-serial # TODO(krzyzacy) this job is temporary, remove once we verify it works 
+  name: ci-kubernetes-e2e-gke-cos-oldetcd-serial # TODO(krzyzacy) this job is temporary, remove once we verify it works
   spec:
     containers:
     - args:
@@ -16486,7 +16555,7 @@ periodics:
 
 - interval: 2h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-cos-oldetcd-slow # TODO(krzyzacy) this job is temporary, remove once we verify it works 
+  name: ci-kubernetes-e2e-gke-cos-oldetcd-slow # TODO(krzyzacy) this job is temporary, remove once we verify it works
   spec:
     containers:
     - args:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -109,8 +109,14 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-ingress-gce-image-push
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-image-push
 - name: ci-ingress-gce-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e
+- name: ci-ingress-gce-upgrade-e2e
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-upgrade-e2e
+- name: ci-ingress-gce-downgrade-e2e
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-downgrade-e2e
 - name: ci-kubernetes-build-1.9
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.9
 - name: ci-kubernetes-build
@@ -3890,6 +3896,18 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-gce-e2e
     test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-image-push
+    test_group_name: ci-ingress-gce-image-push
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-upgrade-e2e
+    test_group_name: ci-ingress-gce-upgrade-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-downgrade-e2e
+    test_group_name: ci-ingress-gce-downgrade-e2e
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-ingress-release-1.6


### PR DESCRIPTION
This PR adds boilerplate for two more CI jobs for ingress-gce. Specifically, these jobs will run e2e tests after a GLBC is upgraded/downgraded.

Also tons of cleanup: 

1. remove dind for presubmit job.
2. have a ci-build job build/push latest image for ingress-gce. This will result in previous kubetest code which built ingress not being needed anymore since the ci job can just run make.
3. ci-e2e, ci-upgrade, ci-downgrade can consume the image built from ci-build job