### PR TITLE
Delete gke-cvm-stable-gci jobs which never pass

### DIFF
--- a/jobs/BUILD
+++ b/jobs/BUILD
@@ -25,6 +25,7 @@ py_test(
     deps = [
         ":config_sort",
         ":env_gc",
+        "@yaml",
     ],
 )
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6778,27 +6778,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--deployment=gke",
-      "--extract=ci/latest",
-      "--extract=v1.7.5",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
-      "--gcp-node-image=container_vm",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--timeout=900m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-kubernetes-e2e-gke-device-plugin-gpu": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -18533,40 +18533,6 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
-- interval: 2h
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master
-  spec:
-    containers:
-    - args:
-      - --timeout=920
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu
   interval: 2h
   agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1683,8 +1683,6 @@ test_groups:
   - configuration_value: Commit
   - configuration_value: infra-commit
 # master-2 to master
-- name: ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master
 - name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
 # master-1 to master
@@ -2734,9 +2732,6 @@ dashboards:
 
 - name: sig-release-master-upgrade-optional
   dashboard_tab:
-  - name: gke-cvm-1.7-gci-master-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master
-    description: 'Upgrade master only, in gke, from container_vm 1.6 to gci master'
   - name: gke-gci-1.7-gci-master-upgrade-master
     test_group_name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
     description: 'Upgrade master only, in gke, from gci 1.6 to gci master'


### PR DESCRIPTION
http://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1

Have never passed in 213 days

@kubernetes/sig-gcp-test-failures 