### PR TITLE
Update kazel

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -1,7 +1,7 @@
 py_binary(
     name = "flakedetector",
     srcs = ["flakedetector.py"],
-    deps = ["@requests//:requests"],
+    deps = ["@requests"],
 )
 
 py_binary(

--- a/hack/BUILD
+++ b/hack/BUILD
@@ -28,12 +28,12 @@ py_binary(
     srcs = ["pylint_bin.py"],
     # NOTE: this should only contain direct third party imports and pylint
     deps = [
-        "@influxdb//:influxdb",
-        "@pylint//:pylint",
-        "@pytz//:pytz",
-        "@requests//:requests",  # TODO(fejta): figure out a better solution
+        "@influxdb",
+        "@pylint",
+        "@pytz",
+        "@requests",  # TODO(fejta): figure out a better solution
         "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
-        "@yaml//:yaml",
+        "@yaml",
     ],
 )
 

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -35,7 +35,7 @@ rm -f ${TESTINFRA_ROOT}/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/kubernetes/repo-infra/kazel \
-  e26fc85d14a1d3dc25569831acc06919673c545a \
+  2a736b4fba317cf3038e3cbd06899b544b875fae \
   "${TMP_GOPATH}"
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -22,7 +22,7 @@ TMP_GOPATH=$(mktemp -d)
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/kubernetes/repo-infra/kazel \
-  e26fc85d14a1d3dc25569831acc06919673c545a \
+  2a736b4fba317cf3038e3cbd06899b544b875fae \
   "${TMP_GOPATH}"
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \

--- a/kettle/BUILD
+++ b/kettle/BUILD
@@ -10,8 +10,8 @@ py_test(
     # https://github.com/bazelbuild/bazel/issues/2056
     local = True,
     deps = [
-        "@requests//:requests",
-        "@yaml//:yaml",
+        "@requests",
+        "@yaml",
     ],
 )
 
@@ -41,7 +41,7 @@ py_test(
     ],
     data = ["schema.json"],
     deps = [
-        "@requests//:requests",
+        "@requests",
     ],
 )
 
@@ -56,7 +56,7 @@ py_test(
     data = ["//:buckets"],
     # idem
     local = True,
-    deps = ["@yaml//:yaml"],
+    deps = ["@yaml"],
 )
 
 filegroup(

--- a/metrics/BUILD
+++ b/metrics/BUILD
@@ -33,11 +33,11 @@ py_binary(
         ":k8": ["@jq_linux//file"],
     }),
     deps = [
-        "@dateutil//:dateutil",
-        "@influxdb//:influxdb",
-        "@pytz//:pytz",
-        "@requests//:requests",
-        "@yaml//:yaml",
+        "@dateutil",
+        "@influxdb",
+        "@pytz",
+        "@requests",
+        "@yaml",
     ],
 )
 
@@ -56,10 +56,10 @@ py_test(
         ":darwin": ["@jq_osx//file"],
     }),
     deps = [
-        "@dateutil//:dateutil",
-        "@influxdb//:influxdb",
-        "@pytz//:pytz",
-        "@requests//:requests",
-        "@yaml//:yaml",
+        "@dateutil",
+        "@influxdb",
+        "@pytz",
+        "@requests",
+        "@yaml",
     ],
 )

--- a/velodrome/BUILD
+++ b/velodrome/BUILD
@@ -8,7 +8,7 @@ py_test(
     ],
     main = "config.py",
     deps = [
-        "@yaml//:yaml",
+        "@yaml",
     ],
 )
 


### PR DESCRIPTION
kubernetes/repo-infra had an old copy of the buildifier library which was rewriting comments incorrectly.

Thanks to @cblecker, we now have updated deps, which seem to include bugfixes. This PR updates our `kazel` dependency with these fixes.

x-ref https://github.com/bazelbuild/bazel-gazelle/issues/92
/assign @BenTheElder 
/area bazel
cc @kargakis 