### PR TITLE
kops: set KUBE_SSH_USER where needed

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8440,6 +8440,7 @@
     "args": [
       "--cluster=e2e-kops-aws-canary.test-cncf-aws.k8s.io",
       "--deployment=kops",
+      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -8493,7 +8494,7 @@
     "args": [
       "--cluster=e2e-kops-aws-imageubuntu1604.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env-file=jobs/platform/kops_aws.env",
+      "--env=KUBE_SSH_USER=ubuntu",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180122",
@@ -8511,6 +8512,7 @@
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io",
       "--deployment=kops",
+      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",


### PR DESCRIPTION
Otherwise the SSH user defaults to the user under which the tests are
running, likely `prow`