### PR TITLE
Improve logging in Tide and needs-rebase.

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -108,7 +109,7 @@ func main() {
 	c := tide.NewController(ghcSync, ghcStatus, kc, configAgent, gc, logger)
 
 	start := time.Now()
-	sync(c)
+	sync(logger, c)
 	if *runOnce {
 		return
 	}
@@ -116,16 +117,16 @@ func main() {
 		for {
 			time.Sleep(time.Until(start.Add(configAgent.Config().Tide.SyncPeriod)))
 			start = time.Now()
-			sync(c)
+			sync(logger, c)
 		}
 	}()
 	logger.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), c))
 }
 
-func sync(c *tide.Controller) {
+func sync(logger *logrus.Entry, c *tide.Controller) {
 	start := time.Now()
 	if err := c.Sync(); err != nil {
 		logrus.WithError(err).Error("Error syncing.")
 	}
-	logrus.Infof("Sync time: %v", time.Since(start))
+	logger.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Synced")
 }

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -152,9 +152,11 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 
 func periodicUpdate(log *logrus.Entry, pa *plugins.PluginAgent, ghc *github.Client, period time.Duration) {
 	update := func() {
+		start := time.Now()
 		if err := plugin.HandleAll(log, ghc, pa.Config()); err != nil {
 			log.WithError(err).Error("Error during periodic update of all PRs.")
 		}
+		log.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Periodic update complete.")
 	}
 
 	update()

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -590,7 +590,8 @@ func TestDividePool(t *testing.T) {
 		refs: map[string]string{"k/t-i heads/master": "123"},
 	}
 	c := &Controller{
-		ghc: fc,
+		ghc:    fc,
+		logger: logrus.WithField("component", "tide"),
 	}
 	var pulls []PullRequest
 	for _, p := range testPulls {
@@ -693,6 +694,7 @@ func TestPickBatch(t *testing.T) {
 		},
 	}
 	sp := subpool{
+		log:    logrus.WithField("component", "tide"),
 		org:    "o",
 		repo:   "r",
 		branch: "master",
@@ -907,6 +909,7 @@ func TestTakeAction(t *testing.T) {
 		}
 
 		sp := subpool{
+			log:    logrus.WithField("component", "tide"),
 			org:    "o",
 			repo:   "r",
 			branch: "master",


### PR DESCRIPTION
Improves Tide's logging by:
- Logging fewer times per subpool sync.
- Moving important info into log fields so that we can query logs by field more easily.
- Adding a `log` field to `subpool` to minimize repetitive code needed to add context to logs.

Improves `needs-rebase` by logging the sync duration after periodic updates (it is hard to tell if the periodic update is complete otherwise).

/area prow
/cc @stevekuznetsov @rmmh 