### PR TITLE
Whitelist the 1.10 branch manager for manual merges

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -103,6 +103,7 @@ slack:
     - wojtek-t # 1.7 patch release manager
     - jpbetz # 1.8 patch release manager
     - mbohlool # 1.9 patch release manager
+    - calebamiles # 1.10 branch manager
   - repos:
     - kubernetes/test-infra
     channels:


### PR DESCRIPTION
I just saw @calebamiles get nagged in kubernetes-dev for doing his job, let's fix that