### PR TITLE
Improve slack bot responses

### DIFF
--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -98,7 +98,7 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	if mw := getMergeWarning(pc.SlackConfig.MergeWarnings, pe.Repo.Owner.Login, pe.Repo.Name); mw != nil {
 		//If the MergeWarning whitelist has the merge user then no need to send a message.
 		if !stringInArray(pe.Pusher.Name, mw.WhiteList) && !stringInArray(pe.Sender.Login, mw.WhiteList) {
-			message := fmt.Sprintf("Warning: <@%s> manually merged %s", pe.Sender.Login, pe.Compare)
+			message := fmt.Sprintf("*Warning:* %s (@%s) manually merged %s", pe.Sender.Login, pe.Sender.Login, pe.Compare)
 			for _, channel := range mw.Channels {
 				if err := pc.SlackClient.WriteMessage(message, channel); err != nil {
 					return err
@@ -156,7 +156,7 @@ func echoToSlack(pc client, e github.GenericCommentEvent) error {
 			continue
 		}
 
-		msg := fmt.Sprintf("%s was mentioned by <@%s> on Github. (%s)\n>>>%s", sig, e.User.Login, e.HTMLURL, e.Body)
+		msg := fmt.Sprintf("%s was mentioned by %s (@%s) on Github. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
 		if err := pc.SlackClient.WriteMessage(msg, sig); err != nil {
 			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %v", sig, msg, err)
 		}

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -83,8 +83,8 @@ func TestPush(t *testing.T) {
 			name:    "If PR merged manually by a user we send message to sig-contribex and kubernetes-dev.",
 			pushReq: pushEvManual,
 			expectedMessages: map[string][]string{
-				"sig-contribex":  {"Warning: <@tester> manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
-				"kubernetes-dev": {"Warning: <@tester> manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}},
+				"sig-contribex":  {"*Warning:* tester (@tester) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
+				"kubernetes-dev": {"*Warning:* tester (@tester) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}},
 		},
 		{
 			name:             "If PR merged by k8s merge bot we should NOT send message to sig-contribex and kubernetes-dev.",

--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -51,6 +51,9 @@ const (
 	channelsList = apiURL + "channels.list"
 
 	chatPostMessage = apiURL + "chat.postMessage"
+
+	botName      = "prow"
+	botIconEmoji = ":prow:"
 )
 
 type APIResponse struct {
@@ -162,6 +165,8 @@ func (sl *Client) VerifyAuth() (bool, error) {
 
 func (sl *Client) urlValues() *url.Values {
 	uv := url.Values{}
+	uv.Add("username", botName)
+	uv.Add("icon_emoji", botIconEmoji)
 	uv.Add("token", sl.token)
 	return &uv
 }


### PR DESCRIPTION
Based on info from: https://api.slack.com/methods/chat.postMessage

Currently, when the prow slack plugin posts a merge warning and there isn't a slack user with the same github username, it looks like the following:

<img width="531" alt="screenshot 2018-02-02 10 46 26" src="https://user-images.githubusercontent.com/1431969/35749533-a9523ac2-0806-11e8-8f0f-db91026ab19e.png">

This PR does a few things to change this:
- Changes "bot" to "prow"
- Changes the icon to use whatever the `:prow:` emoji is
- Prevents Slack from trying to smart link channel/usernames
- Makes the merge warning message stand out with a bolded "warning"

/shrug
/area prow
:left_shark: