### PR TITLE
fix cluster name conflict

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8411,9 +8411,8 @@
   "ci-kubernetes-e2e-kops-aws-beta": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io",
+      "--cluster=e2e-kops-aws-beta.test-cncf-aws.k8s.io",
       "--env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt",
-      "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.9-ci-green.txt",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/k8s-beta",
       "--ginkgo-parallel",
@@ -8553,7 +8552,7 @@
       "--aws",
       "--cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io",
       "--env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-stable1.txt",
-      "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.8-ci-green.txt",
+      "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.9-ci-green.txt",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/k8s-stable1",
       "--ginkgo-parallel",


### PR DESCRIPTION
fix the conflict kops cluster name, hopefully this will help http://k8s-testgrid.appspot.com/sig-release-1.9-blocking#kops-aws-1.9, and let stable1 publish green to latest-1.9

this is part of https://github.com/kubernetes/test-infra/pull/6686, I'll let @justinsb finish the renaming

/assign @BenTheElder @justinsb @mbohlool 