### PR TITLE
Fix ingress image push job env vars

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -209,8 +209,8 @@
   },
   "ci-ingress-gce-image-push": {
     "args": [
-      "REGISTRY=gcr.io/k8s-ingress-image-push",
-      "VERSION=latest",
+      "--env REGISTRY=gcr.io/k8s-ingress-image-push",
+      "--env VERSION=latest",
       "make",
       "push-e2e"
     ],


### PR DESCRIPTION
Adds --env before the flags for ci-ingress-gce-image-push