### PR TITLE
point test-infra bazel canary at the cache

### DIFF
--- a/experiment/nursery/create_bazel_cache_rcs.sh
+++ b/experiment/nursery/create_bazel_cache_rcs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THIS IS TEMPORARY (!)
+# Once this moves out of experiment/ we will create these files in the bazel
+# images instead (!)
+# TODO(bentheelder): verify that this works and move it into the images
+CACHE_HOST="http://bazel-cache:8080"
+
+make_bazel_rc () {
+    echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256" >> $1
+    echo "build --spawn_strategy=remote" >> $1
+    echo "build --strategy=Javac=remote" >> $1
+    echo "build --genrule_strategy=remote" >> $1
+    echo "build --remote_rest_cache=${CACHE_HOST}" >> $1
+}
+
+# https://docs.bazel.build/versions/master/user-manual.html#bazelrc
+# bazel will look for two RC files, taking the first option in each set of paths
+# firstly:
+# - The path specified by the --bazelrc=file startup option. If specified, this option must appear before the command name (e.g. build)
+# - A file named .bazelrc in your base workspace directory
+# - A file named .bazelrc in your home directory
+make_bazel_rc "${HOME}/.bazelrc"
+# Aside from the optional configuration file described above, Bazel also looks for a master rc file next to the binary, in the workspace at tools/bazel.rc or system-wide at /etc/bazel.bazelrc.
+# These files are here to support installation-wide options or options shared between users. Reading of this file can be disabled using the --nomaster_bazelrc option.
+make_bazel_rc "/etc/bazel.bazelrc"
+# hopefully no repos create *both* of these ...

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4680,6 +4680,7 @@ presubmits:
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."
         - "--test-args=--test_output=errors"
+        - "--experimental-add-caching-configs"
         env:
         - name: TEST_TMPDIR
           value: /scratch/.cache/bazel

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -135,6 +135,9 @@ def clean_file_in_dir(dirname, filename):
 def main(args):
     """Trigger a bazel build/test run, and upload results."""
     # pylint:disable=too-many-branches, too-many-statements, too-many-locals
+    if args.experimental_add_caching_configs:
+        check(test_infra('experiment', 'nursery', 'create_bazel_cache_rcs.sh'))
+
     if args.install:
         for install in args.install:
             if not os.path.isfile(install):
@@ -253,7 +256,11 @@ def create_parser():
         default='gs://kubernetes-release-dev/bazel',
         help='GCS path for where to push build')
     parser.add_argument(
-        '--batch', action='store_true', help=" run Bazel in batch mode")
+        '--batch', action='store_true', help='run Bazel in batch mode')
+    # TODO(bentheelder): remove this
+    parser.add_argument(
+        '--experimental-add-caching-configs', action='store_true', help='experimental, do not use'
+    )
     return parser
 
 def parse_args(args=None):


### PR DESCRIPTION
I'm creating `bazelrc`s with the necessary options because this will allow us to support arbitrary bazel usage, in the future these configs can just live in our bazel images.

/area jobs
