### PR TITLE
Fix repo name in ci-federation-build job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5822,7 +5822,7 @@ periodics:
       args:
       - --clean
       - --git-cache=/root/.cache/git
-      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/federation=master
       - --repo=k8s.io/release
       - --root=/go/src
       - --timeout=50


### PR DESCRIPTION
federation build job on master started failing when it was moved from jenkins to prow. https://k8s-testgrid.appspot.com/sig-multicluster-federation-gce#build

The repo name is incorrect in the job. hence this fix.

/assign @krzyzacy 
/cc @irfanurrehman @kubernetes/sig-multicluster-bugs 