### PR TITLE
Change the pull-cluster-registry-verify-gensrc job to use the kubekins-e2e image.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -685,7 +685,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-gensrc),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
This is intended to work around the absence of `go` tools in the `bazelbuild` image.

cf. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/cluster-registry/178/pull-cluster-registry-verify-gensrc/96/

