### PR TITLE
Pin etcd version and admission controllers for kube-proxy downgrade job

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
@@ -2,3 +2,13 @@
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_PROXY_DAEMONSET=false
+
+# TODO: This is pinned to the 1.8 version of etcd. 1.9 was changed to
+# 3.1.x. ETCD doesn't downgrade minor versions. So for downgrades, we
+# pin this to the lower version. The long term fix is to change
+# downgrade/upgrade to not upgrade/downgrade etcd.
+TEST_ETCD_VERSION=3.0.17
+
+# Only include the ones that may be needed.
+# Especially don't include the new ones or downgrade will fail.
+KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PodPreset,DefaultTolerationSeconds,NodeRestriction,Priority,ResourceQuota


### PR DESCRIPTION
From https://k8s-testgrid.appspot.com/sig-network-gce#gci-gce-latest-downgrade-kube-proxy-ds&width=5.

kube-proxy downgrade job has been failing for a long while, took a quick look and found two symptoms combined:
- etcd can not be downgraded.
- New admission controller is not recognized by the downgrade master.

This PR pins etcd to an older version and filters out those newly added admission controllers. Hopefully it fixes the issue.