### PR TITLE
Adding scripts to create a kubetest image with kubemci

### DIFF
--- a/images/kubemci/Dockerfile
+++ b/images/kubemci/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-testimages/kubekins-e2e:latest-master
+LABEL maintainer "nikhiljindal@google.com"
+
+RUN apt-get update && apt-get install -y \
+    git && \
+    apt-get clean
+
+# Build latest kubemci from HEAD.
+RUN cd /${GOPATH}/src && \
+    mkdir -p github.com/GoogleCloudPlatform && \
+    cd github.com/GoogleCloudPlatform && \
+    git clone https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress.git && \
+    cd k8s-multicluster-ingress && \
+    make build && \
+    cp kubemci /bin && \
+    rm -rf /${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-multicluster-ingress

--- a/images/kubemci/Makefile
+++ b/images/kubemci/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+IMG = "gcr.io/k8s-testimages/e2e-kubemci"
+
+# Build a versioned image.
+image:
+	docker build --no-cache -t "$(IMG):$(VERSION)" --build-arg "IMAGE_ARG=$(IMG):$(VERSION)" .
+
+# Build both the versioned and latest images.
+image-latest: image
+	docker build --no-cache -t "$(IMG):latest" --build-arg "IMAGE_ARG=$(IMG):latest" .
+
+# Build and push the versioned image.
+push: image
+	docker push "$(IMG):$(VERSION)"
+
+# Build and push both the versioned and latest images.
+push-latest: push image-latest
+	docker push "$(IMG):latest"
+
+.PHONY: image image-latest push push-latest


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/issues/6624

As discussed, adding a Makefile and a Dockerfile to create a docker image to create an image with both kubetest and kubemci.

cc @krzyzacy @BenTheElder @G-Harmon @MrHohn 