### PR TITLE
fix bazel-cache deployment to dedicated node

### DIFF
--- a/experiment/nursery/README.md
+++ b/experiment/nursery/README.md
@@ -9,6 +9,8 @@ Setup (for [prow.k8s.io](https://prow.k8s.io/)):
 ```
 make -C prow get-build-cluster-credentials
 gcloud beta container node-pools create bazel-cache --cluster=prow --project=k8s-prow-builds --zone=us-central1-f --node-taints dedicated=bazel-cache:NoSchedule --machine-type=n1-standard-8 --num-nodes=1 --local-ssd-count=1
+kubectl label nodes $(kubectl get no | grep cache | cut -d" " -f1) dedicated=bazel-cache
+kubectl taint nodes $(kubectl get no | grep cache | cut -d" " -f1) dedicated=bazel-cache:NoSchedule
 kubectl apply -f experiment/nursery/deployment.yaml
 kubectl apply -f experiment/nursery/service.yaml
 ```

--- a/experiment/nursery/deployment.yaml
+++ b/experiment/nursery/deployment.yaml
@@ -51,3 +51,5 @@ spec:
         operator: "Equal"
         value: "bazel-cache"
         effect: "NoSchedule"
+      nodeSelector:
+        dedicated: "bazel-cache"


### PR DESCRIPTION
updated the readme with commands used after tweaking the deployment to properly use `nodeSelector` + a label to pin to the dedicated node