### PR TITLE
get rid of the Jenkins heapster test

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -85,11 +85,6 @@
         max-total: 5
         repo-name: 'k8s.io/charts'
         timeout: 10
-    - heapster-e2e:  # owner: pszczesniak@google.com
-        job-name: pull-heapster-e2e
-        max-total: 5
-        repo-name: 'k8s.io/heapster'
-        timeout: 40
     - kubernetes-cross:
         max-total: 12
         job-name: pull-kubernetes-cross

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10998,12 +10998,6 @@
       "sig-instrumentation"
     ]
   },
-  "pull-heapster-e2e-prow": {
-    "scenario": "kubernetes_heapster",
-    "sigOwners": [
-      "sig-instrumentation"
-    ]
-  },
   "pull-ingress-gce-test": {
     "args": [
       "make",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -403,17 +403,11 @@ presubmits:
           path: /mnt/disks/ssd0
   kubernetes/heapster:
   - name: pull-heapster-e2e
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-heapster-e2e
     rerun_command: "/test pull-heapster-e2e"
     trigger: "(?m)^/test( all| pull-heapster-e2e),?(\\s+|$)"
-  - name: pull-heapster-e2e-prow
-    agent: kubernetes
-    always_run: false
-    context: pull-heapster-e2e-prow
-    rerun_command: "/test pull-heapster-e2e-prow"
-    trigger: "(?m)^/test pull-heapster-e2e-prow,?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -392,6 +392,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes/cluster-registry",
 		"kubernetes/federation",
 		"kubernetes/kops",
+		"kubernetes/heapster",
 		"tensorflow/k8s",
 	}) {
 		jobs[job.Name] = false


### PR DESCRIPTION
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/heapster/1922/pull-heapster-e2e-prow/15/ passed, let's drop the Jenkins entry

/assign @BenTheElder 