### PR TITLE
Tolerate empty report templates

### DIFF
--- a/prow/report/report.go
+++ b/prow/report/report.go
@@ -223,8 +223,10 @@ func createComment(reportTemplate *template.Template, pj kube.ProwJob, entries [
 		plural = "s"
 	}
 	var b bytes.Buffer
-	if err := reportTemplate.Execute(&b, &pj); err != nil {
-		return "", err
+	if reportTemplate != nil {
+		if err := reportTemplate.Execute(&b, &pj); err != nil {
+			return "", err
+		}
 	}
 	lines := []string{
 		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun them all:", pj.Spec.Refs.Pulls[0].Author, plural),
@@ -233,10 +235,14 @@ func createComment(reportTemplate *template.Template, pj kube.ProwJob, entries [
 		"--- | --- | --- | ---",
 	}
 	lines = append(lines, entries...)
+	if reportTemplate != nil {
+		lines = append(lines, []string{
+			"",
+			b.String(),
+			"",
+		}...)
+	}
 	lines = append(lines, []string{
-		"",
-		b.String(),
-		"",
 		"<details>",
 		"",
 		plugins.AboutThisBot,


### PR DESCRIPTION
The report template is not necessary for reporting back to Github since the failed tests are already added into a table in a comment. We actually don't have any useful links to provide in our private repos since we won't use Gubernator initially due to its lack of oauth.

/area prow

@stevekuznetsov @cjwagner 