### PR TITLE
Make the 'cla/linuxfoundation' Github status context required for all k8s repos.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25,6 +25,8 @@ log_level: info
 branch-protection:
   orgs:
     kubernetes:
+      require-contexts:
+      - cla/linuxfoundation
       repos:
         kubernetes/test-infra:
           protect: true


### PR DESCRIPTION
/cc @fejta 