### PR TITLE
Add a cadvisor prow job which ssh into new cadvisor instances

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -80,11 +80,6 @@
         job-name: pull-kubernetes-kubemark-e2e-gce
         repo-name: 'k8s.io/kubernetes'
         timeout: 85
-    - cadvisor-e2e:  # owner: stclair@google.com
-        job-name: pull-cadvisor-e2e
-        max-total: 5
-        repo-name: 'github.com/google/cadvisor'
-        timeout: 10
     - charts-e2e:
         job-name: pull-charts-e2e
         max-total: 5

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -77,11 +77,39 @@ tide:
 presubmits:
   google/cadvisor:
   - name: pull-cadvisor-e2e
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-cadvisor-e2e
     rerun_command: "/test pull-cadvisor-e2e"
     trigger: "(?m)^/test( all| pull-cadvisor-e2e),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20180108-a65d3dd32
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: CADVISOR_APPLICATION_CREDENTIALS
+          value: /etc/cadvisor-service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cadvisor-service
+          mountPath: /etc/cadvisor-service-account
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cadvisor-service
+        secret:
+          secretName: cadvisor-service-account
   google/kubeflow:
   - name: kubeflow-presubmit
     context: kubeflow-presubmit


### PR DESCRIPTION
xref https://github.com/kubernetes/test-infra/issues/190

wooo.... legacy issue 190 :joy: 

https://github.com/google/cadvisor/blob/master/build/jenkins_e2e.sh will need to be tweaked a bit, but shouldn't be too much different - this is a proof of concept to show ssh to new instances will work, @dashpole you should be able to pick up from here

/assign @BenTheElder @dashpole 
