### PR TITLE
Add to updater support for uploading, column headers, more row info

### DIFF
--- a/testgrid/cmd/updater/BUILD
+++ b/testgrid/cmd/updater/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//testgrid:state",
         "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/google.golang.org/api/iterator:go_default_library",
     ],
 )

--- a/testgrid/cmd/updater/BUILD
+++ b/testgrid/cmd/updater/BUILD
@@ -7,6 +7,7 @@ go_library(
     importpath = "k8s.io/test-infra/testgrid/cmd/updater",
     visibility = ["//visibility:private"],
     deps = [
+        "//testgrid:config",
         "//testgrid:state",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/testgrid/cmd/updater/main_test.go
+++ b/testgrid/cmd/updater/main_test.go
@@ -24,10 +24,11 @@ import (
 
 func Test_ExtractRows(t *testing.T) {
 	cases := []struct {
-		name     string
-		content  string
-		expected map[string]state.Row_Result
-		err      bool
+		name    string
+		content string
+		results map[string]state.Row_Result
+		metrics map[string]map[string]float64
+		err     bool
 	}{
 		{
 			name: "basic testsuite",
@@ -37,7 +38,7 @@ func Test_ExtractRows(t *testing.T) {
 			    <testcase name="bad"><failure/></testcase>
 			    <testcase name="skip"><skipped/></testcase>
 			  </testsuite>`,
-			expected: map[string]state.Row_Result{
+			results: map[string]state.Row_Result{
 				"good": state.Row_PASS,
 				"bad":  state.Row_FAIL,
 			},
@@ -54,29 +55,73 @@ func Test_ExtractRows(t *testing.T) {
 			    <testcase name="skip"><skipped/></testcase>
 			  </testsuite>
 			  </testsuites>`,
-			expected: map[string]state.Row_Result{
+			results: map[string]state.Row_Result{
 				"good": state.Row_PASS,
 				"bad":  state.Row_FAIL,
+			},
+		},
+		{
+			name: "basic timing",
+			content: `
+			  <testsuite>
+			    <testcase name="slow" time="100.1" />
+			    <testcase name="slow-failure" time="123456789">
+			      <failure>terrible</failure>
+			    </testcase>
+			    <testcase name="fast" time="0.0001" />
+			    <testcase name="nothing-elapsed" time="0" />
+			  </testsuite>`,
+			results: map[string]state.Row_Result{
+				"slow":            state.Row_PASS,
+				"slow-failure":    state.Row_FAIL,
+				"fast":            state.Row_PASS,
+				"nothing-elapsed": state.Row_PASS,
+			},
+			metrics: map[string]map[string]float64{
+				"slow":         {elapsedKey: 100.1},
+				"slow-failure": {elapsedKey: 123456789},
+				"fast":         {elapsedKey: 0.0001},
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		actual := map[string]state.Row_Result{}
-		err := extractRows([]byte(tc.content), actual)
+		results := map[string]state.Row_Result{}
+		metrics := map[string]map[string]float64{}
+
+		err := extractRows([]byte(tc.content), results, metrics)
 		switch {
 		case err == nil && tc.err:
 			t.Errorf("%s: failed to raise an error", tc.name)
 		case err != nil && !tc.err:
 			t.Errorf("%s: unexpected err: %v", tc.name, err)
-		case len(actual) > len(tc.expected):
-			t.Errorf("%s: extra keys: actual %#v != expected %#v", tc.name, actual, tc.expected)
+		case len(results) > len(tc.results):
+			t.Errorf("%s: extra results: actual %v != expected %v", tc.name, results, tc.results)
+		case len(metrics) > len(tc.metrics):
+			t.Errorf("%s: extra metrics: actual %v != expected %v", tc.name, metrics, tc.metrics)
 		default:
-			for target, er := range tc.expected {
-				if ar, ok := actual[target]; !ok {
-					t.Errorf("%s: missing key: %s", tc.name, target)
+			for target, er := range tc.results {
+				if ar, ok := results[target]; !ok {
+					t.Errorf("%s: missing result: %s", tc.name, target)
 				} else if ar != er {
-					t.Errorf("%s: actual %s != expected %s", tc.name, ar, er)
+					t.Errorf("%s: %s actual %s != expected %s", tc.name, target, ar, er)
+				}
+			}
+			for target, ems := range tc.metrics {
+				ams, ok := metrics[target]
+				switch {
+				case !ok:
+					t.Errorf("%s: missing metrics for %s", tc.name, target)
+				case len(ams) > len(ems):
+					t.Errorf("%s: extra metrics for %s: actual %v != expected %v", tc.name, target, ams, ems)
+				default:
+					for name, ev := range ems {
+						if av, ok := ams[name]; !ok {
+							t.Errorf("%s: missing %s in %s", tc.name, target, name)
+						} else if av != ev {
+							t.Errorf("%s: %s %s actual %f != expected %f", tc.name, target, name, av, ev)
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* Support rows that include metrics, messages, icons, cell ids.
* Support columns with extra headers.
* Marshal, compress and upload grid message
* Unit tests for metadata info

/assign @rmmh @michelle192837 

Many things this still does not do (sort by name, list builds in correct order, append metadata to row name, actually use the config to determine which builds to list, optimize for performance, run inside a container, etc...)