### PR TITLE
Service account preset all the jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -117,6 +117,8 @@ presubmits:
     context: pull-cadvisor-e2e
     rerun_command: "/test pull-cadvisor-e2e"
     trigger: "(?m)^/test( all| pull-cadvisor-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -128,8 +130,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: CADVISOR_APPLICATION_CREDENTIALS
           value: /etc/cadvisor-service-account/service-account.json
         - name: USER
@@ -139,9 +139,6 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cadvisor-service
           mountPath: /etc/cadvisor-service-account
           readOnly: true
@@ -149,9 +146,6 @@ presubmits:
           mountPath: /etc/ssh-key-secret
           readOnly: true
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cadvisor-service
         secret:
           secretName: cadvisor-service-account
@@ -169,21 +163,13 @@ presubmits:
     trigger: "(?m)^/test( all| kubeflow-presubmit),?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/mlkube-testing/kubeflow-testing:latest
         imagePullPolicy: Always
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
+
   kubernetes/charts:
   - name: pull-charts-e2e
     agent: kubernetes
@@ -191,6 +177,8 @@ presubmits:
     context: pull-charts-e2e
     rerun_command: "/test pull-charts-e2e"
     trigger: "(?m)^/test( all| pull-charts-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
@@ -202,24 +190,16 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -232,6 +212,8 @@ presubmits:
     rerun_command: "/test pull-community-verify"
     trigger: "(?m)^/test( all| pull-community-verify),?(\\s+|$)"
     always_run: true
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -240,22 +222,13 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -268,6 +241,8 @@ presubmits:
     rerun_command: "/test pull-kubernetes-dns-test"
     trigger: "(?m)^/test( all| pull-kubernetes-dns-test),?(\\s+|$)"
     always_run: true
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -276,22 +251,13 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -304,6 +270,8 @@ presubmits:
     rerun_command: "/test pull-ingress-gce-test"
     trigger: "(?m)^/test( all| pull-ingress-gce-test),?(\\s+|$)"
     always_run: true
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -315,24 +283,16 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -345,6 +305,8 @@ presubmits:
     rerun_command: "/test pull-kubernetes-multicluster-ingress-test"
     trigger: "(?m)^/test( all| pull-kubernetes-multicluster-ingress-test),?(\\s+|$)"
     always_run: true
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -353,20 +315,11 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: coveralls
           mountPath: /etc/coveralls-token
           readOnly: true
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: coveralls
         secret:
           secretName: k8s-multicluster-ingress-coveralls-token
@@ -377,6 +330,8 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-federation-bazel-test"
     trigger: "(?m)^/test( all| pull-federation-bazel-test),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -400,9 +355,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -412,9 +364,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -424,6 +373,8 @@ presubmits:
     context: pull-federation-e2e-gce
     rerun_command: "/test pull-federation-e2e-gce"
     trigger: "(?m)^/test( all| pull-federation-e2e-gce),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
@@ -436,8 +387,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -448,9 +397,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         - name: ssh
@@ -460,9 +406,6 @@ presubmits:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -476,6 +419,8 @@ presubmits:
     rerun_command: "/test pull-federation-verify"
     trigger: "/test( all| pull-federation-verify)"
     always_run: true
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -484,22 +429,13 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -510,6 +446,8 @@ presubmits:
     context: pull-heapster-e2e
     rerun_command: "/test pull-heapster-e2e"
     trigger: "(?m)^/test( all| pull-heapster-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -521,8 +459,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -530,9 +466,6 @@ presubmits:
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         - name: ssh
@@ -544,9 +477,6 @@ presubmits:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -561,6 +491,8 @@ presubmits:
     context: pull-kops-e2e-kubernetes-aws
     rerun_command: "/test pull-kops-e2e-kubernetes-aws"
     trigger: "(?m)^/test( all| pull-kops-e2e-kubernetes-aws),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -575,8 +507,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -589,9 +519,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         - mountPath: /etc/aws-ssh
@@ -607,9 +534,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -628,6 +552,8 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-cluster-registry-bazel"
     trigger: "(?m)^/test( all| pull-cluster-registry-bazel),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -645,9 +571,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -657,9 +580,6 @@ presubmits:
           requests:
             memory: "2Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -669,6 +589,8 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-cluster-registry-verify-bazel"
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-bazel),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -681,23 +603,17 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         resources:
           requests:
             memory: "2Gi"
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
   - name: pull-cluster-registry-verify-gensrc
     agent: kubernetes
     context: pull-cluster-registry-verify-gensrc
     always_run: true
     rerun_command: "/test pull-cluster-registry-verify-gensrc"
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-gensrc),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -709,17 +625,12 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -729,9 +640,6 @@ presubmits:
           requests:
             memory: "2Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -741,6 +649,8 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-cluster-registry-verify-gosrc"
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-gosrc),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -752,22 +662,12 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         resources:
           requests:
             memory: "2Gi"
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
   containerd/cri-containerd:
   - name: pull-cri-containerd-build
     agent: kubernetes
@@ -777,6 +677,8 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cri-containerd-build),?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -784,17 +686,6 @@ presubmits:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
     run_after_success:
     - name: pull-cri-containerd-node-e2e
       agent: kubernetes
@@ -806,6 +697,8 @@ presubmits:
       context: pull-cri-containerd-node-e2e
       rerun_command: "/test pull-cri-containerd-node-e2e"
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -822,8 +715,6 @@ presubmits:
           - "--"
           - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd --node-env=PULL_REFS=$(PULL_REFS)"
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: USER
             value: prow
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -843,9 +734,6 @@ presubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             defaultMode: 256
@@ -861,6 +749,8 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cri-containerd-verify),?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -868,17 +758,7 @@ presubmits:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
+
   kubernetes/kubernetes:
   - name: pull-kubernetes-bazel-build
     agent: kubernetes
@@ -910,9 +790,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -922,9 +799,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -953,8 +827,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -962,9 +834,6 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -974,9 +843,6 @@ presubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -993,6 +859,8 @@ presubmits:
     branches:
     - release-1.7
     - release-1.8
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -1013,9 +881,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -1025,9 +890,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1043,6 +905,8 @@ presubmits:
       branches:
       - release-1.7
       - release-1.8
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -1055,8 +919,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -1064,9 +926,6 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -1076,9 +935,6 @@ presubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -1095,6 +951,8 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-bazel-build-canary,?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
@@ -1116,18 +974,12 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: bazel-scratch
           mountPath: /scratch/.cache
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: bazel-scratch
         emtpyDir: {}
     run_after_success:
@@ -1141,6 +993,8 @@ presubmits:
       run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
       rerun_command: "/test pull-kubernetes-e2e-kubeadm-gce-canary"
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -1153,8 +1007,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -1162,9 +1014,6 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -1174,9 +1023,6 @@ presubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -1195,6 +1041,8 @@ presubmits:
     - release-1.6 # doesn't have BUILD files under //vendor/k8s.io
     - release-1.7 # different set of targets
     - release-1.8 # different set of targets
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -1218,9 +1066,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -1230,9 +1075,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1245,6 +1087,8 @@ presubmits:
     branches:
     - release-1.7
     - release-1.8
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -1267,9 +1111,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -1279,9 +1120,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1294,6 +1132,8 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-bazel-test-canary,?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
@@ -1319,9 +1159,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -1331,9 +1168,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1344,6 +1178,8 @@ presubmits:
     rerun_command: "/test pull-kubernetes-cross"
     trigger: "(?m)^/test pull-kubernetes-cross,?(\\s+|$)"
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
@@ -1358,15 +1194,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         - name: docker-graph
@@ -1381,9 +1212,6 @@ presubmits:
             cpu: 6
             memory: "15Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1398,6 +1226,8 @@ presubmits:
     rerun_command: "/test pull-kubernetes-cross-prow"
     trigger: "(?m)^/test pull-kubernetes-cross-prow,?(\\s+|$)"
     always_run: false
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:latest
@@ -1413,15 +1243,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         - name: docker-graph
@@ -1434,9 +1259,6 @@ presubmits:
             cpu: 6
             memory: "15Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1451,6 +1273,8 @@ presubmits:
     always_run: false
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1466,8 +1290,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1492,9 +1314,6 @@ presubmits:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1514,6 +1333,8 @@ presubmits:
     - release-1.6 # per-release image
     - release-1.7 # per-release image
     - release-1.8 # per-release image
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1528,8 +1349,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1557,9 +1376,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1575,6 +1391,8 @@ presubmits:
     always_run: true
     branches:
     - release-1.8
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1589,8 +1407,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1618,9 +1434,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1636,6 +1449,8 @@ presubmits:
     always_run: true
     branches:
     - release-1.7
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1650,8 +1465,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1679,9 +1492,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1702,6 +1512,8 @@ presubmits:
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
     rerun_command: "/test pull-kubernetes-e2e-gce-device-plugin-gpu"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -1716,8 +1528,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1745,9 +1555,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1765,6 +1572,8 @@ presubmits:
     context: pull-kubernetes-e2e-gce-device-plugin-gpu
     rerun_command: "/test pull-kubernetes-e2e-gce-device-plugin-gpu"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -1779,8 +1588,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1808,9 +1615,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1832,6 +1636,8 @@ presubmits:
     - release-1.6 # per-release image
     - release-1.7 # per-release image
     - release-1.8 # per-release image
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1846,8 +1652,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1875,9 +1679,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1894,6 +1695,8 @@ presubmits:
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
     branches:
     - release-1.8
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1908,8 +1711,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1937,9 +1738,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -1956,6 +1754,8 @@ presubmits:
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
     branches:
     - release-1.7
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -1970,8 +1770,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -1999,9 +1797,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2022,6 +1817,8 @@ presubmits:
     context: pull-kubernetes-e2e-gke-device-plugin-gpu
     rerun_command: "/test pull-kubernetes-e2e-gke-device-plugin-gpu"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2036,8 +1833,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2065,9 +1860,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2085,6 +1877,8 @@ presubmits:
     context: pull-kubernetes-e2e-gke-device-plugin-gpu
     rerun_command: "/test pull-kubernetes-e2e-gke-device-plugin-gpu"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -2099,8 +1893,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2128,9 +1920,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2150,6 +1939,8 @@ presubmits:
     context: pull-kubernetes-e2e-kops-aws
     rerun_command: "/test pull-kubernetes-e2e-kops-aws"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2164,8 +1955,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -2198,9 +1987,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -2221,6 +2007,8 @@ presubmits:
     context: pull-kubernetes-e2e-kops-aws
     rerun_command: "/test pull-kubernetes-e2e-kops-aws"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -2235,8 +2023,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -2269,9 +2055,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -2292,6 +2075,8 @@ presubmits:
     context: pull-kubernetes-e2e-kops-aws
     rerun_command: "/test pull-kubernetes-e2e-kops-aws"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
@@ -2306,8 +2091,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -2340,9 +2123,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -2365,6 +2145,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2384,8 +2166,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2413,9 +2193,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2435,6 +2212,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -2454,8 +2233,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2483,9 +2260,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2505,6 +2279,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
@@ -2524,8 +2300,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2553,9 +2327,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2578,6 +2349,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce-big
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2597,8 +2370,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2626,9 +2397,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2648,6 +2416,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce-big
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -2667,8 +2437,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2696,9 +2464,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2718,6 +2483,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce-big
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
@@ -2737,8 +2504,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2766,9 +2531,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2789,6 +2551,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce-scale
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-scale"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-scale,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2808,8 +2572,6 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2837,9 +2599,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2862,6 +2621,8 @@ presubmits:
     context: pull-kubernetes-node-e2e
     rerun_command: "/test pull-kubernetes-node-e2e"
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -2877,8 +2638,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2901,9 +2660,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2920,6 +2676,8 @@ presubmits:
     context: pull-kubernetes-node-e2e
     rerun_command: "/test pull-kubernetes-node-e2e"
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -2935,8 +2693,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -2959,9 +2715,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -2978,6 +2731,8 @@ presubmits:
     context: pull-kubernetes-node-e2e
     rerun_command: "/test pull-kubernetes-node-e2e"
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
@@ -2993,8 +2748,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -3017,9 +2770,6 @@ presubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -3037,6 +2787,8 @@ presubmits:
     context: pull-kubernetes-node-e2e-containerd
     rerun_command: "/test pull-kubernetes-node-e2e-containerd"
     trigger: "(?m)^/test pull-kubernetes-node-e2e-containerd,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -3051,8 +2803,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -3072,9 +2822,6 @@ presubmits:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -3088,6 +2835,8 @@ presubmits:
     context: pull-kubernetes-unit
     rerun_command: "/test pull-kubernetes-unit"
     trigger: "(?m)^/test( all| pull-kubernetes-unit),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
@@ -3101,15 +2850,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
@@ -3119,9 +2863,6 @@ presubmits:
           requests:
             cpu: 4
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -3131,6 +2872,8 @@ presubmits:
     context: pull-kubernetes-unit-prow
     rerun_command: "/test pull-kubernetes-unit-prow"
     trigger: "(?m)^/test pull-kubernetes-unit-prow,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:latest
@@ -3146,15 +2889,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         - name: docker-graph
@@ -3166,9 +2904,6 @@ presubmits:
           requests:
             cpu: 4
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -3181,6 +2916,8 @@ presubmits:
     context: pull-kubernetes-verify
     rerun_command: "/test pull-kubernetes-verify"
     trigger: "(?m)^/test( all| pull-kubernetes-verify),?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
@@ -3194,15 +2931,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
@@ -3212,9 +2944,6 @@ presubmits:
           requests:
             cpu: 4
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -3224,6 +2953,8 @@ presubmits:
     context: pull-kubernetes-verify-prow
     rerun_command: "/test pull-kubernetes-verify-prow"
     trigger: "(?m)^/test pull-kubernetes-verify-prow,?(\\s+|$)"
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:latest
@@ -3238,15 +2969,10 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
@@ -3256,9 +2982,6 @@ presubmits:
           requests:
             cpu: 4
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -3285,6 +3008,8 @@ presubmits:
       - release-1.7
       - release-1.8
       skip_report: true
+      label:
+        preset: service-account
       spec:
         containers:
         - args:
@@ -3296,8 +3021,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -3317,9 +3040,6 @@ presubmits:
           - mountPath: /etc/ssh-security
             name: ssh-security
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             defaultMode: 256
@@ -3335,6 +3055,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3361,9 +3083,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3392,6 +3111,8 @@ presubmits:
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
       run_if_changed: ^(cmd/kubeadm|build/debs).*$
       skip_report: true
+      label:
+        preset: service-account
       spec:
         containers:
         - args:
@@ -3403,8 +3124,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -3424,9 +3143,6 @@ presubmits:
           - mountPath: /etc/ssh-security
             name: ssh-security
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             defaultMode: 256
@@ -3438,6 +3154,8 @@ presubmits:
       trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\s+|$)
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3464,9 +3182,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3491,6 +3206,8 @@ presubmits:
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce-canary
       run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
       skip_report: false
+      label:
+        preset: service-account
       spec:
         containers:
         - args:
@@ -3502,8 +3219,6 @@ presubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -3523,9 +3238,6 @@ presubmits:
           - mountPath: /etc/ssh-security
             name: ssh-security
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             defaultMode: 256
@@ -3537,6 +3249,8 @@ presubmits:
       trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\s+|$)
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3567,9 +3281,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: bazel-scratch
       - name: ssh-security
         secret:
@@ -3589,6 +3300,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3618,9 +3331,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3638,6 +3348,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-bazel-test
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3666,9 +3378,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3685,6 +3394,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-bazel-test-canary
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3716,9 +3427,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3733,6 +3441,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-cross
     run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3746,8 +3456,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
         name: ""
         resources:
@@ -3767,9 +3475,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - emptyDir: {}
         name: var-lib-docker
       - name: ssh-security
@@ -3788,6 +3493,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-cross-prow
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3801,8 +3508,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         name: ""
@@ -3821,9 +3526,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -3842,6 +3544,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-containerd-gce
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3854,8 +3558,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -3877,9 +3579,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -3902,6 +3601,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3913,8 +3614,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -3938,9 +3637,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -3961,6 +3657,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -3972,8 +3670,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -3997,9 +3693,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4020,6 +3713,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4031,8 +3726,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4056,9 +3749,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4081,6 +3771,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4094,8 +3786,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4119,9 +3809,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4142,6 +3829,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4155,8 +3844,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4180,9 +3867,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4205,6 +3889,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4216,8 +3902,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4241,9 +3925,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4264,6 +3945,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke
     run_if_changed: ^(cluster/gce|cluster/addons).*$
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4275,8 +3958,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4300,9 +3981,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4323,6 +4001,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke
     run_if_changed: ^(cluster/gce|cluster/addons).*$
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4334,8 +4014,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4359,9 +4037,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4384,6 +4059,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4397,8 +4074,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4422,9 +4097,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4445,6 +4117,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke-device-plugin-gpu
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4458,8 +4132,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4483,9 +4155,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4508,6 +4177,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4521,8 +4192,6 @@ presubmits:
         - --timeout=75
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -4551,9 +4220,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -4578,6 +4244,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-kops-aws
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4591,8 +4259,6 @@ presubmits:
         - --timeout=75
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -4621,9 +4287,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -4648,6 +4311,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-kops-aws
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4661,8 +4326,6 @@ presubmits:
         - --timeout=75
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -4691,9 +4354,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: aws-ssh
         secret:
           defaultMode: 256
@@ -4720,6 +4380,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4735,8 +4397,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4762,9 +4422,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4787,6 +4444,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4802,8 +4461,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4829,9 +4486,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4854,6 +4508,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4869,8 +4525,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4896,9 +4550,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4923,6 +4574,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -4938,8 +4591,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -4965,9 +4616,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -4990,6 +4638,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5005,8 +4655,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5032,9 +4680,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5057,6 +4702,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5072,8 +4719,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5099,9 +4744,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5124,6 +4766,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-scale
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5139,8 +4783,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5166,9 +4808,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5193,6 +4832,8 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5207,8 +4848,6 @@ presubmits:
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5230,9 +4869,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5253,6 +4889,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5267,8 +4905,6 @@ presubmits:
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5290,9 +4926,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5313,6 +4946,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5327,8 +4962,6 @@ presubmits:
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5350,9 +4983,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5373,6 +5003,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e-containerd
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5386,8 +5018,6 @@ presubmits:
         - --timeout=90
         - --ssh=/etc/ssh-security/ssh-security
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: USER
           value: prow
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -5407,9 +5037,6 @@ presubmits:
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           defaultMode: 256
@@ -5428,6 +5055,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-unit
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5441,8 +5070,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
         name: ""
         resources:
@@ -5459,9 +5086,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -5478,6 +5102,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-unit-prow
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5491,8 +5117,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         name: ""
@@ -5510,9 +5134,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -5529,6 +5150,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-verify
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5542,8 +5165,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
         name: ""
         resources:
@@ -5560,9 +5181,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -5579,6 +5197,8 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-verify-prow
     run_if_changed: ""
     skip_report: false
+    label:
+      preset: service-account
     spec:
       containers:
       - args:
@@ -5592,8 +5212,6 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         name: ""
@@ -5611,9 +5229,6 @@ presubmits:
         - mountPath: /docker-graph
           name: auto-generated-docker-graph-volume-mount
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh-security
         secret:
           defaultMode: 256
@@ -5799,6 +5414,8 @@ presubmits:
     rerun_command: "/test pull-test-infra-verify-deps"
     trigger: "/test pull-test-infra-verify-deps"
     run_if_changed: '^(Gopkg\.|^vendor/).*$'
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -5815,18 +5432,12 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: bazel-scratch
           mountPath: /scratch/.cache
         resources:
           requests:
             memory: "2Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: bazel-scratch
         emptyDir: {}
 
@@ -5877,22 +5488,13 @@ presubmits:
     trigger: "(?m)^/test( all| tf-k8s-presubmit),?(\\s+|$)"
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
       - image: gcr.io/mlkube-testing/builder:latest
         imagePullPolicy: Always
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
 postsubmits:
   kubeflow/kubeflow:
@@ -5900,26 +5502,20 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/mlkube-testing/kubeflow-testing:latest
         imagePullPolicy: Always
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
+
   kubernetes/ingress-gce:
   - name: ci-ingress-gce-image-push
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -5931,24 +5527,16 @@ postsubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
         ports:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
@@ -5957,6 +5545,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -5977,9 +5567,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -5989,15 +5576,14 @@ postsubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: ci-kubernetes-bazel-test
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -6020,9 +5606,6 @@ postsubmits:
           securityContext:
             privileged: true
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: cache-ssd
             mountPath: /root/.cache
           ports:
@@ -6032,9 +5615,6 @@ postsubmits:
             requests:
               memory: "6Gi"
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
@@ -6043,6 +5623,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - release-1.7
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -6062,9 +5644,6 @@ postsubmits:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -6074,15 +5653,14 @@ postsubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: ci-kubernetes-bazel-test-1-7
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -6101,9 +5679,6 @@ postsubmits:
           - name: TEST_TMPDIR
             value: /root/.cache/bazel
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: cache-ssd
             mountPath: /root/.cache
           ports:
@@ -6113,14 +5688,13 @@ postsubmits:
             requests:
               memory: "6Gi"
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
     - name: ci-kubernetes-e2e-kubeadm-gce-1-7
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -6133,16 +5707,11 @@ postsubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -6152,9 +5721,6 @@ postsubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -6167,6 +5733,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - release-1.8
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -6186,9 +5754,6 @@ postsubmits:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -6198,15 +5763,14 @@ postsubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: ci-kubernetes-bazel-test-1-8
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -6225,9 +5789,6 @@ postsubmits:
           - name: TEST_TMPDIR
             value: /root/.cache/bazel
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: cache-ssd
             mountPath: /root/.cache
           ports:
@@ -6237,14 +5798,13 @@ postsubmits:
             requests:
               memory: "6Gi"
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
     - name: ci-kubernetes-e2e-kubeadm-gce-1-8
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -6257,16 +5817,11 @@ postsubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -6276,9 +5831,6 @@ postsubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -6288,6 +5840,8 @@ postsubmits:
             path: /mnt/disks/ssd0
     - name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -6300,16 +5854,11 @@ postsubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -6319,9 +5868,6 @@ postsubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -6334,6 +5880,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - release-1.9
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -6354,9 +5902,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -6366,15 +5911,14 @@ postsubmits:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: ci-kubernetes-bazel-test-1-9
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -6397,9 +5941,6 @@ postsubmits:
           securityContext:
             privileged: true
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: cache-ssd
             mountPath: /root/.cache
           ports:
@@ -6409,14 +5950,13 @@ postsubmits:
             requests:
               memory: "6Gi"
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
     - name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
       agent: kubernetes
+      label:
+        preset: service-account
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -6429,16 +5969,11 @@ postsubmits:
           env:
           - name: USER
             value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
             value: /etc/ssh-key-secret/ssh-private
           - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
             value: /etc/ssh-key-secret/ssh-public
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: ssh
             mountPath: /etc/ssh-key-secret
             readOnly: true
@@ -6448,9 +5983,6 @@ postsubmits:
           - containerPort: 9999
             hostPort: 9999
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: ssh
           secret:
             secretName: ssh-key-secret
@@ -6465,6 +5997,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -6488,9 +6022,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -6500,9 +6031,6 @@ postsubmits:
           requests:
             memory: "2Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -6511,6 +6039,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -6522,21 +6052,13 @@ postsubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: PROW_SERVICE_ACCOUNT
           value: /etc/prow-build-service/prow-build-service.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: prow-build-service
           mountPath: /etc/prow-build-service
           readOnly: true
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: prow-build-service
         secret:
           secretName: prow-build-service
@@ -6545,6 +6067,8 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -6556,48 +6080,31 @@ postsubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         resources:
           requests:
             memory: "1Gi"
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
   tensorflow/k8s:
   - name: tf-k8s-postsubmit
     agent: kubernetes
     branches:
     - master
+    label:
+      preset: service-account
     spec:
       containers:
       # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
       - image: gcr.io/mlkube-testing/builder:latest
         imagePullPolicy: Always
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
 periodics:
 - name: ci-benchmark-scheduler-master
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -6606,21 +6113,14 @@ periodics:
       - --timeout=40
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: GOPATH
         value: /go
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - name: ci-cri-containerd-build
   interval: 30m
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -6628,29 +6128,18 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   interval: 3h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=300"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -6666,9 +6155,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6683,8 +6169,6 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=170"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6700,9 +6184,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6711,14 +6192,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gce-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6734,9 +6215,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6745,14 +6223,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6768,9 +6246,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6779,14 +6254,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-alpha-features
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=200"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6802,9 +6277,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6819,8 +6291,6 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=110"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6836,9 +6306,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6847,14 +6314,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-etcd3
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6870,9 +6337,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6881,14 +6345,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=200"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6904,9 +6368,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6915,14 +6376,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=110"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6938,9 +6399,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6949,14 +6407,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-ip-alias
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -6972,9 +6430,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -6983,14 +6438,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-proto
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7006,9 +6461,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7023,8 +6475,6 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=200"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7040,9 +6490,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7057,8 +6504,6 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=1340"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7074,9 +6519,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7085,14 +6527,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=520"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7108,9 +6550,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7119,14 +6558,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-gci-gce-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=170"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7142,9 +6581,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7159,8 +6595,6 @@ periodics:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=110"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7176,9 +6610,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7187,14 +6618,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-cri-containerd-e2e-ubuntu-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - "--repo=github.com/containerd/cri-containerd=master"
       - "--timeout=70"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7210,9 +6641,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7221,6 +6649,8 @@ periodics:
 - name: ci-cri-containerd-node-e2e
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7232,8 +6662,6 @@ periodics:
       - --
       - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -7243,16 +6671,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -7261,6 +6683,8 @@ periodics:
 - name: ci-cri-containerd-node-e2e-benchmark
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7272,8 +6696,6 @@ periodics:
       - --
       - "--node-args=--image-config-file=test/e2e_node/benchmark-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -7283,16 +6705,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -7302,6 +6718,8 @@ periodics:
 - name: ci-cri-containerd-node-e2e-flaky
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7313,8 +6731,6 @@ periodics:
       - --
       - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -7324,16 +6740,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -7342,6 +6752,8 @@ periodics:
 - name: ci-cri-containerd-node-e2e-serial
   interval: 4h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7353,8 +6765,6 @@ periodics:
       - --
       - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -7364,16 +6774,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -7382,6 +6786,8 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-federation-e2e-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -7390,8 +6796,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7412,9 +6816,6 @@ periodics:
       - name: var-lib-docker
         mountPath: /var/lib/docker
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7424,6 +6825,8 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-federation-e2e-gce-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -7432,8 +6835,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7454,9 +6855,6 @@ periodics:
       - name: var-lib-docker
         mountPath: /var/lib/docker
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7467,6 +6865,8 @@ periodics:
 - name: ci-ingress-gce-downgrade-e2e
   agent: kubernetes
   interval: 24h
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7476,23 +6876,15 @@ periodics:
       env:
       - name: USER
         value: prow
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - mountPath: /etc/ssh-key-secret
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7500,6 +6892,8 @@ periodics:
 - name: ci-ingress-gce-e2e
   agent: kubernetes
   interval: 60m
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7509,23 +6903,15 @@ periodics:
       env:
       - name: USER
         value: prow
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - mountPath: /etc/ssh-key-secret
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7533,6 +6919,8 @@ periodics:
 - name: ci-ingress-gce-upgrade-e2e
   agent: kubernetes
   interval: 60m
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -7542,23 +6930,15 @@ periodics:
       env:
       - name: USER
         value: prow
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - mountPath: /etc/ssh-key-secret
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7566,6 +6946,8 @@ periodics:
 - name: ci-kubernetes-bazel-build
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -7586,9 +6968,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -7598,15 +6977,14 @@ periodics:
         requests:
           memory: "6Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
   run_after_success:
   - name: ci-kubernetes-e2e-kubeadm-gce
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7619,16 +6997,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7638,9 +7011,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7650,6 +7020,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-ipvs
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7661,29 +7033,23 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
           defaultMode: 0400
   - name: periodic-kubernetes-e2e-kubeadm-gce-selfhosting
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7696,16 +7062,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7715,9 +7076,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7727,6 +7085,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7739,16 +7099,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7758,9 +7113,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7770,6 +7122,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7782,16 +7136,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7801,9 +7150,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7813,6 +7159,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7825,16 +7173,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7844,9 +7187,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7856,6 +7196,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7868,16 +7210,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7887,9 +7224,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7899,6 +7233,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -7911,16 +7247,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -7930,9 +7261,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -7943,6 +7271,8 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-charts-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -7950,8 +7280,6 @@ periodics:
       - --repo=k8s.io/charts
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -7967,9 +7295,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -7978,14 +7303,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-cos-docker-validation
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8001,9 +7326,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8012,14 +7334,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-cos-docker-validation-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8035,9 +7357,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8046,14 +7365,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-cos-docker-validation-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8069,9 +7388,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8080,14 +7396,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-alpha-api
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=80
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8103,9 +7419,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8114,14 +7427,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-alpha-features-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8137,9 +7450,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8148,14 +7458,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8171,9 +7481,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8182,14 +7489,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8205,9 +7512,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8216,14 +7520,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8239,9 +7543,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8250,14 +7551,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8273,9 +7574,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8284,14 +7582,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-canary
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=60
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8308,9 +7606,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8321,14 +7616,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8344,9 +7639,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8363,8 +7655,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8380,9 +7670,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8393,14 +7680,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8416,9 +7703,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8435,8 +7719,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8452,9 +7734,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8465,14 +7744,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8488,9 +7767,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8501,14 +7777,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8524,9 +7800,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8537,14 +7810,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable1-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8560,9 +7833,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8579,8 +7849,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8596,9 +7864,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8609,14 +7874,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8632,9 +7897,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8651,8 +7913,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8668,9 +7928,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8681,14 +7938,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8704,9 +7961,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8717,14 +7971,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8740,9 +7994,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8753,14 +8004,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8776,9 +8027,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8795,8 +8043,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8812,9 +8058,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8825,14 +8068,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable2-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8848,9 +8091,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8867,8 +8107,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8884,9 +8122,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8897,14 +8132,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8920,9 +8155,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8933,14 +8165,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8956,9 +8188,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -8969,14 +8198,14 @@ periodics:
   interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable3-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -8992,9 +8221,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9011,8 +8237,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9028,9 +8252,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9041,14 +8262,14 @@ periodics:
   interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9064,9 +8285,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9083,8 +8301,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9100,9 +8316,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9113,14 +8326,14 @@ periodics:
   interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9136,9 +8349,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9149,14 +8359,14 @@ periodics:
   interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cos-k8sstable3-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9172,9 +8382,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9191,8 +8398,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9208,9 +8413,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9221,14 +8423,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9244,9 +8446,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9257,14 +8456,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9280,9 +8479,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9299,8 +8495,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9316,9 +8510,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9335,8 +8526,6 @@ periodics:
       - --bare
       - --timeout=40
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9352,9 +8541,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9365,14 +8551,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9388,9 +8574,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9401,14 +8584,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9424,9 +8607,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9443,8 +8623,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9460,9 +8638,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9473,14 +8648,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9496,9 +8671,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9509,14 +8681,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9532,9 +8704,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9551,8 +8720,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9568,9 +8735,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9581,14 +8745,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9604,9 +8768,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9617,14 +8778,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9640,9 +8801,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9659,8 +8817,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9676,9 +8832,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9689,14 +8842,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9712,9 +8865,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9725,14 +8875,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosbeta-k8sstable3-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9748,9 +8898,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9767,8 +8914,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9784,9 +8929,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9797,14 +8939,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9820,9 +8962,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9833,14 +8972,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9856,9 +8995,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9875,8 +9011,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9892,9 +9026,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9905,14 +9036,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9928,9 +9059,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9941,14 +9069,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -9964,9 +9092,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -9983,8 +9108,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10000,9 +9123,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10013,14 +9133,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10036,9 +9156,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10049,14 +9166,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10072,9 +9189,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10091,8 +9205,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10108,9 +9220,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10121,14 +9230,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10144,9 +9253,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10157,14 +9263,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10180,9 +9286,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10199,8 +9302,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10216,9 +9317,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10229,14 +9327,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10252,9 +9350,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10265,14 +9360,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10288,9 +9383,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10307,8 +9399,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10324,9 +9414,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10337,14 +9424,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10360,9 +9447,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10373,14 +9457,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10396,9 +9480,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10415,8 +9496,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10432,9 +9511,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10445,14 +9521,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10468,9 +9544,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10481,14 +9554,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10504,9 +9577,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10523,8 +9593,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10540,9 +9608,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10553,14 +9618,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10576,9 +9641,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10589,14 +9651,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10612,9 +9674,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10623,14 +9682,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -10646,9 +9705,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10657,14 +9713,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -10680,9 +9736,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10691,14 +9744,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -10714,9 +9767,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10725,14 +9775,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-federation-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10748,9 +9798,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10759,14 +9806,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-federation-release-1-8
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10782,9 +9829,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10793,14 +9837,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-ci-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10816,9 +9860,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10827,14 +9868,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-ci-serial-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10850,9 +9891,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10861,14 +9899,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-ci-slow-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10884,9 +9922,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10895,14 +9930,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10918,9 +9953,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10929,14 +9961,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10952,9 +9984,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10963,14 +9992,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-m62
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -10986,9 +10015,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -10997,14 +10023,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-m63
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11020,9 +10046,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11031,14 +10054,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-m64
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11054,9 +10077,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11065,14 +10085,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-m65
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11088,9 +10108,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11099,14 +10116,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11122,9 +10139,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11133,14 +10147,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-m62
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11156,9 +10170,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11167,14 +10178,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-m63
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11190,9 +10201,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11201,14 +10209,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-m64
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11224,9 +10232,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11235,14 +10240,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-m65
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11258,9 +10263,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11269,14 +10271,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11292,9 +10294,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11303,14 +10302,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-slow-m62
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11326,9 +10325,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11337,14 +10333,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-slow-m63
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11360,9 +10356,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11371,14 +10364,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-slow-m64
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11394,9 +10387,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11405,14 +10395,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-slow-m65
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11428,9 +10418,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11439,14 +10426,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-slow-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11462,9 +10449,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11473,14 +10457,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=520
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11496,9 +10480,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11507,14 +10488,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-gpu
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -11530,9 +10511,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11541,14 +10519,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-gpu-beta
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -11564,9 +10542,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11575,14 +10550,14 @@ periodics:
 - name: ci-kubernetes-e2e-gce-gpu-stable1
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -11598,9 +10573,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11609,14 +10581,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ha-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=240
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11632,9 +10604,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11643,14 +10612,14 @@ periodics:
 - cron: '1 6 * * 2,4,6' # Run at 22:01PST on Mon,Wed,Fri (06:01 UTC Tue,Thur,Sat)
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-large-correctness
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=420
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11670,9 +10639,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11681,14 +10647,14 @@ periodics:
 - cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-large-manual-down
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11705,9 +10671,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11716,14 +10679,14 @@ periodics:
 - cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-large-manual-up
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11740,9 +10703,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11753,14 +10713,14 @@ periodics:
   name: ci-kubernetes-e2e-gce-large-performance
   tags:
   - "perfDashPrefix: gce-2kNodes-master"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=540
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11780,9 +10740,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11791,14 +10748,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11814,9 +10771,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11825,14 +10779,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11848,9 +10802,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11859,14 +10810,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11882,9 +10833,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11893,14 +10841,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11916,9 +10864,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11933,8 +10878,6 @@ periodics:
       - --timeout=520
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11950,9 +10893,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11967,8 +10907,6 @@ periodics:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -11984,9 +10922,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -11995,14 +10930,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12018,9 +10953,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12029,14 +10961,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12052,9 +10984,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12063,14 +10992,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12086,9 +11015,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12097,14 +11023,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12120,9 +11046,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12131,14 +11054,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12154,9 +11077,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12165,14 +11085,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12188,9 +11108,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12199,14 +11116,14 @@ periodics:
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-reboot-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12222,9 +11139,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12233,14 +11147,14 @@ periodics:
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12256,9 +11170,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12267,14 +11178,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-scalability-canary
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12291,9 +11202,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12302,14 +11210,14 @@ periodics:
 - cron: '1 22 * * 2,4,6' # Run at 14:01PST (22:01 UTC) on even days
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-scale-correctness
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=600
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12329,9 +11237,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12342,14 +11247,14 @@ periodics:
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5kNodes-master"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12369,9 +11274,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12380,14 +11282,14 @@ periodics:
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-serial-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=520
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12403,9 +11305,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12414,14 +11313,14 @@ periodics:
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-slow-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12437,9 +11336,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12448,14 +11344,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12471,9 +11367,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12482,14 +11375,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12505,9 +11398,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12516,14 +11406,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12539,9 +11429,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12550,14 +11437,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12573,9 +11460,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12584,14 +11468,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12607,9 +11491,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12618,14 +11499,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12641,9 +11522,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12652,14 +11530,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12675,9 +11553,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12686,14 +11561,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12709,9 +11584,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12720,14 +11592,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12743,9 +11615,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12754,14 +11623,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12777,9 +11646,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12788,14 +11654,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12811,9 +11677,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12822,14 +11685,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12845,9 +11708,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12856,14 +11716,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12879,9 +11739,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12890,14 +11747,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12913,9 +11770,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12924,14 +11778,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12947,9 +11801,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -12964,8 +11815,6 @@ periodics:
       - --timeout=80
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -12981,9 +11830,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13000,8 +11846,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13017,9 +11861,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13030,14 +11871,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13053,9 +11894,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13066,14 +11904,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13089,9 +11927,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13108,8 +11943,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13125,9 +11958,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13138,14 +11968,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13161,9 +11991,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13174,14 +12001,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13197,9 +12024,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13216,8 +12040,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13233,9 +12055,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13246,14 +12065,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13269,9 +12088,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13282,14 +12098,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13305,9 +12121,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13324,8 +12137,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13341,9 +12152,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13354,14 +12162,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13377,9 +12185,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13390,14 +12195,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13413,9 +12218,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13432,8 +12234,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13449,9 +12249,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13462,14 +12259,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev2-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13485,9 +12282,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13498,14 +12292,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev2-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13521,9 +12315,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13540,8 +12331,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13557,9 +12346,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13570,14 +12356,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev2-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13593,9 +12379,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13606,14 +12389,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntudev2-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13629,9 +12412,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13648,8 +12428,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13665,9 +12443,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13678,14 +12453,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13701,9 +12476,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13714,14 +12486,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13737,9 +12509,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13756,8 +12525,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13773,9 +12540,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13786,14 +12550,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13809,9 +12573,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13822,14 +12583,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13845,9 +12606,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13864,8 +12622,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13881,9 +12637,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13894,14 +12647,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13917,9 +12670,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13930,14 +12680,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13953,9 +12703,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13964,14 +12711,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -13987,9 +12734,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -13998,14 +12742,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-alpha-features
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14021,9 +12765,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14038,8 +12779,6 @@ periodics:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14055,9 +12794,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14066,14 +12802,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14089,9 +12825,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14106,8 +12839,6 @@ periodics:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14123,9 +12854,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14134,14 +12862,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-etcd3
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14157,9 +12885,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14168,14 +12893,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14191,9 +12916,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14202,14 +12924,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14225,9 +12947,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14236,14 +12955,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-garbage
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14259,9 +12978,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14270,14 +12986,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14293,9 +13009,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14304,14 +13017,14 @@ periodics:
 - interval: 60m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14327,9 +13040,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14338,14 +13048,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-ip-alias
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14361,9 +13071,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14372,14 +13079,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14395,9 +13102,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14406,14 +13110,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14429,9 +13133,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14440,14 +13141,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-proto
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14463,9 +13164,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14480,8 +13178,6 @@ periodics:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14497,9 +13193,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14510,14 +13203,14 @@ periodics:
   name: ci-kubernetes-e2e-gci-gce-scalability
   tags:
   - "perfDashPrefix: gce-100Nodes-master"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14533,9 +13226,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14546,14 +13236,14 @@ periodics:
   name: ci-kubernetes-e2e-gci-gce-scalability-beta
   tags:
   - "perfDashPrefix: gce-100Nodes-1.9"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14570,9 +13260,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14583,14 +13270,14 @@ periodics:
   name: ci-kubernetes-e2e-gci-gce-scalability-release-1-7
   tags:
   - "perfDashPrefix: gce-100Nodes-1.7"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14606,9 +13293,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14619,14 +13303,14 @@ periodics:
   name: ci-kubernetes-e2e-gci-gce-scalability-stable1
   tags:
   - "perfDashPrefix: gce-100Nodes-1.8"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14642,9 +13326,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14659,8 +13340,6 @@ periodics:
       - --timeout=1340
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14676,9 +13355,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14687,14 +13363,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=520
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14710,9 +13386,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14721,14 +13394,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14744,9 +13417,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14755,14 +13425,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14778,9 +13448,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14795,8 +13462,6 @@ periodics:
       - --timeout=110
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14812,9 +13477,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14823,14 +13485,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14846,9 +13508,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14857,14 +13516,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-alpha-features
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14880,9 +13539,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14925,14 +13581,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14948,9 +13604,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14959,14 +13612,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -14982,9 +13635,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -14999,8 +13649,6 @@ periodics:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15016,9 +13664,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15027,14 +13672,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-prod
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15050,9 +13695,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15061,14 +13703,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-prod-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15084,9 +13726,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15095,14 +13734,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-prod-smoke
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15118,9 +13757,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15135,8 +13771,6 @@ periodics:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15152,9 +13786,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15163,14 +13794,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=520
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15186,9 +13817,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15197,14 +13825,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15220,9 +13848,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15231,14 +13856,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=170
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15254,9 +13879,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15265,14 +13887,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=50
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15288,9 +13910,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15299,14 +13918,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-alpha-features-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15322,9 +13941,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15333,14 +13949,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15356,9 +13972,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15367,14 +13980,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15390,9 +14003,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15401,14 +14011,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15424,9 +14034,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15435,14 +14042,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15458,9 +14065,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15469,14 +14073,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-canary
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15493,9 +14097,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15512,8 +14113,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15529,9 +14128,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15542,14 +14138,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sbeta-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15565,9 +14161,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15584,8 +14177,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15601,9 +14192,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15614,14 +14202,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15637,9 +14225,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15650,14 +14235,14 @@ periodics:
   interval: 48h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15673,9 +14258,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15692,8 +14274,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15709,9 +14289,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15722,14 +14299,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable1-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15745,9 +14322,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15764,8 +14338,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15781,9 +14353,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15794,14 +14363,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15817,9 +14386,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15830,14 +14396,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15853,9 +14419,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15872,8 +14435,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15889,9 +14450,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15902,14 +14460,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable2-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15925,9 +14483,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15944,8 +14499,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15961,9 +14514,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -15974,14 +14524,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -15997,9 +14547,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16010,14 +14557,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16033,9 +14580,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16052,8 +14596,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16069,9 +14611,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16082,14 +14621,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable3-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16105,9 +14644,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16124,8 +14660,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16141,9 +14675,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16154,14 +14685,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16177,9 +14708,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16190,14 +14718,14 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-k8sstable3-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16213,9 +14741,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16224,14 +14749,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-oldetcd-default # TODO(krzyzacy) this job is temporary, remove once we verify it works
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16247,9 +14772,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16258,14 +14780,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-oldetcd-serial # TODO(krzyzacy) this job is temporary, remove once we verify it works
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16281,9 +14803,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16292,14 +14811,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cos-oldetcd-slow # TODO(krzyzacy) this job is temporary, remove once we verify it works
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16315,9 +14834,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16328,14 +14844,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sbeta-soak
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=620
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16351,9 +14867,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16364,14 +14877,14 @@ periodics:
   interval: 3h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sbeta-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16387,9 +14900,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16400,14 +14910,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sdev-soak
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=620
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16423,9 +14933,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16436,14 +14943,14 @@ periodics:
   interval: 3h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sdev-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16459,9 +14966,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16472,14 +14976,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable1-soak
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=620
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16495,9 +14999,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16508,14 +15009,14 @@ periodics:
   interval: 3h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable1-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16531,9 +15032,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16544,14 +15042,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable2-soak
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=620
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16567,9 +15065,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16580,14 +15075,14 @@ periodics:
   interval: 3h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable2-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16603,9 +15098,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16616,14 +15108,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable3-soak
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=620
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16639,9 +15131,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16652,14 +15141,14 @@ periodics:
   interval: 3h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cosbeta-k8sstable3-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16675,9 +15164,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16686,14 +15172,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16709,9 +15195,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16720,14 +15203,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16743,9 +15226,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16754,14 +15234,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -16777,9 +15257,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16788,14 +15265,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16811,9 +15288,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16822,14 +15296,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16845,9 +15319,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16856,14 +15327,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
   interval: 3h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16879,9 +15350,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16890,14 +15358,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100
   interval: 12h #expensive test
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16913,9 +15381,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16924,14 +15389,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   interval: 12h #expensive test
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16947,9 +15412,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16958,14 +15420,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -16981,9 +15443,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -16992,14 +15451,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-ci-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17015,9 +15474,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17027,14 +15483,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17050,9 +15506,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17061,14 +15514,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17084,9 +15537,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17095,14 +15545,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17118,9 +15568,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17129,14 +15576,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17152,9 +15599,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17163,14 +15607,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17186,9 +15630,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17197,14 +15638,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17220,9 +15661,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17231,14 +15669,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=320
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17254,9 +15692,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17265,14 +15700,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17288,9 +15723,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17299,14 +15731,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17322,9 +15754,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17333,14 +15762,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17356,9 +15785,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17367,14 +15793,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17390,9 +15816,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17401,14 +15824,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17424,9 +15847,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17435,14 +15855,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17458,9 +15878,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17469,14 +15886,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17492,9 +15909,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17503,14 +15917,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17526,9 +15940,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17537,14 +15948,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17560,9 +15971,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17571,14 +15979,14 @@ periodics:
 - name: ci-kubernetes-e2e-gke-gpu-1-7
   interval: 12h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=300
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -17594,9 +16002,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17605,14 +16010,14 @@ periodics:
 - cron: '1 23 * * 0' # Run at 15:01PST (23:01UTC) on sunday
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-correctness
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=480
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17632,9 +16037,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17643,14 +16045,14 @@ periodics:
 - cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-deploy
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1220
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17667,9 +16069,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17680,14 +16079,14 @@ periodics:
   name: ci-kubernetes-e2e-gke-large-performance
   tags:
   - "perfDashPrefix: gke-2kNodes-master"
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=600
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17707,9 +16106,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17718,14 +16114,14 @@ periodics:
 - cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-teardown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=200
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17742,9 +16138,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17753,14 +16146,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17776,9 +16169,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17787,14 +16177,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17810,9 +16200,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17821,14 +16208,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17844,9 +16231,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17855,14 +16239,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17878,9 +16262,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17889,14 +16270,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-prod
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17912,9 +16293,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17923,14 +16301,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-prod-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17946,9 +16324,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -17957,14 +16332,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-prod-smoke
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -17980,9 +16355,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18025,14 +16397,14 @@ periodics:
 - cron: "0 0 31 2 *" # manual (set to Feb 31 so it won't trigger) (TODO: automate this when possible)
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-scale-correctness
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1020
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18052,9 +16424,6 @@ periodics:
           cpu: 6
           memory: "16Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18063,14 +16432,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18086,9 +16455,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18103,8 +16469,6 @@ periodics:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18120,9 +16484,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18131,14 +16492,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18154,9 +16515,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18165,14 +16523,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18188,9 +16546,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18205,8 +16560,6 @@ periodics:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18222,9 +16575,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18233,14 +16583,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=1400
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18256,9 +16606,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18267,14 +16614,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18290,9 +16637,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18301,14 +16645,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18324,9 +16668,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18335,14 +16676,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18358,9 +16699,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18369,14 +16707,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18392,9 +16730,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18403,14 +16738,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18426,9 +16761,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18437,14 +16769,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18460,9 +16792,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18471,14 +16800,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18494,9 +16823,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18505,14 +16831,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18528,9 +16854,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18539,14 +16862,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18562,9 +16885,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18573,14 +16893,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stackdriver
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=70
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18596,9 +16916,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18607,14 +16924,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18630,9 +16947,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18641,14 +16955,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18664,9 +16978,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18675,14 +16986,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18698,9 +17009,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18709,14 +17017,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18732,9 +17040,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18743,14 +17048,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18766,9 +17071,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18777,14 +17079,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18800,9 +17102,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18811,14 +17110,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-default-latest-upgrade-cluster
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18834,9 +17133,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18845,14 +17141,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-default-latest-upgrade-cluster-new
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18868,9 +17164,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18879,14 +17172,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-default-latest-upgrade-master
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=920
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18902,9 +17195,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18913,14 +17203,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-default-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18936,9 +17226,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18947,14 +17234,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-default-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -18970,9 +17257,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -18981,14 +17265,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19004,9 +17288,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19015,14 +17296,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-latest-parallel
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=100
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19038,9 +17319,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19049,14 +17327,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-latest-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19072,9 +17350,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19085,14 +17360,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19108,9 +17383,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19127,8 +17399,6 @@ periodics:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19144,9 +17414,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19163,8 +17430,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19180,9 +17445,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19193,14 +17455,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19216,9 +17478,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19229,14 +17488,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19252,9 +17511,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19271,8 +17527,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19288,9 +17542,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19301,14 +17552,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19324,9 +17575,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19337,14 +17585,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19360,9 +17608,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19373,14 +17618,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=50
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19396,9 +17641,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19409,14 +17651,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19432,9 +17674,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19451,8 +17690,6 @@ periodics:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19468,9 +17705,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19487,8 +17721,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19504,9 +17736,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19518,14 +17747,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19541,9 +17770,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19554,14 +17780,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19577,9 +17803,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19596,8 +17819,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19613,9 +17834,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19626,14 +17844,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19649,9 +17867,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19662,14 +17877,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19685,9 +17900,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19698,14 +17910,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=50
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19721,9 +17933,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19734,14 +17943,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19757,9 +17966,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19776,8 +17982,6 @@ periodics:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19793,9 +17997,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19812,8 +18013,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19829,9 +18028,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19842,14 +18038,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19865,9 +18061,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19878,14 +18071,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19901,9 +18094,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19920,8 +18110,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19937,9 +18125,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19950,14 +18135,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -19973,9 +18158,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -19986,14 +18168,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20009,9 +18191,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20022,14 +18201,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=50
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20045,9 +18224,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20058,14 +18234,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-alphafeatures
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20081,9 +18257,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20100,8 +18273,6 @@ periodics:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20117,9 +18288,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20136,8 +18304,6 @@ periodics:
       - --bare
       - --timeout=70
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20153,9 +18319,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20166,14 +18329,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-flaky
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=320
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20189,9 +18352,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20202,14 +18362,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-ingress
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=110
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20225,9 +18385,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20244,8 +18401,6 @@ periodics:
       - --bare
       - --timeout=200
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20261,9 +18416,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20274,14 +18426,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=520
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20297,9 +18449,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20310,14 +18459,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-slow
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=170
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20333,9 +18482,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20346,14 +18492,14 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-ubuntustable2-k8sbeta-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --bare
       - --timeout=50
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20369,9 +18515,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20380,14 +18523,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=50
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20403,9 +18546,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20414,14 +18554,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20442,9 +18582,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20457,14 +18594,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-beta
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20485,9 +18622,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20500,14 +18634,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-canary
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20529,9 +18663,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20544,14 +18675,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-channelalpha
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20573,9 +18704,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20588,14 +18716,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-ena-nvme
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20617,9 +18745,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20632,14 +18757,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20661,9 +18786,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20676,14 +18798,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-newrunner
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20705,9 +18827,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20721,14 +18840,14 @@ periodics:
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-release-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20749,9 +18868,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20764,14 +18880,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-sig-cli
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20792,9 +18908,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20807,14 +18920,14 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-stable1
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20835,9 +18948,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20850,14 +18960,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-updown
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=50
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20878,9 +18988,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20893,14 +19000,14 @@ periodics:
 - interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-weave
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_AWS_CREDENTIALS_FILE
@@ -20921,9 +19028,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-ssh
       secret:
         defaultMode: 256
@@ -20936,14 +19040,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-gce
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20959,9 +19063,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -20970,14 +19071,14 @@ periodics:
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-gce-channelalpha
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20993,9 +19094,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21004,14 +19102,14 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-gce-ha
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=140
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21027,9 +19125,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21038,6 +19133,8 @@ periodics:
 - name: ci-kubernetes-e2e-node-canary
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -21047,8 +19144,6 @@ periodics:
       - --timeout=110
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -21058,16 +19153,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -21076,6 +19165,8 @@ periodics:
 - name: ci-kubernetes-e2e-prow-canary
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -21084,8 +19175,6 @@ periodics:
       - --bare
       - --timeout=85
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -21093,16 +19182,10 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -21120,8 +19203,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21139,9 +19220,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21152,6 +19230,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosbeta-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21159,8 +19239,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21178,9 +19256,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21198,8 +19273,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21217,9 +19290,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21230,6 +19300,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosbeta-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21237,8 +19309,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21256,9 +19326,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21276,8 +19343,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21295,9 +19360,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21308,6 +19370,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosbeta-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21315,8 +19379,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21334,9 +19396,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21354,8 +19413,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21373,9 +19430,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21386,6 +19440,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosbeta-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21393,8 +19449,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21412,9 +19466,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21432,8 +19483,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.7
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21451,9 +19500,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21464,6 +19510,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosbeta-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21471,8 +19519,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.7
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21490,9 +19536,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21510,8 +19553,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21529,9 +19570,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21542,6 +19580,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosstable1-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21549,8 +19589,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21568,9 +19606,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21588,8 +19623,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21607,9 +19640,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21620,6 +19650,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosstable1-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21627,8 +19659,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21646,9 +19676,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21666,8 +19693,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21685,9 +19710,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21698,6 +19720,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosstable1-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21705,8 +19729,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21724,9 +19746,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21744,8 +19763,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21763,9 +19780,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21776,6 +19790,8 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosstable1-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21783,8 +19799,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21802,9 +19816,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21822,8 +19833,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.7
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21841,9 +19850,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21854,6 +19860,8 @@ periodics:
   interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2enode-cosstable1-k8sstable3-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21861,8 +19869,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.7
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21880,9 +19886,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21893,6 +19896,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sdev-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21900,8 +19905,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21919,9 +19922,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21932,6 +19932,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21939,8 +19941,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21958,9 +19958,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -21971,6 +19968,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sstable1-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -21978,8 +19977,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -21997,9 +19994,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22010,6 +20004,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22017,8 +20013,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22036,9 +20030,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22049,6 +20040,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sstable2-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22056,8 +20049,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22075,9 +20066,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22088,6 +20076,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22095,8 +20085,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22114,9 +20102,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22127,6 +20112,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev2-k8sbeta-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22134,8 +20121,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22153,9 +20138,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22166,6 +20148,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev2-k8sbeta-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22173,8 +20157,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.10
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22192,9 +20174,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22205,6 +20184,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev2-k8sdev-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22212,8 +20193,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22231,9 +20210,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22244,6 +20220,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntudev2-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22251,8 +20229,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22270,9 +20246,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22283,6 +20256,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sdev-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22290,8 +20265,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22309,9 +20282,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22322,6 +20292,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sdev-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22329,8 +20301,6 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22348,9 +20318,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22361,6 +20328,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sstable1-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22368,8 +20337,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22387,9 +20354,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22400,6 +20364,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sstable1-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22407,8 +20373,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.9
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22426,9 +20390,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22439,6 +20400,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sstable2-gkespec
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22446,8 +20409,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22465,9 +20426,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22478,6 +20436,8 @@ periodics:
   interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2enode-ubuntustable1-k8sstable2-serial
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -22485,8 +20445,6 @@ periodics:
       - --repo=k8s.io/kubernetes=release-1.8
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -22504,9 +20462,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -22515,6 +20470,8 @@ periodics:
 - name: ci-kubernetes-kubemark-100-canary
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22524,8 +20481,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22533,9 +20488,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22549,9 +20501,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22565,6 +20514,8 @@ periodics:
   - "perfDashPrefix: kubemark-100Nodes-master"
   interval: 3h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22574,8 +20525,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22583,9 +20532,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22599,9 +20545,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22613,6 +20556,8 @@ periodics:
 - name: ci-kubernetes-kubemark-5-gce
   interval: 30m
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22622,8 +20567,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22631,9 +20574,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22647,9 +20587,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22661,6 +20598,8 @@ periodics:
 - name: ci-kubernetes-kubemark-5-gce-last-release
   interval: 30m
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22670,8 +20609,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22679,9 +20616,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22695,9 +20629,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22709,6 +20640,8 @@ periodics:
 - name: ci-kubernetes-kubemark-5-prow-canary
   cron: "0 * * * *"
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -22719,8 +20652,6 @@ periodics:
       env:
       - name: KUBEMARK_BAZEL_BUILD
         value: "y"
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22728,9 +20659,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22738,9 +20666,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22751,6 +20676,8 @@ periodics:
   - "perfDashPrefix: kubemark-500Nodes-master"
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22760,8 +20687,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22769,9 +20694,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22785,9 +20707,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22801,6 +20720,8 @@ periodics:
   - "perfDashPrefix: kubemark-5kNodes-master"
   interval: 12h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22810,8 +20731,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22819,9 +20738,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22835,9 +20751,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22851,6 +20764,8 @@ periodics:
   - "perfDashPrefix: kubemark-100Nodes-master-hd"
   interval: 24h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22860,8 +20775,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22869,9 +20782,6 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -22885,9 +20795,6 @@ periodics:
       securityContext:
         privileged: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22899,6 +20806,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22907,8 +20816,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22918,16 +20825,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22936,6 +20837,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-benchmark
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22944,8 +20847,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22955,16 +20856,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -22973,6 +20868,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-beta
   interval: 48h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -22981,8 +20878,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -22992,16 +20887,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23010,6 +20899,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-conformance
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23018,8 +20909,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23029,16 +20918,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23047,6 +20930,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-flaky
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23055,8 +20940,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23066,16 +20949,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23084,6 +20961,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-serial
   interval: 4h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23092,8 +20971,6 @@ periodics:
       - --timeout=240
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23103,16 +20980,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23121,6 +20992,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23129,8 +21002,6 @@ periodics:
       - --timeout=240
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23140,16 +21011,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23158,6 +21023,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-stable1
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.9
@@ -23166,8 +21033,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23177,16 +21042,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23195,6 +21054,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-stable2
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.8
@@ -23203,8 +21064,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23214,16 +21073,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23232,6 +21085,8 @@ periodics:
 - name: ci-kubernetes-node-kubelet-stable3
   interval: 24h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-1.7
@@ -23240,8 +21095,6 @@ periodics:
       - --timeout=90
       - --root=/go/src
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23251,16 +21104,10 @@ periodics:
       - name: GOPATH
         value: /go
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23269,14 +21116,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-cos-docker-validation
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23293,9 +21140,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23304,14 +21148,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gce-1-7
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23328,9 +21172,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23339,14 +21180,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gce-gci
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23363,9 +21204,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23374,14 +21212,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gci-gce-stable1
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23398,9 +21236,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23409,14 +21244,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gci-gce-stable2
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23433,9 +21268,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23444,14 +21276,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gci-gce-stable3
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23468,9 +21300,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23479,14 +21308,14 @@ periodics:
 - interval: 12h
   agent: kubernetes
   name: ci-kubernetes-soak-gke-gci
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=620
       - --bare
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -23503,9 +21332,6 @@ periodics:
         name: ssh
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -23515,6 +21341,8 @@ periodics:
 - name: ci-perf-tests-e2e-gce-clusterloader
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23524,8 +21352,6 @@ periodics:
       - "--root=/go/src"
       - "--timeout=60"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23533,16 +21359,10 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23551,6 +21371,8 @@ periodics:
 - name: ci-perf-tests-kubemark-100-benchmark
   interval: 2h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
@@ -23559,22 +21381,14 @@ periodics:
       - "--root=/go/src"
       - "--timeout=10"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - name: ci-test-infra-bazel
   interval: 1h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -23598,9 +21412,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -23610,9 +21421,6 @@ periodics:
         requests:
           memory: "2Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
@@ -23639,6 +21447,8 @@ periodics:
 - cron: "1 5 * * *" # Run at 21:01PST daily (05:01 UTC)
   agent: kubernetes
   name: cluster-registry-nightly
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -23652,15 +21462,10 @@ periodics:
       env:
       - name: TEST_TMPDIR
         value: /root/.cache/bazel
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -23670,15 +21475,14 @@ periodics:
         requests:
           memory: "2Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
 - name: issue-creator
   agent: kubernetes
   interval: 24h
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/issue-creator:v20170907-5240cca5
@@ -23702,6 +21506,8 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: istio-periodic-e2e-gke-addon
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180129-9bc72b9fb-master
@@ -23710,8 +21516,6 @@ periodics:
       - "--repo=github.com/istio/istio=master"
       - "--timeout=90"
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -23719,16 +21523,10 @@ periodics:
       - name: USER
         value: prow
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         secretName: ssh-key-secret
@@ -23737,25 +21535,18 @@ periodics:
 - name: kubeflow-periodic
   interval: 8h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/mlkube-testing/kubeflow-testing:latest
       imagePullPolicy: Always
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - interval: 1h
   agent: kubernetes
   name: maintenance-ci-aws-janitor
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -23764,8 +21555,6 @@ periodics:
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: AWS_SHARED_CREDENTIALS_FILE
         value: /workspace/.aws/credentials
       image: gcr.io/k8s-test-infra-aws/aws-janitor:0.3
@@ -23777,9 +21566,6 @@ periodics:
         name: aws-cred
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: aws-cred
       secret:
         defaultMode: 256
@@ -23788,6 +21574,8 @@ periodics:
 - interval: 24h
   agent: kubernetes
   name: maintenance-ci-janitor
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -23796,21 +21584,18 @@ periodics:
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - interval: 1h
   agent: kubernetes
   name: maintenance-pull-janitor
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
@@ -23819,17 +21604,12 @@ periodics:
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - name: metrics-bigquery
   interval: 24h
@@ -23860,6 +21640,8 @@ periodics:
 - name: periodic-kubernetes-bazel-build-1-7
   interval: 12h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -23879,9 +21661,6 @@ periodics:
       - name: TEST_TMPDIR
         value: /root/.cache/bazel
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -23891,15 +21670,14 @@ periodics:
         requests:
           memory: "6Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
   run_after_success:
   - name: periodic-kubernetes-bazel-test-1-7
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -23918,9 +21696,6 @@ periodics:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -23930,14 +21705,13 @@ periodics:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
   - name: periodic-kubernetes-e2e-kubeadm-gce-1-7
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -23952,16 +21726,11 @@ periodics:
           value: prow
         - name: REPO_NAME
           value: kubernetes=release-1.7
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -23971,9 +21740,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -23985,6 +21751,8 @@ periodics:
 - name: periodic-kubernetes-bazel-build-1-8
   interval: 6h
   agent: kubernetes
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -24004,9 +21772,6 @@ periodics:
       - name: TEST_TMPDIR
         value: /root/.cache/bazel
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -24016,15 +21781,14 @@ periodics:
         requests:
           memory: "6Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
   run_after_success:
   - name: periodic-kubernetes-bazel-test-1-8
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.6.1
@@ -24043,9 +21807,6 @@ periodics:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -24055,14 +21816,13 @@ periodics:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
   - name: periodic-kubernetes-e2e-kubeadm-gce-1-8
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -24077,16 +21837,11 @@ periodics:
           value: prow
         - name: REPO_NAME
           value: kubernetes=release-1.8
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -24096,9 +21851,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -24108,6 +21860,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -24120,16 +21874,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -24139,9 +21888,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -24155,6 +21901,8 @@ periodics:
   agent: kubernetes
   branches:
   - master
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -24175,9 +21923,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: cache-ssd
         mountPath: /root/.cache
       ports:
@@ -24187,15 +21932,14 @@ periodics:
         requests:
           memory: "6Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: cache-ssd
       hostPath:
         path: /mnt/disks/ssd0
   run_after_success:
   - name: periodic-kubernetes-bazel-test-1-9
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82af-0.8.1
@@ -24218,9 +21962,6 @@ periodics:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /root/.cache
         ports:
@@ -24230,14 +21971,13 @@ periodics:
           requests:
             memory: "6Gi"
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
   - name: periodic-kubernetes-e2e-kubeadm-gce-1-9
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -24250,16 +21990,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -24269,9 +22004,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -24281,6 +22013,8 @@ periodics:
           path: /mnt/disks/ssd0
   - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
     agent: kubernetes
+    label:
+      preset: service-account
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180123-fe0e523d9
@@ -24293,16 +22027,11 @@ periodics:
         env:
         - name: USER
           value: prow
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: ssh
           mountPath: /etc/ssh-key-secret
           readOnly: true
@@ -24312,9 +22041,6 @@ periodics:
         - containerPort: 9999
           hostPort: 9999
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: ssh
         secret:
           secretName: ssh-key-secret
@@ -24328,26 +22054,18 @@ periodics:
 - interval: 24h
   agent: kubernetes
   name: periodic-kubernetes-e2e-debs-pushed
+  label:
+    preset: service-account
   spec:
     containers:
     - args:
       - --timeout=60
       - --repo=k8s.io/kubeadm=master
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: USER
         value: prow
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - name: periodic-test-infra-close
   interval: 1h
@@ -24494,6 +22212,8 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: spark-periodic-default-gke
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-e55a886b4-master
@@ -24506,8 +22226,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -24518,9 +22236,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -24534,9 +22249,6 @@ periodics:
           cpu: 6
           memory: "8Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -24548,6 +22260,8 @@ periodics:
 - interval: 2h
   agent: kubernetes
   name: spark-periodic-latest-gke
+  label:
+    preset: service-account
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-e55a886b4-master
@@ -24560,8 +22274,6 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: true
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
@@ -24572,9 +22284,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
@@ -24588,9 +22297,6 @@ periodics:
           cpu: 6
           memory: "8Gi"
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: ssh
       secret:
         defaultMode: 256
@@ -24602,19 +22308,10 @@ periodics:
 - interval: 8h
   agent: kubernetes
   name: tf-k8s-periodic
+  label:
+    preset: service-account
   spec:
     containers:
     # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
     - image: gcr.io/mlkube-testing/builder:latest
       imagePullPolicy: Always
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3008,8 +3008,6 @@ presubmits:
       - release-1.7
       - release-1.8
       skip_report: true
-      label:
-        preset: service-account
       spec:
         containers:
         - args:
@@ -3031,9 +3029,6 @@ presubmits:
           name: ""
           resources: {}
           volumeMounts:
-          - mountPath: /etc/service-account
-            name: service
-            readOnly: true
           - mountPath: /etc/ssh-key-secret
             name: ssh
             readOnly: true
@@ -3055,8 +3050,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3077,9 +3070,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
@@ -3111,8 +3101,6 @@ presubmits:
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
       run_if_changed: ^(cmd/kubeadm|build/debs).*$
       skip_report: true
-      label:
-        preset: service-account
       spec:
         containers:
         - args:
@@ -3134,9 +3122,6 @@ presubmits:
           name: ""
           resources: {}
           volumeMounts:
-          - mountPath: /etc/service-account
-            name: service
-            readOnly: true
           - mountPath: /etc/ssh-key-secret
             name: ssh
             readOnly: true
@@ -3154,8 +3139,6 @@ presubmits:
       trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\s+|$)
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3176,9 +3159,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
@@ -3206,8 +3186,6 @@ presubmits:
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce-canary
       run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
       skip_report: false
-      label:
-        preset: service-account
       spec:
         containers:
         - args:
@@ -3229,9 +3207,6 @@ presubmits:
           name: ""
           resources: {}
           volumeMounts:
-          - mountPath: /etc/service-account
-            name: service
-            readOnly: true
           - mountPath: /etc/ssh-key-secret
             name: ssh
             readOnly: true
@@ -3249,8 +3224,6 @@ presubmits:
       trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\s+|$)
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3273,9 +3246,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /scratch/.cache
           name: bazel-scratch
         - mountPath: /etc/ssh-security
@@ -3300,8 +3270,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3325,9 +3293,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
@@ -3348,8 +3313,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-bazel-test
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3372,9 +3335,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
@@ -3394,8 +3354,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-bazel-test-canary
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3421,9 +3379,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
       volumes:
@@ -3441,8 +3396,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-cross
     run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3465,9 +3418,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /var/lib/docker
           name: var-lib-docker
         - mountPath: /etc/ssh-security
@@ -3493,8 +3443,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-cross-prow
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3518,9 +3466,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
         - mountPath: /docker-graph
@@ -3544,8 +3489,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-containerd-gce
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3601,8 +3544,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3657,8 +3598,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3713,8 +3652,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3771,8 +3708,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3829,8 +3764,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3889,8 +3822,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -3945,8 +3876,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke
     run_if_changed: ^(cluster/gce|cluster/addons).*$
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4001,8 +3930,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke
     run_if_changed: ^(cluster/gce|cluster/addons).*$
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4059,8 +3986,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4117,8 +4042,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-gke-device-plugin-gpu
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4177,8 +4100,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4244,8 +4165,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-kops-aws
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4311,8 +4230,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-e2e-kops-aws
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4380,8 +4297,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4444,8 +4359,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4508,8 +4421,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4574,8 +4485,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4638,8 +4547,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4702,8 +4609,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-big
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4766,8 +4671,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-kubemark-e2e-gce-scale
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4832,8 +4735,6 @@ presubmits:
     - release-1.7
     - release-1.8
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4889,8 +4790,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -4946,8 +4845,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5003,8 +4900,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-node-e2e-containerd
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5055,8 +4950,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-unit
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5078,9 +4971,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
         - mountPath: /docker-graph
@@ -5102,8 +4992,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-unit-prow
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5126,9 +5014,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
         - mountPath: /docker-graph
@@ -5150,8 +5035,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-verify
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5173,9 +5056,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
         - mountPath: /docker-graph
@@ -5197,8 +5077,6 @@ presubmits:
     rerun_command: /test pull-security-kubernetes-verify-prow
     run_if_changed: ""
     skip_report: false
-    label:
-      preset: service-account
     spec:
       containers:
       - args:
@@ -5221,9 +5099,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
         - mountPath: /etc/ssh-security
           name: ssh-security
         - mountPath: /docker-graph
@@ -21590,7 +21465,6 @@ periodics:
         name: service
         readOnly: true
     volumes:
-
 - interval: 1h
   agent: kubernetes
   name: maintenance-pull-janitor
@@ -21610,7 +21484,6 @@ periodics:
         name: service
         readOnly: true
     volumes:
-
 - name: metrics-bigquery
   interval: 24h
   agent: kubernetes


### PR DESCRIPTION
After Waaaaaay too much regex find & replace this PR moves all usage of the primary prow service account into a preset. We've already been doing this on test-infra jobs

Shrinks the config by ~ two thousand lines. SSH-key creds are up next.

/area jobs