### PR TITLE
Rename kubernetes-incubator/cri-containerd to containerd/cri-containerd.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11326,7 +11326,7 @@
       "--deployment=node",
       "--gcp-project=k8s-c8d-pr-node-e2e",
       "--gcp-zone=us-central1-f",
-      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd",
+      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd",
       "--node-test-args=--container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/ --container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\" --extra-log=\"{\\\"name\\\": \\\"cri-containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"cri-containerd\\\"]}\"",
       "--node-tests=true",
       "--provider=gce",

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -12,8 +12,8 @@ TEST_ETCD_VERSION=2.2.1
 
 # Envs for cri-containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd cri-containerd cri-containerd-installation
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/var/run/cri-containerd.sock
 KUBE_LOAD_IMAGE_COMMAND=/home/cri-containerd/usr/local/bin/cri-containerd load

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -522,7 +522,7 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  kubernetes-incubator/cri-containerd:
+  containerd/cri-containerd:
   - name: pull-cri-containerd-build
     agent: kubernetes
     always_run: true
@@ -574,7 +574,7 @@ presubmits:
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=90"
           - "--"
-          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd --node-env=PULL_REFS=$(PULL_REFS)"
+          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd --node-env=PULL_REFS=$(PULL_REFS)"
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/service-account/service-account.json
@@ -1360,7 +1360,7 @@ presubmits:
         - --root=/go/src
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
-        - --repo=github.com/kubernetes-incubator/cri-containerd
+        - --repo=github.com/containerd/cri-containerd
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --git-cache=/root/.cache/git
         - --clean
@@ -2829,7 +2829,7 @@ presubmits:
         - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=github.com/kubernetes-incubator/cri-containerd"
+        - "--repo=github.com/containerd/cri-containerd"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
@@ -3770,7 +3770,7 @@ presubmits:
         - --root=/go/src
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
-        - --repo=github.com/kubernetes-incubator/cri-containerd
+        - --repo=github.com/containerd/cri-containerd
         - --upload=gs://kubernetes-security-jenkins/pr-logs
         - --git-cache=/root/.cache/git
         - --clean
@@ -5239,7 +5239,7 @@ presubmits:
         - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=github.com/kubernetes-incubator/cri-containerd"
+        - "--repo=github.com/containerd/cri-containerd"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-security-jenkins/pr-logs"
         - "--timeout=90"
@@ -6552,7 +6552,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
       args:
-      - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
+      - "--repo=github.com/containerd/cri-containerd=master"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       env:
@@ -6573,7 +6573,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
+      - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -6607,7 +6607,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
+      - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -6644,10 +6644,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/kubernetes-incubator/cri-containerd=master
+      - --repo=github.com/containerd/cri-containerd=master
       - --timeout=90
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -6684,10 +6684,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/kubernetes-incubator/cri-containerd=master
+      - --repo=github.com/containerd/cri-containerd=master
       - --timeout=120
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -6724,10 +6724,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/kubernetes-incubator/cri-containerd=master
+      - --repo=github.com/containerd/cri-containerd=master
       - --timeout=240
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -13,6 +13,10 @@ triggers:
   - GoogleCloudPlatform/k8s-multicluster-ingress
   trusted_org: kubernetes
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+- repos:
+  - containerd/cri-containerd
+  trusted_org: containerd
+  join_org_url: "https://github.com/containerd/containerd/blob/master/MAINTAINERS"
 
 approve:
 - repos:
@@ -196,7 +200,13 @@ plugins:
   - lifecycle
   - size
 
-  kubernetes-incubator/cri-containerd:
+  containerd/cri-containerd:
+  - assign
+  - cla
+  - label
+  - lgtm
+  - lifecycle
+  - size
   - trigger
 
   kubernetes-security/kubernetes:


### PR DESCRIPTION
cri-containerd has been moved from `kubernetes-incubator/cri-containerd` to `containerd/cri-containerd`.