### PR TITLE
Correct labels.yaml configmap name

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -121,12 +121,9 @@ milestonestatus:
 
 config_updater:
   maps:
-    label_sync/labels.yaml: label-sync
+    label_sync/labels.yaml: label-config
     prow/config.yaml: config
     prow/plugins.yaml: plugins
-  # Following two fields are deprecated
-  config_file: prow/config.yaml
-  plugin_file: prow/plugins.yaml
 
 plugins:
   google/cadvisor:


### PR DESCRIPTION
Also retire deprecated `config_file` and `plugin_file` fields

name now matches https://github.com/kubernetes/test-infra/blob/master/label_sync/Makefile#L39