### PR TITLE
kops weave job: specify kops-version

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8592,6 +8592,7 @@
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=weave",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"


### PR DESCRIPTION
Simply doesn't work without specifying the version.