### PR TITLE
Use allow-dup flag to fix federation build job failures

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -421,6 +421,7 @@
   },
   "ci-federation-build": {
     "args": [
+      "--allow-dup",
       "--fast",
       "--release=kubernetes-federation-dev",
       "--release-kind=federation"
@@ -9651,6 +9652,7 @@
   },
   "ci-kubernetes-federation-build-1-7": {
     "args": [
+      "--allow-dup",
       "--fast",
       "--federation=k8s-jkns-e2e-gce-f8n-1-7",
       "--release=kubernetes-federation-release-1-7"
@@ -9662,6 +9664,7 @@
   },
   "ci-kubernetes-federation-build-1-8": {
     "args": [
+      "--allow-dup",
       "--fast",
       "--federation=k8s-jkns-e2e-gce-f8n-1-8",
       "--release=kubernetes-federation-release-1-8"


### PR DESCRIPTION
Fixes current federation build job failures, eg https://k8s-testgrid.appspot.com/sig-multicluster-federation-gce-old#build-1.7.

@krzyzacy 