### PR TITLE
Create gce ingress scale job and add to sig-network dashboard

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -511,6 +511,24 @@
       "sig-network"
     ]
   },
+  "ci-ingress-gce-e2e-scale": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:latest",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-ingress-e2e-scale-backup",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=1",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:IngressScale\\]",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-ingress-gce-image-push": {
     "args": [
       "--env=REGISTRY=gcr.io/k8s-ingress-image-push",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5924,6 +5924,18 @@ periodics:
       args:
       - "--timeout=320"
       - "--bare"
+- name: ci-ingress-gce-e2e-scale
+  agent: kubernetes
+  interval: 6h
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180205-d99d9c246-master
+      args:
+      - "--timeout=340"
+      - "--bare"
 - name: ci-ingress-gce-upgrade-e2e
   agent: kubernetes
   interval: 60m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -152,6 +152,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-image-push
 - name: ci-ingress-gce-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e
+- name: ci-ingress-gce-e2e-scale
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-scale
 - name: ci-ingress-gce-upgrade-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-upgrade-e2e
 - name: ci-ingress-gce-downgrade-e2e
@@ -3814,6 +3816,10 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-gce-e2e
     test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-scale
+    test_group_name: ci-ingress-gce-e2e-scale
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-gce-image-push


### PR DESCRIPTION
Note that the ingress scale job is using project "k8s-ingress-e2e-scale-backup" explicitly.

cc @rramkumar1 @bowei 