### PR TITLE
Add tests for kops alpha channel

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8580,6 +8580,24 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-channelalpha": {
+    "args": [
+      "--cluster=e2e-kops-aws-channelalpha.test-cncf-aws.k8s.io",
+      "--deployment=kops",
+      "--env-file=jobs/platform/kops_aws.env",
+      "--extract=ci/latest",
+      "--ginkgo-parallel",
+      "--kops-args=--channel=alpha",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-cncf-canary": {
     "args": [
       "--aws",
@@ -8746,6 +8764,25 @@
       "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt",
       "--extract=ci/latest",
       "--ginkgo-parallel=30",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
+      "--kops-zones=us-central1-a",
+      "--provider=gce",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
+  "ci-kubernetes-e2e-kops-gce-channelalpha": {
+    "args": [
+      "--cluster=e2e-kops-gce-channelalpha.k8s.local",
+      "--deployment=kops",
+      "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt",
+      "--extract=ci/latest",
+      "--ginkgo-parallel=30",
+      "--kops-args=--channel=alpha",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--kops-zones=us-central1-a",
       "--provider=gce",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20824,6 +20824,50 @@ periodics:
 
 - interval: 1h
   agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-channelalpha
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_AWS_CREDENTIALS_FILE
+        value: /etc/aws-cred/credentials
+      - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/aws-ssh
+        name: aws-ssh
+        readOnly: true
+      - mountPath: /etc/aws-cred
+        name: aws-cred
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: aws-ssh
+      secret:
+        defaultMode: 256
+        secretName: aws-ssh-key-secret
+    - name: aws-cred
+      secret:
+        defaultMode: 256
+        secretName: aws-cred-new
+
+- interval: 1h
+  agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-cncf-canary
   spec:
     containers:
@@ -21215,6 +21259,40 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-gce
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-gce-channelalpha
   spec:
     containers:
     - args:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -143,6 +143,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-weave
 - name: ci-kubernetes-e2e-kops-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce
+- name: ci-kubernetes-e2e-kops-gce-channelalpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-channelalpha
 - name: ci-kubernetes-e2e-kops-gce-ha
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-ha
 - name: ci-kubernetes-e2e-gce-canary
@@ -1204,6 +1206,8 @@ test_groups:
   - configuration_value: node_os_image
   - configuration_value: Commit
   - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-kops-aws-channelalpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-channelalpha
 - name: ci-kubernetes-e2e-kops-aws-ena-nvme
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ena-nvme
 - name: ci-kubernetes-e2e-kops-aws-newrunner
@@ -2245,6 +2249,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-updown
   - name: kops-aws-weave
     test_group_name: ci-kubernetes-e2e-kops-aws-weave
+  - name: kops-aws-channelalpha
+    test_group_name: ci-kubernetes-e2e-kops-aws-channelalpha
   - name: kops-aws-ena-nvme
     test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
   - name: kops-aws-newrunner
@@ -2328,6 +2334,8 @@ dashboards:
   dashboard_tab:
   - name: kops-gce
     test_group_name: ci-kubernetes-e2e-kops-gce
+  - name: kops-gce-channelalpha
+    test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
   - name: kops-gce-ha
     test_group_name: ci-kubernetes-e2e-kops-gce-ha
 


### PR DESCRIPTION
The alpha channel has the upcoming cloud images, so we can catch issues
before images are committed to the stable channel.

This will also let us gather data for issues which may be image
dependent e.g.
https://github.com/kubernetes/kubernetes/issues/58578