### PR TITLE
Actually use default value for failures/passes on alerts.

### DIFF
--- a/testgrid/config/yaml2proto/yaml2proto.go
+++ b/testgrid/config/yaml2proto/yaml2proto.go
@@ -65,6 +65,13 @@ func ReconcileTestGroup(currentTestGroup *config.TestGroup, defaultTestGroup *co
 		currentTestGroup.AlertStaleResultsHours = defaultTestGroup.AlertStaleResultsHours
 	}
 
+	if currentTestGroup.NumFailuresToAlert == 0 {
+		currentTestGroup.NumFailuresToAlert = defaultTestGroup.NumFailuresToAlert
+	}
+
+	if currentTestGroup.NumPassesToDisableAlert == 0 {
+		currentTestGroup.NumPassesToDisableAlert = defaultTestGroup.NumPassesToDisableAlert
+	}
 	// is_external and user_kubernetes_client should always be true
 	currentTestGroup.IsExternal = true
 	currentTestGroup.UseKubernetesClient = true


### PR DESCRIPTION
Fixing a bug where the default value from test group isn't actually passed through.

We shouldn't need the dashboard tab's values for failures/passes for alerts, since we already use the test group's versions of these.