### PR TITLE
Enable implicit_self_approval on k8s repos.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -23,11 +23,15 @@ approve:
   - kubernetes/charts
   - kubernetes/cluster-registry
   - kubernetes/community
+  - kubernetes/contrib
   - kubernetes/dashboard
   - kubernetes/features
+  - kubernetes/federation
   - kubernetes/ingress-nginx
+  - kubernetes/kops
   - kubernetes/kube-deploy
   - kubernetes/kubectl
+  - kubernetes/kubernetes-template-project
   - kubernetes/minikube
   - kubernetes/sig-release
   - kubernetes/steering


### PR DESCRIPTION
This will enable implicit self approval on k/contrib, k/federation, k/kops, and k/kubernetes-template-project in order to make the approve process more consistent across k8s repos.

@porridge closes #6221 

/cc @spiffxp @chrislovecnm @marun 