### PR TITLE
Update prow to use new AWS credentials everywhere

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2016,7 +2016,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -2092,7 +2092,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -4628,7 +4628,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
@@ -4711,7 +4711,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd


### PR DESCRIPTION
As otherwise e.g. pull-kops-e2e-kubernetes-aws is broken:
https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-kubernetes-aws