### PR TITLE
Move Tide status update logic into its own goroutine.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -439,6 +439,15 @@ func parseConfig(c *Config) error {
 		}
 		c.Tide.SyncPeriod = period
 	}
+	if c.Tide.StatusUpdatePeriodString == "" {
+		c.Tide.StatusUpdatePeriod = c.Tide.SyncPeriod
+	} else {
+		period, err := time.ParseDuration(c.Tide.StatusUpdatePeriodString)
+		if err != nil {
+			return fmt.Errorf("cannot parse duration for tide.status_update_period: %v", err)
+		}
+		c.Tide.StatusUpdatePeriod = period
+	}
 
 	if c.Tide.MaxGoroutines == 0 {
 		c.Tide.MaxGoroutines = 20

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -32,6 +32,11 @@ type Tide struct {
 	SyncPeriodString string `json:"sync_period,omitempty"`
 	// SyncPeriod specifies how often Tide will sync jobs with Github. Defaults to 1m.
 	SyncPeriod time.Duration `json:"-"`
+	// StatusUpdatePeriodString compiles into StatusUpdatePeriod at load time.
+	StatusUpdatePeriodString string `json:"status_update_period,omitempty"`
+	// StatusUpdatePeriod specifies how often Tide will update Github status contexts.
+	// Defaults to the value of SyncPeriod.
+	StatusUpdatePeriod time.Duration `json:"-"`
 	// Queries must not overlap. It must be impossible for any two queries to
 	// ever return the same PR.
 	// TODO: This will only be possible when we allow specifying orgs. At that

--- a/prow/tide/BUILD
+++ b/prow/tide/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/shurcooL/githubql:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -31,6 +31,7 @@ import (
 	"github.com/shurcooL/githubql"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
@@ -65,12 +66,27 @@ type Controller struct {
 	kc     kubeClient
 	gc     *git.Client
 
+	sc *statusController
+
+	m     sync.Mutex
+	pools []Pool
+}
+
+type statusController struct {
+	logger *logrus.Entry
+	ca     *config.Agent
+	ghc    githubClient
+
+	// newPoolPending is a size 1 chan that signals that the main Tide loop has
+	// updated the 'poolPRs' field with a freshly updated pool.
+	newPoolPending chan bool
+
 	// lastSyncStartTime is used to only list PRs that have changed since we last
 	// checked in order to make status context updates cheaper.
 	lastSyncStartTime time.Time
 
-	m     sync.Mutex
-	pools []Pool
+	sync.Mutex
+	poolPRs []PullRequest
 }
 
 // Action represents what actions the controller can take. It will take
@@ -109,46 +125,59 @@ type Pool struct {
 
 // NewController makes a Controller out of the given clients.
 func NewController(ghc *github.Client, kc *kube.Client, ca *config.Agent, gc *git.Client, logger *logrus.Entry) *Controller {
+	sc := &statusController{
+		logger:         logger.WithField("controller", "status-update"),
+		ghc:            ghc,
+		ca:             ca,
+		newPoolPending: make(chan bool, 1),
+	}
+	go sc.run()
 	return &Controller{
-		logger: logger,
+		logger: logger.WithField("controller", "sync"),
 		ghc:    ghc,
 		kc:     kc,
 		ca:     ca,
 		gc:     gc,
+		sc:     sc,
 	}
 }
 
-// org/repo -> number -> pr
-func byRepoAndNumber(prs []PullRequest) map[string]map[int]PullRequest {
-	m := make(map[string]map[int]PullRequest)
+func prKey(pr *PullRequest) string {
+	return fmt.Sprintf("%s#%d", string(pr.Repository.NameWithOwner), int(pr.Number))
+}
+
+// org/repo#number -> pr
+func byRepoAndNumber(prs []PullRequest) map[string]PullRequest {
+	m := make(map[string]PullRequest)
 	for _, pr := range prs {
-		r := string(pr.Repository.NameWithOwner)
-		if _, ok := m[r]; !ok {
-			m[r] = make(map[int]PullRequest)
-		}
-		m[r][int(pr.Number)] = pr
+		key := prKey(&pr)
+		m[key] = pr
 	}
 	return m
 }
 
 // Returns expected status state and description.
 // TODO(spxtr): Useful information such as "missing label: foo."
-func expectedStatus(pr PullRequest, pool map[string]map[int]PullRequest) (string, string) {
-	if _, ok := pool[string(pr.Repository.NameWithOwner)][int(pr.Number)]; !ok {
+func expectedStatus(pr *PullRequest, pool map[string]PullRequest) (string, string) {
+	key := prKey(pr)
+	if _, ok := pool[key]; !ok {
 		return github.StatusPending, statusNotInPool
 	}
 	return github.StatusSuccess, statusInPool
 }
 
-func (c *Controller) setStatuses(all, pool []PullRequest) {
+func (sc *statusController) setStatuses(all, pool []PullRequest) {
 	poolM := byRepoAndNumber(pool)
-	for _, pr := range all {
-		log := c.logger.WithFields(pr.logFields())
+	processed := sets.NewString()
 
-		contexts, err := headContexts(log, c.ghc, &pr)
+	process := func(pr *PullRequest) {
+		processed.Insert(prKey(pr))
+
+		log := sc.logger.WithFields(pr.logFields())
+		contexts, err := headContexts(log, sc.ghc, pr)
 		if err != nil {
 			log.WithError(err).Error("Getting head commit status contexts, skipping...")
-			continue
+			return
 		}
 
 		wantState, wantDesc := expectedStatus(pr, poolM)
@@ -161,7 +190,7 @@ func (c *Controller) setStatuses(all, pool []PullRequest) {
 			}
 		}
 		if wantState != strings.ToLower(string(actualState)) || wantDesc != actualDesc {
-			if err := c.ghc.CreateStatus(
+			if err := sc.ghc.CreateStatus(
 				string(pr.Repository.Owner.Login),
 				string(pr.Repository.Name),
 				string(pr.HeadRefOID),
@@ -169,7 +198,7 @@ func (c *Controller) setStatuses(all, pool []PullRequest) {
 					Context:     statusContext,
 					State:       wantState,
 					Description: wantDesc,
-					TargetURL:   c.ca.Config().Tide.TargetURL,
+					TargetURL:   sc.ca.Config().Tide.TargetURL,
 				}); err != nil {
 				log.WithError(err).Errorf(
 					"Failed to set status context from %q to %q.",
@@ -179,17 +208,66 @@ func (c *Controller) setStatuses(all, pool []PullRequest) {
 			}
 		}
 	}
+
+	for _, pr := range all {
+		process(&pr)
+	}
+	// The list of all open PRs may not contain a PR if it was merged before we
+	// listed all open PRs. To prevent a new PR that starts in the pool and
+	// immediately merges from missing a tide status context we need to ensure that
+	// every PR in the pool is processed even if it doesn't appear in all.
+	//
+	// Note: We could still fail to update a status context if the statusController
+	// falls behind the main Tide sync loop by multiple loops (if we are lapped).
+	// This would be unlikely to occur, could only occur if the status update sync
+	// period is smaller than the main sync period, and would only result in a
+	// missing tide status context on a successfully merged PR.
+	for key, poolPR := range poolM {
+		if !processed.Has(key) {
+			process(&poolPR)
+		}
+	}
+}
+
+func (sc *statusController) run() {
+	lastStart := time.Time{} // Zero value so that we don't wait the first loop.
+	// wait for a new pool
+	for range sc.newPoolPending {
+		// wait for the min sync period time to elapse if needed.
+		time.Sleep(time.Until(lastStart.Add(sc.ca.Config().Tide.StatusUpdatePeriod)))
+		lastStart = time.Now()
+
+		sc.Lock()
+		pool := sc.poolPRs
+		sc.Unlock()
+		sc.sync(pool)
+	}
+}
+
+func (sc *statusController) sync(pool []PullRequest) {
+	ctx := context.Background()
+	syncStartTime := time.Now()
+	var all []PullRequest
+	for _, q := range sc.ca.Config().Tide.Queries {
+		allPRs, err := search(sc.ghc, sc.logger, ctx, q.AllPRsSince(sc.lastSyncStartTime))
+		if err != nil {
+			sc.logger.WithError(err).Errorf("Searching for open PRs.")
+			return
+		}
+		all = append(all, allPRs...)
+	}
+	// We were able to find all open PRs so update the last sync time.
+	sc.lastSyncStartTime = syncStartTime
+	sc.setStatuses(all, pool)
 }
 
 // Sync runs one sync iteration.
 func (c *Controller) Sync() error {
 	ctx := context.Background()
-	syncStartTime := time.Now()
 	c.logger.Info("Building tide pool.")
 	var pool []PullRequest
-	var all []PullRequest
 	for _, q := range c.ca.Config().Tide.Queries {
-		poolPRs, err := c.search(ctx, q.Query())
+		poolPRs, err := search(c.ghc, c.logger, ctx, q.Query())
 		if err != nil {
 			return err
 		}
@@ -199,15 +277,15 @@ func (c *Controller) Sync() error {
 				pool = append(pool, pr)
 			}
 		}
-		allPRs, err := c.search(ctx, q.AllPRsSince(c.lastSyncStartTime))
-		if err != nil {
-			return err
-		}
-		all = append(all, allPRs...)
 	}
-	// We were able to find all open PRs so update the last sync time.
-	c.lastSyncStartTime = syncStartTime
-	c.setStatuses(all, pool)
+	// Notify statusController about the new pool.
+	c.sc.Lock()
+	c.sc.poolPRs = pool
+	select {
+	case c.sc.newPoolPending <- true:
+	default:
+	}
+	c.sc.Unlock()
 
 	var pjs []kube.ProwJob
 	var err error
@@ -686,7 +764,7 @@ func (c *Controller) dividePool(pool []PullRequest, pjs []kube.ProwJob) (chan su
 	return ret, nil
 }
 
-func (c *Controller) search(ctx context.Context, q string) ([]PullRequest, error) {
+func search(ghc githubClient, log *logrus.Entry, ctx context.Context, q string) ([]PullRequest, error) {
 	var ret []PullRequest
 	vars := map[string]interface{}{
 		"query":        githubql.String(q),
@@ -696,7 +774,7 @@ func (c *Controller) search(ctx context.Context, q string) ([]PullRequest, error
 	var remaining int
 	for {
 		sq := searchQuery{}
-		if err := c.ghc.Query(ctx, &sq, vars); err != nil {
+		if err := ghc.Query(ctx, &sq, vars); err != nil {
 			return nil, err
 		}
 		totalCost += int(sq.RateLimit.Cost)
@@ -709,7 +787,7 @@ func (c *Controller) search(ctx context.Context, q string) ([]PullRequest, error
 		}
 		vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
 	}
-	c.logger.Infof("Search for query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
+	log.Infof("Search for query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
 	return ret, nil
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -124,17 +124,17 @@ type Pool struct {
 }
 
 // NewController makes a Controller out of the given clients.
-func NewController(ghc *github.Client, kc *kube.Client, ca *config.Agent, gc *git.Client, logger *logrus.Entry) *Controller {
+func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, ca *config.Agent, gc *git.Client, logger *logrus.Entry) *Controller {
 	sc := &statusController{
 		logger:         logger.WithField("controller", "status-update"),
-		ghc:            ghc,
+		ghc:            ghcStatus,
 		ca:             ca,
 		newPoolPending: make(chan bool, 1),
 	}
 	go sc.run()
 	return &Controller{
 		logger: logger.WithField("controller", "sync"),
-		ghc:    ghc,
+		ghc:    ghcSync,
 		kc:     kc,
 		ca:     ca,
 		gc:     gc,


### PR DESCRIPTION
I created a new `statusController` that is responsible for syncing status contexts. It updates contexts when the main sync loop provides a newly updated list of pooled PRs **and** the minimum status update period has elapsed.
addresses #6663 
- [X] Use a separate goroutine so that the main tide loop isn't blocked if lots of statuses need to be set.
- [X] Allow for a configurable update period separate from the sync period so that statuses can be updated less frequently than the frequency of the main sync loop.
- [x] Use a separate github client with a different token usage throttling configuration.

~~Note: The first 2 commits in this PR are part of #6630~~

/cc @rmmh @kargakis @BenTheElder 
/area prow