### PR TITLE
Restore old blunderbuss behavior

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -18,6 +18,7 @@ package blunderbuss
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 
@@ -40,14 +41,20 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	var pluralSuffix string
-	if config.Blunderbuss.ReviewerCount != 1 {
+	var reviewCount int
+	if config.Blunderbuss.ReviewerCount != nil {
+		reviewCount = *config.Blunderbuss.ReviewerCount
+	} else if config.Blunderbuss.ReviewerCount != nil {
+		reviewCount = *config.Blunderbuss.FileWeightCount
+	}
+	if reviewCount != 1 {
 		pluralSuffix = "s"
 	}
 	// Omit the fields [WhoCanUse, Usage, Examples] because this plugin is not triggered by human actions.
 	return &pluginhelp.PluginHelp{
 			Description: "The blunderbuss plugin automatically requests reviews from reviewers when a new PR is created. The reviewers are selected based on the reviewers specified in the OWNERS files that apply to the files modified by the PR.",
 			Config: map[string]string{
-				"": fmt.Sprintf("Blunderbuss is currently configured to request reviews from %d reviewer%s.", config.Blunderbuss.ReviewerCount, pluralSuffix),
+				"": fmt.Sprintf("Blunderbuss is currently configured to request reviews from %d reviewer%s.", reviewCount, pluralSuffix),
 			},
 		},
 		nil
@@ -74,22 +81,35 @@ func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) err
 		return fmt.Errorf("error loading RepoOwners: %v", err)
 	}
 
-	return handle(pc.GitHubClient, oc, pc.Logger, pc.PluginConfig.Blunderbuss.ReviewerCount, &pre)
+	return handle(
+		pc.GitHubClient,
+		oc, pc.Logger,
+		pc.PluginConfig.Blunderbuss.ReviewerCount,
+		pc.PluginConfig.Blunderbuss.FileWeightCount,
+		&pre,
+	)
 }
 
-func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount int, pre *github.PullRequestEvent) error {
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount, oldReviewCount *int, pre *github.PullRequestEvent) error {
 	changes, err := ghc.GetPullRequestChanges(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
 	if err != nil {
 		return fmt.Errorf("error getting PR changes: %v", err)
 	}
 
-	reviewers, err := getReviewers(oc, pre.PullRequest.User.Login, changes, reviewerCount)
-	if err != nil {
-		return err
+	var reviewers []string
+	switch {
+	case oldReviewCount != nil:
+		reviewers = getReviewersOld(log, oc, pre.PullRequest.User.Login, changes, *oldReviewCount)
+	case reviewerCount != nil:
+		reviewers, err = getReviewers(oc, pre.PullRequest.User.Login, changes, *reviewerCount)
+		if err != nil {
+			return err
+		}
+		if missing := *reviewerCount - len(reviewers); missing > 0 {
+			log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), reviewerCount)
+		}
 	}
-	if missing := reviewerCount - len(reviewers); missing > 0 {
-		log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), reviewerCount)
-	}
+
 	if len(reviewers) > 0 {
 		log.Infof("Requesting reviews from users %s.", reviewers)
 		return ghc.RequestReview(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, reviewers)
@@ -141,4 +161,94 @@ func popRandom(set sets.String) string {
 	sel := list[rand.Intn(len(list))]
 	set.Delete(sel)
 	return sel
+}
+
+func getReviewersOld(log *logrus.Entry, oc ownersClient, author string, changes []github.PullRequestChange, reviewerCount int) []string {
+	potentialReviewers, weightSum := getPotentialReviewers(oc, author, changes, true)
+	reviewers := selectMultipleReviewers(log, potentialReviewers, weightSum, reviewerCount)
+	if len(reviewers) < reviewerCount {
+		// Didn't find enough leaf reviewers, need to include reviewers from parent OWNERS files.
+		potentialReviewers, weightSum := getPotentialReviewers(oc, author, changes, false)
+		for _, reviewer := range reviewers {
+			delete(potentialReviewers, reviewer)
+		}
+		reviewers = append(reviewers, selectMultipleReviewers(log, potentialReviewers, weightSum, reviewerCount-len(reviewers))...)
+		if missing := reviewerCount - len(reviewers); missing > 0 {
+			log.Errorf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), reviewerCount)
+		}
+	}
+	return reviewers
+}
+
+// weightMap is a map of user to a weight for that user.
+type weightMap map[string]int64
+
+func getPotentialReviewers(owners ownersClient, author string, files []github.PullRequestChange, leafOnly bool) (weightMap, int64) {
+	potentialReviewers := weightMap{}
+	weightSum := int64(0)
+	var fileOwners sets.String
+	for _, file := range files {
+		fileWeight := int64(1)
+		if file.Changes != 0 {
+			fileWeight = int64(file.Changes)
+		}
+		// Judge file size on a log scale-- effectively this
+		// makes three buckets, we shouldn't have many 10k+
+		// line changes.
+		fileWeight = int64(math.Log10(float64(fileWeight))) + 1
+		if leafOnly {
+			fileOwners = owners.LeafReviewers(file.Filename)
+		} else {
+			fileOwners = owners.Reviewers(file.Filename)
+		}
+
+		for _, owner := range fileOwners.List() {
+			if owner == author {
+				continue
+			}
+			potentialReviewers[owner] = potentialReviewers[owner] + fileWeight
+			weightSum += fileWeight
+		}
+	}
+	return potentialReviewers, weightSum
+}
+
+func selectMultipleReviewers(log *logrus.Entry, potentialReviewers weightMap, weightSum int64, count int) []string {
+	for name, weight := range potentialReviewers {
+		log.Debugf("Reviewer %s had chance %02.2f%%", name, chance(weight, weightSum))
+	}
+
+	// Make a copy of the map
+	pOwners := weightMap{}
+	for k, v := range potentialReviewers {
+		pOwners[k] = v
+	}
+
+	owners := []string{}
+
+	for i := 0; i < count; i++ {
+		if len(pOwners) == 0 || weightSum == 0 {
+			break
+		}
+		selection := rand.Int63n(weightSum)
+		owner := ""
+		for o, w := range pOwners {
+			owner = o
+			selection -= w
+			if selection <= 0 {
+				break
+			}
+		}
+
+		owners = append(owners, owner)
+		weightSum -= pOwners[owner]
+
+		// Remove this person from the map.
+		delete(pOwners, owner)
+	}
+	return owners
+}
+
+func chance(val, total int64) float64 {
+	return 100.0 * float64(val) / float64(total)
 }

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -184,9 +185,14 @@ type ExternalPlugin struct {
 }
 
 type Blunderbuss struct {
-	// ReviewerCount is the number of reviewers to request reviews from.
-	// A value of 0 will default to requesting reviews from 2 reviewers.
-	ReviewerCount int `json:"request_count,omitempty"`
+	// ReviewerCount is the minimum number of reviewers to request
+	// reviews from. Defaults to requesting reviews from 2 reviewers
+	// if none of the given options is set.
+	ReviewerCount *int `json:"request_count,omitempty"`
+	// FileWeightCount is the maximum number of reviewers to request
+	// reviews from. Selects reviewers based on file weighting.
+	// This and request_count are mutually exclusive options.
+	FileWeightCount *int `json:"file_weight_count,omitempty"`
 }
 
 // Owners contains configuration related to handling OWNERS files.
@@ -402,8 +408,9 @@ func (c *Configuration) setDefaults() {
 			c.ExternalPlugins[repo][i].Endpoint = fmt.Sprintf("http://%s", p.Name)
 		}
 	}
-	if c.Blunderbuss.ReviewerCount == 0 {
-		c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
+	if c.Blunderbuss.ReviewerCount == nil && c.Blunderbuss.FileWeightCount == nil {
+		c.Blunderbuss.ReviewerCount = new(int)
+		*c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
 	}
 	for i, trigger := range c.Triggers {
 		if trigger.TrustedOrg == "" || trigger.JoinOrgURL != "" {
@@ -438,6 +445,9 @@ func (pa *PluginAgent) Load(path string) error {
 		return err
 	}
 	if err := validateExternalPlugins(np.ExternalPlugins); err != nil {
+		return err
+	}
+	if err := validateBlunderbuss(&np.Blunderbuss); err != nil {
 		return err
 	}
 	// regexp compilation should run after defaulting
@@ -520,6 +530,19 @@ func validateExternalPlugins(pluginMap map[string][]ExternalPlugin) error {
 
 	if len(errors) > 0 {
 		return fmt.Errorf("invalid plugin configuration:\n\t%v", strings.Join(errors, "\n\t"))
+	}
+	return nil
+}
+
+func validateBlunderbuss(b *Blunderbuss) error {
+	if b.ReviewerCount != nil && b.FileWeightCount != nil {
+		return errors.New("cannot use both request_count and file_weight_count in blunderbuss")
+	}
+	if b.ReviewerCount != nil && *b.ReviewerCount < 1 {
+		return fmt.Errorf("invalid request_count: %v (needs to be positive)", *b.ReviewerCount)
+	}
+	if b.FileWeightCount != nil && *b.FileWeightCount < 1 {
+		return fmt.Errorf("invalid file_weight_count: %v (needs to be positive)", *b.FileWeightCount)
 	}
 	return nil
 }


### PR DESCRIPTION
@cjwagner @stevekuznetsov @fejta this PR restores the old behavior of the review selection algorithm while retaining the current behavior (introduced in https://github.com/kubernetes/test-infra/pull/5960). I have had negative feedback for the current selection mainly because it is too noisy and we need to fallback to the old behavior.

Fixes https://github.com/kubernetes/test-infra/issues/6295