### PR TITLE
Move operator out of config

### DIFF
--- a/experiment/refresh/BUILD
+++ b/experiment/refresh/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
+        "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/report:go_default_library",

--- a/experiment/refresh/main.go
+++ b/experiment/refresh/main.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/jenkins"
 )
 
 var (
@@ -65,7 +65,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error validating flags.")
 	}
 
-	configAgent := &config.Agent{}
+	// TODO: Make it so that this plugin can read every report template
+	// in the config.
+	configAgent := &jenkins.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}

--- a/experiment/refresh/server.go
+++ b/experiment/refresh/server.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/jenkins"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/report"
@@ -41,12 +41,12 @@ type Server struct {
 	hmacSecret  []byte
 	credentials string
 	prowURL     string
-	configAgent *config.Agent
+	configAgent *jenkins.Agent
 	ghc         *github.Client
 	log         *logrus.Entry
 }
 
-func NewServer(creds string, hmac []byte, ghc *github.Client, prowURL string, configAgent *config.Agent) *Server {
+func NewServer(creds string, hmac []byte, ghc *github.Client, prowURL string, configAgent *jenkins.Agent) *Server {
 	return &Server{
 		hmacSecret:  hmac,
 		credentials: creds,

--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -32,11 +32,16 @@ fi
 
 cd $(dirname $0)
 
+if [[ -z $PULL ]]; then
+  PULL="true"
+fi
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
 for i in "$@"; do
   echo "program: $i"
   echo "new version: $new_version"
-  gcloud docker -- pull "${PREFIX:-gcr.io/k8s-prow}/${i}:${new_version}"
+  if [[ "$PULL" == "true" ]]; then
+    gcloud docker -- pull "${PREFIX:-gcr.io/k8s-prow}/${i}:${new_version}"
+  fi
 
   $SED -i "s/\(${i}:\)v[a-f0-9-]\+/\1$new_version/I" cluster/*.yaml
 done

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20180130-e29943801
+            image: gcr.io/k8s-prow/branchprotector:v20180131-48dd46a96
             args:
             - --config-path=/etc/config/config
             - --github-token-path=/etc/github/oauth

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180130-4388f0875
+        image: gcr.io/k8s-prow/deck:v20180131-48dd46a96
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180129-3123648b4
+        image: gcr.io/k8s-prow/hook:v20180131-48dd46a96
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180129-3123648b4
+        image: gcr.io/k8s-prow/horologium:v20180131-48dd46a96
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:v20180129-3123648b4
+        image: gcr.io/k8s-prow/jenkins-operator:v20180131-48dd46a96
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180129-3123648b4
+        image: gcr.io/k8s-prow/plank:v20180131-48dd46a96
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:v20180129-3123648b4
+        image: gcr.io/k8s-prow/sinker:v20180131-48dd46a96
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: splice
         args:
         - --always-run=pull-kubernetes-cross
-        image: gcr.io/k8s-prow/splice:v20180129-3123648b4
+        image: gcr.io/k8s-prow/splice:v20180131-48dd46a96
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180129-3123648b4
+        image: gcr.io/k8s-prow/hook:v20180131-48dd46a96
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180129-3123648b4
+        image: gcr.io/k8s-prow/plank:v20180131-48dd46a96
         args:
         - --dry-run=false
         volumeMounts:
@@ -189,7 +189,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20180129-3123648b4
+        image: gcr.io/k8s-prow/sinker:v20180131-48dd46a96
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -220,7 +220,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180130-4388f0875
+        image: gcr.io/k8s-prow/deck:v20180131-48dd46a96
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -263,7 +263,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180129-3123648b4
+        image: gcr.io/k8s-prow/horologium:v20180131-48dd46a96
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180129-3123648b4
+        image: gcr.io/k8s-prow/tide:v20180131-48dd46a96
         args:
         - --dry-run=false
         ports:

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -25,7 +25,6 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/jenkins"
 	"k8s.io/test-infra/prow/kube"
@@ -63,7 +62,7 @@ func main() {
 		logger.WithError(err).Fatal("Error parsing label selector.")
 	}
 
-	configAgent := &config.Agent{}
+	configAgent := &jenkins.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {
 		logger.WithError(err).Fatal("Error starting config agent.")
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -49,9 +49,6 @@ type Config struct {
 	Deck             Deck             `json:"deck,omitempty"`
 	BranchProtection BranchProtection `json:"branch-protection,omitempty"`
 
-	// TODO: Move this out of the main config.
-	JenkinsOperator JenkinsOperator `json:"jenkins_operator,omitempty"`
-
 	// ProwJobNamespace is the namespace in the cluster that prow
 	// components will use for looking up ProwJobs. The namespace
 	// needs to exist and will not be created by prow.
@@ -122,11 +119,6 @@ type Controller struct {
 
 // Plank is config for the plank controller.
 type Plank struct {
-	Controller `json:",inline"`
-}
-
-// JenkinsOperator is config for the jenkins-operator controller.
-type JenkinsOperator struct {
 	Controller `json:",inline"`
 }
 
@@ -206,13 +198,13 @@ func Load(path string) (*Config, error) {
 	if err := yaml.Unmarshal(b, nc); err != nil {
 		return nil, fmt.Errorf("error unmarshaling %s: %v", path, err)
 	}
-	if err := parseConfig(nc); err != nil {
+	if err := ParseConfig(nc); err != nil {
 		return nil, err
 	}
 	return nc, nil
 }
 
-func parseConfig(c *Config) error {
+func ParseConfig(c *Config) error {
 	// Ensure that presubmit regexes are valid.
 	for _, vs := range c.Presubmits {
 		if err := SetRegexes(vs); err != nil {
@@ -324,10 +316,6 @@ func parseConfig(c *Config) error {
 
 	if err := ValidateController(&c.Plank.Controller); err != nil {
 		return fmt.Errorf("validating plank config: %v", err)
-	}
-
-	if err := ValidateController(&c.JenkinsOperator.Controller); err != nil {
-		return fmt.Errorf("validating jenkins-operator config: %v", err)
 	}
 
 	for i, agentToTmpl := range c.Deck.ExternalAgentLogs {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -789,7 +789,7 @@ func TestMergePreset(t *testing.T) {
 				},
 			},
 		}
-		if err := parseConfig(conf); err == nil && tc.shouldError {
+		if err := ParseConfig(conf); err == nil && tc.shouldError {
 			t.Fatalf("For test \"%s\": expected error but got none.", tc.name)
 		} else if err != nil && !tc.shouldError {
 			t.Fatalf("For test \"%s\": expected no error but got %v.", tc.name, err)

--- a/prow/jenkins/BUILD
+++ b/prow/jenkins/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "config.go",
         "controller.go",
         "doc.go",
         "jenkins.go",
@@ -22,6 +23,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/report:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/jenkins/config.go
+++ b/prow/jenkins/config.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jenkins
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+// JenkinsOperator is config for the jenkins-operator controller.
+type JenkinsOperator struct {
+	config.Controller `json:",inline"`
+}
+
+// Config is a read-only snapshot of the config.
+type Config struct {
+	config.Config   `json:",inline"`
+	JenkinsOperator JenkinsOperator `json:"jenkins_operator,omitempty"`
+}
+
+// Load loads and parses the config at path.
+func Load(path string) (*Config, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", path, err)
+	}
+	nc := &Config{}
+	if err := yaml.Unmarshal(b, nc); err != nil {
+		return nil, fmt.Errorf("error unmarshaling %s: %v", path, err)
+	}
+	if err := config.ParseConfig(&nc.Config); err != nil {
+		return nil, err
+	}
+	if err := parseConfig(nc); err != nil {
+		return nil, err
+	}
+	return nc, nil
+}
+
+func parseConfig(c *Config) error {
+	if err := config.ValidateController(&c.JenkinsOperator.Controller); err != nil {
+		return fmt.Errorf("validating jenkins-operator config: %v", err)
+	}
+	return nil
+}
+
+// Agent watches a path and automatically loads the config stored
+// therein.
+type Agent struct {
+	sync.Mutex
+	c *Config
+}
+
+// Start will begin polling the config file at the path. If the first load
+// fails, Start with return the error and abort. Future load failures will log
+// the failure message but continue attempting to load.
+func (ca *Agent) Start(path string) error {
+	c, err := Load(path)
+	if err != nil {
+		return err
+	}
+	ca.c = c
+	go func() {
+		for range time.Tick(1 * time.Minute) {
+			if c, err := Load(path); err != nil {
+				logrus.WithField("path", path).WithError(err).Error("Error loading config.")
+			} else {
+				ca.Lock()
+				ca.c = c
+				ca.Unlock()
+			}
+		}
+	}()
+	return nil
+}
+
+// Config returns the latest config. Do not modify the config.
+func (ca *Agent) Config() *Config {
+	ca.Lock()
+	defer ca.Unlock()
+	return ca.c
+}

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
@@ -58,7 +57,7 @@ type githubClient interface {
 }
 
 type configAgent interface {
-	Config() *config.Config
+	Config() *Config
 }
 
 type syncFn func(kube.ProwJob, chan<- kube.ProwJob, map[string]JenkinsBuild) error
@@ -84,7 +83,7 @@ type Controller struct {
 }
 
 // NewController creates a new Controller from the provided clients.
-func NewController(kc *kube.Client, jc *Client, ghc *github.Client, logger *logrus.Entry, ca *config.Agent, selector string) *Controller {
+func NewController(kc *kube.Client, jc *Client, ghc *github.Client, logger *logrus.Entry, ca *Agent, selector string) *Controller {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -34,7 +34,7 @@ import (
 
 type fca struct {
 	sync.Mutex
-	c *config.Config
+	c *Config
 }
 
 func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
@@ -68,21 +68,23 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 	}
 
 	return &fca{
-		c: &config.Config{
-			JenkinsOperator: config.JenkinsOperator{
+		c: &Config{
+			JenkinsOperator: JenkinsOperator{
 				Controller: config.Controller{
 					JobURLTemplate: template.Must(template.New("test").Parse("{{.Status.PodName}}/{{.Status.State}}")),
 					MaxConcurrency: maxConcurrency,
 					MaxGoroutines:  20,
 				},
 			},
-			Presubmits: presubmitMap,
+			Config: config.Config{
+				Presubmits: presubmitMap,
+			},
 		},
 	}
 
 }
 
-func (f *fca) Config() *config.Config {
+func (f *fca) Config() *Config {
 	f.Lock()
 	defer f.Unlock()
 	return f.c


### PR DESCRIPTION
This PR moves the last Jenkins-related bits out of the rest of the prow binaries. A follow-up to put config loading behind an interface may be a nice improvement but not sure it's worth it now.

/cc @cjwagner @stevekuznetsov 