### PR TITLE
Add USER=prow env for ci-ingress-gce-e2e to fix log dumping

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8199,6 +8199,8 @@ periodics:
       - "--timeout=320"
       - "--bare"
       env:
+      - name: USER
+        value: prow
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE


### PR DESCRIPTION
From https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-ingress-gce-e2e/489?log#log, seems like `log-dump.sh` is hitting permission issue without setting the prow user.
```
I0130 21:54:49.774] Copying 'kern kube-proxy fluentd node-problem-detector startupscript docker kubelet supervisor/supervisord supervisor/kubelet-stdout supervisor/kubelet-stderr supervisor/docker-stdout supervisor/docker-stderr' from e2e-489-minion-group-gkwt
I0130 21:54:49.774] Copying 'kern kube-proxy fluentd node-problem-detector startupscript docker kubelet supervisor/supervisord supervisor/kubelet-stdout supervisor/kubelet-stderr supervisor/docker-stdout supervisor/docker-stderr' from e2e-489-minion-group-3p27
W0130 21:54:49.875] ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255].
I0130 21:54:49.976] Copying 'kern kube-proxy fluentd node-problem-detector startupscript docker kubelet supervisor/supervisord supervisor/kubelet-stdout supervisor/kubelet-stderr supervisor/docker-stdout supervisor/docker-stderr' from e2e-489-minion-group-fvqm
W0130 21:54:50.497] 
W0130 21:54:50.497] Specify --start=43791 in the next get-serial-port-output invocation to get only the new output starting from here.
W0130 21:54:50.528] 
W0130 21:54:50.528] Specify --start=43345 in the next get-serial-port-output invocation to get only the new output starting from here.
W0130 21:54:50.711] 
W0130 21:54:50.711] Specify --start=43290 in the next get-serial-port-output invocation to get only the new output starting from here.
W0130 21:54:51.493] Permission denied (publickey).
W0130 21:54:51.497] ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [1].
W0130 21:54:51.529] Permission denied (publickey).
W0130 21:54:51.533] ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [1].
W0130 21:54:51.746] Permission denied (publickey).
W0130 21:54:51.751] ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [1].
W0130 21:54:51.817] 2018/01/30 21:54:51 util.go:157: Step './cluster/log-dump/log-dump.sh /workspace/_artifacts' finished in 2m11.998659934s
```

/assign @rramkumar1 @krzyzacy 