### PR TITLE
Fix indentation issue in branchprotector cronjob

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -26,12 +26,11 @@ spec:
             - name: config
               mountPath: /etc/config
               readOnly: true
-        restartPolicy: Never
-        volumes:
-        - name: oauth
-          secret:
-            secretName: oauth-token
-        - name: config
-          configMap:
-            name: config
-
+          restartPolicy: Never
+          volumes:
+          - name: oauth
+            secret:
+              secretName: oauth-token
+          - name: config
+            configMap:
+              name: config


### PR DESCRIPTION
/assign @cjwagner @BenTheElder @cblecker 

Indent `restartPolicy` and `volumes` keys by 2 more spaces to be inside `template.spec` rather than `template`