### PR TITLE
Add multicluster federation release job.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -474,6 +474,15 @@
       "sig-multicluster"
     ]
   },
+  "ci-federation-release": {
+    "args": [
+      "./hack/release.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-multicluster"
+    ]
+  },
   "ci-ingress-gce-downgrade-e2e": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4658,6 +4658,42 @@ postsubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+
+  kubernetes/federation:
+  - agent: kubernetes
+    name: ci-federation-release
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+          # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "2Gi"
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build
     agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1950,6 +1950,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-federation-e2e-gce
 - name: ci-federation-e2e-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-federation-e2e-gce-serial
+- name: ci-federation-release
+  gcs_prefix: kubernetes-jenkins/logs/ci-federation-release
 # GCE Guest compute-image-tools
 - name: ci-daisy-e2e
   gcs_prefix: compute-image-tools-test/logs/ci-daisy-e2e
@@ -3725,6 +3727,8 @@ dashboards:
     test_group_name: ci-federation-e2e-gce-serial
   - name: build
     test_group_name: ci-federation-build
+  - name: release
+    test_group_name: ci-federation-release
 
 - name: sig-instrumentation
   dashboard_tab:


### PR DESCRIPTION
The job triggers hack/release.sh from k8s.io/federation repo, which
ideally will be a no-op unless there is a tag on the latest commit pushed.
If a tag is found, it will build and push the tars and image at the default locations.