### PR TITLE
run dep ensure and prune with -v

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -48,8 +48,8 @@ drop-dep() {
 
 main() {
   pushd "$(dirname "${BASH_SOURCE}")/.."
-  dep ensure
-  dep prune
+  dep ensure -v
+  dep prune -v
   hack/update-bazel.sh
   drop-dep vendor/golang.org/x/text/language vendor/golang.org/x/text/internal
   drop-dep vendor/google.golang.org/api/transport/grpc vendor/google.golang.org/api/transport


### PR DESCRIPTION
This makes dep output each completed package instead of running silently, which seems consistent with the `set -o xtrace` for the rest of what `hack/update-deps.sh` does.

/area horrible-hacks
/shrug