### PR TITLE
enable dind for benchmark integration test

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3,6 +3,7 @@
     "args": [
       "--branch=master",
       "--force",
+      "--prow",
       "--script='./hack/jenkins/benchmark-dockerized.sh ./test/integration/scheduler_perf'"
     ],
     "scenario": "kubernetes_verify",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6904,7 +6904,7 @@ postsubmits:
 
 periodics:
 - name: ci-benchmark-scheduler-master
-  interval: 1h
+  interval: 6h
   agent: kubernetes
   spec:
     containers:
@@ -6914,20 +6914,34 @@ periodics:
       - --timeout=40
       - --root=/go/src
       env:
+      # This job runs k8s integration test thus need dind
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: GOPATH
         value: /go
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
         readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
     volumes:
     - name: service
       secret:
         secretName: service-account
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-cri-containerd-build
   interval: 30m


### PR DESCRIPTION
it runs test-integration which need dind, so add the setup goodies
and reduced frequency to 6h for now

/shrug
/assign @shyamjvs @BenTheElder 