### PR TITLE
Remove kops_aws.env from newrunner job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8787,7 +8787,6 @@
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",


### PR DESCRIPTION
I believe none of the env vars are used, now we've gone to
kubernetes_e2e runner and kubetest.  The google cloud SDK ones I believe
are done by kubernetes_e2e.