### PR TITLE
set platform when building barnacle for bootstrap image

### DIFF
--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -18,8 +18,8 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 build:
-	bazel build //images/bootstrap/barnacle:barnacle
-	cp ./../../bazel-bin/images/bootstrap/barnacle/linux_amd64_stripped/barnacle ./barnacle/barnacle
+	bazel build //images/bootstrap/barnacle:barnacle --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+	cp ./../../bazel-bin/images/bootstrap/barnacle/linux_amd64_pure_stripped/barnacle ./barnacle/barnacle
 	docker build --build-arg IMAGE_ARG=$(IMG):$(TAG) -t $(IMG):$(TAG) .
 	rm ./barnacle/barnacle
 	docker tag $(IMG):$(TAG) $(IMG):latest

--- a/images/bootstrap/barnacle/BUILD
+++ b/images/bootstrap/barnacle/BUILD
@@ -16,6 +16,7 @@ go_binary(
     name = "barnacle",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/images/bootstrap/barnacle",
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Now that we have bazel 0.10 we can do this.

- Also use pure compilation always for consistency when local testing and avoiding incidental cgo

/area images
/area bazel