### PR TITLE
Duplicate most gce test for cri-containerd.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -38,19 +38,314 @@
       "sig-node"
     ]
   },
+  "ci-cri-containerd-e2e-gce-alpha-api": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-alpha-api.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-e2e-gce-alpha-api-access",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:GCEAlphaFeature\\] --minStartupPods=8",
+      "--timeout=60m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gce-device-plugin-gpu": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:GPUDevicePlugin\\] --minStartupPods=8",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gce-multizone": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-multizone.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-jkns-e2e-gce-ubelite",
+      "--gcp-zone=us-central1-a",
+      "--ginkgo-parallel=25",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gce-stackdriver": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-stackdriver.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-e2e-gce-stackdriver",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\]|\\[Feature:StackdriverCustomMetrics\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-cri-containerd-e2e-gci-gce": {
     "args": [
       "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce.env",
       "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
       "--extract=ci/latest",
-      "--gcp-master-image=gci",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-alpha-features": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-alpha-features.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes|PodPreset|MountPropagation|PVCProtection|ExpandPersistentVolumes)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-es-logging": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-es-logging.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\] --minStartupPods=8",
+      "--timeout=90m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-etcd3": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=25",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-flaky": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-ingress": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=ingress-project",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-ip-alias": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-ip-alias.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-jenkins-gce-gci-ip-aliases",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-proto": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-proto.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=25",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-reboot": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-sd-logging": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-sd-logging.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-serial": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-slow": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=25",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-gci-gce-statefulset": {
+    "args": [
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -795,6 +795,22 @@ class JobTest(unittest.TestCase):
             'ci-cri-containerd-node-e2e': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-serial': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-flaky': 'cri-containerd-node-e2e-*',
+            # ci-cri-containerd-e2e-gce-alpha-api intentionally share projects with
+            # ci-kubernetes-e2e-gce-alpha-api.
+            'ci-kubernetes-e2e-gce-alpha-api': 'k8s-e2e-gce-alpha-api-access',
+            'ci-cri-containerd-e2e-gce-alpha-api': 'k8s-e2e-gce-alpha-api-access',
+            # ci-cri-containerd-e2e-gce-multizone intentionally share projects with
+            # ci-kubernetes-e2e-gce-multizone.
+            'ci-kubernetes-e2e-gce-multizone': 'k8s-jkns-e2e-gce-ubelite',
+            'ci-cri-containerd-e2e-gce-multizone': 'k8s-jkns-e2e-gce-ubelite',
+            # ci-cri-containerd-e2e-gce-stackdriver intentionally share projects with
+            # ci-kubernetes-e2e-gce-stackdriver.
+            'ci-kubernetes-e2e-gce-stackdriver': 'k8s-jkns-e2e-gce-stackdriver',
+            'ci-cri-containerd-e2e-gce-stackdriver': 'k8s-jkns-e2e-gce-stackdriver',
+            # ci-cri-containerd-e2e-gci-gce-ip-alias intentionally share projects with
+            # ci-kubernetes-e2e-gci-gce-ip-alias.
+            'ci-kubernetes-e2e-gci-gce-ip-alias': 'k8s-jenkins-gce-gci-ip-aliases',
+            'ci-cri-containerd-e2e-gci-gce-ip-alias': 'k8s-jenkins-gce-gci-ip-aliases',
             # ingress-GCE e2e jobs
             'pull-ingress-gce-e2e': 'e2e-ingress-gce',
             'ci-ingress-gce-e2e': 'e2e-ingress-gce',

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -1,15 +1,4 @@
 ### job-env
-# This list should match the list in kubernetes-pull-build-test-e2e-gce.
-NUM_NODES=4
-# For now explicitly test etcd v2 mode in this suite.
-STORAGE_BACKEND=etcd2
-TEST_ETCD_IMAGE=2.2.1
-TEST_ETCD_VERSION=2.2.1
-
-# Enable the PodSecurityPolicy in tests.
-# TODO(random-liu): Re-enable this after the pod security policy feature is finished.
-# ENABLE_POD_SECURITY_POLICY=true
-
 # Envs for cri-containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd cri-containerd cri-containerd-installation
 KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3535,6 +3535,7 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION
             value: "true"
           image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
+          name: ""
           resources: {}
           volumeMounts:
           - mountPath: /etc/service-account
@@ -3577,6 +3578,7 @@ presubmits:
         - --release=//build/release-tars
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -3640,6 +3642,7 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION
             value: "true"
           image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
+          name: ""
           resources: {}
           volumeMounts:
           - mountPath: /etc/service-account
@@ -3678,6 +3681,7 @@ presubmits:
         - --release=//build/release-tars
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -3739,6 +3743,7 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION
             value: "true"
           image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
+          name: ""
           resources: {}
           volumeMounts:
           - mountPath: /etc/service-account
@@ -3777,6 +3782,7 @@ presubmits:
         - --release=//build/release-tars
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -3836,6 +3842,7 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION
             value: "true"
           image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
+          name: ""
           resources: {}
           volumeMounts:
           - mountPath: /etc/service-account
@@ -3876,6 +3883,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -3928,6 +3936,7 @@ presubmits:
         - --test-args=--flaky_test_attempts=3
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -3975,6 +3984,7 @@ presubmits:
         - --test-args=--flaky_test_attempts=3
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4021,6 +4031,7 @@ presubmits:
         - --test-args=--flaky_test_attempts=3
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.5.2
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4070,6 +4081,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4115,6 +4127,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        name: ""
         resources:
           requests:
             cpu: "6"
@@ -4170,6 +4183,7 @@ presubmits:
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
+        name: ""
         resources:
           requests:
             cpu: "6"
@@ -4227,6 +4241,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources: {}
         securityContext:
           privileged: true
@@ -4289,6 +4304,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4351,6 +4367,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4413,6 +4430,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4487,6 +4505,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4547,6 +4566,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4611,6 +4631,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4673,6 +4694,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4735,6 +4757,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4809,6 +4832,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4869,6 +4893,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -4936,6 +4961,7 @@ presubmits:
         - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
           value: /etc/aws-ssh/aws-ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5008,6 +5034,7 @@ presubmits:
         - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
           value: /etc/aws-ssh/aws-ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5080,6 +5107,7 @@ presubmits:
         - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
           value: /etc/aws-ssh/aws-ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5166,6 +5194,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5235,6 +5264,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5304,6 +5334,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5384,6 +5415,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5450,6 +5482,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5516,6 +5549,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5583,6 +5617,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5642,6 +5677,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5701,6 +5737,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5760,6 +5797,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.6
+        name: ""
         resources:
           requests:
             memory: 6Gi
@@ -5818,6 +5856,7 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+        name: ""
         resources: {}
         volumeMounts:
         - mountPath: /etc/service-account
@@ -5866,6 +5905,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        name: ""
         resources:
           requests:
             cpu: "4"
@@ -5916,6 +5956,7 @@ presubmits:
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
+        name: ""
         resources:
           requests:
             cpu: "4"
@@ -5965,6 +6006,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        name: ""
         resources:
           requests:
             cpu: "4"
@@ -6015,6 +6057,7 @@ presubmits:
           value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
+        name: ""
         resources:
           requests:
             cpu: "4"
@@ -7225,6 +7268,142 @@ periodics:
       secret:
         secretName: service-account
 
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gce-alpha-api
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=80"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=300"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gce-multizone
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=170"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gce-stackdriver
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce
@@ -7233,6 +7412,414 @@ periodics:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-alpha-features
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=200"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-es-logging
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=110"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-etcd3
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-flaky
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=200"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-ingress
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=110"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-ip-alias
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-proto
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-reboot
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=200"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-sd-logging
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=1340"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-serial
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=520"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-slow
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=170"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce-statefulset
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--timeout=110"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -88,6 +88,38 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce
 - name: ci-cri-containerd-e2e-ubuntu-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-ubuntu-gce
+- name: ci-cri-containerd-e2e-gci-gce-reboot
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-reboot
+- name: ci-cri-containerd-e2e-gci-gce-etcd3
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-etcd3
+- name: ci-cri-containerd-e2e-gci-gce-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-serial
+- name: ci-cri-containerd-e2e-gci-gce-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-slow
+- name: ci-cri-containerd-e2e-gci-gce-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-flaky
+- name: ci-cri-containerd-e2e-gci-gce-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-alpha-features
+- name: ci-cri-containerd-e2e-gci-gce-statefulset
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-statefulset
+- name: ci-cri-containerd-e2e-gci-gce-proto
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-proto
+- name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-device-plugin-gpu
+- name: ci-cri-containerd-e2e-gce-alpha-api
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-alpha-api
+- name: ci-cri-containerd-e2e-gci-gce-ingress
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-ingress
+- name: ci-cri-containerd-e2e-gce-multizone
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-multizone
+- name: ci-cri-containerd-e2e-gci-gce-sd-logging
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-sd-logging
+- name: ci-cri-containerd-e2e-gci-gce-es-logging
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-es-logging
+- name: ci-cri-containerd-e2e-gce-stackdriver
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-stackdriver
+- name: ci-cri-containerd-e2e-gci-gce-ip-alias
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-ip-alias
 - name: ci-cri-containerd-node-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e
   test_name_config:
@@ -3567,6 +3599,8 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-serial-cpu-manager
     alert_options:
       alert_mail_to_addresses: 'balaji.warft@gmail.com, connor.p.d@gmail.com'
+  - name: cri-containerd-device-plugin-gpu
+    test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
 
 - name: sig-api-machinery
   dashboard_tab:
@@ -4142,6 +4176,38 @@ dashboards:
     test_group_name: ci-cri-containerd-e2e-gci-gce
   - name: e2e-ubuntu
     test_group_name: ci-cri-containerd-e2e-ubuntu-gce
+  - name: e2e-gci-etcd3
+    test_group_name: ci-cri-containerd-e2e-gci-gce-etcd3
+  - name: e2e-gci-reboot
+    test_group_name: ci-cri-containerd-e2e-gci-gce-reboot
+  - name: e2e-gci-serial
+    test_group_name: ci-cri-containerd-e2e-gci-gce-serial
+  - name: e2e-gci-slow
+    test_group_name: ci-cri-containerd-e2e-gci-gce-slow
+  - name: e2e-gci-flaky
+    test_group_name: ci-cri-containerd-e2e-gci-gce-flaky
+  - name: e2e-gci-alpha-features
+    test_group_name: ci-cri-containerd-e2e-gci-gce-alpha-features
+  - name: e2e-gci-statefulset
+    test_group_name: ci-cri-containerd-e2e-gci-gce-statefulset
+  - name: e2e-gci-proto
+    test_group_name: ci-cri-containerd-e2e-gci-gce-proto
+  - name: e2e-gci-device-plugin-gpu
+    test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+  - name: e2e-gci-alpha-api
+    test_group_name: ci-cri-containerd-e2e-gce-alpha-api
+  - name: e2e-gci-ingress
+    test_group_name: ci-cri-containerd-e2e-gci-gce-ingress
+  - name: e2e-gci-multizone
+    test_group_name: ci-cri-containerd-e2e-gce-multizone
+  - name: e2e-gci-sd-logging
+    test_group_name: ci-cri-containerd-e2e-gci-gce-sd-logging
+  - name: e2e-gci-es-logging
+    test_group_name: ci-cri-containerd-e2e-gci-gce-es-logging
+  - name: e2e-gci-stackdriver
+    test_group_name: ci-cri-containerd-e2e-gce-stackdriver
+  - name: e2e-gci-ip-alias
+    test_group_name: ci-cri-containerd-e2e-gci-gce-ip-alias
   - name: node-e2e-serial
     test_group_name: ci-cri-containerd-node-e2e-serial
   - name: node-e2e-flaky


### PR DESCRIPTION
This PR duplicates following test suites for cri-containerd:
* gci-gce-alpha-features
* gce-stackdriver
* gci-gce-es-logging
* gci-gce-sd-logging
* gci-gce-etcd3
* gci-gce-flaky
* gci-gce-ingress
* gce-multizone
* gci-gce-statefulset
* gci-gce-proto
* gci-gce-reboot
* gci-gce-ip-alias
* gce-alpha-api
* gci-gce-serial
* gci-gce-slow
* gce-device-plugin-gpu

Note that following test gce projects are reused:
* k8s-e2e-gce-alpha-api-access
* k8s-jkns-e2e-gce-ubelite
* k8s-jkns-e2e-gce-stackdriver
* k8s-jenkins-gce-gci-ip-aliases