### PR TITLE
Setup automation for kubernetes-sig-testing/frameworks

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -70,6 +70,16 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     reviewApprovedRequired: true
+  - repos:
+    - kubernetes-sig-testing/frameworks
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
   merge_method:
     kubernetes/charts: squash
   target_url: https://prow.k8s.io/tide.html

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -7,6 +7,7 @@ triggers:
   - kubernetes
   - kubernetes-incubator
   - kubernetes-security
+  - kubernetes-sig-testing
   - google/cadvisor
   - google/kubeflow
   - tensorflow/k8s
@@ -36,6 +37,9 @@ approve:
   - kubernetes/sig-release
   - kubernetes/steering
   - kubernetes/test-infra
+  implicit_self_approve: true
+- repos:
+  - kubernetes-sig-testing
   implicit_self_approve: true
 - repos:
   - kubernetes/kubernetes
@@ -216,6 +220,23 @@ plugins:
   - lgtm
   - lifecycle
   - size
+
+  kubernetes-sig-testing:
+  - assign
+  - approve
+  - blunderbuss
+  - cla
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - shrug
+  - size
+  - skip
+  - wip
+  - yuks
 
   containerd/cri-containerd:
   - assign


### PR DESCRIPTION
First, setup automation for the kubernetes-sig-testing org, using kubernetes as a model for plugins:
- use a separate entry for repos in approve just to keep orgs separate
- use approve and blunderbuss org-wide to start with
- no golint or slackevents for now
- no milestonestatus (don't intend on following that workflow here)
- no sigmention (don't have all the sig teams here)

Then, setup tide for kubernetes-sig-testing/frameworks with bare-bones labels

A lot of these plugins beg the creation of these labels for the kubernetes-sig-testing github org.  I'm assuming if they don't exist, they'll just be created (with incorrect colors).  Next step (I think?) would be to setup a [label_sync](https://github.com/kubernetes/test-infra/tree/master/label_sync) cronjob for the kubernetes-sig-testing org