### PR TITLE
Testgrid updater: custom row names, sort correctly

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -755,6 +755,12 @@
   packages = ["pkg/common"]
   revision = "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
 
+[[projects]]
+  branch = "master"
+  name = "vbom.ml/util"
+  packages = ["sortorder"]
+  revision = "256737ac55c46798123f754ab7d2c784e2c71783"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1

--- a/hack/prune-libraries.sh
+++ b/hack/prune-libraries.sh
@@ -46,6 +46,7 @@ unused-go-libraries() {
   # Find all the go_library rules in vendor except those that something outside
   # of vendor eventually depends on.
   required_items=( "${REQUIRED[@]/#/+ }" )
+  echo "Looking for //vendor targets that no one outside of //vendor depends on..." >&2
   bazel query "kind('go_library rule', //vendor/... -deps(//... -//vendor/... ${required_items[@]}))"
 }
 

--- a/testgrid/cmd/updater/BUILD.bazel
+++ b/testgrid/cmd/updater/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_library(
     name = "go_default_library",
@@ -13,6 +12,7 @@ go_library(
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/google.golang.org/api/iterator:go_default_library",
+        "//vendor/vbom.ml/util/sortorder:go_default_library",
     ],
 )
 

--- a/testgrid/cmd/updater/BUILD.bazel
+++ b/testgrid/cmd/updater/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_library(
     name = "go_default_library",

--- a/testgrid/cmd/updater/main_test.go
+++ b/testgrid/cmd/updater/main_test.go
@@ -22,14 +22,103 @@ import (
 	"k8s.io/test-infra/testgrid/state"
 )
 
+func Test_ValidateName(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		context   string
+		timestamp string
+		thread    string
+		empty     bool
+	}{
+
+		{
+			name:  "not junit",
+			input: "./started.json",
+			empty: true,
+		},
+		{
+			name:  "forgot suffix",
+			input: "./junit",
+			empty: true,
+		},
+		{
+			name:  "basic",
+			input: "./junit.xml",
+		},
+		{
+			name:    "context",
+			input:   "./junit_hello world isn't-this exciting!.xml",
+			context: "hello world isn't-this exciting!",
+		},
+		{
+			name:    "numeric context",
+			input:   "./junit_12345.xml",
+			context: "12345",
+		},
+		{
+			name:    "context and thread",
+			input:   "./junit_context_12345.xml",
+			context: "context",
+			thread:  "12345",
+		},
+		{
+			name:      "context and timestamp",
+			input:     "./junit_context_20180102-1234.xml",
+			context:   "context",
+			timestamp: "20180102-1234",
+		},
+		{
+			name:      "context thread timestamp",
+			input:     "./junit_context_20180102-1234_5555.xml",
+			context:   "context",
+			timestamp: "20180102-1234",
+			thread:    "5555",
+		},
+	}
+
+	for _, tc := range cases {
+		actual := ValidateName(tc.input)
+		switch {
+		case actual == nil && !tc.empty:
+			t.Errorf("%s: unexpected nil map", tc.name)
+		case actual != nil && tc.empty:
+			t.Errorf("%s: should not have returned a map: %v", tc.name, actual)
+		case actual != nil:
+			for k, expected := range map[string]string{
+				"Context":   tc.context,
+				"Thread":    tc.thread,
+				"Timestamp": tc.timestamp,
+			} {
+				if a, ok := actual[k]; !ok {
+					t.Errorf("%s: missing key %s", tc.name, k)
+				} else if a != expected {
+					t.Errorf("%s: %s actual %s != expected %s", tc.name, k, a, expected)
+				}
+			}
+		}
+	}
+
+}
+
 func Test_ExtractRows(t *testing.T) {
 	cases := []struct {
-		name    string
-		content string
-		results map[string]state.Row_Result
-		metrics map[string]map[string]float64
-		err     bool
+		name     string
+		content  string
+		metadata map[string]string
+		rows     map[string][]Row
+		err      bool
 	}{
+		{
+			name:    "not xml",
+			content: `{"super": 123}`,
+			err:     true,
+		},
+		{
+			name:    "not junit",
+			content: `<amazing><content/></amazing>`,
+			err:     true,
+		},
 		{
 			name: "basic testsuite",
 			content: `
@@ -38,9 +127,23 @@ func Test_ExtractRows(t *testing.T) {
 			    <testcase name="bad"><failure/></testcase>
 			    <testcase name="skip"><skipped/></testcase>
 			  </testsuite>`,
-			results: map[string]state.Row_Result{
-				"good": state.Row_PASS,
-				"bad":  state.Row_FAIL,
+			rows: map[string][]Row{
+				"good": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "good",
+						},
+					},
+				},
+				"bad": {
+					{
+						Result: state.Row_FAIL,
+						Metadata: map[string]string{
+							"Tests name": "bad",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -55,9 +158,66 @@ func Test_ExtractRows(t *testing.T) {
 			    <testcase name="skip"><skipped/></testcase>
 			  </testsuite>
 			  </testsuites>`,
-			results: map[string]state.Row_Result{
-				"good": state.Row_PASS,
-				"bad":  state.Row_FAIL,
+			rows: map[string][]Row{
+				"good": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "good",
+						},
+					},
+				},
+				"bad": {
+					{
+						Result: state.Row_FAIL,
+						Metadata: map[string]string{
+							"Tests name": "bad",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "suite name",
+			content: `
+			  <testsuite name="hello">
+			    <testcase name="world" />
+			  </testsuite>`,
+			rows: map[string][]Row{
+				"hello.world": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "hello.world",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate target names",
+			content: `
+			  <testsuite>
+			    <testcase name="multi">
+			      <failure>doh</failure>
+		            </testcase>
+			    <testcase name="multi" />
+			  </testsuite>`,
+			rows: map[string][]Row{
+				"multi": {
+					{
+						Result: state.Row_FAIL,
+						Metadata: map[string]string{
+							"Tests name": "multi",
+						},
+					},
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "multi",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -71,55 +231,131 @@ func Test_ExtractRows(t *testing.T) {
 			    <testcase name="fast" time="0.0001" />
 			    <testcase name="nothing-elapsed" time="0" />
 			  </testsuite>`,
-			results: map[string]state.Row_Result{
-				"slow":            state.Row_PASS,
-				"slow-failure":    state.Row_FAIL,
-				"fast":            state.Row_PASS,
-				"nothing-elapsed": state.Row_PASS,
+			rows: map[string][]Row{
+				"slow": {
+					{
+						Result:  state.Row_PASS,
+						Metrics: map[string]float64{elapsedKey: 100.1},
+						Metadata: map[string]string{
+							"Tests name": "slow",
+						},
+					},
+				},
+				"slow-failure": {
+					{
+						Result:  state.Row_FAIL,
+						Metrics: map[string]float64{elapsedKey: 123456789},
+						Metadata: map[string]string{
+							"Tests name": "slow-failure",
+						},
+					},
+				},
+				"fast": {
+					{
+						Result:  state.Row_PASS,
+						Metrics: map[string]float64{elapsedKey: 0.0001},
+						Metadata: map[string]string{
+							"Tests name": "fast",
+						},
+					},
+				},
+				"nothing-elapsed": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "nothing-elapsed",
+						},
+					},
+				},
 			},
-			metrics: map[string]map[string]float64{
-				"slow":         {elapsedKey: 100.1},
-				"slow-failure": {elapsedKey: 123456789},
-				"fast":         {elapsedKey: 0.0001},
+		},
+		{
+			name: "add metadata",
+			content: `
+			  <testsuite>
+			    <testcase name="fancy" />
+			    <testcase name="ketchup" />
+			  </testsuite>`,
+			metadata: map[string]string{
+				"Context":   "debian",
+				"Timestamp": "1234",
+				"Thread":    "7",
+			},
+			rows: map[string][]Row{
+				"fancy": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "fancy",
+							"Context":    "debian",
+							"Timestamp":  "1234",
+							"Thread":     "7",
+						},
+					},
+				},
+				"ketchup": {
+					{
+						Result: state.Row_PASS,
+						Metadata: map[string]string{
+							"Tests name": "ketchup",
+							"Context":    "debian",
+							"Timestamp":  "1234",
+							"Thread":     "7",
+						},
+					},
+				},
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		results := map[string]state.Row_Result{}
-		metrics := map[string]map[string]float64{}
+		rows := map[string][]Row{}
 
-		err := extractRows([]byte(tc.content), results, metrics)
+		err := extractRows([]byte(tc.content), rows, tc.metadata)
 		switch {
 		case err == nil && tc.err:
 			t.Errorf("%s: failed to raise an error", tc.name)
 		case err != nil && !tc.err:
 			t.Errorf("%s: unexpected err: %v", tc.name, err)
-		case len(results) > len(tc.results):
-			t.Errorf("%s: extra results: actual %v != expected %v", tc.name, results, tc.results)
-		case len(metrics) > len(tc.metrics):
-			t.Errorf("%s: extra metrics: actual %v != expected %v", tc.name, metrics, tc.metrics)
+		case len(rows) > len(tc.rows):
+			t.Errorf("%s: extra rows: actual %v != expected %v", tc.name, rows, tc.rows)
 		default:
-			for target, er := range tc.results {
-				if ar, ok := results[target]; !ok {
-					t.Errorf("%s: missing result: %s", tc.name, target)
-				} else if ar != er {
-					t.Errorf("%s: %s actual %s != expected %s", tc.name, target, ar, er)
+			for target, expectedRows := range tc.rows {
+				actualRows, ok := rows[target]
+				if !ok {
+					t.Errorf("%s: missing row %s", tc.name, target)
+					continue
+				} else if len(actualRows) != len(expectedRows) {
+					t.Errorf("%s: bad results for %s: actual %v != expected %v", tc.name, target, actualRows, expectedRows)
+					continue
 				}
-			}
-			for target, ems := range tc.metrics {
-				ams, ok := metrics[target]
-				switch {
-				case !ok:
-					t.Errorf("%s: missing metrics for %s", tc.name, target)
-				case len(ams) > len(ems):
-					t.Errorf("%s: extra metrics for %s: actual %v != expected %v", tc.name, target, ams, ems)
-				default:
-					for name, ev := range ems {
-						if av, ok := ams[name]; !ok {
-							t.Errorf("%s: missing %s in %s", tc.name, target, name)
-						} else if av != ev {
-							t.Errorf("%s: %s %s actual %f != expected %f", tc.name, target, name, av, ev)
+				for i, er := range expectedRows {
+					ar := actualRows[i]
+					if er.Result != ar.Result {
+						t.Errorf("%s: %s %d actual %v != expected %v", tc.name, target, i, ar.Result, er.Result)
+					}
+
+					if len(ar.Metrics) > len(er.Metrics) {
+						t.Errorf("%s: extra %s %d metrics: actual %v != expected %v", tc.name, target, i, ar.Metrics, er.Metrics)
+					} else {
+						for m, ev := range er.Metrics {
+							if av, ok := ar.Metrics[m]; !ok {
+								t.Errorf("%s: %s %d missing %s metric", tc.name, target, i, m)
+							} else if ev != av {
+								t.Errorf("%s: %s %d bad %s metric: actual %f != expected %f", tc.name, target, i, m, av, ev)
+							}
+						}
+					}
+
+					if len(ar.Metadata) > len(er.Metadata) {
+						t.Errorf("%s: extra %s %d metadata: actual %v != expected %v", tc.name, target, i, ar.Metadata, er.Metadata)
+					} else {
+						for m, ev := range er.Metadata {
+							if av, ok := ar.Metadata[m]; !ok {
+								t.Errorf("%s: %s %d missing %s metadata", tc.name, target, i, m)
+							} else if ev != av {
+								t.Errorf("%s: %s %d bad %s metadata: actual %s != expected %s", tc.name, target, i, m, av, ev)
+							}
 						}
 					}
 				}

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -164,6 +164,7 @@ filegroup(
         "//vendor/k8s.io/apiserver/pkg/util/flag:all-srcs",
         "//vendor/k8s.io/contrib/test-utils/utils:all-srcs",
         "//vendor/k8s.io/kube-openapi/pkg/common:all-srcs",
+        "//vendor/vbom.ml/util/sortorder:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/vendor/vbom.ml/util/LICENSE
+++ b/vendor/vbom.ml/util/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) 2015 Frits van Bommel
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/vbom.ml/util/sortorder/BUILD
+++ b/vendor/vbom.ml/util/sortorder/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "natsort.go",
+    ],
+    importpath = "vbom.ml/util/sortorder",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/vbom.ml/util/sortorder/README.md
+++ b/vendor/vbom.ml/util/sortorder/README.md
@@ -1,0 +1,5 @@
+## sortorder [![GoDoc](https://godoc.org/vbom.ml/util/sortorder?status.svg)](https://godoc.org/vbom.ml/util/sortorder)
+
+    import "vbom.ml/util/sortorder"
+
+Sort orders and comparison functions.

--- a/vendor/vbom.ml/util/sortorder/doc.go
+++ b/vendor/vbom.ml/util/sortorder/doc.go
@@ -1,0 +1,5 @@
+// Package sortorder implements sort orders and comparison functions.
+//
+// Currently, it only implements so-called "natural order", where integers
+// embedded in strings are compared by value.
+package sortorder // import "vbom.ml/util/sortorder"

--- a/vendor/vbom.ml/util/sortorder/natsort.go
+++ b/vendor/vbom.ml/util/sortorder/natsort.go
@@ -1,0 +1,76 @@
+package sortorder
+
+// Natural implements sort.Interface to sort strings in natural order. This
+// means that e.g. "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+type Natural []string
+
+func (n Natural) Len() int           { return len(n) }
+func (n Natural) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n Natural) Less(i, j int) bool { return NaturalLess(n[i], n[j]) }
+
+func isdigit(b byte) bool { return '0' <= b && b <= '9' }
+
+// NaturalLess compares two strings using natural ordering. This means that e.g.
+// "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+func NaturalLess(str1, str2 string) bool {
+	idx1, idx2 := 0, 0
+	for idx1 < len(str1) && idx2 < len(str2) {
+		c1, c2 := str1[idx1], str2[idx2]
+		dig1, dig2 := isdigit(c1), isdigit(c2)
+		switch {
+		case dig1 != dig2: // Digits before other characters.
+			return dig1 // True if LHS is a digit, false if the RHS is one.
+		case !dig1: // && !dig2, because dig1 == dig2
+			// UTF-8 compares bytewise-lexicographically, no need to decode
+			// codepoints.
+			if c1 != c2 {
+				return c1 < c2
+			}
+			idx1++
+			idx2++
+		default: // Digits
+			// Eat zeros.
+			for ; idx1 < len(str1) && str1[idx1] == '0'; idx1++ {
+			}
+			for ; idx2 < len(str2) && str2[idx2] == '0'; idx2++ {
+			}
+			// Eat all digits.
+			nonZero1, nonZero2 := idx1, idx2
+			for ; idx1 < len(str1) && isdigit(str1[idx1]); idx1++ {
+			}
+			for ; idx2 < len(str2) && isdigit(str2[idx2]); idx2++ {
+			}
+			// If lengths of numbers with non-zero prefix differ, the shorter
+			// one is less.
+			if len1, len2 := idx1-nonZero1, idx2-nonZero2; len1 != len2 {
+				return len1 < len2
+			}
+			// If they're not equal, string comparison is correct.
+			if nr1, nr2 := str1[nonZero1:idx1], str2[nonZero2:idx2]; nr1 != nr2 {
+				return nr1 < nr2
+			}
+			// Otherwise, the one with less zeros is less.
+			// Because everything up to the number is equal, comparing the index
+			// after the zeros is sufficient.
+			if nonZero1 != nonZero2 {
+				return nonZero1 < nonZero2
+			}
+		}
+		// They're identical so far, so continue comparing.
+	}
+	// So far they are identical. At least one is ended. If the other continues,
+	// it sorts last.
+	return len(str1) < len(str2)
+}


### PR DESCRIPTION
/assign @rmmh @michelle192837 

* Sort rows by name
* Ensure that `build2 < build10` and `test case 14 < test case 200`
* Support parsing the context, thread, timestamp from the junit path and adding it to the metadata.
* Support formatting the row name (for example to append the context like [kubelet](https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet) does)
* Refactor into `BuildResult` with `Metrics Metadata Results` maps into a `Column` struct with a map to a list of `Row` structs, which include `Metrics`, `Metadata` and `Results` fields.
* Slightly more unit tests for `extractRows`, unit tests for `ValidateName`

Still lots more to do! Such as:
* Accept a `--config` flag and generate results for everything in that config.
* Read current grid message and append to it
* Failure messages
* Correct icons
* Unit test everything (especially input build files -> resulting grid messages)
* etc