### PR TITLE
build bootstrap image barnacle with bazel

### DIFF
--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -18,7 +18,8 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./barnacle/barnacle ./barnacle/
+	bazel build //images/bootstrap/barnacle:barnacle
+	cp ./../../bazel-bin/images/bootstrap/barnacle/linux_amd64_stripped/barnacle ./barnacle/barnacle
 	docker build --build-arg IMAGE_ARG=$(IMG):$(TAG) -t $(IMG):$(TAG) .
 	rm ./barnacle/barnacle
 	docker tag $(IMG):$(TAG) $(IMG):latest


### PR DESCRIPTION
this saves us from fighting with `hack/update-deps.sh` more to get updated bootstrap images

/are images

TODO: once bazel 0.10 is out switch barnacle to `pure="on"` and use cross compilation to enable building this image from macOS (xref: https://github.com/bazelbuild/rules_go/issues/1161)