### PR TITLE
Don't use a `main()` in `hack/update-deps.sh`

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -46,21 +46,15 @@ drop-dep() {
   sed -i -e "\|//$1:go_default_library|d" "$path"
 }
 
-main() {
-  pushd "$(dirname "${BASH_SOURCE}")/.."
-  dep ensure -v
-  dep prune -v
-  hack/update-bazel.sh
-  drop-dep vendor/golang.org/x/text/language vendor/golang.org/x/text/internal
-  drop-dep vendor/google.golang.org/api/transport/grpc vendor/google.golang.org/api/transport
-  drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/grpc vendor/github.com/golang/protobuf/protoc-gen-go
-  drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/generator vendor/github.com/golang/protobuf/protoc-gen-go
-  hack/prune-libraries.sh --fix
-  hack/update-bazel.sh  # Update child :all-srcs in case parent was deleted
-}
-
-if ! main; then
-  echo FAILED >&2
-  exit 1
-fi
+trap 'echo "FAILED" >&2' ERR
+pushd "$(dirname "${BASH_SOURCE}")/.."
+dep ensure -v
+dep prune -v
+hack/update-bazel.sh
+drop-dep vendor/golang.org/x/text/language vendor/golang.org/x/text/internal
+drop-dep vendor/google.golang.org/api/transport/grpc vendor/google.golang.org/api/transport
+drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/grpc vendor/github.com/golang/protobuf/protoc-gen-go
+drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/generator vendor/github.com/golang/protobuf/protoc-gen-go
+hack/prune-libraries.sh --fix
+hack/update-bazel.sh  # Update child :all-srcs in case parent was deleted
 echo SUCCESS


### PR DESCRIPTION
The construct

    if ! main; then
        # etc...
    fi

Will turn off `set -o errexit` inside of `main` by turning off the `ERR`
signal. If we still want the `set -o errexit` behavior in our script we
should just trap the error behavior on `ERR` ourselves.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 