### PR TITLE
switch aws janitor mark path

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10365,7 +10365,7 @@
       "/aws-janitor",
       "--",
       "--ttl=2h30m",
-      "--path=s3://janitor-jenkins/objs.json"
+      "--path=s3://k8s-kops-prow/objs.json"
     ],
     "scenario": "execute",
     "sigOwners": [


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/2421
https://github.com/kubernetes/test-infra/issues/6497

maybe? From the code seems the path flag just a path to store complete marks, please let me know if otherwise..

/shrug
/assign @justinsb @zmerlynn 