### PR TITLE
Revert "Support /unhold (totally a word) as an alias for /hold cancel."

### DIFF
--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -36,7 +36,7 @@ const pluginName = "hold"
 var (
 	label         = "do-not-merge/hold"
 	labelRe       = regexp.MustCompile(`(?mi)^/hold\s*$`)
-	labelCancelRe = regexp.MustCompile(`(?mi)^/(hold cancel|unh..d)\s*$`)
+	labelCancelRe = regexp.MustCompile(`(?mi)^/hold cancel\s*$`)
 )
 
 type hasLabelFunc func(label string, issueLabels []github.Label) bool
@@ -51,11 +51,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "The hold plugin allows anyone to add or remove the '" + label + "' label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/hold [cancel] | /unhold",
+		Usage:       "/hold [cancel]",
 		Description: "Adds or removes the `" + label + "` label which is used to indicate that the PR should not be automatically merged.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can use the /hold command to add or remove the '" + label + "' label.",
-		Examples:    []string{"/hold", "/hold cancel", "/unhold"},
+		Examples:    []string{"/hold", "/hold cancel"},
 	})
 	return pluginHelp, nil
 }

--- a/prow/plugins/hold/hold_test.go
+++ b/prow/plugins/hold/hold_test.go
@@ -63,13 +63,6 @@ func TestHandle(t *testing.T) {
 			shouldUnlabel: true,
 		},
 		{
-			name:          "requested unhold",
-			body:          "/unhold",
-			hasLabel:      true,
-			shouldLabel:   false,
-			shouldUnlabel: true,
-		},
-		{
 			name:          "requested hold cancel, label already gone",
 			body:          "/hold cancel",
 			hasLabel:      false,


### PR DESCRIPTION
This reverts commit d12bf7bc60fc6e86a9d34e4c74c944142f051d9c.

Based on the discussion [here](https://kubernetes.slack.com/archives/C09QZ4DQB/p1517871153000152). 

/hold for comment