### PR TITLE
Shard jenkins-operator config

### DIFF
--- a/experiment/refresh/BUILD
+++ b/experiment/refresh/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/report:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )
 

--- a/experiment/refresh/server.go
+++ b/experiment/refresh/server.go
@@ -22,8 +22,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"text/template"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
@@ -163,16 +165,32 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		return nil
 	}
 
-	jenkinsReport := s.configAgent.Config().JenkinsOperator.ReportTemplate
+	jenkinsConfig := s.configAgent.Config().JenkinsOperators
 	kubeReport := s.configAgent.Config().Plank.ReportTemplate
 	for _, pj := range pjutil.GetLatestProwJobs(presubmits, kube.PresubmitJob) {
-		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		reportTemplate := jenkinsReport
-		if pj.Spec.Agent == "kubernetes" {
+		var reportTemplate *template.Template
+		switch pj.Spec.Agent {
+		case kube.KubernetesAgent:
 			reportTemplate = kubeReport
+		case kube.JenkinsAgent:
+			reportTemplate = s.reportForProwJob(pj, jenkinsConfig)
 		}
+		if reportTemplate == nil {
+			continue
+		}
+
+		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
 		if err := report.Report(s.ghc, reportTemplate, pj); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
+		}
+	}
+	return nil
+}
+
+func (s *Server) reportForProwJob(pj kube.ProwJob, configs []config.JenkinsOperator) *template.Template {
+	for _, cfg := range configs {
+		if cfg.LabelSelector.Matches(labels.Set(pj.Labels)) {
+			return cfg.ReportTemplate
 		}
 	}
 	return nil


### PR DESCRIPTION
@stevekuznetsov this will help us use different config for the operator responsible for ci.dev w/o the need to maintain a separate configmap.

@cjwagner unfortunately this is a breaking change and I have to update the config at the same PR to fix unit tests.

/hold