### PR TITLE
Migrate stale into lifecycle/stale

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -60,6 +60,8 @@ labels:
     name: lifecycle/rotten
   - color: "795548"
     name: lifecycle/stale
+    previously:
+      - name: stale
   - color: b60205
     name: needs-ok-to-test
   - color: BDBDBD


### PR DESCRIPTION
Some repos have a `stale` label. This migrates it into the proper lifecycle/stale label.

/cc @nikhita 