### PR TITLE
Fix kettle JUnit parser to ignore non-<testcase> tags.

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -52,7 +52,7 @@ def parse_junit(xml):
     # Knowing that a given build could have ran a test but didn't for some reason
     # isn't very interesting.
     if tree.tag == 'testsuite':
-        for child in tree:
+        for child in tree.findall('testcase'):
             name = child.attrib['name']
             time = float(child.attrib['time'] or 0)
             failure_text = None

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -68,6 +68,7 @@ class MakeJsonTest(unittest.TestCase):
                metadata=[{'key': 'pull', 'value': 'asdf'}, {'key': 'repo', 'value': 'ignored'}])
         expect(path, None, None, ['''
                    <testsuite>
+                    <properties><property name="test" value="don't crash!"></property></properties>
                     <testcase name="t1" time="1.0"><failure>stacktrace</failure></testcase>
                     <testcase name="t2" time="2.0"></testcase>
                     <testcase name="t2#1" time="2.0"></testcase>


### PR DESCRIPTION
This was failing with the Spark junit XML, like in `gs://kubernetes-jenkins/logs/spark-periodic-default-gke/65`.

It has \<properties\> tags that we don't normally output!