### PR TITLE
Remove obsolete # gazelle:exclude

### DIFF
--- a/jenkins/BUILD
+++ b/jenkins/BUILD
@@ -1,6 +1,3 @@
-# The aws-janitor is not properly vendored in this repo
-# gazelle:exclude aws-janitor
-
 py_test(
     name = "bootstrap_test",
     srcs = [
@@ -14,7 +11,7 @@ py_test(
         "//jobs",
         "//prow:config.yaml",
     ],
-    deps = ["@yaml//:yaml"],
+    deps = ["@yaml"],
 )
 
 filegroup(


### PR DESCRIPTION
This no longer has any effect, and was intended to be removed in #6204.

x-ref #6242 

/assign @fejta @BenTheElder 