### PR TITLE
minor command-help fixes

### DIFF
--- a/prow/cmd/deck/static/command-help.html
+++ b/prow/cmd/deck/static/command-help.html
@@ -36,8 +36,8 @@
                 <aside>
                     <div class="card-box">
                         <ul class="noBullets">
-                            <li>Plugin help for</li>
-                            <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
+                            <li>Command help for</li>
+                            <li><select id="repo" onchange="redraw();"><option>all commands</option></select></li>
                         </ul>
                     </div>
                 </aside>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -5,7 +5,8 @@
   <meta http-equiv="refresh" content="5; url=./command-help.html">
   <title>Plugin Help</title>
 </head>
-<body>
-  <h3>Plugin Help is now <a href="./command-help.html">Command Help</a>. Redirecting after 5 seconds</h3>
+<body style="text-align: center">
+  <h2>Plugin Help is now <a href="./command-help.html">Command Help</a>.</h2>
+  <h3>Automatically redirecting after 5 seconds...</h3>
 </body>
 </html>


### PR DESCRIPTION
- clean up / center text in plugin-help redirect page
- `s/plugin/command/` in the repo selection box

/area prow