### PR TITLE
prow: allow serving hidden jobs

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -48,6 +48,8 @@ var (
 	hookURL      = flag.String("hook-url", "", "Path to hook plugin help endpoint.")
 	// use when behind a load balancer
 	redirectHTTPTo = flag.String("redirect-http-to", "", "host to redirect http->https to based on x-forwarded-proto == http.")
+	// use when behind an oauth proxy
+	hiddenOnly = flag.Bool("hidden-only", false, "Show only hidden jobs. Useful for serving hidden jobs behind an oauth proxy.")
 )
 
 // Matches letters, numbers, hyphens, and underscores.
@@ -67,7 +69,7 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatal("Error getting client.")
 	}
-	kc.SetHiddenReposProvider(func() []string { return configAgent.Config().Deck.HiddenRepos })
+	kc.SetHiddenReposProvider(func() []string { return configAgent.Config().Deck.HiddenRepos }, *hiddenOnly)
 
 	var pkcs map[string]*kube.Client
 	if *buildCluster == "" {

--- a/prow/kube/client_test.go
+++ b/prow/kube/client_test.go
@@ -80,7 +80,7 @@ func TestSetHiddenReposProviderGet(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	c.SetHiddenReposProvider(func() []string { return []string{"hidden-org"} })
+	c.SetHiddenReposProvider(func() []string { return []string{"hidden-org"} }, false)
 	pj, err := c.GetProwJob("pja")
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
@@ -92,6 +92,32 @@ func TestSetHiddenReposProviderGet(t *testing.T) {
 	pj, err = c.GetProwJob("pjb")
 	if err == nil {
 		t.Fatal("Expected error getting hidden prowjob, but did not receive an error.")
+	}
+}
+
+func TestHiddenReposProviderGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		switch r.URL.Path {
+		case "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs/pja":
+			fmt.Fprint(w, `{"spec": {"job": "a", "refs": {"org": "org", "repo": "repo"}}}`)
+		case "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs/pjb":
+			fmt.Fprint(w, `{"spec": {"job": "b", "refs": {"org": "hidden-org", "repo": "repo"}}}`)
+		default:
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	c.SetHiddenReposProvider(func() []string { return []string{"hidden-org"} }, true)
+	pj, err := c.GetProwJob("pjb")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if got, expected := pj.Spec.Job, "b"; got != expected {
+		t.Errorf("Expected returned prowjob to be job %q, but got %q.", expected, got)
 	}
 }
 
@@ -107,7 +133,7 @@ func TestSetHiddenReposProviderList(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	c.SetHiddenReposProvider(func() []string { return []string{"org/hidden-repo"} })
+	c.SetHiddenReposProvider(func() []string { return []string{"org/hidden-repo"} }, false)
 	pjs, err := c.ListProwJobs(EmptySelector)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
@@ -116,6 +142,31 @@ func TestSetHiddenReposProviderList(t *testing.T) {
 		t.Fatalf("Expected one prowjobs, but got %v.", pjs)
 	}
 	if got, expected := pjs[0].Spec.Job, "b"; got != expected {
+		t.Errorf("Expected returned prowjob to be job %q, but got %q.", expected, got)
+	}
+}
+
+func TestHiddenReposProviderList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"items": [{"spec": {"job": "a", "refs": {"org": "org", "repo": "hidden-repo"}}}, {"spec": {"job": "b", "refs": {"org": "org", "repo": "repo"}}}]}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	c.SetHiddenReposProvider(func() []string { return []string{"org/hidden-repo"} }, true)
+	pjs, err := c.ListProwJobs(EmptySelector)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if len(pjs) != 1 {
+		t.Fatalf("Expected one prowjobs, but got %v.", pjs)
+	}
+	if got, expected := pjs[0].Spec.Job, "a"; got != expected {
 		t.Errorf("Expected returned prowjob to be job %q, but got %q.", expected, got)
 	}
 }


### PR DESCRIPTION
Useful for running a separate deck deployment behind an oauth proxy that exposes only hidden repos w/o maintaining a separate prow config.

@cjwagner @BenTheElder @stevekuznetsov @fejta thoughts?