### PR TITLE
Update hook to v20180128-aa465afc5

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -19,26 +19,29 @@ all: build test
 ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
+
+# YYYYmmdd-commitish
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= v20180126-11ec8c92e
+HOOK_VERSION             ?= $(TAG)
 # SINKER_VERSION is the version of the sinker image
-SINKER_VERSION           ?= v20180125-b72c696dc
+SINKER_VERSION           ?= $(TAG)
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= v20180127-f2ebdaaae
+DECK_VERSION             ?= $(TAG)
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= v20180125-b72c696dc
+SPLICE_VERSION           ?= $(TAG)
 # TOT_VERSION is the version of the tot image
-TOT_VERSION              ?= v20180125-b72c696dc
+TOT_VERSION              ?= $(TAG)
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= v20180125-b72c696dc
+HOROLOGIUM_VERSION       ?= $(TAG)
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= v20180125-b72c696dc
+PLANK_VERSION            ?= $(TAG)
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= v20180125-b72c696dc
+JENKINS-OPERATOR_VERSION ?= $(TAG)
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= v20180125-b72c696dc
+TIDE_VERSION             ?= $(TAG)
 # CLONEREFS_VERSION is the version of the clonerefs image
-CLONEREFS_VERSION        ?=v20180125-b72c696dc
+CLONEREFS_VERSION        ?= $(TAG)
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -32,12 +32,8 @@ cd $(dirname $0)
 
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
 for i in "$@"; do
-  makefile_version_re="^\(${i}_VERSION.*=\s*\)"
-  version=$($SED -n "s/$makefile_version_re//Ip" Makefile)
   echo "program: $i"
-  echo "old version: $version"
   echo "new version: $new_version"
 
-  $SED -i "s/$makefile_version_re.*/\1$new_version/I" Makefile
-  $SED -i "s/\(${i}:\)[0-9]\+\.[0-9]\+/\1$new_version/I" cluster/*.yaml
+  $SED -i "s/\(${i}:\)v[a-f0-9-]\+/\1$new_version/I" cluster/*.yaml
 done

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180126-11ec8c92e
+        image: gcr.io/k8s-prow/hook:v20180128-aa465afc5
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180126-11ec8c92e
+        image: gcr.io/k8s-prow/hook:v20180128-aa465afc5
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
/assign @BenTheElder @stevekuznetsov 

Also update build process to automatically generate version:

* Change `Makefile` to use `TAG = YYYYmmdd-commitish` like most other places
* Set `HOOK_VERSION` and friends to default to `TAG`
* Update `bump.sh` to only set new version and ignore `Makefile`

Fixes https://github.com/kubernetes/test-infra/issues/6483