### PR TITLE
Update command links to point to go.k8s.io/bot-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the different services interact.
   - [Gubernator](https://k8s-gubernator.appspot.com/) formats the output of each run
 * [PR Dashboard](https://k8s-gubernator.appspot.com/pr) finds PRs that need your attention
 * [Prow](https://prow.k8s.io) schedules testing and updates issues
-  - Prow responds to GitHub events, timers and [manual commands](commands.md)
+  - Prow responds to GitHub events, timers and [manual commands](https://go.k8s.io/bot-commands)
     given in GitHub comments.
   - The [prow dashboard](https://prow.k8s.io/) shows what it is currently testing
   - Configure prow to run new tests at [prow/config.yaml](prow/config.yaml)
@@ -83,7 +83,7 @@ $GOPATH/src/k8s.io/test-infra/jenkins/bootstrap.py \
 
 #### Release branch jobs & Image validation jobs
 
-Release branch jobs and image validation jobs are defined in [test_config.yaml](experiment/test_config.yaml). 
+Release branch jobs and image validation jobs are defined in [test_config.yaml](experiment/test_config.yaml).
 We test different master/node image versions against multiple k8s branches on different features.
 
 Those jobs are using channel based versions, current supported testing map is:

--- a/commands.md
+++ b/commands.md
@@ -1,44 +1,7 @@
 # k8s Bot Commands
 
-`k8s-ci-robot` and `k8s-merge-robot` understand several commands. They should all be uttered on their own line, and they are case-sensitive.
+The command list has been migrated to https://go.k8s.io/bot-commands
 
-For more detailed documentation on each of these commands, consult Prow's [plugin
-help](https://prow.k8s.io/plugin-help.html).
-
-Command | Implemented By | Who can run it | Description
---- | --- | --- | ---
-`/approve` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | approve all the files for which you are an approver
-`/approve no-issue` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | approve when a PR doesn't have an associated issue
-`/approve cancel` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | removes your approval on this pull-request
-`/area [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | adds an area/<> label(s) if it exists
-`/remove-area [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | removes an area/<> label(s) if it exists
-`/assign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | anyone | Assigns specified people (or yourself if no one is specified). Target must be a kubernetes org member.
-`/unassign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | anyone | Unassigns specified people (or yourself if no one is specified). Target must already be assigned.
-`/cc [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | anyone | Request review from specified people (or yourself if no one is specified). Target must be a kubernetes org member.
-`/uncc [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | anyone | Dismiss review request for specified people (or yourself if no one is specified). Target must already have had a review requested.
-`/close` | prow [lifecycle](./prow/plugins/lifecycle) | authors and assignees | closes the issue/PR
-`/reopen` | prow [lifecycle](./prow/plugins/lifecycle) | authors and assignees | reopens a closed issue/PR
-`/help` | prow [help](./prow/plugins/help) | anyone | adds the `help wanted` label
-`/remove-help` | prow [help](./prow/plugins/help) | anyone | removes the `help wanted` label
-`/hold` | prow [hold](./prow/plugins/hold) | anyone | adds the `do-not-merge/hold` label
-`/hold cancel` | prow [hold](./prow/plugins/hold) | anyone | removes the `do-not-merge/hold` label
-`/joke` | prow [yuks](./prow/plugins/yuks) | anyone | tells a bad joke, sometimes
-`/kind [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | adds a kind/<> label(s) if it exists
-`/remove-kind [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | removes a kind/<> label(s) if it exists
-`/lifecycle [state]` | prow [lifecycle](./prow/plugins/lifecycle) | anyone | adds a stale, rotten or frozen state label
-`/remove-lifecycle [state]` | prow [lifecycle](./prow/plugins/lifecycle) | anyone | removes a stale, rotten or frozen state label
-`/lgtm` | prow [lgtm](./prow/plugins/lgtm) | assignees | adds the `lgtm` label
-`/lgtm cancel` | prow [lgtm](./prow/plugins/lgtm) | authors and assignees | removes the `lgtm` label
-`/meow [category]` | prow [cat](./prow/plugins/cat) | anyone | Replies with a cat picture.
-`/ok-to-test` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | allows the PR author to `/test all`
-`/test all`<br>`/test <some-test-name>` | prow [trigger](./prow/plugins/trigger) | anyone on trusted PRs | runs tests defined in [config.yaml](./prow/config.yaml)
-`/retest` | prow [trigger](./prow/plugins/trigger) | anyone on trusted PRs | reruns failed tests
-`/priority [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | adds a priority/<> label(s) if it exists
-`/remove-priority [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | removes a priority/<> label(s) if it exists
-`/sig [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | adds a sig/<> label(s) if it exists
-`@kubernetes/sig-<some-github-team>` | prow [label](./prow/plugins/label) | kubernetes org members | adds the corresponding `sig` label
-`/remove-sig [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | removes a sig/<> label(s) if it exists
-`/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note` label
-`/release-note-action-required` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-action-required` label
-`/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-none` label
-`/status [label1 label2 ...]` | prow [milestonestatus](./prow/plugins/milestonestatus) | members of the [kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers/members) github team | adds a status/<> label(s) if it exists
+<!--
+This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
+-->

--- a/mungegithub/README.md
+++ b/mungegithub/README.md
@@ -25,7 +25,7 @@ A Github oauth token is required, even in readonly/test mode. For production, we
 After successfully running the local binary one may build, test, and deploy in readonly mode to a real kube cluster. To do so, one must make sure that one's kubeconfig file is set up for the test/read-only cluster by running any necessary `kubectl config` commands by hand. One may also need a container repository with read & write access. It is just as easy to create a new dockerhub account, and a public repository named `submit-queue` within that. We will refer to the repository as `docker.io/$USERNAME` where `$USERNAME` is a placeholder. The steps required to deploy on a real cluster for the submit-queue application are as follows. The instructions to run the cherrypick application are along the same lines. Below, we explain the steps to run on the kubernetes main repository. Running on other repositories is similar, except that the corresponding YAML files are in a directory for that repository.
 
 First store your personal access token in a plain text file named (token) in the mungegithub directory. If the app you are deploying uses github webhooks, store the github secret key in file named (hook-secret) in the mungegithub directory just like the access token.
- 
+
 Also create a persistent disk named `<reponame>-cache` on the mungegithub cluster for every repo that a submit-queue will target.
 
 If you are deploying for the first time to a new cluster run `APP=submit-queue TARGET=<reponame> make first_time_deploy` to create and upload a persistent volume and persistent volume claim, a new service, a new `<reponame>-github-token` secret, a configmap, and the actual deployment. If you are updating a deployment or if setup is partially complete, see the step-by-step instructions for deployment below.
@@ -114,7 +114,3 @@ APP=submit-queue TARGET=<TARGET> make push_secret
 * Create the service which is of type NodePort using `APP=submit-queue TARGET=<TARGET> make push_service`.
 * Finally, update the ingress.yaml with the new URL and the new service to point to.
 * Apply changes to the running ingress instance.
-
-## Communicating with the Bot
-
-The bot understands the commands in [k8s-ci-robot Commands](../commands.md).

--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -92,7 +92,7 @@ const (
 <summary>Help</summary>
 <ul>
  <li><a href="https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md">Additional instructions</a></li>
- <li><a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">Commands for setting labels</a></li>
+ <li><a href="https://go.k8s.io/bot-commands">Commands for setting labels</a></li>
 </ul>
 </details>
 `

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -128,7 +128,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 <summary>Help</summary>
 <ul>
  <li><a href="https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md">Additional instructions</a></li>
- <li><a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">Commands for setting labels</a></li>
+ <li><a href="https://go.k8s.io/bot-commands">Commands for setting labels</a></li>
 </ul>
 </details>`
 	if comments[0].Body == nil || expectedBody != *comments[0].Body {

--- a/mungegithub/mungers/sig-mention-handler.go
+++ b/mungegithub/mungers/sig-mention-handler.go
@@ -121,7 +121,7 @@ func (s *SigMentionHandler) Munge(obj *github.MungeObject) {
 		}
 
 		msg := fmt.Sprintf(`@%s
-There are no sig labels on this issue. Please [add a sig label](https://github.com/kubernetes/test-infra/blob/master/commands.md) by:
+There are no sig labels on this issue. Please [add a sig label](https://go.k8s.io/bot-commands) by:
 
 1. mentioning a sig: `+"`@kubernetes/sig-<group-name>-<group-suffix>`"+`
     e.g., `+"`@kubernetes/sig-contributor-experience-<group-suffix>`"+` to notify the contributor experience sig, OR
@@ -129,7 +129,7 @@ There are no sig labels on this issue. Please [add a sig label](https://github.c
 2. specifying the label manually: `+"`/sig <label>`"+`
     e.g., `+"`/sig scalability`"+` to apply the `+"`sig/scalability`"+` label
 
-Note: Method 1 will trigger an email to the group. See the [group list](https://github.com/kubernetes/community/blob/master/sig-list.md) and [label list](https://github.com/kubernetes/kubernetes/labels).
+Note: Method 1 will trigger an email to the group. See the [group list](https://git.k8s.io/community/sig-list.md) and [label list](https://github.com/kubernetes/kubernetes/labels).
 The `+"`<group-suffix>`"+` in the method 1 has to be replaced with one of these: _**bugs, feature-requests, pr-reviews, test-failures, proposals**_`, *obj.Issue.User.Login)
 
 		if err := obj.WriteComment(msg); err != nil {

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -268,7 +268,7 @@
                     <span>
                       Authors, reviewers, and owners can communicate with <code>k8s-ci-robot</code> by commenting on a PR with the
                       various commands entered in comments.<br/>Specific syntax is available
-                      <a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">here</a>.
+                      <a href="https://go.k8s.io/bot-commands">here</a>.
                     </span>
                 </md-content>
                 </md-tab>

--- a/prow/README.md
+++ b/prow/README.md
@@ -27,8 +27,8 @@ New features added to each components:
  - *February 1, 2018* `updateconfig` will now update any configmap on merge
  - *November 14, 2017* `jenkins-operator:0.58` exposes prometheus metrics.
  - *November 8, 2017* `horologium:0.14` prow periodic job now support cron
-   triggers. See https://godoc.org/gopkg.in/robfig/cron.v2 for doc to the 
-   cron library we are using. 
+   triggers. See https://godoc.org/gopkg.in/robfig/cron.v2 for doc to the
+   cron library we are using.
 
 Breaking changes to external APIs (labels, GitHub interactions, configuration
 or deployment) will be documented in this section. Prow is in a pre-release
@@ -145,8 +145,7 @@ types in `plugins`. In that package's `init` function, call
 empty import so that your plugin is included. If you forget this step then a
 unit test will fail when you try to add it to `plugins.yaml`. Don't add a brand
 new plugin to the main `kubernetes/kubernetes` repo right away, start with
-somewhere smaller and make sure it is well-behaved. If you add a command,
-document it in [commands.md](../commands.md).
+somewhere smaller and make sure it is well-behaved.
 
 The LGTM plugin is a good place to start if you're looking for an example
 plugin to mimic.

--- a/prow/commands.md
+++ b/prow/commands.md
@@ -1,1 +1,7 @@
-This file has moved to: https://github.com/kubernetes/test-infra/blob/master/commands.md
+# k8s Bot Commands
+
+The command list has been migrated to https://go.k8s.io/bot-commands
+
+<!--
+This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
+-->


### PR DESCRIPTION
Prow's command help page looks pretty, and is autogenerated. I don't believe there are any actual slash commands left that mungegithub runs. As such, I think it's time we point everyone to the right place!

Depends on https://github.com/kubernetes/k8s.io/pull/103 merging, so that go.k8s.io/bot-commands doesn't just loop back to the tombstone.

/cc fejta spiffxp ixdy
/assign cjwagner
/hold