### PR TITLE
Patch config_test.py to remove --extract restriction for ingress jobs

### DIFF
--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -567,6 +567,8 @@ class JobTest(unittest.TestCase):
 
                     if shared_builds or node_e2e:
                         expected = 0
+                    elif 'ingress' in job:
+                        expected = 1
                     elif any(s in job for s in [
                             'upgrade', 'skew', 'downgrade', 'rollback',
                             'ci-kubernetes-e2e-gce-canary',


### PR DESCRIPTION
This will allow us to only have to specify --extract one when running ingress upgrade/downgrade jobs

/assign @krzyzacy 
cc @MrHohn 