### PR TITLE
fix lifecycle labels

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13795,8 +13795,8 @@ periodics:
       args:
       - |-
         --query=org:kubernetes
-        -labels:lifecycle/frozen
-        labels:lifecycle/rotten
+        -label:lifecycle/frozen
+        label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/token/bot-github-token
       - |-
@@ -13868,9 +13868,9 @@ periodics:
       args:
       - |-
         --query=org:kubernetes
-        -labels:lifecycle/frozen
-        labels:lifecycle/stale
-        -labels:lifecycle/rotten
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+        -label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/token/bot-github-token
       - |-
@@ -13903,9 +13903,9 @@ periodics:
       args:
       - |-
         --query=org:kubernetes
-        -labels:lifecycle/frozen
-        -labels:lifecycle/stale
-        -labels:lifecycle/rotten
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
       - --updated=2160h
       - --token=/etc/token/bot-github-token
       - |-


### PR DESCRIPTION
/shrug
we did s/label/labels in https://github.com/kubernetes/test-infra/pull/6549 and because github cannot load that diff so @fejta-bot took a few days off
/assign @fejta @BenTheElder 