### PR TITLE
Setup automation for kubernetes-sigs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,6 +32,10 @@ branch-protection:
           protect-by-default: true
         test-infra:
           protect-by-default: true
+    kubernetes-sigs:
+      protect-by-default: true
+      require-contexts:
+      - cla/linuxfoundation
     kubernetes-sig-testing:
       repos:
         frameworks:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -7,6 +7,7 @@ triggers:
   - kubernetes
   - kubernetes-incubator
   - kubernetes-security
+  - kubernetes-sigs
   - kubernetes-sig-testing
   - google/cadvisor  
   - tensorflow/k8s
@@ -48,6 +49,7 @@ approve:
   - kubernetes/website
   implicit_self_approve: true
 - repos:
+  - kubernetes-sigs
   - kubernetes-sig-testing
   implicit_self_approve: true
 
@@ -244,6 +246,24 @@ plugins:
   - lgtm
   - lifecycle
   - size
+
+  kubernetes-sigs:
+  - assign
+  - blunderbuss
+  - cat
+  - cla
+  - dog
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - shrug
+  - size
+  - skip
+  - wip
+  - yuks
 
   kubernetes-sig-testing:
   - assign


### PR DESCRIPTION
Basically the same set of automation as kubernetes-sig-testing, minus:
- tide
- approve plugin

See commits for details