### PR TITLE
Remove container vm test jobs

### DIFF
--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -9,9 +9,6 @@ images:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
-  containervm:
-    image: e2e-node-containervm-v20161208-image # docker 1.11.2
-    project: kubernetes-node-e2e-images
   cos-stable2:
     image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
     project: cos-cloud

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -9,9 +9,6 @@ images:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
-  containervm:
-    image: e2e-node-containervm-v20161208-image # docker 1.11.2
-    project: kubernetes-node-e2e-images
   cos-stable1:
     image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
     project: cos-cloud


### PR DESCRIPTION
Container VM images have been deprecated and no longer maintained.
This change removes the node e2e test jobs from the master branch,
while keeping the jobs for the previous releases.