### PR TITLE
Cleans up PluginHelp redundant fields

### DIFF
--- a/prow/pluginhelp/pluginhelp.go
+++ b/prow/pluginhelp/pluginhelp.go
@@ -41,18 +41,6 @@ type PluginHelp struct {
 	// Description is a description of what the plugin does and what purpose it achieves.
 	// This field may include HTML.
 	Description string
-	// WhoCanUse is a description of the permissions/role/authorization required to use the plugin.
-	// This is usually specified as a github permissions, but it can also be a github team, an
-	// OWNERS file alias, etc.
-	// This field may include HTML.
-	// TODO(qhuynh96): This field is about to be deprecated. WhoCanUse is now under the scope of Command.
-	WhoCanUse string
-	// Usage is a usage string for the plugin. Leave empty if not applicable.
-	// TODO(qhuynh96): This field is about to be deprecated. Usage is now under the scope of Command.
-	Usage string
-	// Examples is a list of usage examples for the plugin. Leave empty if not applicable.
-	// TODO(qhuynh96): This field is about to be deprecated. Examples is now under the scope of Command
-	Examples []string
 	// Config is a map from org/repo strings to a string describing the configuration for that repo.
 	// The key "" should map to a string describing configuration that applies to all repos if any.
 	// This configuration strings may include HTML.

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -101,16 +101,12 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		opts := optionsForRepo(config, parts[0], parts[1])
 		approveConfig[repo] = fmt.Sprintf("Pull requests %srequire an associated issue.<br>Pull request authors %simplicitly approve their own PRs.", doNot(opts.IssueRequired), doNot(opts.ImplicitSelfApprove))
 	}
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The approve plugin implements a pull request approval process that manages the '` + approvedLabel + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
 <br>
 <br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
 <br>For more information see <a href="https://git.k8s.io/test-infra/prow/plugins/approve/approvers/README.md">here</a>.`,
-		WhoCanUse: "Users listed as 'approvers' in appropriate OWNERS files.",
-		Usage:     "/(approve|lgtm) [no-issue|cancel]",
-		Examples:  []string{"/approve", "/approve no-issue", "/lgtm", "/lgtm cancel"},
-		Config:    approveConfig,
+		Config: approveConfig,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(approve|lgtm) [no-issue|cancel]",

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -42,12 +42,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no user is specified the commands default to targetting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
-		WhoCanUse:   "Anyone can use the assign plugin to assign or request reviews, but the target must be a member of the organization that owns the repository.",
-		Usage:       "/[un](assign|cc) [[@]<username>...]",
-		Examples:    []string{"/assign", "/assign @k8s-ci-robot", "/unassign", "/cc k8s-ci-robot k8s-merge-robot", "/uncc @k8s-ci-robot"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[un]assign [[@]<username>...]",

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -56,12 +56,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The cat plugin adds a cat image to an issue in response to the `/meow` command.",
-		WhoCanUse:   "Anyone",
-		Usage:       "/meow [category]",
-		Examples:    []string{"/meow", "/meow caturday"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/meow",

--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -48,12 +48,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The dog plugin adds a dog image to an issue in response to the `/woof` command.",
-		WhoCanUse:   "Anyone",
-		Usage:       "/(woof|bark)",
-		Examples:    []string{"/woof", "/bark"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(woof|bark)",

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -49,12 +49,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The golint plugin runs golint on changes made to *.go files in a PR. It then creates a new review on the pull request and leaves golint warnings at the appropriate lines of code.",
-		WhoCanUse:   "Anyone can trigger this plugin on a PR.",
-		Usage:       "/lint",
-		Examples:    []string{"/lint"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/lint",

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -51,12 +51,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The help plugin provides commands that add or remove the '" + helpLabel + "' label from issues.",
-		WhoCanUse:   "Anyone can trigger this plugin on a PR.",
-		Usage:       "/[remove-]help",
-		Examples:    []string{"/help", "/remove-help"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[remove-]help",

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -47,12 +47,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The hold plugin allows anyone to add or remove the '" + label + "' label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
-		WhoCanUse:   "Anyone can use the /hold command to add or remove the '" + label + "' label.",
-		Usage:       "/hold [cancel] | /unhold",
-		Examples:    []string{"/hold", "/hold cancel", "/unhold"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/hold [cancel] | /unhold",

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -42,12 +42,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'priority/*' and 'sig/*'.",
-		WhoCanUse:   "Anyone can trigger this plugin on a PR.",
-		Usage:       "/[remove-](area|committee|kind|priority|sig) <target>",
-		Examples:    []string{"/kind bug", "/remove-area prow", "/sig testing"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[remove-](area|committee|kind|priority|sig) <target>",

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -41,12 +41,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
-		WhoCanUse:   "Members of the organization that owns the repository. '/lgtm cancel' can be used additionally by the PR author.",
-		Usage:       "/lgtm [cancel]",
-		Examples:    []string{"/lgtm", "/lgtm cancel"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/lgtm [cancel]",

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -41,12 +41,8 @@ func init() {
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "Close, reopen, flag and/or unflag an issue or PR as stale/putrid/rotten/frozen",
-		WhoCanUse:   "Authors and assignees can close/reopen. Anyone can flag/unflag",
-		Usage:       "/close\n/reopen\n/lifecycle <frozen|stale|putrid|rotten>\n/remove-lifecycle <frozen|stale|putrid|rotten",
-		Examples:    []string{"/close", "/reopen", "/lifecycle frozen", "/remove-lifecycle stale"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/close",

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -53,12 +53,8 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The milestonestatus plugin allows members of the milestone maintainers Github team to specify the 'status/*' label that should apply to a pull request.",
-		WhoCanUse:   "Members of the milestone maintainers Github team can use the '/status' command. This team is specified in the config by providing the Github team's ID.",
-		Usage:       "/status (approved-for-milestone|in-progress|in-review)",
-		Examples:    []string{"/status approved-for-milestone", "/status in-progress", "/status in-review"},
 		Config: map[string]string{
 			"": fmt.Sprintf("The milestone maintainers team is the Github team with ID: %d.", config.MilestoneStatus.MaintainersID),
 		},

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -86,8 +86,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 <ol><li>PRs with a normal release note in the 'releasenote' block are given the label '` + releaseNote + `'.</li>
 <li>PRs that have a release note of 'none' in the block are given the label '` + releaseNoteNone + `' to indicate that the PR does not warrant a release note.</li>
 <li>PRs that contain 'action required' in their 'releasenote' block are given the label '` + releaseNoteActionRequired + `' to indicate that the PR introduces potentially breaking changes that necessitate user action before upgrading to the release.</li></ol>
-To support old behavior, this plugin also provides a '/release-note-none' command that can be used by organization members to specify that no release note is needed for the PR as an alternative to setting the 'releasenote' block contents to 'none'.`,
-			Usage: "In the pull request body text:\n\n```releasenote\n<release note content>\n```",
+To support old behavior, this plugin also provides a '/release-note-none' command that can be used by organization members to specify that no release note is needed for the PR as an alternative to setting the 'releasenote' block contents to 'none'.` + "To use the plugin, in the pull request body text:\n\n```releasenote\n<release note content>\n```",
 		},
 		nil
 }

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -49,12 +49,8 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The skip plugin allows users to clean up Github stale commit statuses for non-blocking jobs on a PR.",
-		WhoCanUse:   "Anyone can trigger this plugin on a PR.",
-		Usage:       "/skip",
-		Examples:    []string{"/skip"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/skip",

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -50,15 +50,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		trusted, _ := trustedOrgForRepo(config, parts[0], parts[1])
 		configInfo[repo] = fmt.Sprintf("The trusted Github organization for this repository is %q.", trusted)
 	}
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
 <br>Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command.
 <br>The '/retest' command can be used to rerun jobs that have reported failure.`,
-		WhoCanUse: "Anyone can use the '/test' and '/retest' commands on a trusted PR.<br>Members of the trusted organization for the repo can use the '/ok-to-test' command to mark an untrusted PR as trusted.",
-		Usage:     "/ok-to-test\n/test (<job name>|all)\n/retest",
-		Examples:  []string{"/ok-to-test", "/test all", "/test pull-bazel-test", "/retest"},
-		Config:    configInfo,
+		Config: configInfo,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/ok-to-test",

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -47,12 +47,8 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	// TODO(qhuynh96): Removes all the fields of pluginHelp except Description.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The yuks plugin comments with jokes in response to the `/joke` command.",
-		WhoCanUse:   "Anyone can use the `/joke` command.",
-		Usage:       "/joke",
-		Examples:    []string{"/joke"},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/joke",


### PR DESCRIPTION
Removes `WhoCanUse`, `Usage` and `Examples` fields from `struct PluginHelp` as those fields should be specified for `Command` 