### PR TITLE
Remove alpha-api test for containerd, and fix ip-alias test.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -38,27 +38,6 @@
       "sig-node"
     ]
   },
-  "ci-cri-containerd-e2e-gce-alpha-api": {
-    "args": [
-      "--check-leaked-resources",
-      "--cluster=",
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/env/ci-kubernetes-e2e-gce-alpha-api.env",
-      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
-      "--extract=ci/latest",
-      "--gcp-node-image=gci",
-      "--gcp-project=k8s-e2e-gce-alpha-api-access",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel=30",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:GCEAlphaFeature\\] --minStartupPods=8",
-      "--timeout=60m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-node"
-    ]
-  },
   "ci-cri-containerd-e2e-gce-device-plugin-gpu": {
     "args": [
       "--check-leaked-resources",
@@ -235,7 +214,6 @@
       "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
       "--extract=ci/latest",
       "--gcp-node-image=gci",
-      "--gcp-project=k8s-jenkins-gce-gci-ip-aliases",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
       "--provider=gce",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -796,10 +796,6 @@ class JobTest(unittest.TestCase):
             'ci-cri-containerd-node-e2e-serial': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-flaky': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-benchmark': 'cri-containerd-node-e2e-*',
-            # ci-cri-containerd-e2e-gce-alpha-api intentionally share projects with
-            # ci-kubernetes-e2e-gce-alpha-api.
-            'ci-kubernetes-e2e-gce-alpha-api': 'k8s-e2e-gce-alpha-api-access',
-            'ci-cri-containerd-e2e-gce-alpha-api': 'k8s-e2e-gce-alpha-api-access',
             # ci-cri-containerd-e2e-gce-multizone intentionally share projects with
             # ci-kubernetes-e2e-gce-multizone.
             'ci-kubernetes-e2e-gce-multizone': 'k8s-jkns-e2e-gce-ubelite',
@@ -808,10 +804,6 @@ class JobTest(unittest.TestCase):
             # ci-kubernetes-e2e-gce-stackdriver.
             'ci-kubernetes-e2e-gce-stackdriver': 'k8s-jkns-e2e-gce-stackdriver',
             'ci-cri-containerd-e2e-gce-stackdriver': 'k8s-jkns-e2e-gce-stackdriver',
-            # ci-cri-containerd-e2e-gci-gce-ip-alias intentionally share projects with
-            # ci-kubernetes-e2e-gci-gce-ip-alias.
-            'ci-kubernetes-e2e-gci-gce-ip-alias': 'k8s-jenkins-gce-gci-ip-aliases',
-            'ci-cri-containerd-e2e-gci-gce-ip-alias': 'k8s-jenkins-gce-gci-ip-aliases',
             # ingress-GCE e2e jobs
             'pull-ingress-gce-e2e': 'e2e-ingress-gce',
             'ci-ingress-gce-e2e': 'e2e-ingress-gce',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7268,40 +7268,6 @@ periodics:
       secret:
         secretName: service-account
 
-- interval: 2h
-  agent: kubernetes
-  name: ci-cri-containerd-e2e-gce-alpha-api
-  spec:
-    containers:
-    - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
-      - "--timeout=80"
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   interval: 2h
   agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -106,8 +106,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-proto
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-device-plugin-gpu
-- name: ci-cri-containerd-e2e-gce-alpha-api
-  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-alpha-api
 - name: ci-cri-containerd-e2e-gci-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-ingress
 - name: ci-cri-containerd-e2e-gce-multizone
@@ -4201,8 +4199,6 @@ dashboards:
     test_group_name: ci-cri-containerd-e2e-gci-gce-proto
   - name: e2e-gci-device-plugin-gpu
     test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
-  - name: e2e-gci-alpha-api
-    test_group_name: ci-cri-containerd-e2e-gce-alpha-api
   - name: e2e-gci-ingress
     test_group_name: ci-cri-containerd-e2e-gci-gce-ingress
   - name: e2e-gci-multizone


### PR DESCRIPTION
Remove alpha-api test for containerd. Discussed with @yujuhong, we don't need this test.
Remove dedicated project for ip-alias test for containerd. Discussed with @bowei, he told me that the test only needs a normal GCE project.

Signed-off-by: Lantao Liu <lantaol@google.com>