### PR TITLE
Protect community branch

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25,11 +25,13 @@ log_level: info
 branch-protection:
   orgs:
     kubernetes:
+      require-contexts:
+      - cla/linuxfoundation
       repos:
+        community:
+          protect-by-default: true
         test-infra:
           protect-by-default: true
-          require-contexts:
-          - cla/linuxfoundation
     kubernetes-sig-testing:
       repos:
         frameworks:


### PR DESCRIPTION
Also move `cla/linuxfoundation` into an org level assert.

Note that this will also automatically identify required prow jobs and make them required contexts (in addition to the ones manually specified).

/assign @idvoretskyi @bgrant0607 @cblecker 

Dry run output:
```
time="2018-01-30T13:58:02-08:00" level=info msg="GetBranches(kubernetes, community)" client=github 
time="2018-01-30T13:58:03-08:00" level=info msg="UpdateBranchProtection(kubernetes, community, bgrant0607-backlog-update-1, [cla/linuxfoundation pull-community-verify], [])" client=github 
time="2018-01-30T13:58:03-08:00" level=info msg="UpdateBranchProtection(kubernetes, community, idvoretskyi-patch-1, [cla/linuxfoundation pull-community-verify], [])" client=github 
time="2018-01-30T13:58:03-08:00" level=info msg="UpdateBranchProtection(kubernetes, community, master, [cla/linuxfoundation pull-community-verify], [])" client=github 
time="2018-01-30T13:58:03-08:00" level=info msg="UpdateBranchProtection(kubernetes, community, release-1.6, [cla/linuxfoundation pull-community-verify], [])" client=github 
```