### PR TITLE
Make tide slow down batch merges and wait for mergeability to be calculated if needed.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -388,6 +388,13 @@ func parseConfig(c *Config) error {
 		c.Tide.SyncPeriod = period
 	}
 
+	if c.Tide.MaxGoroutines == 0 {
+		c.Tide.MaxGoroutines = 20
+	}
+	if c.Tide.MaxGoroutines <= 0 {
+		return fmt.Errorf("tide has invalid max_goroutines (%d), it needs to be a positive number", c.Tide.MaxGoroutines)
+	}
+
 	if c.ProwJobNamespace == "" {
 		c.ProwJobNamespace = "default"
 	}

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -44,6 +44,11 @@ type Tide struct {
 	// We can consider allowing this to be set separately for separate repos, or
 	// allowing it to be a template.
 	TargetURL string `json:"target_url,omitempty"`
+
+	// MaxGoroutines is the maximum number of goroutines spawned inside the
+	// controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
+	// positive number.
+	MaxGoroutines int `json:"max_goroutines,omitempty"`
 }
 
 // MergeMethod returns the merge method to use for a repo. The default of merge is

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1383,6 +1383,10 @@ type UnmergablePRError string
 
 func (e UnmergablePRError) Error() string { return string(e) }
 
+type UnmergablePRBaseChangedError string
+
+func (e UnmergablePRBaseChangedError) Error() string { return string(e) }
+
 // Merge merges a PR.
 func (c *Client) Merge(org, repo string, pr int, details MergeDetails) error {
 	c.log("Merge", org, repo, pr, details)
@@ -1399,6 +1403,9 @@ func (c *Client) Merge(org, repo string, pr int, details MergeDetails) error {
 		return err
 	}
 	if ec == 405 {
+		if strings.Contains(res.Message, "Base branch was modified") {
+			return UnmergablePRBaseChangedError(res.Message)
+		}
 		return UnmergablePRError(res.Message)
 	} else if ec == 409 {
 		return ModifiedHeadError(res.Message)

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -608,7 +608,7 @@ func TestDividePool(t *testing.T) {
 	if len(sps) == 0 {
 		t.Error("No subpools.")
 	}
-	for _, sp := range sps {
+	for sp := range sps {
 		name := fmt.Sprintf("%s/%s %s", sp.org, sp.repo, sp.branch)
 		sha := fc.refs[sp.org+"/"+sp.repo+" heads/"+sp.branch]
 		if sp.sha != sha {


### PR DESCRIPTION
I didn't want to use `IsMergeable` as originally planned because it will always cost us 1 more API token per merged PR than we would have needed if we just retried the merge with a delay.

fixes #5171 
/area prow
/kind bug
/cc @stevekuznetsov @spxtr 