### PR TITLE
branch out image config

### DIFF
--- a/jobs/e2e_node/image-config-1-8.yaml
+++ b/jobs/e2e_node/image-config-1-8.yaml
@@ -1,0 +1,19 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
+  coreos-alpha:
+    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    project: coreos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  cos-stable1:
+    image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+  cos-stable2:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/image-config-1-9.yaml
+++ b/jobs/e2e_node/image-config-1-9.yaml
@@ -1,0 +1,19 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
+  coreos-alpha:
+    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    project: coreos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  cos-stable1:
+    image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+  cos-stable2:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
jobs like https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable2/710 starts to fail because it cannot find the image config

branch out the master image config to 1.8/1.9 so that test can pass, and we can update them accordingly.

/assign @yguo0905 @BenTheElder 