### PR TITLE
add user env to spark jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25357,6 +25357,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -25409,6 +25411,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
got `./cluster/log-dump/../../cluster/gce/../../cluster/gce/config-test.sh: line 85: USER: unbound variable` in https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/spark-periodic-latest-gke/225, but not in gke-default - from https://github.com/kubernetes/kubernetes/commit/19fbd198410ef6107d109097eaa9cce2f96392a2

/assign @foxish 