### PR TITLE
Gather metrics even when Jenkins is broken

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -34,7 +34,7 @@ HOROLOGIUM_VERSION       ?= 0.21
 # PLANK_VERSION is the version of the plank image
 PLANK_VERSION            ?= 0.65
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.61
+JENKINS-OPERATOR_VERSION ?= 0.62
 # TIDE_VERSION is the version of the tide image
 TIDE_VERSION             ?= 0.20
 # CLONEREFS_VERSION is the version of the clonerefs image

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.61
+        image: gcr.io/k8s-prow/jenkins-operator:0.62
         ports:
         - name: logs
           containerPort: 8080


### PR DESCRIPTION
Collect prowjobs metrics in the Jenkins operator before
calling out to Jenkins since when Jenkins breaks down,
metrics (specifically metrics about new prowjobs) get
stale due to the sync loop being aborted prematurely.