### PR TITLE
Make branch protection config use 'repo' instead of 'org/repo' keys.

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -223,7 +223,7 @@ func (p *Protector) UpdateOrg(orgName string, org config.Org, protect *bool, con
 	}
 	for _, repo := range repos {
 		repoName := repo.Name
-		err := p.UpdateRepo(orgName, repoName, org.Repos[orgName+"/"+repoName], protect, oc, op)
+		err := p.UpdateRepo(orgName, repoName, org.Repos[repoName], protect, oc, op)
 		if err != nil {
 			return err
 		}

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -295,7 +295,7 @@ func TestProtect(t *testing.T) {
 						"org": {
 							Protect: &yes,
 							Repos: map[string]config.Repo{
-								"org/skip": {
+								"skip": {
 									Protect: &no,
 								},
 							},
@@ -335,7 +335,7 @@ func TestProtect(t *testing.T) {
 						"org": {
 							Contexts: []string{"org-presubmit"},
 							Repos: map[string]config.Repo{
-								"org/repo": {
+								"repo": {
 									Contexts: []string{"repo-presubmit"},
 									Branches: map[string]config.Branch{
 										"master": {
@@ -369,7 +369,7 @@ func TestProtect(t *testing.T) {
 						"org": {
 							Pushers: []string{"org-team"},
 							Repos: map[string]config.Repo{
-								"org/repo": {
+								"repo": {
 									Pushers: []string{"repo-team"},
 									Branches: map[string]config.Branch{
 										"master": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,7 +26,7 @@ branch-protection:
   orgs:
     kubernetes:
       repos:
-        kubernetes/test-infra:
+        test-infra:
           protect: true
           # Contexts: inherited from presubmits
           # Pushers: only admins


### PR DESCRIPTION
Specifying the org is redundant.
/cc @fejta 
/hold