### PR TITLE
Add comment to kube.Cluster describing how to get the needed credentials.

### DIFF
--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -279,6 +279,8 @@ func NewClientInCluster(namespace string) (*Client, error) {
 
 // Cluster represents the information necessary to talk to a Kubernetes
 // master endpoint.
+// NOTE: if your cluster runs on GKE you can use the following command to get these credentials:
+// gcloud --project <gcp_project> container clusters describe --zone <zone> <cluster_name>
 type Cluster struct {
 	// The IP address of the cluster's master endpoint.
 	Endpoint string `yaml:"endpoint"`


### PR DESCRIPTION
I had a surprisingly hard time trying to figure out how to get these credentials on GKE. The [docs](https://cloud.google.com/sdk/gcloud/reference/container/clusters/describe) for the command that is needed don't mention what it returns so the searches I made for "GKE client certificate" didn't yield useful results.
Thanks @spxtr for pointing me to the correct command!

/cc @rmmh 