### PR TITLE
Add --kops-publish-version flag to kubetest

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8875,9 +8875,9 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
+      "--kops-publish=gs://kops-ci/bin/latest-ci-updown-green.txt",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--provider=aws",
-      "--publish=gs://kops-ci/bin/latest-ci-updown-green.txt",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]",
       "--timeout=30m"
     ],

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -315,7 +315,7 @@ func run(deploy deployer, o options) error {
 				return err
 			}
 			log.Printf("Set %s version to %s", o.publish, string(v))
-			return finishRunning(exec.Command("gsutil", "cp", "version", o.publish))
+			return gcsWrite(o.publish, v)
 		}))
 	}
 

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -302,6 +302,11 @@ func run(deploy deployer, o options) error {
 			}))
 		}
 	}
+	if len(errs) == 0 {
+		if pub, ok := deploy.(publisher); ok {
+			errs = appendError(errs, pub.Publish())
+		}
+	}
 	if len(errs) == 0 && o.publish != "" {
 		errs = appendError(errs, xmlWrap("Publish version", func() error {
 			// Use plaintext version file packaged with kubernetes.tar.gz

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -53,6 +53,7 @@ var (
 	kopsBaseURL      = flag.String("kops-base-url", "", "Base URL for a prebuilt version of kops")
 	kopsVersion      = flag.String("kops-version", "", "URL to a file containing a valid kops-base-url")
 	kopsDiskSize     = flag.Int("kops-disk-size", 48, "Disk size to use for nodes and masters")
+	kopsPublish      = flag.String("kops-publish", "", "Publish kops version to the specified gs:// path on success")
 )
 
 type kops struct {
@@ -79,6 +80,12 @@ type kops struct {
 
 	// Cloud provider in use (gce, aws)
 	provider string
+
+	// kopsVersion is the version of kops we are running (used for publishing)
+	kopsVersion string
+
+	// kopsPublish is the path where we will publish kopsVersion, after a successful test
+	kopsPublish string
 }
 
 var _ deployer = kops{}
@@ -243,6 +250,8 @@ func newKops(provider, gcpProject, cluster string) (*kops, error) {
 		provider:      provider,
 		gcpProject:    gcpProject,
 		diskSize:      *kopsDiskSize,
+		kopsVersion:   *kopsBaseURL,
+		kopsPublish:   *kopsPublish,
 	}, nil
 }
 
@@ -486,4 +495,49 @@ func (k *kops) runKopsDump() (*kopsDump, error) {
 	}
 
 	return dump, nil
+}
+
+// kops deployer implements publisher
+var _ publisher = &kops{}
+
+// Publish will publish a success file, it is called if the tests were successful
+func (k kops) Publish() error {
+	if k.kopsPublish == "" {
+		// No publish destination set
+		return nil
+	}
+
+	if k.kopsVersion == "" {
+		return errors.New("kops-version not set; cannot publish")
+	}
+
+	return xmlWrap("Publish kops version", func() error {
+		log.Printf("Set %s version to %s", k.kopsPublish, k.kopsVersion)
+		return gcsWrite(k.kopsVersion, []byte(k.kopsPublish))
+	})
+}
+
+// gcsWrite uploads contents to the dest location in GCS.
+// It currently shells out to gsutil, but this could change in future.
+func gcsWrite(dest string, contents []byte) error {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return fmt.Errorf("error creating temp file: %v", err)
+	}
+
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			log.Printf("error removing temp file: %v", err)
+		}
+	}()
+
+	if _, err := f.Write(contents); err != nil {
+		return fmt.Errorf("error writing temp file: %v", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error closing temp file: %v", err)
+	}
+
+	return finishRunning(exec.Command("gsutil", "cp", f.Name(), dest))
 }

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -516,28 +516,3 @@ func (k kops) Publish() error {
 		return gcsWrite(k.kopsVersion, []byte(k.kopsPublish))
 	})
 }
-
-// gcsWrite uploads contents to the dest location in GCS.
-// It currently shells out to gsutil, but this could change in future.
-func gcsWrite(dest string, contents []byte) error {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		return fmt.Errorf("error creating temp file: %v", err)
-	}
-
-	defer func() {
-		if err := os.Remove(f.Name()); err != nil {
-			log.Printf("error removing temp file: %v", err)
-		}
-	}()
-
-	if _, err := f.Write(contents); err != nil {
-		return fmt.Errorf("error writing temp file: %v", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("error closing temp file: %v", err)
-	}
-
-	return finishRunning(exec.Command("gsutil", "cp", f.Name(), dest))
-}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -257,6 +257,12 @@ type deployer interface {
 	GetClusterCreated(gcpProject string) (time.Time, error)
 }
 
+// publisher is implemented by deployers that want to publish status on success
+type publisher interface {
+	// Publish is called when the tests were successful; the deployer should publish a success file
+	Publish() error
+}
+
 func getDeployer(o *options) (deployer, error) {
 	switch o.deployment {
 	case "bash":

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -1020,5 +1020,5 @@ func publish(pub string) error {
 		return err
 	}
 	log.Printf("Set %s version to %s", pub, string(v))
-	return finishRunning(exec.Command("gsutil", "cp", "version", pub))
+	return gcsWrite(pub, v)
 }


### PR DESCRIPTION
This flag will publish the kops version on success, as oppposed to
the `--publish` flag which publishes the kubernetes version.