### PR TITLE
Extend updateconfig to update any configmap

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -24,6 +24,7 @@ See also: [Life of a Prow Job](./architecture.md)
 
 New features added to each components:
 
+ - *February 1, 2018* `updateconfig` will now update any configmap on merge
  - *November 14, 2017* `jenkins-operator:0.58` exposes prometheus metrics.
  - *November 8, 2017* `horologium:0.14` prow periodic job now support cron
    triggers. See https://godoc.org/gopkg.in/robfig/cron.v2 for doc to the 
@@ -36,6 +37,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *February 1, 2018* The `config_updater` section in `plugins.yaml`
+ now uses a `maps` object instead of `config_file`, `plugin_file` strings.
+ Please switch over before July.
  - *November 30, 2017* If you use tide, you'll need to switch your query format
  and bump all prow component versions to reflect the changes in #5754.
  - *November 14, 2017* `horologium:0.17` fixes cron job not being scheduled.

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -117,6 +117,11 @@ milestonestatus:
   maintainers_id: 2460384
 
 config_updater:
+  maps:
+    label_sync/labels.yaml: label-sync
+    prow/config.yaml: config
+    prow/plugins.yaml: plugins
+  # Following two fields are deprecated
   config_file: prow/config.yaml
   plugin_file: prow/plugins.yaml
 

--- a/prow/plugins/updateconfig/README.md
+++ b/prow/plugins/updateconfig/README.md
@@ -1,0 +1,21 @@
+
+
+`updateconfig` allows prow to update configmaps when files in a repo change.
+
+## Usage
+
+Update your `plugins.yaml` file to something along the following lines:
+```
+plugins:
+  my-github/repo:
+  - config-updater
+
+config_updater:
+  maps:
+    # Update the whatever configmap whenever thing changes
+    path/to/some/other/thing: whatever
+    # Update the config configmap whenever config.yaml changes
+    prow/config.yaml: config
+    # Update the plugin configmap whenever plugins.yaml changes
+    prow/plugins.yaml: plugin
+```

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -187,7 +187,12 @@ func TestUpdateConfig(t *testing.T) {
 			maps: map[string]kube.ConfigMap{},
 		}
 
-		if err := handle(fgc, fkc, log, event, "prow/config.yaml", "prow/plugins.yaml"); err != nil {
+		m := map[string]string{
+			"prow/config.yaml":  "config",
+			"prow/plugins.yaml": "plugins",
+		}
+
+		if err := handle(fgc, fkc, log, event, m); err != nil {
 			t.Fatal(err)
 		}
 
@@ -197,12 +202,14 @@ func TestUpdateConfig(t *testing.T) {
 			}
 
 			comment := fgc.IssueComments[basicPR.Number][0].Body
-			if tc.configUpdate && !strings.Contains(comment, "I updated Prow config for you!") {
-				t.Fatalf("tc %s : Expect comment %s to contain 'I updated Prow config for you!'", comment, fgc.IssueComments[basicPR.Number][0].Body)
+			if !strings.Contains(comment, "Updated the") {
+				t.Errorf("%s: missing Updated the from %s", tc.name, comment)
 			}
-
-			if tc.pluginsUpdate && !strings.Contains(comment, "I updated Prow plugins config for you!") {
-				t.Fatalf("tc %s : Expect comment %s to contain 'I updated Prow plugins config for you!'", comment, fgc.IssueComments[basicPR.Number][0].Body)
+			if tc.configUpdate && !strings.Contains(comment, "config") {
+				t.Errorf("%s: missing config from %s", tc.name, comment)
+			}
+			if tc.pluginsUpdate && !strings.Contains(comment, "plugins") {
+				t.Errorf("%s: missing plugins from %s", tc.name, comment)
 			}
 		}
 


### PR DESCRIPTION
Also configure it to update `label-sync` whenever `label_sync/labels.yaml` changes (this will need a new hook version)

Continue to read `config_file` `plugin_file` values but start warning that this is deprecated, ask them to change to `maps`

/assign @spiffxp @krzyzacy @stevekuznetsov

Implements the beginning of https://docs.google.com/document/d/1Gmt4wq-QC9gOGvR6P4ls7uMRyoQwzzOuTlKhxHqM8uo/edit#