### PR TITLE
Make tide use HeadRef to get SHA instead of last commit if possible.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -36,7 +36,7 @@ PLANK_VERSION            ?= 0.65
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
 JENKINS-OPERATOR_VERSION ?= 0.62
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.20
+TIDE_VERSION             ?= 0.21
 # CLONEREFS_VERSION is the version of the clonerefs image
 CLONEREFS_VERSION        ?=0.1
 

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.20
+        image: gcr.io/k8s-prow/tide:0.21
         args:
         - --dry-run=false
         ports:

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -19,6 +19,7 @@ package tide
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -334,6 +335,9 @@ func (f *fgc) Query(ctx context.Context, q interface{}, vars map[string]interfac
 }
 
 func (f *fgc) Merge(org, repo string, number int, details github.MergeDetails) error {
+	if details.SHA == "uh oh" {
+		return errors.New("invalid sha")
+	}
 	f.merged++
 	return nil
 }
@@ -891,9 +895,10 @@ func TestTakeAction(t *testing.T) {
 				}
 				var pr PullRequest
 				pr.Number = githubql.Int(i)
+				pr.HeadRef.Target.OID = githubql.String(fmt.Sprintf("origin/pr-%d", i))
 				pr.Commits.Nodes = []struct {
 					Commit Commit
-				}{{Commit: Commit{OID: githubql.String(fmt.Sprintf("origin/pr-%d", i))}}}
+				}{{Commit: Commit{OID: githubql.String("uh oh")}}}
 				sp.prs = append(sp.prs, pr)
 				prs = append(prs, pr)
 			}


### PR DESCRIPTION
This is a partial revert of https://github.com/kubernetes/test-infra/pull/6225 

Currently Tide gets the latest commit sha for a PR by getting the 'last' commit via graphql. Previously it got the sha from `HeadRef.Target.OID` field, but we cannot read this field if the forked repo has been deleted so we switched to using the last commit. Unfortunately the 'last' commit is determined by author date not commit date so if commits are reordered non-chronologically tide tests the wrong commit and fails to merge the PR. 

This temporary fix uses the HeadRef if it exists and falls back to the potentially mis-ordered commits if it doesn't. This should only fail on PRs with mis-ordered commits where the forked repo has been deleted.

fixes #6343 
/area prow
/kind bug
/cc @rmmh @ixdy 