### PR TITLE
more accurate resource requests for cross build

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1305,8 +1305,8 @@ presubmits:
           hostPort: 9999
         resources:
           requests:
-            cpu: 6
-            memory: "15Gi"
+            cpu: 7
+            memory: "41Gi"
       volumes:
       - name: cache-ssd
         hostPath:
@@ -1352,8 +1352,8 @@ presubmits:
           hostPort: 9999
         resources:
           requests:
-            cpu: 6
-            memory: "15Gi"
+            cpu: 7
+            memory: "41Gi"
       volumes:
       - name: cache-ssd
         hostPath:
@@ -3234,8 +3234,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "6"
-            memory: 15Gi
+            cpu: "7"
+            memory: 41Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -3284,8 +3284,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "6"
-            memory: 15Gi
+            cpu: "7"
+            memory: 41Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -6448,8 +6448,8 @@ periodics:
         hostPort: 9999
       resources:
         requests:
-          cpu: 6
-          memory: "15Gi"
+          cpu: 7
+          memory: "41Gi"
     volumes:
     - name: cache-ssd
       hostPath:


### PR DESCRIPTION
a cross job landed on the same node as https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-bazel-build-canary/26/ and totally waylaid it. cross jobs are bursting *way* above their requests right now. 

this should be a bit more realistic.

/area jobs
/assign @krzyzacy 