### PR TITLE
switch test-infra to bazel 0.10

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5129,7 +5129,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.10.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5881,7 +5881,7 @@ postsubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.10.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5951,7 +5951,7 @@ postsubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.10.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17226,7 +17226,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.10.0
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
seems to work fine here in the canary PR and locally: https://github.com/kubernetes/test-infra/pull/5137

should be a no-op for test-infra but will let us keep up to date and use new features

/area bazel
/area jobs