### PR TITLE
Fix Skipping of RunIfChanged jobs.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,7 +20,7 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.194
+HOOK_VERSION             ?= 0.195
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.27
 # DECK_VERSION is the version of the deck image

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.194
+        image: gcr.io/k8s-prow/hook:0.195
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.194
+        image: gcr.io/k8s-prow/hook:0.195
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -26,11 +26,7 @@ import (
 	"testing"
 )
 
-var (
-	podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
-
-	noChangesProvider = func() ([]string, error) { return nil, nil }
-)
+var podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 const (
 	testThis   = "/test all"
@@ -265,7 +261,7 @@ func TestCommentBodyMatches(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actualJobs, _ := c.MatchingPresubmits(tc.repo, tc.body, regexp.MustCompile(`/ok-to-test`).MatchString(tc.body), noChangesProvider)
+		actualJobs := c.MatchingPresubmits(tc.repo, tc.body, regexp.MustCompile(`/ok-to-test`).MatchString(tc.body))
 		match := true
 		if len(actualJobs) != len(tc.expectedJobs) {
 			match = false
@@ -351,7 +347,7 @@ func TestRetestPresubmits(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actualContexts, _ := c.RetestPresubmits("org/repo", tc.skipContexts, tc.runContexts, noChangesProvider)
+		actualContexts := c.RetestPresubmits("org/repo", tc.skipContexts, tc.runContexts)
 		match := true
 		if len(actualContexts) != len(tc.expectedContexts) {
 			match = false

--- a/prow/plugins/trigger/BUILD
+++ b/prow/plugins/trigger/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -253,7 +253,7 @@ func TestHandleIssueComment(t *testing.T) {
 			StartsExactly: "pull-jib",
 		},
 		{
-			name:   "Rerun of run_if_changed job that has passed",
+			name:   "/test of run_if_changed job that has passed",
 			Author: "t",
 			Body:   "/test jub",
 			State:  "open",
@@ -359,6 +359,44 @@ func TestHandleIssueComment(t *testing.T) {
 				},
 			},
 			ShouldReport: true,
+		},
+		{
+			name: "/retest of RunIfChanged job that doesn't need to run and hasn't run",
+
+			Author: "t",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:         "jeb",
+						RunIfChanged: "CHANGED2",
+						Context:      "pull-jeb",
+						Trigger:      `/test all`,
+					},
+				},
+			},
+			ShouldReport: true,
+		},
+		{
+			name: "explicit /test for RunIfChanged job that doesn't need to run",
+
+			Author: "t",
+			Body:   "/test pull-jeb",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:         "jeb",
+						RunIfChanged: "CHANGED2",
+						Context:      "pull-jib",
+						Trigger:      `/test (all|pull-jeb)`,
+					},
+				},
+			},
+			ShouldBuild: true,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
RunIfChanged jobs were not being properly skipped by issue comment based triggers such as `/ok-to-test` and `/retest` on PRs where the jobs were not required based on the file changes.

I reworked the triggering logic to handle this case correctly while still allowing RunIfChanged jobs to be manually triggered with `/test foo` on PRs where they are not required based on the file changes.

/area prow
/kind bug
@cblecker 
/cc @rmmh @kargakis @BenTheElder 