### PR TITLE
kops kubetest: wait for sequential successes

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -263,7 +263,7 @@ func (k *kubernetesAnywhere) Up() error {
 		return err
 	}
 
-	return waitForReadyNodes(k.NumNodes+1, *kubernetesAnywhereUpTimeout)
+	return waitForReadyNodes(k.NumNodes+1, *kubernetesAnywhereUpTimeout, 1)
 }
 
 func (k *kubernetesAnywhere) IsUp() error {

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -312,10 +312,14 @@ func (k kops) Up() error {
 	if err := finishRunning(exec.Command(k.path, "update", "cluster", k.cluster, "--yes")); err != nil {
 		return fmt.Errorf("kops bringup failed: %v", err)
 	}
+
+	// We require repeated successes, so we know that the cluster is stable
+	// (e.g. in HA scenarios, or where we're using multiple DNS servers)
+	requiredConsecutiveSuccesses := 4
 	// TODO(zmerlynn): More cluster validation. This should perhaps be
 	// added to kops and not here, but this is a fine place to loop
 	// for now.
-	return waitForReadyNodes(k.nodes+1, *kopsUpTimeout)
+	return waitForReadyNodes(k.nodes+1, *kopsUpTimeout, requiredConsecutiveSuccesses)
 }
 
 func (k kops) IsUp() error {


### PR DESCRIPTION
It's possible to consider the cluster as ready when it isn't fully
stable otherwise, for example where DNS has only partially propagated,
or where we are running multiple masters.

As a heuristic, we wait to observe 4 sequential successes.  We poll
faster after success so this shouldn't affect timeouts.