### PR TITLE
Add 'owners-label' plugin to Prow to replace 'owner-label' and 'path-label' mungers.

### DIFF
--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -65,6 +65,7 @@ filegroup(
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",
         "//prow/plugins/milestonestatus:all-srcs",
+        "//prow/plugins/owners-label:all-srcs",
         "//prow/plugins/releasenote:all-srcs",
         "//prow/plugins/requiresig:all-srcs",
         "//prow/plugins/shrug:all-srcs",

--- a/prow/plugins/owners-label/BUILD
+++ b/prow/plugins/owners-label/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["owners-label.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/owners-label",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["owners-label_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ownerslabel
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	pluginName = "owners-label"
+)
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	return &pluginhelp.PluginHelp{
+			Description: "The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes.",
+		},
+		nil
+}
+
+type ownersClient interface {
+	FindLabelsForFile(path string) sets.String
+}
+
+type githubClient interface {
+	AddLabel(org, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
+}
+
+func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
+		return nil
+	}
+
+	oc, err := pc.OwnersClient.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name)
+	if err != nil {
+		return fmt.Errorf("error loading RepoOwners: %v", err)
+	}
+
+	return handle(pc.GitHubClient, oc, pc.Logger, &pre)
+}
+
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.PullRequestEvent) error {
+	changes, err := ghc.GetPullRequestChanges(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
+	if err != nil {
+		return fmt.Errorf("error getting PR changes: %v", err)
+	}
+	labels, err := ghc.GetIssueLabels(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
+	if err != nil {
+		return fmt.Errorf("error getting PR labels: %v", err)
+	}
+
+	currentLabels := sets.NewString()
+	for _, label := range labels {
+		currentLabels.Insert(label.Name)
+	}
+	neededLabels := sets.NewString()
+	for _, change := range changes {
+		neededLabels.Insert(oc.FindLabelsForFile(change.Filename).List()...)
+	}
+
+	for _, toAdd := range neededLabels.Difference(currentLabels).List() {
+		if err := ghc.AddLabel(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, toAdd); err != nil {
+			log.WithError(err).Errorf("Adding %q label.", toAdd)
+		}
+	}
+	return nil
+}

--- a/prow/plugins/owners-label/owners-label_test.go
+++ b/prow/plugins/owners-label/owners-label_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ownerslabel
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+)
+
+type fakeGithubClient struct {
+	changes       []github.PullRequestChange
+	initialLabels []github.Label
+	labelsAdded   sets.String
+}
+
+func newFakeGithubClient(filesChanged []string, initialLabels []string) *fakeGithubClient {
+	changes := make([]github.PullRequestChange, 0, len(filesChanged))
+	for _, name := range filesChanged {
+		changes = append(changes, github.PullRequestChange{Filename: name})
+	}
+	labels := make([]github.Label, 0, len(initialLabels))
+	for _, label := range initialLabels {
+		labels = append(labels, github.Label{Name: label})
+	}
+	return &fakeGithubClient{
+		changes:       changes,
+		initialLabels: labels,
+		labelsAdded:   sets.NewString(),
+	}
+}
+
+func (c *fakeGithubClient) AddLabel(org, repo string, number int, label string) error {
+	if org != "org" {
+		return errors.New("org should be 'org'")
+	}
+	if repo != "repo" {
+		return errors.New("repo should be 'repo'")
+	}
+	if number != 5 {
+		return errors.New("number should be 5")
+	}
+	c.labelsAdded.Insert(label)
+	return nil
+}
+
+func (c *fakeGithubClient) GetPullRequestChanges(org, repo string, num int) ([]github.PullRequestChange, error) {
+	if org != "org" {
+		return nil, errors.New("org should be 'org'")
+	}
+	if repo != "repo" {
+		return nil, errors.New("repo should be 'repo'")
+	}
+	if num != 5 {
+		return nil, errors.New("number should be 5")
+	}
+	return c.changes, nil
+}
+
+func (c *fakeGithubClient) GetIssueLabels(org, repo string, num int) ([]github.Label, error) {
+	if org != "org" {
+		return nil, errors.New("org should be 'org'")
+	}
+	if repo != "repo" {
+		return nil, errors.New("repo should be 'repo'")
+	}
+	if num != 5 {
+		return nil, errors.New("number should be 5")
+	}
+	return c.initialLabels, nil
+}
+
+type fakeOwnersClient struct {
+	labels map[string]sets.String
+}
+
+func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
+	return foc.labels[path]
+}
+
+// TestHandle tests that the handle function requests reviews from the correct number of unique users.
+func TestHandle(t *testing.T) {
+	foc := &fakeOwnersClient{
+		labels: map[string]sets.String{
+			"a.go": sets.NewString("lgtm", "approved", "kind/docs"),
+			"b.go": sets.NewString("lgtm"),
+			"c.go": sets.NewString("lgtm", "dnm/frozen-docs"),
+			"d.sh": sets.NewString("dnm/bash"),
+			"e.sh": sets.NewString("dnm/bash"),
+		},
+	}
+
+	var testcases = []struct {
+		name          string
+		filesChanged  []string
+		initialLabels []string
+		expectedAdded sets.String
+	}{
+		{
+			name:          "no labels",
+			filesChanged:  []string{"other.go", "something.go"},
+			expectedAdded: sets.NewString(),
+		},
+		{
+			name:          "1 file 1 label",
+			filesChanged:  []string{"b.go"},
+			expectedAdded: sets.NewString("lgtm"),
+		},
+		{
+			name:          "1 file 3 labels",
+			filesChanged:  []string{"a.go"},
+			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs"),
+		},
+		{
+			name:          "2 files no overlap",
+			filesChanged:  []string{"c.go", "d.sh"},
+			expectedAdded: sets.NewString("lgtm", "dnm/frozen-docs", "dnm/bash"),
+		},
+		{
+			name:          "2 files partial overlap",
+			filesChanged:  []string{"a.go", "b.go"},
+			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs"),
+		},
+		{
+			name:          "2 files complete overlap",
+			filesChanged:  []string{"d.sh", "e.sh"},
+			expectedAdded: sets.NewString("dnm/bash"),
+		},
+		{
+			name:          "3 files partial overlap",
+			filesChanged:  []string{"a.go", "b.go", "c.go"},
+			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs", "dnm/frozen-docs"),
+		},
+		{
+			name:          "no labels to add, initial unrelated label",
+			filesChanged:  []string{"other.go", "something.go"},
+			initialLabels: []string{"lgtm"},
+			expectedAdded: sets.NewString(),
+		},
+		{
+			name:          "1 file 1 label, already present",
+			filesChanged:  []string{"b.go"},
+			initialLabels: []string{"lgtm"},
+			expectedAdded: sets.NewString(),
+		},
+		{
+			name:          "2 files no overlap, 1 label already present",
+			filesChanged:  []string{"c.go", "d.sh"},
+			initialLabels: []string{"dnm/bash", "approved"},
+			expectedAdded: sets.NewString("lgtm", "dnm/frozen-docs"),
+		},
+		{
+			name:          "2 files complete overlap, label already present",
+			filesChanged:  []string{"d.sh", "e.sh"},
+			initialLabels: []string{"dnm/bash"},
+			expectedAdded: sets.NewString(),
+		},
+	}
+	for _, tc := range testcases {
+		fghc := newFakeGithubClient(tc.filesChanged, tc.initialLabels)
+		pre := &github.PullRequestEvent{
+			Number:      5,
+			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
+			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+		}
+
+		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), pre); err != nil {
+			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
+			continue
+		}
+		if !fghc.labelsAdded.Equal(tc.expectedAdded) {
+			t.Errorf("[%s] expected the labels %q to be added, but got %q.", tc.name, tc.expectedAdded.List(), fghc.labelsAdded.List())
+		}
+	}
+}


### PR DESCRIPTION
The functionality of the `path-label` munger (regexp based path labeling) can now be achieved with OWNERS files thanks to #6411 so this is really just a migration of the `owner-label` munger.

fixes #6033 
/area prow
/bark
/cc @rmmh @BenTheElder 