### PR TITLE
Add a temporary re-direct page that helps inform users that we are adopting to new Command page

### DIFF
--- a/prow/cmd/deck/static/command-help-script.js
+++ b/prow/cmd/deck/static/command-help-script.js
@@ -386,10 +386,10 @@ function redraw() {
     const repoSel = selectionText(document.getElementById("repo"));
     if (window.history && window.history.replaceState !== undefined) {
         if (repoSel !== "") {
-            history.replaceState(null, "", "/plugin-help.html?repo="
+            history.replaceState(null, "", "/command-help.html?repo="
                 + encodeURIComponent(repoSel));
         } else {
-            history.replaceState(null, "", "/plugin-help.html")
+            history.replaceState(null, "", "/command-help.html")
         }
     }
     redrawOptions();

--- a/prow/cmd/deck/static/command-help.html
+++ b/prow/cmd/deck/static/command-help.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Prow Command Help</title>
+        <link id="favicon" rel="icon" type="image/png" href="favicon.ico">
+        <link rel="stylesheet" type="text/css" href="style.css">
+        <link rel="stylesheet" type="text/css" href="extensions/style.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="dialog-polyfill.css">
+        <script type="text/javascript" src="command-help-script.js"></script>
+        <script type="text/javascript" src="dialog-polyfill.js"></script>
+        <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
+        <script type="text/javascript" src="extensions/script.js"></script>
+        <script type="text/javascript" src="branding.js?var=branding"></script>
+        <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    </head>
+    <body>
+        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+            <header class="mdl-layout__header">
+                <div class="mdl-layout__header-row">
+                    <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow" class="logo"><img id="img" src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
+                    <span class="mdl-layout-title header-title">Command Help</span>
+                </div>
+            </header>
+            <div class="mdl-layout__drawer">
+                <span class="mdl-layout-title">Prow Dashboard</span>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link" href="/">Prow Status</a>
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/command-help.html">Command Help</a>
+                    <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
+                </nav>
+            </div>
+            <main class="mdl-layout__content">
+                <aside>
+                    <div class="card-box">
+                        <ul class="noBullets">
+                            <li>Plugin help for</li>
+                            <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
+                        </ul>
+                    </div>
+                </aside>
+                <table id="command-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp plugin-table">
+                    <thead>
+                    <tr>
+                        <th></th>
+                        <th class="mdl-data-table__cell--non-numeric">Command</th>
+                        <th class="mdl-data-table__cell--non-numeric">Example</th>
+                        <th class="mdl-data-table__cell--non-numeric">Description</th>
+                        <th class="mdl-data-table__cell--non-numeric">Who Can Use</th>
+                        <th class="mdl-data-table__cell--non-numeric">Plugin</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </main>
+        </div>
+        <dialog id="dialog" class="mdl-dialog">
+            <h4 class="mdl-dialog__title"></h4>
+            <div class="mdl-dialog__content">
+            </div>
+            <div class="mdl-dialog__actions">
+                <button type="button" class="mdl-button close">Close</button>
+            </div>
+        </dialog>
+        <div id="toast" class="mdl-js-snackbar mdl-snackbar">
+            <div class="mdl-snackbar__text"></div>
+            <button class="mdl-snackbar__action" type="button"></button>
+        </div>
+    </body>
+</html>

--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -26,7 +26,7 @@
                 <span class="mdl-layout-title">Prow Dashboard</span>
                 <nav class="mdl-navigation">
                     <a class="mdl-navigation__link mdl-navigation__link--current" href="/">Prow Status</a>
-                    <a class="mdl-navigation__link" href="/plugin-help.html">Plugin Help</a>
+                    <a class="mdl-navigation__link" href="/command-help.html">Command Help</a>
                     <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
                 </nav>
             </div>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -1,75 +1,11 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Prow Plugin Help</title>
-        <link id="favicon" rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css">
-        <link rel="stylesheet" type="text/css" href="extensions/style.css">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="dialog-polyfill.css">
-        <script type="text/javascript" src="plugin-help-script.js"></script>
-        <script type="text/javascript" src="dialog-polyfill.js"></script>
-        <script type="text/javascript" src="plugin-help-script.js"></script>
-        <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
-        <script type="text/javascript" src="extensions/script.js"></script>
-        <script type="text/javascript" src="branding.js?var=branding"></script>
-        <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
-    </head>
-    <body>
-        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
-            <header class="mdl-layout__header">
-                <div class="mdl-layout__header-row">
-                    <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow" class="logo"><img id="img" src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
-                    <span class="mdl-layout-title header-title">Plugin Help</span>
-                </div>
-            </header>
-            <div class="mdl-layout__drawer">
-                <span class="mdl-layout-title">Prow Dashboard</span>
-                <nav class="mdl-navigation">
-                    <a class="mdl-navigation__link" href="/">Prow Status</a>
-                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/plugin-help.html">Plugin Help</a>
-                    <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
-                </nav>
-            </div>
-            <main class="mdl-layout__content">
-                <aside>
-                    <div class="card-box">
-                        <ul class="noBullets">
-                            <li>Plugin help for</li>
-                            <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
-                        </ul>
-                    </div>
-                </aside>
-                <table id="command-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp plugin-table">
-                    <thead>
-                    <tr>
-                        <th></th>
-                        <th class="mdl-data-table__cell--non-numeric">Command</th>
-                        <th class="mdl-data-table__cell--non-numeric">Example</th>
-                        <th class="mdl-data-table__cell--non-numeric">Description</th>
-                        <th class="mdl-data-table__cell--non-numeric">Who Can Use</th>
-                        <th class="mdl-data-table__cell--non-numeric">Plugin</th>
-                        <th></th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    </tbody>
-                </table>
-            </main>
-        </div>
-        <dialog id="dialog" class="mdl-dialog">
-            <h4 class="mdl-dialog__title"></h4>
-            <div class="mdl-dialog__content">
-            </div>
-            <div class="mdl-dialog__actions">
-                <button type="button" class="mdl-button close">Close</button>
-            </div>
-        </dialog>
-        <div id="toast" class="mdl-js-snackbar mdl-snackbar">
-            <div class="mdl-snackbar__text"></div>
-            <button class="mdl-snackbar__action" type="button"></button>
-        </div>
-    </body>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="5; url=./command-help.html">
+  <title>Plugin Help</title>
+</head>
+<body>
+  <h3>Plugin Help is now <a href="./command-help.html">Command Help</a>. Redirecting after 5 seconds</h3>
+</body>
 </html>

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -27,7 +27,7 @@
                 <span class="mdl-layout-title">Prow Dashboard</span>
                 <nav class="mdl-navigation">
                     <a class="mdl-navigation__link" href="/">Prow Status</a>
-                    <a class="mdl-navigation__link" href="/plugin-help.html">Plugin Help</a>
+                    <a class="mdl-navigation__link" href="/command-help.html">Command Help</a>
                     <a class="mdl-navigation__link mdl-navigation__link--current" href="/tide.html">Tide Status</a>
                 </nav>
             </div>


### PR DESCRIPTION
* The temporary redirection should be removed as soon as possible
* TODO: Refactor terminology from "plugin-help" to "command-help
* Fixes #6485