### PR TITLE
add --cluster to spark ci jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11559,6 +11559,7 @@
   "spark-periodic-default-gke": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=",
       "--deployment=gke",
       "--extract=gke",
       "--gcp-node-image=gci",
@@ -11578,6 +11579,7 @@
   "spark-periodic-latest-gke": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=",
       "--deployment=gke",
       "--extract=gke-latest",
       "--gcp-node-image=gci",


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/spark-periodic-default-gke/202/build-log.txt
this might be a bug in kubetest:
when we create the cluster, without the cluster name, it will try to create a firewall rule base off instance group name. We create firewall rules before the cluster and lead to calls like
```
W0122 18:31:29.159] $ gcloud compute firewall-rules create <FIREWALL_NAME> --network bootstrap-e2e --allow tcp,udp,icmp --source-ranges <IP_RANGE>
W0122 18:31:29.159] $ gcloud compute firewall-rules create <FIREWALL_NAME> --network bootstrap-e2e --allow tcp:22,tcp:3389,icmp
```

and in the end of the job we will try to tear down the firewall we've never created and lead to
```
W0122 19:10:20.486] 2018/01/22 19:10:20 util.go:155: Running: gcloud compute firewall-rules delete -q e2e-ports-d38f5caf --project=k8s-gke-dg-g1-6-g1-5-dwngr-clu
W0122 19:10:21.384] ERROR: (gcloud.compute.firewall-rules.delete) Could not fetch resource:
W0122 19:10:21.385]  - The resource 'projects/k8s-gke-dg-g1-6-g1-5-dwngr-clu/global/firewalls/e2e-ports-d38f5caf' was not found
W0122 19:10:21.385] 
```

add the `--cluster` flag to mitigate the issue for now, seems all of our gke jobs has this flag so
/shrug

cc @zmerlynn 
/assign @foxish 