### PR TITLE
Turn on approve plugin and tide for k/website

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -84,6 +84,7 @@ tide:
     - needs-ok-to-test
   merge_method:
     kubernetes/charts: squash
+    kubernetes/website: squash
   target_url: https://prow.k8s.io/tide.html
 
 presubmits:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -50,6 +50,7 @@ tide:
     - kubernetes/sig-release
     - kubernetes/steering
     - kubernetes/test-infra
+    - kubernetes/website
     labels:
     - lgtm
     - approved

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -42,6 +42,7 @@ approve:
   - kubernetes/sig-release
   - kubernetes/steering
   - kubernetes/test-infra
+  - kubernetes/website
   implicit_self_approve: true
 - repos:
   - kubernetes-sig-testing
@@ -210,6 +211,7 @@ plugins:
   - approve
 
   kubernetes/website:
+  - approve
   - blunderbuss
 
   kubernetes:


### PR DESCRIPTION
/cc @chenopis @heckj @zacharysarah
/hold
Assuming this LG, `/hold cancel` when you're ready for this to roll out

ref: kubernetes/website#6906