### PR TITLE
Update the pull-cluster-registry-verify-gensrc job to use a clean bazel cache.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -640,30 +640,25 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180123-1260ba9fc-master
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         env:
         - name: TEST_TMPDIR
-          value: /root/.cache/bazel
+          value: /scratch/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
+        - name: bazel-scratch
+          mountPath: /scratch/.cache
         resources:
           requests:
             memory: "2Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
+      - name: bazel-scratch
+        emtpyDir: {}
   - name: pull-cluster-registry-verify-gosrc
     agent: kubernetes
     context: pull-cluster-registry-verify-gosrc


### PR DESCRIPTION
This is intended to fix [these failures](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/cluster-registry/189/pull-cluster-registry-verify-gensrc/124/).

The assumption is that the bazel cache is not valid across different Prow runs, and that this job is failing periodically when it runs on a machine that has a non-functional cache. The evidence in favor of this hypothesis is that the job has always passed when it takes >4 minutes (i.e., is not hitting the cache), and fails sometimes when it takes ~2 minutes (i.e., is hitting the cache).

@font FYI