### PR TITLE
fix create_bazel_cache_rcs.sh

### DIFF
--- a/experiment/nursery/create_bazel_cache_rcs.sh
+++ b/experiment/nursery/create_bazel_cache_rcs.sh
@@ -24,7 +24,7 @@ make_bazel_rc () {
     # since this is the only hash our cache supports
     echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256" >> $1
     # use remote caching for all the things
-    echo "--experimental_remote_spawn_cache" >> $1
+    echo "build --experimental_remote_spawn_cache" >> $1
     # point it at our http cache ...
     echo "build --remote_http_cache=${CACHE_HOST}" >> $1
     # don't fail if the cache is unavailable


### PR DESCRIPTION
In #6682 `build` was left out from the `--experimental_remote_spawn_cache` line after switching
 to this from the previous caching args 🤦‍♂️ 

/area this-is-why-we-have-presubmits
/area bazel
/area jobs
/shrug