### PR TITLE
Kubeflow has moved from google/kubeflow to its own GitHub organization.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -145,7 +145,7 @@ presubmits:
           defaultMode: 256
           secretName: ssh-key-secret
 
-  google/kubeflow:
+  kubeflow/kubeflow:
   - name: kubeflow-presubmit
     context: kubeflow-presubmit
     agent: kubernetes
@@ -6498,7 +6498,7 @@ presubmits:
           secretName: service-account
 
 postsubmits:
-  google/kubeflow:
+  kubeflow/kubeflow:
   - name: kubeflow-postsubmit
     agent: kubernetes
     branches:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -18,7 +18,7 @@ triggers:
   trusted_org: containerd
   join_org_url: "https://github.com/containerd/containerd/blob/master/MAINTAINERS"
 - repos:
-  - kubeflow/kubeflow
+  - kubeflow
   trusted_org: kubeflow
   join_org_url: https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md
 owners:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,8 +8,7 @@ triggers:
   - kubernetes-incubator
   - kubernetes-security
   - kubernetes-sig-testing
-  - google/cadvisor
-  - google/kubeflow
+  - google/cadvisor  
   - tensorflow/k8s
   - GoogleCloudPlatform/k8s-multicluster-ingress
   trusted_org: kubernetes
@@ -18,7 +17,10 @@ triggers:
   - containerd/cri-containerd
   trusted_org: containerd
   join_org_url: "https://github.com/containerd/containerd/blob/master/MAINTAINERS"
-
+- repos:
+  - kubeflow/kubeflow
+  trusted_org: kubeflow
+  join_org_url: https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md
 owners:
   mdyamlrepos:
   - kubernetes/website
@@ -122,7 +124,7 @@ plugins:
   google/cadvisor:
   - trigger
 
-  google/kubeflow:
+  kubeflow/kubeflow:
   - lgtm
   - size
   - trigger

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -384,9 +384,9 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 	}
 
 	// Also check k/k presubmit, prow postsubmit and periodic jobs
-	for _, job := range prowConfig.AllPresubmits([]string{
-		"google/kubeflow",
+	for _, job := range prowConfig.AllPresubmits([]string{		
 		"google/cadvisor",
+		"kubeflow/kubeflow",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -384,7 +384,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 	}
 
 	// Also check k/k presubmit, prow postsubmit and periodic jobs
-	for _, job := range prowConfig.AllPresubmits([]string{		
+	for _, job := range prowConfig.AllPresubmits([]string{
 		"google/cadvisor",
 		"kubeflow/kubeflow",
 		"kubernetes/kubernetes",


### PR DESCRIPTION
* Update all references to google/kubeflow.
* Configure kubeflow as a trusted organization so that members of Kubeflow
  can trigger tests.

* Related to: kubeflow/kubeflow#165