### PR TITLE
Various updates to GPU test suites

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7269,7 +7269,7 @@ periodics:
         secretName: service-account
 
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
-  interval: 2h
+  interval: 3h
   agent: kubernetes
   spec:
     containers:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11723,7 +11723,7 @@ periodics:
         secretName: ssh-key-secret
 
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
-  interval: 2h
+  interval: 6h
   agent: kubernetes
   spec:
     containers:
@@ -12641,7 +12641,7 @@ periodics:
         secretName: ssh-key-secret
 
 - name: ci-kubernetes-e2e-gce-gpu-stable1
-  interval: 2h
+  interval: 6h
   agent: kubernetes
   spec:
     containers:
@@ -18738,7 +18738,7 @@ periodics:
         secretName: ssh-key-secret
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
-  interval: 2h
+  interval: 6h
   agent: kubernetes
   spec:
     containers:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -106,6 +106,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-proto
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-device-plugin-gpu
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 8 # Runs every 3h. Alert when it's been failing for a day.
 - name: ci-cri-containerd-e2e-gci-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-ingress
 - name: ci-cri-containerd-e2e-gce-multizone
@@ -3603,6 +3605,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gke-device-plugin-gpu-cri-containerd
+    test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-gpu-1.7
     test_group_name: ci-kubernetes-e2e-gke-gpu-1-7
     alert_options:
@@ -3614,8 +3620,6 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-serial-cpu-manager
     alert_options:
       alert_mail_to_addresses: 'balaji.warft@gmail.com, connor.p.d@gmail.com'
-  - name: cri-containerd-device-plugin-gpu
-    test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
 
 - name: sig-api-machinery
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -191,7 +191,7 @@ test_groups:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
   alert_stale_results_hours: 24
-  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+  num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for a day.
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-device-plugin-gpu-beta
   alert_stale_results_hours: 24
@@ -203,7 +203,7 @@ test_groups:
 - name: ci-kubernetes-e2e-gce-gpu-stable1
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1
   alert_stale_results_hours: 24
-  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+  num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for a day.
 - name: ci-kubernetes-e2e-gce-gpu-beta
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-beta
   alert_stale_results_hours: 24
@@ -332,7 +332,7 @@ test_groups:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   alert_stale_results_hours: 24
-  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+  num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for a day.
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   alert_stale_results_hours: 24

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -425,7 +425,7 @@ test_groups:
 - name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   alert_stale_results_hours: 24
-  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+  num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours.
 - name: ci-kubernetes-e2e-gke-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-test
 - name: ci-kubernetes-e2e-gci-gke-test

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3557,36 +3557,36 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-device-plugin-gpu-1.8
-    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
-    alert_options:
-      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gce-device-plugin-gpu-1.9
     test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-device-plugin-gpu-1.8
+    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gce-gpu
     test_group_name: ci-kubernetes-e2e-gce-gpu
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-gpu-1.8
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1
-    alert_options:
-      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gce-gpu-1.9
     test_group_name: ci-kubernetes-e2e-gce-gpu-beta
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-gpu-1.8
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-device-plugin-gpu
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gke-device-plugin-gpu-1.8
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
-    alert_options:
-      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-device-plugin-gpu-1.9
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gke-device-plugin-gpu-1.8
+    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-device-plugin-gpu-p100


### PR DESCRIPTION
- Run GPU jobs on 1.8 branch less frequently. GPUs are expensive, there's not enough change in 1.8 branch anymore.
- GKE Staging is relatively stable. Alert earlier on failure. Want to get early signal if there's a problem with preloaded images.
- Add alerts for the cri-containerd gpu job.
- Order the dashboard tabs better (master, 1.9, 1.8)