### PR TITLE
 Add Jenkins cert-based auth in prow 

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -138,7 +138,7 @@ func main() {
 		log.Fatalf("no jenkins auth token provided")
 	}
 
-	jc := jenkins.NewClient(o.jenkinsURL, &ac, nil, nil)
+	jc := jenkins.NewClient(o.jenkinsURL, nil, &ac, nil, nil)
 
 	token, err := loadToken(o.githubTokenFile)
 	if err != nil {

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -138,7 +138,10 @@ func main() {
 		log.Fatalf("no jenkins auth token provided")
 	}
 
-	jc := jenkins.NewClient(o.jenkinsURL, nil, &ac, nil, nil)
+	jc, err := jenkins.NewClient(o.jenkinsURL, nil, &ac, nil, nil)
+	if err != nil {
+		log.Fatalf("cannot setup Jenkins client: %v", err)
+	}
 
 	token, err := loadToken(o.githubTokenFile)
 	if err != nil {

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -48,6 +50,9 @@ var (
 	jenkinsUserName        = flag.String("jenkins-user", "jenkins-trigger", "Jenkins username")
 	jenkinsTokenFile       = flag.String("jenkins-token-file", "", "Path to the file containing the Jenkins API token.")
 	jenkinsBearerTokenFile = flag.String("jenkins-bearer-token-file", "", "Path to the file containing the Jenkins API bearer token.")
+	certFile               = flag.String("cert-file", "", "Path to a PEM-encoded certificate file.")
+	keyFile                = flag.String("key-file", "", "Path to a PEM-encoded key file.")
+	caCertFile             = flag.String("ca-cert-file", "", "Path to a PEM-encoded CA certificate file.")
 
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
@@ -94,8 +99,16 @@ func main() {
 	} else {
 		logger.Fatal("An auth token for basic or bearer token auth must be supplied.")
 	}
+	var tlsConfig *tls.Config
+	if *certFile != "" && *keyFile != "" {
+		config, err := loadCerts(*certFile, *keyFile, *caCertFile)
+		if err != nil {
+			logger.WithError(err).Fatalf("Could not read certificate files.")
+		}
+		tlsConfig = config
+	}
 	metrics := jenkins.NewMetrics()
-	jc := jenkins.NewClient(*jenkinsURL, ac, logger, metrics.ClientMetrics)
+	jc := jenkins.NewClient(*jenkinsURL, tlsConfig, ac, logger, metrics.ClientMetrics)
 
 	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
 	if err != nil {
@@ -156,6 +169,30 @@ func loadToken(file string) (string, error) {
 		return "", err
 	}
 	return string(bytes.TrimSpace(raw)), nil
+}
+
+func loadCerts(certFile, keyFile, caCertFile string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	if caCertFile != "" {
+		caCert, err := ioutil.ReadFile(caCertFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	tlsConfig.BuildNameToCertificate()
+	return tlsConfig, nil
 }
 
 // serve starts a http server and serves Jenkins logs

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jenkins
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -146,11 +147,11 @@ type BearerTokenAuthConfig struct {
 	Token string
 }
 
-func NewClient(url string, authConfig *AuthConfig, logger *logrus.Entry, metrics *ClientMetrics) *Client {
+func NewClient(url string, tlsConfig *tls.Config, authConfig *AuthConfig, logger *logrus.Entry, metrics *ClientMetrics) *Client {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}
-	return &Client{
+	c := &Client{
 		logger:     logger.WithField("client", "jenkins"),
 		baseURL:    url,
 		authConfig: authConfig,
@@ -159,6 +160,10 @@ func NewClient(url string, authConfig *AuthConfig, logger *logrus.Entry, metrics
 		},
 		metrics: metrics,
 	}
+	if tlsConfig != nil {
+		c.client.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+	return c
 }
 
 // measure records metrics about the provided method, path, and code.

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -34,9 +34,15 @@ import (
 )
 
 const (
+	// Maximum retries for a request to Jenkins.
+	// Retries on transport failures and 500s.
 	maxRetries = 5
+	// Backoff delay used after a request retry.
+	// Doubles on every retry.
 	retryDelay = 100 * time.Millisecond
-	buildID    = "buildId"
+	// Deprecated: Key for unique build number across Jenkins builds.
+	buildID = "buildId"
+	// Key for unique build number across Jenkins builds.
 	newBuildID = "BUILD_ID"
 )
 
@@ -134,7 +140,10 @@ type Client struct {
 // AuthConfig configures how we auth with Jenkins.
 // Only one of the fields will be non-nil.
 type AuthConfig struct {
-	Basic       *BasicAuthConfig
+	// Basic is used for doing basic auth with Jenkins.
+	Basic *BasicAuthConfig
+	// BearerToken is used for doing oauth-based authentication
+	// with Jenkins. Works ootb with the Openshift Jenkins image.
 	BearerToken *BearerTokenAuthConfig
 }
 


### PR DESCRIPTION
Adds certificate based authentication and CSRF protection in the Jenkins client
which effectively enables the operator to work with locked down Jenkins masters.