### PR TITLE
Add node e2e benchmark for cri-containerd.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -388,6 +388,22 @@
       "sig-node"
     ]
   },
+  "ci-cri-containerd-node-e2e-benchmark": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=cri-containerd-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-test-args=--feature-gates=DynamicKubeletConfig=true --container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock --container-runtime-process-name=cri-containerd --container-runtime-pid-file= --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\" --extra-log=\"{\\\"name\\\": \\\"cri-containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"cri-containerd\\\"]}\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1 --skip=\"\\[Flaky\\]\"",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-cri-containerd-node-e2e-flaky": {
     "args": [
       "--deployment=node",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -795,6 +795,7 @@ class JobTest(unittest.TestCase):
             'ci-cri-containerd-node-e2e': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-serial': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-flaky': 'cri-containerd-node-e2e-*',
+            'ci-cri-containerd-node-e2e-benchmark': 'cri-containerd-node-e2e-*',
             # ci-cri-containerd-e2e-gce-alpha-api intentionally share projects with
             # ci-kubernetes-e2e-gce-alpha-api.
             'ci-kubernetes-e2e-gce-alpha-api': 'k8s-e2e-gce-alpha-api-access',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7920,6 +7920,47 @@ periodics:
         secretName: ssh-key-secret
         defaultMode: 0400
 
+- name: ci-cri-containerd-node-e2e-benchmark
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
+      args:
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes
+      - --repo=github.com/containerd/cri-containerd=master
+      - --timeout=90
+      - --
+      - "--node-args=--image-config-file=test/e2e_node/benchmark-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+
 - name: ci-cri-containerd-node-e2e-flaky
   interval: 2h
   agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -141,6 +141,13 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-cri-containerd-node-e2e-benchmark
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e-benchmark
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
 - name: ci-ingress-gce-image-push
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-image-push
 - name: ci-ingress-gce-e2e
@@ -4212,6 +4219,8 @@ dashboards:
     test_group_name: ci-cri-containerd-node-e2e-serial
   - name: node-e2e-flaky
     test_group_name: ci-cri-containerd-node-e2e-flaky
+  - name: node-e2e-benchmark
+    test_group_name: ci-cri-containerd-node-e2e-benchmark
   - name: pull-node-e2e
     test_group_name: pull-kubernetes-node-e2e-containerd
     base_options: 'width=10'


### PR DESCRIPTION
Based on https://github.com/containerd/cri-containerd/pull/576

Add benchmark test for cri-containerd.