### PR TITLE
k-s-testing/frameworks: Add protection & required checks

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -30,6 +30,13 @@ branch-protection:
           protect: true
           # Contexts: inherited from presubmits
           # Pushers: only admins
+    kubernetes-sig-testing:
+      repos:
+        frameworks:
+          protect: true
+          require-contexts:
+          - continuous-integration/travis-ci
+          - cla/linuxfoundation
 
 tide:
   queries:


### PR DESCRIPTION
Based on [this discussion](https://github.com/kubernetes-sig-testing/frameworks/pull/10#issuecomment-359034539) I'd like to enable travis as a required status check on [kubernetes-sig-testing/frameworks](https://github.com/kubernetes-sig-testing/frameworks/).

I am not sure if I got everything right and if explicitly adding the CLA check is really needed.