### PR TITLE
support extension-less page urls in deck

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -51,16 +51,41 @@ var (
 	redirectHTTPTo = flag.String("redirect-http-to", "", "host to redirect http->https to based on x-forwarded-proto == http.")
 	// use when behind an oauth proxy
 	hiddenOnly = flag.Bool("hidden-only", false, "Show only hidden jobs. Useful for serving hidden jobs behind an oauth proxy.")
+	runLocal   = flag.Bool("run-local", false, "serve a local copy of the UI, used by the prow/cmd/deck/runlocal script")
 )
 
 // Matches letters, numbers, hyphens, and underscores.
 var objReg = regexp.MustCompile(`^[\w-]+$`)
 
 func main() {
+	// common setup
 	flag.Parse()
+
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 	logger := logrus.WithField("component", "deck")
 
+	mux := http.NewServeMux()
+
+	staticHandlerFromDir := func(dir string) http.Handler {
+		return defaultExtension(".html",
+			gziphandler.GzipHandler(handleCached(http.FileServer(http.Dir(dir)))))
+	}
+
+	// locally just serve from ./static, otherwise do the full main
+	if *runLocal {
+		mux.Handle("/", staticHandlerFromDir("./static"))
+	} else {
+		mux.Handle("/", staticHandlerFromDir("/static"))
+		prodOnlyMain(logger, mux)
+	}
+
+	// setup done, actually start the server
+	logger.WithError(http.ListenAndServe(":8080", mux)).Fatal("ListenAndServe returned.")
+}
+
+// prodOnlyMain contains logic only used when running deployed, not locally
+func prodOnlyMain(logger *logrus.Entry, mux *http.ServeMux) {
+	// setup config agent, pod log clients etc.
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {
 		logger.WithError(err).Fatal("Error starting config agent.")
@@ -93,10 +118,7 @@ func main() {
 	}
 	ja.Start()
 
-	mux := http.NewServeMux()
-
-	mux.Handle("/", defaultExtension(".html",
-		gziphandler.GzipHandler(handleCached(http.FileServer(http.Dir("/static"))))))
+	// setup prod only handlers
 	mux.Handle("/data.js", gziphandler.GzipHandler(handleData(ja)))
 	mux.Handle("/prowjobs.js", gziphandler.GzipHandler(handleProwJobs(ja)))
 	mux.Handle("/log", gziphandler.GzipHandler(handleLog(ja)))
@@ -105,14 +127,17 @@ func main() {
 	mux.Handle("/branding.js", gziphandler.GzipHandler(handleBranding(configAgent)))
 
 	if *hookURL != "" {
-		mux.Handle("/plugin-help.js", gziphandler.GzipHandler(handlePluginHelp(newHelpAgent(*hookURL))))
+		mux.Handle("/plugin-help.js",
+			gziphandler.GzipHandler(handlePluginHelp(newHelpAgent(*hookURL))))
 	}
 
 	if *tideURL != "" {
 		ta := &tideAgent{
-			log:          logger.WithField("agent", "tide"),
-			path:         *tideURL,
-			updatePeriod: func() time.Duration { return configAgent.Config().Deck.TideUpdatePeriod },
+			log:  logger.WithField("agent", "tide"),
+			path: *tideURL,
+			updatePeriod: func() time.Duration {
+				return configAgent.Config().Deck.TideUpdatePeriod
+			},
 		}
 		ta.start()
 		mux.Handle("/tide.js", gziphandler.GzipHandler(handleTide(configAgent, ta)))
@@ -140,7 +165,6 @@ func main() {
 		}(mux, *redirectHTTPTo))
 		mux = redirectMux
 	}
-	logger.WithError(http.ListenAndServe(":8080", mux)).Fatal("ListenAndServe returned.")
 }
 
 func loadToken(file string) (string, error) {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -48,10 +48,10 @@ var (
 	tideURL      = flag.String("tide-url", "", "Path to tide. If empty, do not serve tide data.")
 	hookURL      = flag.String("hook-url", "", "Path to hook plugin help endpoint.")
 	// use when behind a load balancer
-	redirectHTTPTo = flag.String("redirect-http-to", "", "host to redirect http->https to based on x-forwarded-proto == http.")
+	redirectHTTPTo = flag.String("redirect-http-to", "", "Host to redirect http->https to based on x-forwarded-proto == http.")
 	// use when behind an oauth proxy
 	hiddenOnly = flag.Bool("hidden-only", false, "Show only hidden jobs. Useful for serving hidden jobs behind an oauth proxy.")
-	runLocal   = flag.Bool("run-local", false, "serve a local copy of the UI, used by the prow/cmd/deck/runlocal script")
+	runLocal   = flag.Bool("run-local", false, "Serve a local copy of the UI, used by the prow/cmd/deck/runlocal script")
 )
 
 // Matches letters, numbers, hyphens, and underscores.

--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
 cd static
 HOST="https://prow.k8s.io"
 if [[ $1 == "openshift" ]]; then
@@ -22,4 +24,4 @@ curl "$HOST/data.js?var=allBuilds" > data.js
 curl "$HOST/tide.js?var=tideData" > tide.js
 curl "$HOST/plugin-help.js?var=allHelp" > plugin-help.js
 curl "$HOST/branding.js?var=branding" > branding.js
-python3 -m http.server
+bazel run --run_under="cd $DIR && " //prow/cmd/deck:deck -- --run-local

--- a/prow/cmd/deck/static/command-help-script.js
+++ b/prow/cmd/deck/static/command-help-script.js
@@ -386,10 +386,10 @@ function redraw() {
     const repoSel = selectionText(document.getElementById("repo"));
     if (window.history && window.history.replaceState !== undefined) {
         if (repoSel !== "") {
-            history.replaceState(null, "", "/command-help.html?repo="
+            history.replaceState(null, "", "/command-help?repo="
                 + encodeURIComponent(repoSel));
         } else {
-            history.replaceState(null, "", "/command-help.html")
+            history.replaceState(null, "", "/command-help")
         }
     }
     redrawOptions();

--- a/prow/cmd/deck/static/command-help.html
+++ b/prow/cmd/deck/static/command-help.html
@@ -28,8 +28,8 @@
                 <span class="mdl-layout-title">Prow Dashboard</span>
                 <nav class="mdl-navigation">
                     <a class="mdl-navigation__link" href="/">Prow Status</a>
-                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/command-help.html">Command Help</a>
-                    <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/command-help">Command Help</a>
+                    <a class="mdl-navigation__link" href="/tide">Tide Status</a>
                 </nav>
             </div>
             <main class="mdl-layout__content">

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="5; url=./command-help.html">
+  <meta http-equiv="refresh" content="5; url=./command-help">
   <title>Plugin Help</title>
 </head>
 <body style="text-align: center">
-  <h2>Plugin Help is now <a href="./command-help.html">Command Help</a>.</h2>
+  <h2>Plugin Help is now <a href="./command-help">Command Help</a>.</h2>
   <h3>Automatically redirecting after 5 seconds...</h3>
 </body>
 </html>

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -27,8 +27,8 @@
                 <span class="mdl-layout-title">Prow Dashboard</span>
                 <nav class="mdl-navigation">
                     <a class="mdl-navigation__link" href="/">Prow Status</a>
-                    <a class="mdl-navigation__link" href="/command-help.html">Command Help</a>
-                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/tide.html">Tide Status</a>
+                    <a class="mdl-navigation__link" href="/command-help">Command Help</a>
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/tide">Tide Status</a>
                 </nav>
             </div>
             <main class="mdl-layout__content">


### PR DESCRIPTION
upstreaming this trick from my site so we have have https://prow.k8s.io/command-help instead of https://prow.k8s.io/command-help.html

Edit: refactored deck a bit and updated `runlocal` to use deck instead of python3, switched to extension-less URLs throughout deck.

Also fixed `cd`ing in runlocal so you can just `$ prow/cmd/deck/runlocal` without `cd`ing to deck first.