### PR TITLE
bump kubetest for spark jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25341,7 +25341,7 @@ periodics:
   name: spark-periodic-default-gke
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-e55a886b4-master
       args:
       - "--clean"
       - "--job=$(JOB_NAME)"
@@ -25393,7 +25393,7 @@ periodics:
   name: spark-periodic-latest-gke
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-e55a886b4-master
       args:
       - "--clean"
       - "--job=$(JOB_NAME)"


### PR DESCRIPTION
for https://github.com/kubernetes/test-infra/pull/6402

also just use `-master` tag to keep update with go versions. (probably a no-op for the job)
/assign @foxish 