### PR TITLE
add experiment/nursery bazel cache

### DIFF
--- a/experiment/nursery/README.md
+++ b/experiment/nursery/README.md
@@ -1,0 +1,14 @@
+# Nursery
+
+Nursery is our bazel [bazel remote caching](https://docs.bazel.build/versions/master/remote-caching.html) setup.
+
+Initially we are using https://github.com/buchgr/bazel-remote but if this goes
+well we will probably want to implement something mores sophisticated.
+
+Setup (for [prow.k8s.io](https://prow.k8s.io/)):
+```
+make -C prow get-build-cluster-credentials
+gcloud beta container node-pools create bazel-cache --cluster=prow --project=k8s-prow-builds --zone=us-central1-f --node-taints dedicated=bazel-cache:NoSchedule --machine-type=n1-standard-8 --num-nodes=1 --local-ssd-count=1
+kubectl apply -f experiment/nursery/deployment.yaml
+kubectl apply -f experiment/nursery/service.yaml
+```

--- a/experiment/nursery/deployment.yaml
+++ b/experiment/nursery/deployment.yaml
@@ -1,0 +1,53 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: bazel-cache
+  labels:
+    app: bazel-cache
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bazel-cache
+    spec:
+      containers:
+      - name: bazel-cache
+        # https://github.com/buchgr/bazel-remote
+        image: buchgr/bazel-remote-cache
+        imagePullPolicy: Always
+        ports:
+        - name: cache
+          containerPort: 8080
+        args:
+        # local ssd is 375 GB
+        - --max_size=370
+        - --dir=/data
+      # mount the local ssd
+        volumeMounts:
+        - name: cache
+          mountPath: /data
+      volumes:
+      - name: cache
+        hostPath:
+          path: /mnt/disks/ssd0/cache
+      # run on our dedicated node
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "bazel-cache"
+        effect: "NoSchedule"

--- a/experiment/nursery/service.yaml
+++ b/experiment/nursery/service.yaml
@@ -1,0 +1,26 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazel-cache
+  labels:
+    run: bazel-cache
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: bazel-cache


### PR DESCRIPTION
This is an MVP experimental bazel caching setup. Once this is deployed I will point `pull-test-infra-bazel-canary` at it and see about speeding up our presubmits

I've created the reserved node but I have not deployed the kubernetes objects yet.