### PR TITLE
Delete gke-test gci-gke-test

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5354,24 +5354,6 @@
       "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gci-gke-test": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--deployment=gke",
-      "--extract=gke",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
-      "--gcp-node-image=gci",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--timeout=480m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
   "ci-kubernetes-e2e-gci-gke-updown": {
     "args": [
       "--check-leaked-resources",
@@ -8187,24 +8169,6 @@
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=600m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
-  "ci-kubernetes-e2e-gke-test": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--deployment=gke",
-      "--extract=gke",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
-      "--gcp-node-image=gci",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16538,40 +16538,6 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
-  name: ci-kubernetes-e2e-gci-gke-test
-  spec:
-    containers:
-    - args:
-      - --timeout=500
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
-- interval: 30m
-  agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-updown
   spec:
     containers:
@@ -20973,40 +20939,6 @@ periodics:
     containers:
     - args:
       - --timeout=620
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
-- interval: 30m
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gke-test
-  spec:
-    containers:
-    - args:
-      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -428,10 +428,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   alert_stale_results_hours: 24
   num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours.
-- name: ci-kubernetes-e2e-gke-test
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-test
-- name: ci-kubernetes-e2e-gci-gke-test
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-test
 - name: ci-kubernetes-e2e-gke-updown
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-updown
 - name: ci-kubernetes-e2e-gci-gke-updown
@@ -2531,10 +2527,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-regional
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: gke-test
-    test_group_name: ci-kubernetes-e2e-gke-test
-  - name: gci-gke-test
-    test_group_name: ci-kubernetes-e2e-gci-gke-test
   - name: gke-updown
     test_group_name: ci-kubernetes-e2e-gke-updown
   - name: gci-gke-updown
@@ -4879,12 +4871,6 @@ dashboards:
     - configuration_value: infra-commit
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-    column_header:
-    - configuration_value: node_os_image
-    - configuration_value: Commit
-    - configuration_value: infra-commit
-  - name: gci-gke-test
-    test_group_name: ci-kubernetes-e2e-gci-gke-test
     column_header:
     - configuration_value: node_os_image
     - configuration_value: Commit


### PR DESCRIPTION

http://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1

These have been failing for 240 days straight, looks like they always time out

@kubernetes/sig-gcp-test-failures 
ref https://github.com/kubernetes/test-infra/issues/2528