### PR TITLE
Revert "Enable PodPriority feature gate for GCE 2k-node performance test"

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
@@ -12,11 +12,10 @@ LOGROTATE_MAX_SIZE=5G
 KUBE_ENABLE_CLUSTER_MONITORING=none
 ALLOWED_NOTREADY_NODES=20
 KUBE_GCE_ENABLE_IP_ALIASES=true
-ENABLE_POD_PRIORITY=true
 # Increase throughput in master components.
 SCHEDULER_TEST_ARGS=--kube-api-qps=100
 CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100
-APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500 --runtime-config=scheduling.k8s.io/v1alpha1=true
+APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500
 # Increase controller-manager's resync period to simulate production
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism


### PR DESCRIPTION
Reverts kubernetes/test-infra#6523

As seems like this is causing scalability test failures on 2k-node clusters:

- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-large-performance/51
- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-large-performance/52
- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-large-performance/53

Explained further here - https://github.com/kubernetes/kubernetes/issues/56032#issuecomment-363823222

/cc @gmarek @bsalamat 