### PR TITLE
Fix handling of nonexistent or partially populated branding in Deck.

### DIFF
--- a/prow/cmd/deck/static/plugin-help-script.js
+++ b/prow/cmd/deck/static/plugin-help-script.js
@@ -35,19 +35,19 @@ document.addEventListener("DOMContentLoaded", function(event) {
 });
 
 function configure() {
-    if(typeof branding === undefined){
+    if(typeof branding === 'undefined'){
         return;
     }
-    if (branding.logo !== '') {
+    if (branding.logo) {
         document.getElementById('img').src = branding.logo;
     }
-    if (branding.favicon !== '') {
+    if (branding.favicon) {
         document.getElementById('favicon').href = branding.favicon;
     }
-    if (branding.background_color !== '') {
+    if (branding.background_color) {
         document.body.style.background = branding.background_color;
     }
-    if (branding.header_color !== '') {
+    if (branding.header_color) {
         document.getElementsByTagName('header')[0].style.backgroundColor = branding.header_color;
     }
 }

--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -72,19 +72,19 @@ document.addEventListener("DOMContentLoaded", function(event) {
 });
 
 function configure() {
-    if(typeof branding === undefined){
+    if(typeof branding === 'undefined'){
         return;
     }
-    if (branding.logo !== '') {
+    if (branding.logo) {
         document.getElementById('img').src = branding.logo;
     }
-    if (branding.favicon !== '') {
+    if (branding.favicon) {
         document.getElementById('favicon').href = branding.favicon;
     }
-    if (branding.background_color !== '') {
+    if (branding.background_color) {
         document.body.style.background = branding.background_color;
     }
-    if (branding.header_color !== '') {
+    if (branding.header_color) {
         document.getElementsByTagName('header')[0].style.backgroundColor = branding.header_color;
     }
 }

--- a/prow/cmd/deck/static/tidescript.js
+++ b/prow/cmd/deck/static/tidescript.js
@@ -9,19 +9,19 @@ document.addEventListener("DOMContentLoaded", function(event) {
 });
 
 function configure() {
-    if(typeof branding === undefined){
+    if(typeof branding === 'undefined'){
         return;
     }
-    if (branding.logo !== '') {
+    if (branding.logo) {
         document.getElementById('img').src = branding.logo;
     }
-    if (branding.favicon !== '') {
+    if (branding.favicon) {
         document.getElementById('favicon').href = branding.favicon;
     }
-    if (branding.background_color !== '') {
+    if (branding.background_color) {
         document.body.style.background = branding.background_color;
     }
-    if (branding.header_color !== '') {
+    if (branding.header_color) {
         document.getElementsByTagName('header')[0].style.backgroundColor = branding.header_color;
     }
 }


### PR DESCRIPTION
/cc @kargakis 
Javascript is so much fun! /s
- `typeof` always returns a string
- `branding.X !== ''` doesn't properly handle the case where `branding.X` is undefined because `X` was empty and therefore omitted from the JSON when serialized.