### PR TITLE
Basic testgrid updater protos

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -57,6 +57,7 @@ filegroup(
         "//robots/issue-creator:all-srcs",
         "//scenarios:all-srcs",
         "//testgrid/config:all-srcs",
+        "//testgrid/updater:all-srcs",
         "//triage:all-srcs",
         "//velodrome:all-srcs",
         "//vendor:all-srcs",

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -16,7 +16,6 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
-go get ./...
-go install ./...
 go vet $(go list ./... | grep -v vendor)

--- a/testgrid/updater/BUILD
+++ b/testgrid/updater/BUILD
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "state_proto",
+    srcs = ["state.proto"],
+)
+
+go_proto_library(
+    name = "state",
+    proto = ":state_proto",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/testgrid/updater",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":state",
+    ],
+)
+
+go_binary(
+    name = "updater",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/testgrid/updater",
+    pure = "on",
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/testgrid/updater/README.md
+++ b/testgrid/updater/README.md
@@ -1,0 +1,7 @@
+
+The testgrid updater reads results from GCS to create a state proto.
+
+The testgrid server reads these protos, converts them to json which the
+javascript UI reads and renders on the screen.
+
+TODO(fejta): provide better documentation soon

--- a/testgrid/updater/main.go
+++ b/testgrid/updater/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/test-infra/testgrid/updater/state"
+)
+
+func main() {
+	g := state.Grid{}
+	g.Columns = append(g.Columns, &state.Column{Build: "first", Started: 1})
+	fmt.Println(g)
+}

--- a/testgrid/updater/state.proto
+++ b/testgrid/updater/state.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+message Column {
+  string build = 1;  // Unique instance of the job, typically BUILD_NUMBER from prow or guid
+  reserved 2; // Useless
+  double started = 3; // milliseconds since start of epoch (python time.time() * 1000)
+  repeated string extra = 4; // Additional column headers like commit, image used, etc.
+}
+
+message Metric {
+  string name = 1;  // Name of metric, such as duration
+  // Sparse encoding of values. So given:
+  //   Indices: [0, 2, 6, 4]
+  //   Values: [0.1,0.2,6.1,6.2,6.3,6.4]
+  // Decoded 12-value equivalent is:
+  // [0.1, 0.2, nil, nil, nil, nil, nil, 6.1, 6.2, 6.3, 6.4, nil, nil, ...]
+  repeated int32 indices = 2; // n=index of first value, n+1=count of filled values
+  repeated double values = 3; // filled values
+}
+
+message Row {
+  string name = 1; // Name to display, which might process id to append/filter info.
+  string id = 2;  // raw id for the row, such as the bazel target or golang package.
+
+  enum Result {
+    NO_RESULT = 0;
+    PASS = 1;
+    PASS_WITH_ERRORS = 2;
+    PASS_WITH_SKIPS = 3;
+    RUNNING = 4;
+    reserved 5 to 11;
+    FAIL = 12;
+    FLAKY = 13;
+  }
+  // Results for this row, run-length encoded to reduce size/improve performance.
+  // Thus (encoded -> decoded equivalent):
+  //   [0, 3, 5, 4] -> [0, 0, 0, 5, 5, 5, 5]
+  //   [5, 1] -> [5]
+  //   [1, 5] -> [1, 1, 1, 1, 1]
+  // The decoded values are Result enums
+  repeated int32 results = 3;
+
+  repeated string cell_ids = 4; // In case each cell has a unique identifier, separate from the column
+  repeated string messages = 5; // Short description of the result, displayed on mouseover
+
+  reserved 6 to 7;  // Consider later
+
+  repeated Metric metrics = 8;  // Numerical performance/timing data, etc.
+
+  repeated string icons = 9;  // Put 1-2 chars inside cell (F for fail, etc)
+
+  reserved 10;  // Consider later
+}
+
+message Grid {
+  repeated Column columns = 1;
+  repeated Row rows = 2;
+
+  reserved 3 to 9;  // Consider later
+}


### PR DESCRIPTION
/assign @michelle192837 @rmmh 

Basic `state.proto` fields. Will follow up with PRs that use them more extensively (will require vendoring gcs)

Also stop making `hack/verify-govet.sh` run `go get ./... && go install ./...` as this is unnecessary given that our code is checked into `vendor`