### PR TITLE
Use the daemonset used in GKE documentation in the test.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7892,6 +7892,7 @@
     "args": [
       "--check-leaked-resources",
       "--deployment=gke",
+      "--env=NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/k8s-1.9/nvidia-driver-installer/cos/daemonset-preloaded.yaml",
       "--extract=gke-latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-node-image=gci",


### PR DESCRIPTION
This depends on https://github.com/kubernetes/kubernetes/pull/58782

/cc @vishh @jiayingz 