### PR TITLE
Re-add lt/gt wrapper around username to be linked

### DIFF
--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -98,7 +98,7 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	if mw := getMergeWarning(pc.SlackConfig.MergeWarnings, pe.Repo.Owner.Login, pe.Repo.Name); mw != nil {
 		//If the MergeWarning whitelist has the merge user then no need to send a message.
 		if !stringInArray(pe.Pusher.Name, mw.WhiteList) && !stringInArray(pe.Sender.Login, mw.WhiteList) {
-			message := fmt.Sprintf("*Warning:* %s (@%s) manually merged %s", pe.Sender.Login, pe.Sender.Login, pe.Compare)
+			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %s", pe.Sender.Login, pe.Sender.Login, pe.Compare)
 			for _, channel := range mw.Channels {
 				if err := pc.SlackClient.WriteMessage(message, channel); err != nil {
 					return err
@@ -156,7 +156,7 @@ func echoToSlack(pc client, e github.GenericCommentEvent) error {
 			continue
 		}
 
-		msg := fmt.Sprintf("%s was mentioned by %s (@%s) on Github. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
+		msg := fmt.Sprintf("%s was mentioned by %s (<@%s>) on Github. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
 		if err := pc.SlackClient.WriteMessage(msg, sig); err != nil {
 			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %v", sig, msg, err)
 		}

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -83,8 +83,8 @@ func TestPush(t *testing.T) {
 			name:    "If PR merged manually by a user we send message to sig-contribex and kubernetes-dev.",
 			pushReq: pushEvManual,
 			expectedMessages: map[string][]string{
-				"sig-contribex":  {"*Warning:* tester (@tester) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
-				"kubernetes-dev": {"*Warning:* tester (@tester) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}},
+				"sig-contribex":  {"*Warning:* tester (<@tester>) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
+				"kubernetes-dev": {"*Warning:* tester (<@tester>) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}},
 		},
 		{
 			name:             "If PR merged by k8s merge bot we should NOT send message to sig-contribex and kubernetes-dev.",


### PR DESCRIPTION
In #6610, I removed the lt/gt signs around the username that we are mentioning. This makes Slack no longer trigger a mention of that username. This re-adds those brackets so that we attempt to mention/ping the username in Slack.