### PR TITLE
Make kubetest be aware of gke-latest upgrade targets

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -397,15 +397,11 @@ func (e extractStrategy) Extract(project, zone string, extractSrc bool) error {
 		}
 		if e.option == "latest" {
 			// get latest supported master version
-			res, err := output(exec.Command("gcloud", "container", "get-server-config", fmt.Sprintf("--project=%v", project), fmt.Sprintf("--zone=%v", zone), "--format=value(validMasterVersions)"))
+			version, err := getLatestGKEVersion(project, zone)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get latest gke version: %s", err)
 			}
-			versions := strings.Split(string(res), ";")
-			if len(versions) == 0 {
-				return fmt.Errorf("invalid gke master version string: %s", string(res))
-			}
-			return getKube("https://storage.googleapis.com/kubernetes-release-gke/release", "v"+versions[0], extractSrc)
+			return getKube("https://storage.googleapis.com/kubernetes-release-gke/release", version, extractSrc)
 		}
 
 		// get default cluster version for default extract strategy

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -228,7 +228,16 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 	*testArgs = strings.Join(setFieldDefault(strings.Fields(*testArgs), "--num-nodes", numNodes), " ")
 
 	if *upgradeArgs != "" {
-		*upgradeArgs = strings.Join(setFieldDefault(strings.Fields(*upgradeArgs), "--num-nodes", numNodes), " ")
+		fields, val, exist := extractField(strings.Fields(*upgradeArgs), "--upgrade-target")
+		if exist {
+			if val == "gke-latest" {
+				if val, err = getLatestGKEVersion(project, zone); err != nil {
+					return nil, fmt.Errorf("fail to get latest gke version : %v", err)
+				}
+			}
+			fields = setFieldDefault(fields, "--upgrade-target", val)
+		}
+		*upgradeArgs = strings.Join(setFieldDefault(fields, "--num-nodes", numNodes), " ")
 	}
 
 	return g, nil

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -561,3 +561,17 @@ func flushMem() {
 		log.Printf("flushMem error (page cache): %v", err)
 	}
 }
+
+// getLatestGKEVersion will return newest validMasterVersions
+// only works in gke environment
+func getLatestGKEVersion(project, zone string) (string, error) {
+	res, err := output(exec.Command("gcloud", "container", "get-server-config", fmt.Sprintf("--project=%v", project), fmt.Sprintf("--zone=%v", zone), "--format=value(validMasterVersions)"))
+	if err != nil {
+		return "", err
+	}
+	versions := strings.Split(string(res), ";")
+	if len(versions) == 0 {
+		return "", fmt.Errorf("invalid gke master version string: %s", string(res))
+	}
+	return "v" + versions[0], nil
+}


### PR DESCRIPTION
essentially https://github.com/kubernetes/kubernetes/pull/57084, but seems it belongs to test-infra

instead of manual bumping every time it should automatically figure out the latest available gke master version - also refactored the function a little bit.

(gke.go does not have unit-test :-\\ )

/assign @BenTheElder 

