### PR TITLE
Make Tide get all open PRs with one search query instead of one per Tide query.

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//vendor/gopkg.in/robfig/cron.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -247,18 +247,15 @@ func (sc *statusController) run() {
 func (sc *statusController) sync(pool []PullRequest) {
 	ctx := context.Background()
 	syncStartTime := time.Now()
-	var all []PullRequest
-	for _, q := range sc.ca.Config().Tide.Queries {
-		allPRs, err := search(sc.ghc, sc.logger, ctx, q.AllPRsSince(sc.lastSyncStartTime))
-		if err != nil {
-			sc.logger.WithError(err).Errorf("Searching for open PRs.")
-			return
-		}
-		all = append(all, allPRs...)
+	query := sc.ca.Config().Tide.Queries.AllPRsSince(sc.lastSyncStartTime)
+	allPRs, err := search(sc.ghc, sc.logger, ctx, query)
+	if err != nil {
+		sc.logger.WithError(err).Errorf("Searching for open PRs.")
+		return
 	}
 	// We were able to find all open PRs so update the last sync time.
 	sc.lastSyncStartTime = syncStartTime
-	sc.setStatuses(all, pool)
+	sc.setStatuses(allPRs, pool)
 }
 
 // Sync runs one sync iteration.


### PR DESCRIPTION
Final item to fix #6663 

After this change, status update API token cost will be limited to ~1 API token per average sync loop  + 1 API token per actual status update.
Whenever Tide is restarted, the first sync loop will require more API tokens in order to list all open PRs instead of listing open PRs that have changed since the last sync loop. However, even after enabling Tide on k/k (for a total of ~1500 open PRs), the first sync loop after a restart should only use ~15 tokens to list open PRs and subsequent sync loops will only require ~1 token to list PRs.

/area prow
/cc @kargakis @rmmh 