### PR TITLE
Reduce Tide token usage related to updating status contexts.

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -107,6 +107,11 @@ func (tq *TideQuery) AllPRsSince(t time.Time) string {
 	for _, r := range tq.Repos {
 		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
 	}
-	toks = append(toks, fmt.Sprintf("updated:>=%s", t.Format(timeFormatISO8601)))
+	// Github's GraphQL API silently fails if you provide it with an invalid time
+	// string.
+	// Dates before 1970 are considered invalid.
+	if t.Year() >= 1970 {
+		toks = append(toks, fmt.Sprintf("updated:>=%s", t.Format(timeFormatISO8601)))
+	}
 	return strings.Join(toks, " ")
 }

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+const timeFormatISO8601 = "2006-01-02T15:04:05Z"
+
 // Tide is config for the tide pool.
 type Tide struct {
 	// SyncPeriodString compiles into SyncPeriod at load time.
@@ -98,11 +100,13 @@ func (tq *TideQuery) Query() string {
 	return strings.Join(toks, " ")
 }
 
-// AllPRs returns all open PRs in the repos covered by the query.
-func (tq *TideQuery) AllPRs() string {
+// AllPRsSince returns all open PRs in the repos covered by the query that
+// have changed since time t.
+func (tq *TideQuery) AllPRsSince(t time.Time) string {
 	toks := []string{"is:pr", "state:open"}
 	for _, r := range tq.Repos {
 		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
 	}
+	toks = append(toks, fmt.Sprintf("updated:>=%s", t.Format(timeFormatISO8601)))
 	return strings.Join(toks, " ")
 }

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -19,23 +19,26 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/test-infra/prow/github"
 )
 
+var testQuery = &TideQuery{
+	Repos:                  []string{"k/k", "k/t-i"},
+	Labels:                 []string{"lgtm", "approved"},
+	MissingLabels:          []string{"foo"},
+	ReviewApprovedRequired: true,
+}
+
 func TestTideQuery(t *testing.T) {
-	tq := &TideQuery{
-		Repos:                  []string{"k/k", "k/t-i"},
-		Labels:                 []string{"lgtm", "approved"},
-		MissingLabels:          []string{"foo"},
-		ReviewApprovedRequired: true,
-	}
-	q := " " + tq.Query() + " "
+	q := " " + testQuery.Query() + " "
 	checkTok := func(tok string) {
 		if !strings.Contains(q, " "+tok+" ") {
 			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
 		}
 	}
+
 	checkTok("is:pr")
 	checkTok("state:open")
 	checkTok("repo:\"k/k\"")
@@ -44,6 +47,34 @@ func TestTideQuery(t *testing.T) {
 	checkTok("label:\"approved\"")
 	checkTok("-label:\"foo\"")
 	checkTok("review:approved")
+}
+
+func TestAllPRsSince(t *testing.T) {
+	testTime, err := time.Parse(time.UnixDate, "Sat Mar  7 11:06:39 PST 2015")
+	if err != nil {
+		t.Fatalf("Error parsing test time string: %v.", err)
+	}
+	q := " " + testQuery.AllPRsSince(testTime) + " "
+	checkTok := func(tok string, shouldExist bool) {
+		if shouldExist == strings.Contains(q, " "+tok+" ") {
+			return
+		} else if shouldExist {
+			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
+		} else {
+			t.Errorf("Expected query to not contain \"%s\", got \"%s\"", tok, q)
+
+		}
+	}
+
+	checkTok("is:pr", true)
+	checkTok("state:open", true)
+	checkTok("repo:\"k/k\"", true)
+	checkTok("repo:\"k/t-i\"", true)
+	checkTok("label:\"lgtm\"", false)
+	checkTok("label:\"approved\"", false)
+	checkTok("-label:\"foo\"", false)
+	checkTok("review:approved", false)
+	checkTok("updated:>=2015-03-07T11:06:39Z", true)
 }
 
 func TestMergeMethod(t *testing.T) {

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -54,7 +54,11 @@ func TestAllPRsSince(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing test time string: %v.", err)
 	}
-	q := " " + testQuery.AllPRsSince(testTime) + " "
+	testTimeOld, err := time.Parse(time.UnixDate, "Sat Mar  7 11:06:39 PST 1915")
+	if err != nil {
+		t.Fatalf("Error parsing test time string: %v.", err)
+	}
+	var q string
 	checkTok := func(tok string, shouldExist bool) {
 		if shouldExist == strings.Contains(q, " "+tok+" ") {
 			return
@@ -66,6 +70,7 @@ func TestAllPRsSince(t *testing.T) {
 		}
 	}
 
+	q = " " + testQuery.AllPRsSince(testTime) + " "
 	checkTok("is:pr", true)
 	checkTok("state:open", true)
 	checkTok("repo:\"k/k\"", true)
@@ -75,6 +80,13 @@ func TestAllPRsSince(t *testing.T) {
 	checkTok("-label:\"foo\"", false)
 	checkTok("review:approved", false)
 	checkTok("updated:>=2015-03-07T11:06:39Z", true)
+
+	// Test that if time is the zero time value, the token is not included.
+	q = " " + testQuery.AllPRsSince(time.Time{}) + " "
+	checkTok("updated:>=0001-01-01T00:00:00Z", false)
+	// Test that if time is before 1970, the token is not included.
+	q = " " + testQuery.AllPRsSince(testTimeOld) + " "
+	checkTok("updated:>=1915-03-07T11:06:39Z", false)
 }
 
 func TestMergeMethod(t *testing.T) {


### PR DESCRIPTION
Only consider PRs that have changed since the last sync loop when listing all open PRs in order to update status contexts.

/area prow
/cc @spxtr @rmmh @kargakis 

