### PR TITLE
Skip Feature:* tests for kube-proxy upgrade job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4573,7 +4573,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--ginkgo.focus=Networking --ginkgo.skip=\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--timeout=90m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],


### PR DESCRIPTION
From http://k8s-testgrid.appspot.com/sig-network-gce#gci-gce-latest-upgrade-kube-proxy-ds&width=20, job is failing on a new added `[Feature:Networking-IPv6]` test, which is not supposed to be included.

Seems like skipping all `[Feature:*]` tests is a better choice.