### PR TITLE
add tool to automatically generate security repo presubmits

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -41,6 +41,7 @@ filegroup(
         "//label_sync:all-srcs",
         "//logexporter/cmd:all-srcs",
         "//maintenance/aws-janitor:all-srcs",
+        "//maintenance/fixconfig:all-srcs",
         "//maintenance/migratestatus:all-srcs",
         "//metrics:all-srcs",
         "//mungegithub:all-srcs",

--- a/maintenance/fixconfig/BUILD
+++ b/maintenance/fixconfig/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/maintenance/fixconfig",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/kube:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "fixconfig",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/maintenance/fixconfig",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/maintenance/fixconfig/main.go
+++ b/maintenance/fixconfig/main.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+fixconfig automatically fixes the prow config to have automatically generated
+security repo presubmits transformed from the kubernetes presubmits
+
+NOTE: this makes a few assumptions
+- $PWD/prow/config.yaml is where the config lives (unless you supply --config=)
+- `presubmits:` exists
+- `  kubernetes-security/kubernetes:` exists in presubmits
+- some other `  org/repo:` exists in presubmits *after* `  kubernetes-security/kubernetes:`
+- the original contents around this will be kept, but this section will be automatically rewritten
+*/
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	flag "github.com/spf13/pflag"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/kube"
+)
+
+var configPath = flag.String("config", "", "path to prow/config.yaml, defaults to $PWD/prow/config.yaml")
+
+func readConfig(path string) (raw []byte, parsed *config.Config, err error) {
+	raw, err = ioutil.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	parsed = &config.Config{}
+	err = yaml.Unmarshal(raw, parsed)
+	if err != nil {
+		return nil, nil, err
+	}
+	return raw, parsed, nil
+}
+
+func getSecurityRepoJobsIndex(configBytes []byte) (start, end int, err error) {
+	// find security-repo config begining
+	// first find presubmits
+	presubmitIdx := bytes.Index(configBytes, ([]byte)("presubmits:"))
+	// then find k-s/k:
+	startRegex := regexp.MustCompile("(?m)^  kubernetes-security/kubernetes:$")
+	loc := startRegex.FindIndex(configBytes[presubmitIdx:])
+	if loc == nil {
+		return 0, 0, fmt.Errorf("failed to find start of security repo presubmits")
+	}
+	start = presubmitIdx + loc[1]
+	// must be like `  org/repo:`
+	loc = regexp.MustCompile("(?m)^  [^ #-][^ #]+/.+:$").FindIndex(configBytes[start:])
+	if loc == nil {
+		return 0, 0, fmt.Errorf("failed to find end of security repo presubmits")
+	}
+	// loc[0] is the beginning of the match
+	end = start + loc[0]
+	return start, end, nil
+}
+
+// convert a kubernetes/kubernetes job to a kubernetes-security/kubernetes job
+// xref: prow/config/config_test.go replace(...)
+func convertJobToSecurityJob(j *config.Presubmit) {
+	// fix name and triggers for all jobs
+	j.Name = strings.Replace(j.Name, "pull-kubernetes", "pull-security-kubernetes", -1)
+	j.RerunCommand = strings.Replace(j.RerunCommand, "pull-kubernetes", "pull-security-kubernetes", -1)
+	j.Trigger = strings.Replace(j.Trigger, "pull-kubernetes", "pull-security-kubernetes", -1)
+	j.Context = strings.Replace(j.Context, "pull-kubernetes", "pull-security-kubernetes", -1)
+	// handle k8s job args, volumes etc
+	if j.Agent == "kubernetes" {
+		j.Cluster = "security"
+		for i, arg := range j.Spec.Containers[0].Args {
+			// handle --repo substitution for main repo
+			if strings.HasPrefix(arg, "--repo=k8s.io/kubernetes") || strings.HasPrefix(arg, "--repo=k8s.io/$(REPO_NAME)") {
+				j.Spec.Containers[0].Args[i] = strings.Replace(arg, "k8s.io/", "github.com/kubernetes-security/", 1)
+
+				// handle upload bucket
+			} else if strings.HasPrefix(arg, "--upload=") {
+				j.Spec.Containers[0].Args[i] = "--upload=gs://kubernetes-security-jenkins/pr-logs"
+			}
+		}
+		j.Spec.Containers[0].Args = append(j.Spec.Containers[0].Args, "--ssh=/etc/ssh-security/ssh-security")
+		j.Spec.Containers[0].VolumeMounts = append(
+			j.Spec.Containers[0].VolumeMounts,
+			kube.VolumeMount{
+				Name:      "ssh-security",
+				MountPath: "/etc/ssh-security",
+			},
+		)
+		j.Spec.Volumes = append(
+			j.Spec.Volumes,
+			kube.Volume{
+				Name: "ssh-security",
+				VolumeSource: kube.VolumeSource{
+					Secret: &kube.SecretSource{
+						Name:        "ssh-security",
+						DefaultMode: 0400,
+					},
+				},
+			},
+		)
+	}
+	// done with this job, check for run_after_success
+	for i := range j.RunAfterSuccess {
+		convertJobToSecurityJob(&j.RunAfterSuccess[i])
+	}
+}
+
+func yamlBytesStripNulls(yamlBytes []byte) []byte {
+	nullRE := regexp.MustCompile("(?m)[\n]+^[^\n]+: null$")
+	return nullRE.ReplaceAll(yamlBytes, []byte{})
+}
+
+func yamlBytesToEntry(yamlBytes []byte, indent int) []byte {
+	var buff bytes.Buffer
+	// spaces of length indent
+	prefix := bytes.Repeat([]byte{32}, indent)
+	// `- ` before the first field of a yaml entry
+	prefix[len(prefix)-2] = byte(45)
+	buff.Write(prefix)
+	// put back space
+	prefix[len(prefix)-2] = byte(32)
+	for i, b := range yamlBytes {
+		buff.WriteByte(b)
+		// indent after newline, except the last one
+		if b == byte(10) && i+1 != len(yamlBytes) {
+			buff.Write(prefix)
+		}
+	}
+	return buff.Bytes()
+}
+
+func main() {
+	flag.Parse()
+	// default to $PWD/prow/config.yaml
+	if *configPath == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("Failed to get $PWD: %v", err)
+		}
+		*configPath = pwd + "/prow/config.yaml"
+	}
+	// read in current prow config
+	originalBytes, parsed, err := readConfig(*configPath)
+	if err != nil {
+		log.Fatalf("Failed to read config file: %v", err)
+	}
+	// find security repo section
+	securityRepoStart, securityRepoEnd, err := getSecurityRepoJobsIndex(originalBytes)
+	if err != nil {
+		log.Fatalf("Failed to find security repo section: %v", err)
+	}
+
+	// create temp file to write updated config
+	f, err := ioutil.TempFile("", "prow-config")
+	if err != nil {
+		log.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	// write the original bytes before the security repo section
+	_, err = f.Write(originalBytes[:securityRepoStart])
+	if err != nil {
+		log.Fatalf("Failed to write temp file: %v", err)
+	}
+	f.Sync()
+	io.WriteString(f, "\n")
+
+	// convert each kubernetes/kubernetes presubmit to a
+	// kubernetes-security/kubernetes presubmit and write to the file
+	for _, job := range parsed.Presubmits["kubernetes/kubernetes"] {
+		convertJobToSecurityJob(&job)
+		jobBytes, err := yaml.Marshal(job)
+		if err != nil {
+			log.Fatalf("Failed to marshal job: %v", err)
+		}
+		// write, properly indented, and stripped of `foo: null`
+		jobBytes = yamlBytesStripNulls(jobBytes)
+		f.Write(yamlBytesToEntry(jobBytes, 4))
+	}
+
+	// write the original bytes after the security repo section
+	_, err = f.Write(originalBytes[securityRepoEnd:])
+	if err != nil {
+		log.Fatalf("Failed to write temp file: %v", err)
+	}
+	f.Sync()
+
+	// copy file to replace original
+	f.Close()
+	err = os.Rename(f.Name(), *configPath)
+	if err != nil {
+		log.Fatalf("Failed to replace config with updated version: %v", err)
+	}
+}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3237,8 +3237,7 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-jenkins/pr-logs
         - --
-        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/...
-          //examples/... //test/... //vendor/k8s.io/...
+        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...
         - --release=//build/release-tars
         - --ssh=/etc/ssh-security/ssh-security
         env:
@@ -3358,8 +3357,7 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-jenkins/pr-logs
         - --
-        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/...
-          //examples/... //test/...
+        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/...
         - --release=//build/release-tars
         - --ssh=/etc/ssh-security/ssh-security
         env:
@@ -3591,8 +3589,7 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-jenkins/pr-logs
         - --
-        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/...
-          //vendor/k8s.io/...
+        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //vendor/k8s.io/...
         - --manual-test=//hack:verify-all
         - --test-args=--test_tag_filters=-integration
         - --test-args=--flaky_test_attempts=3
@@ -3650,8 +3647,7 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-jenkins/pr-logs
         - --
-        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/...
-          -//pkg/kubelet/config:go_default_test
+        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... -//pkg/kubelet/config:go_default_test
         - --manual-test=//hack:verify-all
         - --test-args=--test_tag_filters=-integration
         - --test-args=--flaky_test_attempts=3

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3026,87 +3026,36 @@ presubmits:
           path: /mnt/disks/ssd0/docker-graph
 
   kubernetes-security/kubernetes:
-  - name: pull-security-kubernetes-bazel-build
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-build
+  - agent: kubernetes
     always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-build"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-build),?(\\s+|$)"
-    skip_branches:
-    - release-1.6 # doesn't have BUILD files under //vendor/k8s.io
-    - release-1.7 # different target set
-    - release-1.8 # different target set
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--build=//... -//vendor/..."
-        - "--release=//build/release-tars"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-
+    cluster: security
+    context: pull-security-kubernetes-bazel-build
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-build
+    rerun_command: /test pull-security-kubernetes-bazel-build
     run_after_success:
-    - name: pull-security-kubernetes-e2e-kubeadm-gce
+    - agent: kubernetes
+      always_run: false
       cluster: security
-      agent: kubernetes
       context: pull-security-kubernetes-e2e-kubeadm-gce
       max_concurrency: 8
-      skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
-      rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce"
-      trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+      name: pull-security-kubernetes-e2e-kubeadm-gce
+      rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+      run_if_changed: ^(cmd/kubeadm|build/debs).*$
       skip_branches:
-      - release-1.6 # doesn't have BUILD files under //vendor/k8s.io
-      - release-1.7 # different target set
-      - release-1.8 # different target set
+      - release-1.6
+      - release-1.7
+      - release-1.8
+      skip_report: true
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
-          args:
-          - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-          - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
-          - "--ssh=/etc/ssh-security/ssh-security"
-          - "--timeout=75"
-          - "--clean"
+        - args:
+          - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+          - --upload=gs://kubernetes-security-jenkins/pr-logs
+          - --git-cache=/root/.cache/git
+          - --timeout=75
+          - --clean
+          - --ssh=/etc/ssh-security/ssh-security
           env:
           - name: USER
             value: prow
@@ -3116,115 +3065,123 @@ presubmits:
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
-          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-            value: true
-          volumeMounts:
-          - name: ssh-security
-            mountPath: /etc/ssh-security
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
+          - name: SKIP_RELEASE_VALIDATION
+            value: "true"
+          image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           ports:
           - containerPort: 9999
             hostPort: 9999
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+          - mountPath: /root/.cache
+            name: cache-ssd
+          - mountPath: /etc/ssh-security
+            name: ssh-security
         volumes:
-        - name: ssh-security
-          secret:
-            secretName: ssh-security
-            defaultMode: 0400
         - name: service
           secret:
             secretName: service-account
         - name: ssh
           secret:
+            defaultMode: 256
             secretName: ssh-key-secret
-            defaultMode: 0400
-        - name: cache-ssd
-          hostPath:
+        - hostPath:
             path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-build
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-build
+          name: cache-ssd
+        - name: ssh-security
+          secret:
+            defaultMode: 256
+            secretName: ssh-security
+      trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\s+|$)
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --build=//... -//vendor/...
+        - --release=//build/release-tars
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-build),?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-build"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-build),?(\\s+|$)"
     branches:
     - release-1.7
     - release-1.8
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/..."
-        - "--release=//build/release-tars"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
+    cluster: security
+    context: pull-security-kubernetes-bazel-build
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-build
+    rerun_command: /test pull-security-kubernetes-bazel-build
     run_after_success:
-    - name: pull-security-kubernetes-e2e-kubeadm-gce
-      cluster: security
-      agent: kubernetes
-      context: pull-security-kubernetes-e2e-kubeadm-gce
-      max_concurrency: 8
-      skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
-      rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce"
-      trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+    - agent: kubernetes
+      always_run: false
       branches:
       - release-1.7
       - release-1.8
+      cluster: security
+      context: pull-security-kubernetes-e2e-kubeadm-gce
+      max_concurrency: 8
+      name: pull-security-kubernetes-e2e-kubeadm-gce
+      rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+      run_if_changed: ^(cmd/kubeadm|build/debs).*$
+      skip_report: true
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
-          args:
-          - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-          - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
-          - "--ssh=/etc/ssh-security/ssh-security"
-          - "--timeout=75"
-          - "--clean"
+        - args:
+          - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+          - --upload=gs://kubernetes-security-jenkins/pr-logs
+          - --git-cache=/root/.cache/git
+          - --timeout=75
+          - --clean
+          - --ssh=/etc/ssh-security/ssh-security
           env:
           - name: USER
             value: prow
@@ -3234,113 +3191,118 @@ presubmits:
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
-          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-            value: true
-          volumeMounts:
-          - name: ssh-security
-            mountPath: /etc/ssh-security
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
+          - name: SKIP_RELEASE_VALIDATION
+            value: "true"
+          image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           ports:
           - containerPort: 9999
             hostPort: 9999
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+          - mountPath: /root/.cache
+            name: cache-ssd
+          - mountPath: /etc/ssh-security
+            name: ssh-security
         volumes:
-        - name: ssh-security
-          secret:
-            secretName: ssh-security
-            defaultMode: 0400
         - name: service
           secret:
             secretName: service-account
         - name: ssh
           secret:
+            defaultMode: 256
             secretName: ssh-key-secret
-            defaultMode: 0400
-        - name: cache-ssd
-          hostPath:
+        - hostPath:
             path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-build
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-build
-    always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-build"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-build),?(\\s+|$)"
-    branches:
-    - release-1.6
+          name: cache-ssd
+        - name: ssh-security
+          secret:
+            defaultMode: 256
+            secretName: ssh-security
+      trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\s+|$)
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/..."
-        - "--release=//build/release-tars"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/...
+          //examples/... //test/... //vendor/k8s.io/...
+        - --release=//build/release-tars
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            memory: "6Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-build),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-1.6
+    cluster: security
+    context: pull-security-kubernetes-bazel-build
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-build
+    rerun_command: /test pull-security-kubernetes-bazel-build
     run_after_success:
-    - name: pull-security-kubernetes-e2e-kubeadm-gce
-      cluster: security
-      agent: kubernetes
-      context: pull-security-kubernetes-e2e-kubeadm-gce
-      max_concurrency: 8
-      skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
-      rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce"
-      trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+    - agent: kubernetes
+      always_run: false
       branches:
       - release-1.6
+      cluster: security
+      context: pull-security-kubernetes-e2e-kubeadm-gce
+      max_concurrency: 8
+      name: pull-security-kubernetes-e2e-kubeadm-gce
+      rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+      run_if_changed: ^(cmd/kubeadm|build/debs).*$
+      skip_report: true
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
-          args:
-          - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-          - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
-          - "--ssh=/etc/ssh-security/ssh-security"
-          - "--timeout=75"
-          - "--clean"
+        - args:
+          - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+          - --upload=gs://kubernetes-security-jenkins/pr-logs
+          - --git-cache=/root/.cache/git
+          - --timeout=75
+          - --clean
+          - --ssh=/etc/ssh-security/ssh-security
           env:
           - name: USER
             value: prow
@@ -3350,513 +3312,579 @@ presubmits:
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
-          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-            value: true
-          volumeMounts:
-          - name: ssh-security
-            mountPath: /etc/ssh-security
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
+          - name: SKIP_RELEASE_VALIDATION
+            value: "true"
+          image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           ports:
           - containerPort: 9999
             hostPort: 9999
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+          - mountPath: /root/.cache
+            name: cache-ssd
+          - mountPath: /etc/ssh-security
+            name: ssh-security
         volumes:
-        - name: ssh-security
-          secret:
-            secretName: ssh-security
-            defaultMode: 0400
         - name: service
           secret:
             secretName: service-account
         - name: ssh
           secret:
+            defaultMode: 256
             secretName: ssh-key-secret
-            defaultMode: 0400
-        - name: cache-ssd
-          hostPath:
+        - hostPath:
             path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-build-canary
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-build-canary
-    always_run: false
-    rerun_command: "/test pull-security-kubernetes-bazel-build-canary"
-    trigger: "(?m)^/test pull-security-kubernetes-bazel-build-canary,?(\\s+|$)"
-    branches:
-    - master
+          name: cache-ssd
+        - name: ssh-security
+          secret:
+            defaultMode: 256
+            secretName: ssh-security
+      trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\s+|$)
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
-        imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
-        - "--build=//... -//vendor/..."
-        - "--release=//build/release-tars"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/...
+          //examples/... //test/...
+        - --release=//build/release-tars
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
-          value: /scratch/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
+        - mountPath: /etc/service-account
+          name: service
           readOnly: true
-        - name: bazel-scratch
-          mountPath: /scratch/.cache
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
       - name: ssh-security
         secret:
+          defaultMode: 256
           secretName: ssh-security
-          defaultMode: 0400
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-build),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-bazel-build-canary
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-build-canary
+    rerun_command: /test pull-security-kubernetes-bazel-build-canary
+    run_after_success:
+    - agent: kubernetes
+      always_run: false
+      cluster: security
+      context: pull-security-kubernetes-e2e-kubeadm-gce-canary
+      max_concurrency: 8
+      name: pull-security-kubernetes-e2e-kubeadm-gce-canary
+      rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce-canary
+      run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
+      skip_report: false
+      spec:
+        containers:
+        - args:
+          - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+          - --upload=gs://kubernetes-security-jenkins/pr-logs
+          - --git-cache=/root/.cache/git
+          - --timeout=75
+          - --clean
+          - --ssh=/etc/ssh-security/ssh-security
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          - name: SKIP_RELEASE_VALIDATION
+            value: "true"
+          image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+          - mountPath: /root/.cache
+            name: cache-ssd
+          - mountPath: /etc/ssh-security
+            name: ssh-security
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            defaultMode: 256
+            secretName: ssh-key-secret
+        - hostPath:
+            path: /mnt/disks/ssd0
+          name: cache-ssd
+        - name: ssh-security
+          secret:
+            defaultMode: 256
+            secretName: ssh-security
+      trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\s+|$)
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --batch
+        - --build=//... -//vendor/...
+        - --release=//build/release-tars
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: TEST_TMPDIR
+          value: /scratch/.cache/bazel
+        image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /scratch/.cache
+          name: bazel-scratch
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
       - name: service
         secret:
           secretName: service-account
       - name: bazel-scratch
-        emtpyDir: {}
-    run_after_success:
-    - name: pull-security-kubernetes-e2e-kubeadm-gce-canary
-      cluster: security
-      agent: kubernetes
-      context: pull-security-kubernetes-e2e-kubeadm-gce-canary
-      max_concurrency: 8
-      skip_report: false
-      # use standard (pull-kubernetes-cross) regex we normally make sure
-      # to trigger on dummy / canary testing PRs
-      run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
-      rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce-canary"
-      trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
-          args:
-          - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-          - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
-          - "--ssh=/etc/ssh-security/ssh-security"
-          - "--timeout=75"
-          - "--clean"
-          env:
-          - name: USER
-            value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-            value: true
-          volumeMounts:
-          - name: ssh-security
-            mountPath: /etc/ssh-security
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
-        - name: ssh-security
-          secret:
-            secretName: ssh-security
-            defaultMode: 0400
-        - name: service
-          secret:
-            secretName: service-account
-        - name: ssh
-          secret:
-            secretName: ssh-key-secret
-            defaultMode: 0400
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-test
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-test
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-build-canary,?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-test"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-test),?(\\s+|$)"
+    cluster: security
+    context: pull-security-kubernetes-bazel-test
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test
+    rerun_command: /test pull-security-kubernetes-bazel-test
+    run_if_changed: ""
     skip_branches:
-    - release-1.6 # doesn't have BUILD files under //vendor/k8s.io
-    - release-1.7 # different set of targets
-    - release-1.8 # different set of targets
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--test=//... -//build/... -//vendor/..."
-        - "--manual-test=//hack:verify-all"
-        - "--test-args=--build_tag_filters=-e2e,-integration"
-        - "--test-args=--test_tag_filters=-e2e,-integration"
-        - "--test-args=--flaky_test_attempts=3"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --test=//... -//build/... -//vendor/...
+        - --manual-test=//hack:verify-all
+        - --test-args=--build_tag_filters=-e2e,-integration
+        - --test-args=--test_tag_filters=-e2e,-integration
+        - --test-args=--flaky_test_attempts=3
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            memory: "6Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-test
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-test
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-test),?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-test"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-test),?(\\s+|$)"
     branches:
     - release-1.7
     - release-1.8
+    cluster: security
+    context: pull-security-kubernetes-bazel-test
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test
+    rerun_command: /test pull-security-kubernetes-bazel-test
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //vendor/k8s.io/..."
-        - "--manual-test=//hack:verify-all"
-        - "--test-args=--test_tag_filters=-integration"
-        - "--test-args=--flaky_test_attempts=3"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/...
+          //vendor/k8s.io/...
+        - --manual-test=//hack:verify-all
+        - --test-args=--test_tag_filters=-integration
+        - --test-args=--flaky_test_attempts=3
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            memory: "6Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-test
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-bazel-test
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-test),?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    rerun_command: "/test pull-security-kubernetes-bazel-test"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-test),?(\\s+|$)"
     branches:
     - release-1.6
+    cluster: security
+    context: pull-security-kubernetes-bazel-test
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test
+    rerun_command: /test pull-security-kubernetes-bazel-test
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        # -//pkg/kubelet/config:go_default_test because: https://github.com/kubernetes/kubernetes/issues/53016
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... -//pkg/kubelet/config:go_default_test"
-        - "--manual-test=//hack:verify-all"
-        - "--test-args=--test_tag_filters=-integration"
-        - "--test-args=--flaky_test_attempts=3"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/...
+          -//pkg/kubelet/config:go_default_test
+        - --manual-test=//hack:verify-all
+        - --test-args=--test_tag_filters=-integration
+        - --test-args=--flaky_test_attempts=3
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
+        image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            memory: "6Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-bazel-test-canary
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-bazel-test),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - master
     cluster: security
-    agent: kubernetes
     context: pull-security-kubernetes-bazel-test-canary
-    always_run: false
-    rerun_command: "/test pull-security-kubernetes-bazel-test-canary"
-    trigger: "(?m)^/test pull-security-kubernetes-bazel-test-canary,?(\\s+|$)"
-    branches:
-    - master
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test-canary
+    rerun_command: /test pull-security-kubernetes-bazel-test-canary
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
-        imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
-        - "--test=//... -//build/... -//vendor/..."
-        - "--manual-test=//hack:verify-all"
-        - "--test-args=--build_tag_filters=-e2e"
-        - "--test-args=--test_tag_filters=-e2e"
-        - "--test-args=--flaky_test_attempts=3"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --
+        - --batch
+        - --test=//... -//build/... -//vendor/...
+        - --manual-test=//hack:verify-all
+        - --test-args=--build_tag_filters=-e2e
+        - --test-args=--test_tag_filters=-e2e
+        - --test-args=--flaky_test_attempts=3
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-
-  - name: pull-security-kubernetes-cross
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-cross
-    rerun_command: "/test pull-security-kubernetes-cross"
-    trigger: "(?m)^/test pull-security-kubernetes-cross,?(\\s+|$)"
-    run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        - name: docker-graph
-          mountPath: /docker-graph
-        - name: var-lib-docker
-          mountPath: /var/lib/docker
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            cpu: 6
-            memory: "15Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
-      - name: var-lib-docker
-        emptyDir: {}
-  - name: pull-security-kubernetes-cross-prow
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-cross-prow
-    rerun_command: "/test pull-security-kubernetes-cross-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-cross-prow,?(\\s+|$)"
-    always_run: false
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:latest
+        image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--ssh=/etc/ssh-security/ssh-security"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        - name: docker-graph
-          mountPath: /docker-graph
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            cpu: 6
-            memory: "15Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-e2e-containerd-gce
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-test-canary,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
     cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-e2e-containerd-gce
-    rerun_command: "/test pull-security-kubernetes-e2e-containerd-gce"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-containerd-gce,?(\\s+|$)"
+    context: pull-security-kubernetes-cross
+    max_concurrency: 0
+    name: pull-security-kubernetes-cross
+    rerun_command: /test pull-security-kubernetes-cross
+    run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /var/lib/docker
+          name: var-lib-docker
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+        name: docker-graph
+      - emptyDir: {}
+        name: var-lib-docker
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-cross,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-cross-prow
+    max_concurrency: 0
+    name: pull-security-kubernetes-cross-prow
+    rerun_command: /test pull-security-kubernetes-cross-prow
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        image: gcr.io/k8s-testimages/bootstrap:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-cross-prow,?(\s+|$)
+  - agent: kubernetes
     always_run: false
     branches:
     - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-containerd-gce
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-containerd-gce
+    rerun_command: /test pull-security-kubernetes-e2e-containerd-gce
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
       - args:
@@ -3865,13 +3893,10 @@ presubmits:
         - --repo=k8s.io/release
         - --repo=github.com/containerd/cri-containerd
         - --upload=gs://kubernetes-security-jenkins/pr-logs
-        - --ssh=/etc/ssh-security/ssh-security
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -3881,14 +3906,16 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources: {}
+        securityContext:
+          privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -3897,14 +3924,9 @@ presubmits:
           readOnly: true
         - mountPath: /root/.cache
           name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -3915,19 +3937,24 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
-  - name: pull-security-kubernetes-e2e-gce
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-e2e-gce"
-    trigger: "(?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\\s+|$)"
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-e2e-containerd-gce,?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    # TODO(bentheelder): enforce this pattern (skip all releases) or implement
-    # something better like https://github.com/kubernetes/test-infra/pull/4918
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gce
+    rerun_command: /test pull-security-kubernetes-e2e-gce
+    run_if_changed: ""
     skip_branches:
-    - release-1.6 # per-release image
-    - release-1.7 # per-release image
-    - release-1.8 # per-release image
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
       - args:
@@ -3938,17 +3965,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
-        - --ssh=/etc/ssh-security/ssh-security
-         # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
         - --
         - --build=bazel
         - --mode=local
-        # this only works for 1.7+
         - --runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -3958,33 +3979,29 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - mountPath: /root/.cache
-          name: cache-ssd
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            memory: "6Gi"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -3995,15 +4012,22 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
-  - name: pull-security-kubernetes-e2e-gce
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-e2e-gce"
-    trigger: "(?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\\s+|$)"
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\s+|$)
+  - agent: kubernetes
     always_run: true
     branches:
     - release-1.8
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gce
+    rerun_command: /test pull-security-kubernetes-e2e-gce
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
       - args:
@@ -4014,17 +4038,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
         - --
         - --build=bazel
         - --mode=local
-        # this only works for 1.7+
         - --runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4034,14 +4052,18 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -4050,17 +4072,9 @@ presubmits:
           readOnly: true
         - mountPath: /root/.cache
           name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4071,15 +4085,22 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
-  - name: pull-security-kubernetes-e2e-gce
-    cluster: security
-    agent: kubernetes
-    context: pull-security-kubernetes-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-e2e-gce"
-    trigger: "(?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\\s+|$)"
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\s+|$)
+  - agent: kubernetes
     always_run: true
     branches:
     - release-1.7
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gce
+    rerun_command: /test pull-security-kubernetes-e2e-gce
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
       - args:
@@ -4090,17 +4111,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
         - --
         - --build=bazel
         - --mode=local
-        # this only works for 1.7+
         - --runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4110,14 +4125,18 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -4126,17 +4145,9 @@ presubmits:
           readOnly: true
         - mountPath: /root/.cache
           name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4147,42 +4158,48 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
-  # bazel build works for 1.6 but not bazel-release :-(
-  - name: pull-security-kubernetes-e2e-gce
-    agent: jenkins
-    context: pull-security-kubernetes-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-e2e-gce"
-    trigger: "(?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\\s+|$)"
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\s+|$)
+  - agent: jenkins
     always_run: true
     branches:
     - release-1.6
-
-  - name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
-    cluster: security
-    agent: kubernetes
-    skip_branches:
-    - release-1.6  # not supported
-    - release-1.7  # not supported
-    - release-1.8  # per-release image
-    always_run: true
+    cluster: ""
+    context: pull-security-kubernetes-e2e-gce
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gce
+    rerun_command: /test pull-security-kubernetes-e2e-gce
+    run_if_changed: ""
     skip_report: false
-    max_concurrency: 12
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gce-device-plugin-gpu"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4195,31 +4212,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4227,263 +4240,268 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.8
-    always_run: true
-    skip_report: false
-    max_concurrency: 12
+    cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gce-device-plugin-gpu"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
-        - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
-        - --ssh=/etc/ssh-security/ssh-security
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-
-  - name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
-    cluster: security
-    agent: kubernetes
-    skip_branches:
-    - release-1.6  # not supported
-    - release-1.7  # not supported
-    - release-1.8  # per-release image
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gke-device-plugin-gpu"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
-        - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
-        - --ssh=/etc/ssh-security/ssh-security
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
-    cluster: security
-    agent: kubernetes
-    branches:
-    - release-1.8  # per-release image
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gke-device-plugin-gpu"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
-        - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
-        - --ssh=/etc/ssh-security/ssh-security
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-
-  - name: pull-security-kubernetes-e2e-gke-gci
-    agent: jenkins
-    context: pull-security-kubernetes-e2e-gke-gci
-    rerun_command: "/test pull-security-kubernetes-e2e-gke-gci"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gci,?(\\s+|$)"
-    run_if_changed: '^(cluster/gce|cluster/addons).*$'
-  - name: pull-security-kubernetes-e2e-kops-aws
-    cluster: security
-    agent: kubernetes
-    skip_branches:
-    - release-1.6  # runs on Jenkins?
-    - release-1.7  # per-release image
-    - release-1.8  # per-release image
     max_concurrency: 12
-    always_run: true
-    context: pull-security-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=75"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    max_concurrency: 1
+    name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    rerun_command: /test pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.8
+    cluster: security
+    context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    max_concurrency: 1
+    name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    rerun_command: /test pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\s+|$)
+  - agent: jenkins
+    always_run: false
+    cluster: ""
+    context: pull-security-kubernetes-e2e-gke-gci
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gke-gci
+    rerun_command: /test pull-security-kubernetes-e2e-gke-gci
+    run_if_changed: ^(cluster/gce|cluster/addons).*$
+    skip_report: false
+    trigger: (?m)^/test pull-security-kubernetes-e2e-gke-gci,?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    cluster: security
+    context: pull-security-kubernetes-e2e-kops-aws
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: /test pull-security-kubernetes-e2e-kops-aws
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=75
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4497,12 +4515,16 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -4512,19 +4534,11 @@ presubmits:
         - mountPath: /etc/aws-cred
           name: aws-cred
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4536,38 +4550,41 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: aws-cred-new
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-e2e-kops-aws
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.8
-    max_concurrency: 12
-    always_run: true
+    cluster: security
     context: pull-security-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: /test pull-security-kubernetes-e2e-kops-aws
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=75"
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=75
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4581,12 +4598,16 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -4596,19 +4617,11 @@ presubmits:
         - mountPath: /etc/aws-cred
           name: aws-cred
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4620,38 +4633,41 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: aws-cred
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-e2e-kops-aws
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.7
-    max_concurrency: 12
-    always_run: true
+    cluster: security
     context: pull-security-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: /test pull-security-kubernetes-e2e-kops-aws
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=75"
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=75
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4665,12 +4681,16 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
@@ -4680,19 +4700,11 @@ presubmits:
         - mountPath: /etc/aws-cred
           name: aws-cred
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4704,55 +4716,58 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: aws-cred
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-e2e-kops-aws
-    agent: jenkins
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\s+|$)
+  - agent: jenkins
+    always_run: true
     branches:
     - release-1.6
-    max_concurrency: 12
-    always_run: true
+    cluster: ""
     context: pull-security-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
-  - name: pull-security-kubernetes-kubemark-e2e-gce
-    cluster: security
-    agent: kubernetes
-    always_run: true
     max_concurrency: 12
-    skip_branches:
-    - release-1.6  # runs on Jenkins?
-    - release-1.7  # per-release image
-    - release-1.8  # per-release image
+    name: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: /test pull-security-kubernetes-e2e-kops-aws
+    run_if_changed: ""
+    skip_report: false
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -4763,31 +4778,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4795,47 +4806,47 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-kubemark-e2e-gce
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    max_concurrency: 12
     branches:
     - release-1.8
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -4846,31 +4857,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4878,47 +4885,47 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-kubemark-e2e-gce
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    max_concurrency: 12
     branches:
     - release-1.7
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
-        - --ssh=/etc/ssh-security/ssh-security
-        # the release-1.6 version of this job uses Jenkins, so here we override
-        # some args for jobs on Prow
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --
         - --build=bazel
         - --mode=local
+        - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -4929,31 +4936,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -4961,54 +4964,58 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-kubemark-e2e-gce
-    agent: jenkins
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\s+|$)
+  - agent: jenkins
     always_run: true
-    max_concurrency: 12
-    context: pull-security-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     branches:
     - release-1.6
-
-  - name: pull-security-kubernetes-kubemark-e2e-gce-big
-    cluster: security
-    agent: kubernetes
-    always_run: false
+    cluster: ""
+    context: pull-security-kubernetes-kubemark-e2e-gce
     max_concurrency: 12
-    skip_branches:
-    - release-1.6  # not supported
-    - release-1.7  # per-release image
-    - release-1.8  # per-release image
+    name: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
+    run_if_changed: ""
+    skip_report: false
+    trigger: (?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-big
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
-    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -5019,31 +5026,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5051,42 +5054,44 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-kubemark-e2e-gce-big
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\s+|$)
+  - agent: kubernetes
     always_run: false
-    max_concurrency: 12
     branches:
     - release-1.8
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-big
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
-    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -5097,31 +5102,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5129,42 +5130,44 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-kubemark-e2e-gce-big
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\s+|$)
+  - agent: kubernetes
     always_run: false
-    max_concurrency: 12
     branches:
     - release-1.7
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-big
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
-    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=110"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=110
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        # TODO(krzyzacy): Figure out bazel built kubemark image
-        # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: USER
@@ -5175,31 +5178,27 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-public
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5207,40 +5206,44 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-
-  - name: pull-security-kubernetes-node-e2e
-    cluster: security
-    agent: kubernetes
-    skip_branches:
-    - release-1.6  # per-release image
-    - release-1.7  # per-release image
-    - release-1.8  # per-release image
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    max_concurrency: 12
+    cluster: security
     context: pull-security-kubernetes-node-e2e
-    rerun_command: "/test pull-security-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-node-e2e
+    rerun_command: /test pull-security-kubernetes-node-e2e
+    run_if_changed: ""
+    skip_branches:
+    - release-1.6
+    - release-1.7
+    - release-1.8
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --ssh=/etc/ssh-security/ssh-security
-        - "--" # end bootstrap args, scenario args below
-        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -5250,28 +5253,25 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5279,34 +5279,39 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-node-e2e
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-node-e2e),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.8
-    always_run: true
-    max_concurrency: 12
+    cluster: security
     context: pull-security-kubernetes-node-e2e
-    rerun_command: "/test pull-security-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-node-e2e
+    rerun_command: /test pull-security-kubernetes-node-e2e
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --ssh=/etc/ssh-security/ssh-security
-        - "--" # end bootstrap args, scenario args below
-        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -5316,28 +5321,25 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5345,34 +5347,39 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-node-e2e
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-node-e2e),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.7
-    always_run: true
-    max_concurrency: 12
+    cluster: security
     context: pull-security-kubernetes-node-e2e
-    rerun_command: "/test pull-security-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-node-e2e
+    rerun_command: /test pull-security-kubernetes-node-e2e
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml
         - --ssh=/etc/ssh-security/ssh-security
-        - "--" # end bootstrap args, scenario args below
-        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -5382,28 +5389,25 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5411,34 +5415,39 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-node-e2e
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-node-e2e),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
     branches:
     - release-1.6
-    always_run: true
-    max_concurrency: 12
+    cluster: security
     context: pull-security-kubernetes-node-e2e
-    rerun_command: "/test pull-security-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
+    max_concurrency: 12
+    name: pull-security-kubernetes-node-e2e
+    rerun_command: /test pull-security-kubernetes-node-e2e
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
+        - --
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-6.yaml
         - --ssh=/etc/ssh-security/ssh-security
-        - "--" # end bootstrap args, scenario args below
-        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-6.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -5448,28 +5457,25 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: 6Gi
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            memory: "6Gi"
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5477,33 +5483,37 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-
-  - name: pull-security-kubernetes-node-e2e-containerd
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-node-e2e),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
     branches:
     - master
-    always_run: false
-    max_concurrency: 8
+    cluster: security
     context: pull-security-kubernetes-node-e2e-containerd
-    rerun_command: "/test pull-security-kubernetes-node-e2e-containerd"
-    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\\s+|$)"
+    max_concurrency: 8
+    name: pull-security-kubernetes-node-e2e-containerd
+    rerun_command: /test pull-security-kubernetes-node-e2e-containerd
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
-        args:
+      - args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=github.com/containerd/cri-containerd"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=90"
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=github.com/containerd/cri-containerd
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5514,25 +5524,23 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources: {}
         volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
         - mountPath: /etc/service-account
           name: service
           readOnly: true
         - mountPath: /etc/ssh-key-secret
           name: ssh
           readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
@@ -5540,222 +5548,234 @@ presubmits:
         secret:
           defaultMode: 256
           secretName: ssh-key-secret
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-unit
-    cluster: security
-    agent: kubernetes
+        name: cache-ssd
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\s+|$)
+  - agent: kubernetes
     always_run: true
+    cluster: security
     context: pull-security-kubernetes-unit
-    rerun_command: "/test pull-security-kubernetes-unit"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-unit),?(\\s+|$)"
+    max_concurrency: 0
+    name: pull-security-kubernetes-unit
+    rerun_command: /test pull-security-kubernetes-unit
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
-        args:
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=60"
+      - args:
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=60
         - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: docker-graph
-          mountPath: /docker-graph
+        image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            cpu: 4
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: docker-graph
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-unit-prow
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-unit),?(\s+|$)
+  - agent: kubernetes
     always_run: false
+    cluster: security
     context: pull-security-kubernetes-unit-prow
-    rerun_command: "/test pull-security-kubernetes-unit-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-unit-prow,?(\\s+|$)"
+    max_concurrency: 0
+    name: pull-security-kubernetes-unit-prow
+    rerun_command: /test pull-security-kubernetes-unit-prow
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:latest
-        imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=60"
+      - args:
+        - --clean
+        - --git-cache=/root/.cache/git
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=60
         - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        - name: docker-graph
-          mountPath: /docker-graph
+        image: gcr.io/k8s-testimages/bootstrap:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            cpu: 4
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: cache-ssd
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
+        name: cache-ssd
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-verify
-    cluster: security
-    agent: kubernetes
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-unit-prow,?(\s+|$)
+  - agent: kubernetes
     always_run: true
-    context: pull-security-kubernetes-verify
-    rerun_command: "/test pull-security-kubernetes-verify"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-verify),?(\\s+|$)"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
-        args:
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=75"
-        - --ssh=/etc/ssh-security/ssh-security
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: docker-graph
-          mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            cpu: 4
-      volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
-      - name: service
-        secret:
-          secretName: service-account
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
-  - name: pull-security-kubernetes-verify-prow
     cluster: security
-    agent: kubernetes
-    always_run: false
-    context: pull-security-kubernetes-verify-prow
-    rerun_command: "/test pull-security-kubernetes-verify-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-verify-prow,?(\\s+|$)"
+    context: pull-security-kubernetes-verify
+    max_concurrency: 0
+    name: pull-security-kubernetes-verify
+    rerun_command: /test pull-security-kubernetes-verify
+    run_if_changed: ""
+    skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:latest
-        imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
-        - "--timeout=75"
+      - args:
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=75
         - --ssh=/etc/ssh-security/ssh-security
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: ssh-security
-          mountPath: /etc/ssh-security
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: docker-graph
-          mountPath: /docker-graph
+        image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
         ports:
         - containerPort: 9999
           hostPort: 9999
         resources:
           requests:
-            cpu: 4
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /etc/ssh-security
+          name: ssh-security
       volumes:
-      - name: ssh-security
-        secret:
-          secretName: ssh-security
-          defaultMode: 0400
       - name: service
         secret:
           secretName: service-account
-      - name: docker-graph
-        hostPath:
+      - hostPath:
           path: /mnt/disks/ssd0/docker-graph
-
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-verify),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-verify-prow
+    max_concurrency: 0
+    name: pull-security-kubernetes-verify-prow
+    rerun_command: /test pull-security-kubernetes-verify-prow
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-jenkins/pr-logs
+        - --timeout=75
+        - --ssh=/etc/ssh-security/ssh-security
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        image: gcr.io/k8s-testimages/bootstrap:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /docker-graph
+          name: docker-graph
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+        name: docker-graph
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-verify-prow,?(\s+|$)
   kubernetes/test-infra:
   - name: pull-test-infra-bazel
     agent: kubernetes

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -75,29 +75,24 @@ func replace(j *Presubmit, ks *Presubmit) error {
 		sort.Strings(j.Spec.Containers[0].Args)
 		sort.Strings(ks.Spec.Containers[0].Args)
 		j.Spec.Containers[0].VolumeMounts = append(
-			[]kube.VolumeMount{
-				{
-					Name:      "ssh-security",
-					MountPath: "/etc/ssh-security",
-				},
+			j.Spec.Containers[0].VolumeMounts,
+			kube.VolumeMount{
+				Name:      "ssh-security",
+				MountPath: "/etc/ssh-security",
 			},
-			j.Spec.Containers[0].VolumeMounts...,
 		)
 		j.Spec.Volumes = append(
-			[]kube.Volume{
-				{
-					Name: "ssh-security",
-					VolumeSource: kube.VolumeSource{
-						Secret: &kube.SecretSource{
-							Name:        "ssh-security",
-							DefaultMode: 0400,
-						},
+			j.Spec.Volumes,
+			kube.Volume{
+				Name: "ssh-security",
+				VolumeSource: kube.VolumeSource{
+					Secret: &kube.SecretSource{
+						Name:        "ssh-security",
+						DefaultMode: 0400,
 					},
 				},
 			},
-			j.Spec.Volumes...,
 		)
-
 	}
 
 	j.re = ks.re


### PR DESCRIPTION
 - [x] write a copy of the original config preserving comments etc but excluding the old k-s/k presubmits
 - [x] auto generate the presubmits
 - [ ] require that this wouldn't alter anything in a presubmit (hack/verify style) (doing in a follow up, we need to do some more config tweaking, but I wanted this PR to generate the "same" jobs)

/area jobs