### PR TITLE
Migrate cadvisor ci job to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -45,13 +45,6 @@
     - 'ci-{repo-suffix}'
     name: bootstrap-ci-repo
     repo-suffix:
-    - cadvisor-node-kubelet:  # dawnchen
-        branch: master
-        frequency: 'H/30 * * * *'
-        job-name: ci-cadvisor-node-kubelet
-        repo-name: github.com/google/cadvisor
-        timeout: 90
-
     - kubernetes-verify-master:
         branch: master
         frequency: 'H/5 * * * *'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -20,11 +20,17 @@
       "sig-node"
     ]
   },
-  "ci-cadvisor-node-kubelet": {
+  "ci-cadvisor-e2e": {
     "args": [
-      "./build/jenkins_e2e.sh"
+      "--deployment=node",
+      "--gcp-project=ci-cadvisor-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1--flakeAttempts=2",
+      "--timeout=10m"
     ],
-    "scenario": "execute",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5179,6 +5179,29 @@ periodics:
       - name: GOPATH
         value: /go
 
+- name: ci-cadvisor-e2e
+  interval: 8h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180202-1036088f2-master
+      args:
+      - --job=$(JOB_NAME)
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes
+      - --repo=github.com/google/cadvisor=master
+      - --service-account=/etc/service-account/service-account.json
+      - --timeout=90
+      - --upload=gs://kubernetes-jenkins/logs
+      - --
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml --test-suite=cadvisor
+      env:
+      - name: GOPATH
+        value: /go
+
 - name: ci-cri-containerd-build
   interval: 30m
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -52,8 +52,8 @@ default_dashboard_tab:
 test_groups:
 - name: ci-cadvisor-canarypush
   gcs_prefix: kubernetes-jenkins/logs/ci-cadvisor-canarypush
-- name: ci-cadvisor-node-kubelet
-  gcs_prefix: kubernetes-jenkins/logs/ci-cadvisor-node-kubelet
+- name: ci-cadvisor-e2e
+  gcs_prefix: kubernetes-jenkins/logs/ci-cadvisor-e2e
 - name: ci-kubernetes-node-kubelet-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark
   test_name_config:
@@ -4046,8 +4046,8 @@ dashboards:
   dashboard_tab:
   - name: cadvisor-push
     test_group_name: ci-cadvisor-canarypush
-  - name: cadvisor-kubelet
-    test_group_name: ci-cadvisor-node-kubelet
+  - name: cadvisor-e2e
+    test_group_name: ci-cadvisor-e2e
 
 - name: sig-node-cos-image
   dashboard_tab:


### PR DESCRIPTION
The cadvisor PR job is now passing.  We should change the periodic job to also work.
Do we need to also add something in config.yaml?  I dont see anything there right now...