### PR TITLE
set user-select: none on Merge requirements toggle

### DIFF
--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -34,7 +34,7 @@
             <main class="mdl-layout__content">
                 <article>
                     <div id="info-div" class="card-box">
-                        <h4>Merge Requirements: (click to expand)</h4>
+                        <h4 style="user-select: none">Merge Requirements: (click to expand)</h4>
                         <span class="hidden">
                             <hr>
                             <p><strong>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></strong></p>


### PR DESCRIPTION
This prevents the text from being awkwardly highlighted when clicking on it.
/area prow

