### PR TITLE
cherrypick from @spxtr #5835 Add support for something like PodPresets directly into prow.

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -17,11 +17,61 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"regexp"
 	"time"
 
 	"k8s.io/api/core/v1"
 )
+
+// Preset is intended to match the k8s' PodPreset feature, and may be removed
+// if that feature goes beta.
+type Preset struct {
+	Labels       map[string]string  `json:"labels"`
+	Env          []kube.EnvVar      `json:"env"`
+	Volumes      []kube.Volume      `json:"volumes"`
+	VolumeMounts []kube.VolumeMount `json:"volumeMounts"`
+}
+
+func mergePreset(preset Preset, labels map[string]string, pod *kube.PodSpec) error {
+	if pod == nil {
+		return nil
+	}
+	for l, v := range preset.Labels {
+		if v2, ok := labels[l]; !ok || v2 != v {
+			return nil
+		}
+	}
+	for _, e1 := range preset.Env {
+		for i := range pod.Containers {
+			for _, e2 := range pod.Containers[i].Env {
+				if e1.Name == e2.Name {
+					return fmt.Errorf("env var duplicated in pod spec: %s", e1.Name)
+				}
+			}
+			pod.Containers[i].Env = append(pod.Containers[i].Env, e1)
+		}
+	}
+	for _, v1 := range preset.Volumes {
+		for _, v2 := range pod.Volumes {
+			if v1.Name == v2.Name {
+				return fmt.Errorf("volume duplicated in pod spec: %s", v1.Name)
+			}
+		}
+		pod.Volumes = append(pod.Volumes, v1)
+	}
+	for _, vm1 := range preset.VolumeMounts {
+		for i := range pod.Containers {
+			for _, vm2 := range pod.Containers[i].VolumeMounts {
+				if vm1.Name == vm2.Name {
+					return fmt.Errorf("volume mount duplicated in pod spec: %s", vm1.Name)
+				}
+			}
+			pod.Containers[i].VolumeMounts = append(pod.Containers[i].VolumeMounts, vm1)
+		}
+	}
+	return nil
+}
 
 // Presubmit is the job-specific trigger info.
 type Presubmit struct {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -27,13 +27,13 @@ import (
 // Preset is intended to match the k8s' PodPreset feature, and may be removed
 // if that feature goes beta.
 type Preset struct {
-	Labels       map[string]string  `json:"labels"`
-	Env          []kube.EnvVar      `json:"env"`
-	Volumes      []kube.Volume      `json:"volumes"`
-	VolumeMounts []kube.VolumeMount `json:"volumeMounts"`
+	Labels       map[string]string `json:"labels"`
+	Env          []v1.EnvVar       `json:"env"`
+	Volumes      []v1.Volume       `json:"volumes"`
+	VolumeMounts []v1.VolumeMount  `json:"volumeMounts"`
 }
 
-func mergePreset(preset Preset, labels map[string]string, pod *kube.PodSpec) error {
+func mergePreset(preset Preset, labels map[string]string, pod *v1.PodSpec) error {
 	if pod == nil {
 		return nil
 	}


### PR DESCRIPTION
This PR picks the first commit from https://github.com/kubernetes/test-infra/pull/5835 without the broken bump commit.

The existing PR has been blocked for a while on discussion and/or various rebases. We want to get this in and all we needed is to drop the broken bump commit so I've picked the main commit over to here.