### PR TITLE
Add USER as prow for ingress upgrade & downgrade jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7508,6 +7508,8 @@ periodics:
       - "--timeout=320"
       - "--bare"
       env:
+      - name: USER
+        value: prow
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7570,6 +7572,8 @@ periodics:
       - "--timeout=320"
       - "--bare"
       env:
+      - name: USER
+        value: prow
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE


### PR DESCRIPTION
This change will allow us to make ssh commands from ProwJob's to the cluster's master.

/assign @krzyzacy 
cc @MrHohn 