### PR TITLE
correctly subsitute security-repo job name

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -784,7 +784,7 @@ def job_script(job, extra_job_args):
     with open(test_infra('jobs/config.json')) as fp:
         config = json.loads(fp.read())
     if job.startswith('pull-security-kubernetes-'):
-        job.replace('pull-security-kubernetes-', 'pull-kubernetes', 1)
+        job = job.replace('pull-security-kubernetes-', 'pull-kubernetes-', 1)
     job_config = config[job]
     cmd = test_infra('scenarios/%s.py' % job_config['scenario'])
     return [cmd] + job_args(job_config.get('args', []) + extra_job_args)


### PR DESCRIPTION
@krzyzacy replace returns a new string :man_shrugging: 
Also this was dropping the trailing `-`.

/area hacks