### PR TITLE
better version replacement for bump script

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -32,6 +32,7 @@ DATE="$(date +v%Y%m%d)"
 TAG="${DATE}-$(git describe --tags --always --dirty)"
 pushd "${TREE}/images/kubekins-e2e"
 make push
+K8S=1.9 make push
 K8S=1.8 make push
 K8S=1.7 make push
 K8S=1.6 make push
@@ -42,6 +43,7 @@ echo "TAG = ${TAG}"
 sed -i "s/DEFAULT_KUBEKINS_TAG = '.*'/DEFAULT_KUBEKINS_TAG = '${TAG}-master'/" "${TREE}/scenarios/kubernetes_e2e.py"
 sed -i "s/\/kubekins-e2e:.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/images/kubeadm/Dockerfile"
 sed -i "s/\/kubekins-e2e:v.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/experiment/generate_tests.py"
+sed -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/experiment/test_config.yaml"
 
 pushd "${TREE}"
 bazel run //experiment:generate_tests -- \
@@ -53,11 +55,8 @@ popd
 
 # Scan for kubekins-e2e:v.* as a rudimentary way to avoid
 # replacing :latest.
-sed -i "s/\/kubekins-e2e:v.*-master$/\/kubekins-e2e:${TAG}-master/" "${TREE}/prow/config.yaml"
-sed -i "s/\/kubekins-e2e:v.*-1.8$/\/kubekins-e2e:${TAG}-1.8/" "${TREE}/prow/config.yaml"
-sed -i "s/\/kubekins-e2e:v.*-1.7$/\/kubekins-e2e:${TAG}-1.7/" "${TREE}/prow/config.yaml"
-sed -i "s/\/kubekins-e2e:v.*-1.6$/\/kubekins-e2e:${TAG}-1.6/" "${TREE}/prow/config.yaml"
-git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-master|1.8|1.7|1.6 (using generate_tests and manual)"
+sed -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/prow/config.yaml"
+git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-(master|releases) (using generate_tests and manual)"
 
 # Bump kubeadm image
 


### PR DESCRIPTION
we introduced `ProwImage` into test_config.yaml as well, which is also need to be bumped :-(
and we need to update tags for 1.9, gah

just let sed grab the part after the last dash as the version so that we don't screw up again

/assign @BenTheElder @yguo0905 
cc @MrHohn who hits this in https://github.com/kubernetes/test-infra/pull/6406