### PR TITLE
Fix hack/update-deps.sh to ignore go_binary rules in vendor

### DIFF
--- a/hack/prune-libraries.sh
+++ b/hack/prune-libraries.sh
@@ -35,7 +35,7 @@ find-go-libraries() {
 # Output the target if it has only one dependency (itself)
 is-unused() {
   local n
-  n="$(bazel query "rdeps(//..., \"$1\", 1)" | wc -l)"
+  n="$(bazel query "rdeps(//..., '$1', 1) - kind('go_binary rule', //vendor/...)" | wc -l)"
   if [[ "$n" -gt "1" ]]; then  # Always counts itself
     echo "LIVE: $1" >&2
     return 0

--- a/hack/prune-libraries.sh
+++ b/hack/prune-libraries.sh
@@ -24,31 +24,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Output every go_library rule in the repo
-find-go-libraries() {
-  # Excluding generated //foo:go_default_library~library~
-  bazel query \
-    'kind("go_library rule", //...)' \
-    except 'attr("name", ".*~library~", //...)'
-}
-
-# Output the target if it has only one dependency (itself)
-is-unused() {
-  local n
-  n="$(bazel query "rdeps(//..., '$1', 1) - kind('go_binary rule', //vendor/...)" | wc -l)"
-  if [[ "$n" -gt "1" ]]; then  # Always counts itself
-    echo "LIVE: $1" >&2
-    return 0
-  fi
-  echo "DEAD: $1" >&2
-  echo "$1"
-}
-
-# Filter down to unused targets
-filter-to-unused() {
-  for i in "$@"; do
-    is-unused "$i"
-  done
+unused-go-libraries() {
+  # Find all the go_library rules in vendor except those that something outside
+  # of vendor eventually depends on.
+  bazel query 'kind("go_library rule", //vendor/... -deps(//... -//vendor/...))'
 }
 
 # Output this:source.go that:file.txt sources of //this //that targets
@@ -101,7 +80,6 @@ builds() {
   done
 }
 
-
 # Remove lines with //something:all-srcs from files
 # Usage:
 #   remove-all-srcs <targets-to-remove> <remove-from-packages>
@@ -116,17 +94,18 @@ remove_unused_go_libraries_finished=
 # Remove every go_library() target from workspace with no one depending on it.
 remove-unused-go-libraries() {
   local libraries deps
-  libraries="$(find-go-libraries | sort -u)"
-  deps="$(filter-to-unused $libraries)"
+  deps="$(unused-go-libraries)"
   if [[ -z "$deps" ]]; then
     echo "All remaining go libraries are alive" >&2
     remove_unused_go_libraries_finished=true
     return 0
-  elif [[ "$1" == "--check" || "$1" != "--fix" ]]; then
-    echo "Found unused libraries:" >&2
-    for d in $deps; do
-      echo $d
-    done
+  fi
+  echo "Unused libraries:" >&2
+  for d in $deps; do
+    echo "  DEAD: $d" >&2
+  done
+  if [[ "$1" == "--check" || "$1" != "--fix" ]]; then
+    echo "Correct with $0 --fix" >&2
     exit 1
   else
     echo Cleaning up unused dependencies... >&2

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -55,6 +55,7 @@ drop-dep vendor/golang.org/x/text/language vendor/golang.org/x/text/internal
 drop-dep vendor/google.golang.org/api/transport/grpc vendor/google.golang.org/api/transport
 drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/grpc vendor/github.com/golang/protobuf/protoc-gen-go
 drop-dep vendor/github.com/golang/protobuf/protoc-gen-go/generator vendor/github.com/golang/protobuf/protoc-gen-go
+drop-dep vendor/github.com/golang/protobuf/protoc-gen-go vendor/github.com/golang/protobuf/protoc-gen-go
 drop-dep vendor/github.com/docker/distribution/context vendor/github.com/docker/distribution
 drop-dep vendor/github.com/docker/docker/pkg/term vendor/github.com/docker/docker/cli
 hack/prune-libraries.sh --fix


### PR DESCRIPTION
Ask bazel to find all go libraries that are have no indirect dependency by anything outside vendor

* Aka `bazel query 'kind("go_library rule", //vendor/... -deps(//... -//vendor/...))'`
* This makes prune-libraries.sh run in around a minute instead of 20+

We are not dropping the unused `//vendor/github.com/golang/protobuf/protoc-gen-go` because of the zombie main package in this folder.

Fix this by ignoring `go_binary` rdeps in `//vendor`

Ran `hack/update-deps.sh && bazel test //...` with this change

/assign @stevekuznetsov @BenTheElder 
/cc @kargakis 