### PR TITLE
run testsetup before actual testcmd

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -210,10 +210,14 @@ func run(deploy deployer, o options) error {
 	}
 
 	if o.testCmd != "" {
-		errs = appendError(errs, xmlWrap(o.testCmdName, func() error {
-			cmdLine := os.ExpandEnv(o.testCmd)
-			return finishRunning(exec.Command(cmdLine))
-		}))
+		if err := xmlWrap("test setup", deploy.TestSetup); err != nil {
+			errs = appendError(errs, err)
+		} else {
+			errs = appendError(errs, xmlWrap(o.testCmdName, func() error {
+				cmdLine := os.ExpandEnv(o.testCmd)
+				return finishRunning(exec.Command(cmdLine))
+			}))
+		}
 	}
 
 	// TODO(bentheelder): consider remapping charts, etc to testCmd


### PR DESCRIPTION
it's actually no-op on gce, but the spark job runs on gke thus hits the issue. And we want to support testCmd for other providers in the future.

basically https://github.com/kubernetes/test-infra/blob/master/kubetest/gke.go#L360-L379 is required after create a gke cluster

/area kubetest
/assign @foxish 