### PR TITLE
Make '/test all' run or skip RunIfChanged jobs.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,7 +20,7 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.196
+HOOK_VERSION             ?= 0.197
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.27
 # DECK_VERSION is the version of the deck image

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.196
+        image: gcr.io/k8s-prow/hook:0.197
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.196
+        image: gcr.io/k8s-prow/hook:0.197
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -398,6 +398,43 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 			ShouldBuild: true,
 		},
+		{
+			name:   "/test all of run_if_changed job that has passed and needs to run",
+			Author: "t",
+			Body:   "/test all",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:         "jub",
+						RunIfChanged: "CHANGED",
+						Context:      "pull-jub",
+						Trigger:      `/test jub`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jub",
+		},
+		{
+			name:   "/test all of run_if_changed job that has passed and doesnt need to run",
+			Author: "t",
+			Body:   "/test all",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:         "jub",
+						RunIfChanged: "CHANGED2",
+						Context:      "pull-jub",
+						Trigger:      `/test jub`,
+					},
+				},
+			},
+			ShouldReport: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Logf("running scenario %q", tc.name)

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -158,7 +158,7 @@ func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg stri
 	for _, comment := range comments {
 		commentAuthor := comment.User.Login
 		// Skip comments: by the PR author, or by bot, or not matching "/ok-to-test".
-		if commentAuthor == author || commentAuthor == botName || !okToTest.MatchString(comment.Body) {
+		if commentAuthor == author || commentAuthor == botName || !okToTestRe.MatchString(comment.Body) {
 			continue
 		}
 		// Ensure that the commenter is in the org.


### PR DESCRIPTION
Currently, the stale-green-ci munger is repeatedly commenting with `/test all` on some PRs because the `/test all` command is not triggering the RunIfChanged job statuses to update so the munger continues to see a stale green status. This PR fixes the problem by making the command run or 'skip' RunIfChanged jobs as it should.
We will still need a follow up PR to improve `/test all` logic and resolve #6346.

/area prow
/kind bug
/assign @BenTheElder  @stevekuznetsov 
