### PR TITLE
Bot language clarification

### DIFF
--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -176,6 +176,8 @@ This pull-request has been approved by: *<a href="#" title="Author self-approved
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details >
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -207,6 +209,8 @@ Assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details open>
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -235,6 +239,8 @@ This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 Associated issue requirement bypassed by: *<a href="" title="Approved">Alice</a>*
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:
@@ -265,6 +271,8 @@ This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 Associated issue: *#42*
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:
@@ -305,6 +313,8 @@ This pull-request has been approved by: *<a href="" title="Approved">ALIcE</a>*,
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with `+"`/approve no-issue`"+`
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:
@@ -350,6 +360,8 @@ Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when re
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details open>
 Needs approval from an approver in each of these OWNERS Files:
@@ -424,6 +436,8 @@ Associated issue: *#1*
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details >
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -478,6 +492,8 @@ Approval requirements bypassed by manually added approval.
 This pull-request has been approved by: 
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -181,8 +181,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)~~ [cjwagner]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -200,6 +201,8 @@ You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: 
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **cjwagner**
 
 Assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
@@ -211,8 +214,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)**
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["cjwagner"]} -->`,
 		},
@@ -240,8 +244,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -270,8 +275,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -311,8 +317,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [ALIcE]
 - ~~[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)~~ [cjwagner]
 
-You can indicate your approval by writing `+"`/approve`"+` in a comment
-You can cancel your approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`),
 			},
@@ -341,6 +348,8 @@ You can cancel your approval by writing `+"`/approve cancel`"+` in a comment
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **alice**
 
 Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
@@ -354,8 +363,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`,
 		},
@@ -427,8 +437,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [alice]
 
-You can indicate your approval by writing `+"`/approve`"+` in a comment
-You can cancel your approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`),
 			},
@@ -482,8 +493,9 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`,
 		},

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -181,8 +181,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)~~ [cjwagner]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
@@ -201,7 +201,7 @@ A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's 
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: 
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
 and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **cjwagner**
 
@@ -214,8 +214,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)**
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["cjwagner"]} -->`,
@@ -244,8 +244,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
@@ -275,8 +275,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`,
@@ -348,7 +348,7 @@ A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's 
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
 and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **alice**
 
@@ -363,8 +363,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`,
@@ -493,8 +493,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`,

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -181,9 +181,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)~~ [cjwagner]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -214,9 +213,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)**
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["cjwagner"]} -->`,
 		},
@@ -244,9 +242,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -275,9 +272,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
@@ -317,9 +313,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [ALIcE]
 - ~~[c/OWNERS](https://github.com/org/repo/blob/master/c/OWNERS)~~ [cjwagner]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 </details>
 <!-- META={"approvers":[]} -->`),
 			},
@@ -363,9 +358,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`,
 		},
@@ -437,9 +431,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [alice]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 </details>
 <!-- META={"approvers":[]} -->`),
 			},
@@ -493,9 +486,8 @@ Needs approval from an approver in each of these OWNERS Files:
 
 - **[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)**
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`,
 		},

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -200,8 +200,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: 
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
-and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
+To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
 Assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
@@ -343,8 +342,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
-and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
+To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **alice**
 
 Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -708,6 +708,8 @@ func TestGetMessage(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Bill</a>*
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **alice**
 
 Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
@@ -791,6 +793,8 @@ func TestGetMessageNoneApproved(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Author self-approved">John</a>*
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approvers: **alice**, **bill**
 
 Assign the PR to them by writing ` + "`/assign @alice @bill`" + ` in a comment when ready.

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -722,8 +722,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -762,8 +763,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -803,8 +805,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - **[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)**
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -845,8 +848,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -886,8 +890,9 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-You can indicate your approval by writing ` + "`/approve`" + ` in a comment
-You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -717,6 +717,8 @@ Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when re
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details open>
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -756,6 +758,8 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Al
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:
@@ -799,6 +803,8 @@ Assign the PR to them by writing ` + "`/assign @alice @bill`" + ` in a comment w
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details open>
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -841,6 +847,8 @@ Associated issue: *#12345*
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details >
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -881,6 +889,8 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Al
 Associated issue requirement bypassed by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="Approved">Bill</a>*
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -724,9 +724,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -765,9 +764,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -809,9 +807,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - **[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)**
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -852,9 +849,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
@@ -894,9 +890,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
-OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -708,8 +708,7 @@ func TestGetMessage(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Bill</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
-and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
+To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **alice**
 
 Assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
@@ -791,8 +790,7 @@ func TestGetMessageNoneApproved(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Author self-approved">John</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
-and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
+To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approvers: **alice**, **bill**
 
 Assign the PR to them by writing ` + "`/assign @alice @bill`" + ` in a comment when ready.

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -708,7 +708,7 @@ func TestGetMessage(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Bill</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
 and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver: **alice**
 
@@ -724,8 +724,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice"]} -->`
@@ -765,8 +765,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`
@@ -793,7 +793,7 @@ func TestGetMessageNoneApproved(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Author self-approved">John</a>*
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and ` + "`/lgtm`" + ` a pull request, 
 and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approvers: **alice**, **bill**
 
@@ -809,8 +809,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - **[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)**
 - **[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)**
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
@@ -852,8 +852,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`
@@ -894,8 +894,8 @@ Needs approval from an approver in each of these OWNERS Files:
 - ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
 - ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
 
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+OWNER approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>
 <!-- META={"approvers":[]} -->`

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -565,8 +565,7 @@ Approval requirements bypassed by manually added approval.
 This pull-request has been approved by: {{range $index, $approval := .ap.ListApprovals}}{{if $index}}, {{end}}{{$approval}}{{end}}
 
 {{- if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}
-To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
-and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
+To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver{{if ne 1 (len .ap.GetCCs)}}s{{end}}: {{range $index, $cc := .ap.GetCCs}}{{if $index}}, {{end}}**{{$cc}}**{{end}}
 
 Assign the PR to them by writing `+"`/assign {{range $index, $cc := .ap.GetCCs}}{{if $index}} {{end}}@{{$cc}}{{end}}`"+` in a comment when ready.

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -565,6 +565,8 @@ Approval requirements bypassed by manually added approval.
 This pull-request has been approved by: {{range $index, $approval := .ap.ListApprovals}}{{if $index}}, {{end}}{{$approval}}{{end}}
 
 {{- if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}
+To fully approve this pull request, please assign additional approvers. Any member of the organization can review and `+"`/lgtm`"+` a pull request, 
+and can be assigned to this PR, but in order for the pull request to be merged, it additionally has to be approved by a code owner listed in the OWNERS file for this repository(details below).
 We suggest the following additional approver{{if ne 1 (len .ap.GetCCs)}}s{{end}}: {{range $index, $cc := .ap.GetCCs}}{{if $index}}, {{end}}**{{$cc}}**{{end}}
 
 Assign the PR to them by writing `+"`/assign {{range $index, $cc := .ap.GetCCs}}{{if $index}} {{end}}@{{$cc}}{{end}}`"+` in a comment when ready.

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -588,6 +588,8 @@ Associated issue requirement bypassed by: {{range $index, $approval := .ap.ListN
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
+The pull request process is described [here](https://git.k8s.io/community/contributors/devel/owners.md#the-code-review-process)
+
 <details {{if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}open{{end}}>
 Needs approval from an approver in each of these OWNERS Files:
 

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -591,8 +591,9 @@ The full list of commands accepted by this bot can be found [here](https://go.k8
 Needs approval from an approver in each of these OWNERS Files:
 
 {{range .ap.GetFiles .org .project}}{{.}}{{end}}
-You can indicate your approval by writing `+"`/approve`"+` in a comment
-You can cancel your approval by writing `+"`/approve cancel`"+` in a comment
+OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
+A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
 </details>`, "message", map[string]interface{}{"ap": ap, "org": org, "project": project})
 	if err != nil {
 		ap.owners.log.WithError(err).Errorf("Error generating message.")

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -593,9 +593,8 @@ The full list of commands accepted by this bot can be found [here](https://go.k8
 Needs approval from an approver in each of these OWNERS Files:
 
 {{range .ap.GetFiles .org .project}}{{.}}{{end}}
-OWNER approvers can indicate their approval by writing `+"`/approve`"+` in a comment
-OWNER approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
-A PR needs both /approve and /lgtm to be merged by the bot. An OWNER approver's /lgtm automatically implies an /approve.
+Approvers can indicate their approval by writing `+"`/approve`"+` in a comment
+Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 </details>`, "message", map[string]interface{}{"ap": ap, "org": org, "project": project})
 	if err != nil {
 		ap.owners.log.WithError(err).Errorf("Error generating message.")


### PR DESCRIPTION
Adds clarifying language to bot message on pull requests.
Fixes #6469 

No actual code logic was changed; this is a first attempt to have the bot logically explain the "lgtm" vs "approve" workflow. I am open to suggestions on changing the logic itself.