### PR TITLE
Add support for running hack/local-up-cluster.sh

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "gke.go",
         "kops.go",
         "kubernetes.go",
+        "local.go",
         "main.go",
         "node.go",
         "none.go",

--- a/kubetest/dump.go
+++ b/kubetest/dump.go
@@ -84,7 +84,7 @@ func newLogDumper(sshClientFactory sshClientFactory, artifactsDir string) (*logD
 func (d *logDumper) DumpAllNodes(ctx context.Context, additionalIPs []string) error {
 	var dumped []*node
 
-	nodes, err := kubectlGetNodes()
+	nodes, err := kubectlGetNodes("")
 	if err != nil {
 		log.Printf("Failed to get nodes for dumping via kubectl: %v", err)
 	} else {

--- a/kubetest/kubernetes.go
+++ b/kubetest/kubernetes.go
@@ -25,8 +25,11 @@ import (
 )
 
 // kubectlGetNodes lists nodes by executing kubectl get nodes, parsing the output into a nodeList object
-func kubectlGetNodes() (*nodeList, error) {
-	o, err := output(exec.Command("kubectl", "get", "nodes", "-ojson"))
+func kubectlGetNodes(cmd string) (*nodeList, error) {
+	if cmd == "" {
+		cmd = "kubectl"
+	}
+	o, err := output(exec.Command(cmd, "get", "nodes", "-ojson"))
 	if err != nil {
 		log.Printf("kubectl get nodes failed: %s\n%s", wrapError(err).Error(), string(o))
 		return nil, err
@@ -61,7 +64,7 @@ func waitForReadyNodes(desiredCount int, timeout time.Duration, requiredConsecut
 			break
 		}
 
-		nodes, err := kubectlGetNodes()
+		nodes, err := kubectlGetNodes("")
 		if err != nil {
 			log.Printf("kubectl get nodes failed, sleeping: %v", err)
 			consecutiveSuccesses = 0

--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+var (
+	localUpTimeout = flag.Duration("local-up-timeout", 2*time.Minute, "(local only) Time limit between 'local-up-cluster.sh' and a response from the Kubernetes API.")
+)
+
+type localCluster struct {
+	tempDir    string
+	kubeConfig string
+}
+
+var _ deployer = localCluster{}
+
+func newLocalCluster() *localCluster {
+	tempDir, err := ioutil.TempDir("", "kubetest-local")
+	if err != nil {
+		log.Fatal("unable to create temp directory")
+	}
+	err = os.Chmod(tempDir, 0755)
+	if err != nil {
+		log.Fatal("unable to change temp directory permissions")
+	}
+	return &localCluster{
+		tempDir: tempDir,
+	}
+}
+
+func (n localCluster) Up() error {
+	script := "./hack/local-up-cluster.sh"
+	cmd := exec.Command(script)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "ENABLE_DAEMON=true")
+	cmd.Env = append(cmd.Env, fmt.Sprintf("LOG_DIR=%s", n.tempDir))
+	err := finishRunning(cmd)
+	if err != nil {
+		return err
+	}
+	n.kubeConfig = "/var/run/kubernetes/admin.kubeconfig"
+	_, err = os.Stat(n.kubeConfig)
+	return err
+}
+
+func (n localCluster) IsUp() error {
+	if n.kubeConfig != "" {
+		err := os.Setenv("KUBECONFIG", n.kubeConfig)
+		if err != nil {
+			log.Fatal("unable to set KUBECONFIG environment variable")
+		}
+	}
+	stop := time.Now().Add(*localUpTimeout)
+	for {
+		nodes, err := kubectlGetNodes("cluster/kubectl.sh")
+		if err != nil {
+			return err
+		}
+		readyNodes := countReadyNodes(nodes)
+		if readyNodes > 0 {
+			return nil
+		}
+		if time.Now().After(stop) {
+			break
+		} else {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	return errors.New("local-up-cluster.sh is not ready")
+}
+
+func (n localCluster) DumpClusterLogs(localPath, gcsPath string) error {
+	cmd := exec.Command("sudo", "cp", "-r", n.tempDir, localPath)
+	return finishRunning(cmd)
+}
+
+func (n localCluster) TestSetup() error {
+	return nil
+}
+
+func (n localCluster) Down() error {
+	err := finishRunning(exec.Command("bash", "-c", "docker rm -f $(docker ps -a -q)"))
+	if err != nil {
+		log.Printf("unable to cleanup containers in docker: %v", err)
+	}
+	err = finishRunning(exec.Command("pkill", "hyperkube"))
+	if err != nil {
+		log.Printf("unable to kill hyperkube processes: %v", err)
+	}
+	err = finishRunning(exec.Command("pkill", "etcd"))
+	if err != nil {
+		log.Printf("unable to kill etcd: %v", err)
+	}
+	return nil
+}
+
+func (n localCluster) GetClusterCreated(gcpProject string) (time.Time, error) {
+	return time.Time{}, errors.New("GetClusterCreated not implemented in localCluster")
+}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -117,7 +117,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.checkLeaks, "check-leaked-resources", false, "Ensure project ends with the same resources")
 	flag.StringVar(&o.cluster, "cluster", "", "Cluster name. Must be set for --deployment=gke (TODO: other deployments).")
 	flag.StringVar(&o.clusterIPRange, "cluster-ip-range", "", "Specifies CLUSTER_IP_RANGE value during --up and --test (only relevant for --deployment=bash). Auto-calculated if empty.")
-	flag.StringVar(&o.deployment, "deployment", "bash", "Choices: none/bash/gke/kops/kubernetes-anywhere/node")
+	flag.StringVar(&o.deployment, "deployment", "bash", "Choices: none/bash/gke/kops/kubernetes-anywhere/node/local")
 	flag.BoolVar(&o.down, "down", false, "If true, tear down the cluster before exiting.")
 	flag.StringVar(&o.dump, "dump", "", "If set, dump cluster logs to this location on test or cluster-up failure")
 	flag.Var(&o.extract, "extract", "Extract k8s binaries from the specified release location")
@@ -273,6 +273,8 @@ func getDeployer(o *options) (deployer, error) {
 		return nodeDeploy{}, nil
 	case "none":
 		return noneDeploy{}, nil
+	case "local":
+		return newLocalCluster(), nil
 	default:
 		return nil, fmt.Errorf("unknown deployment strategy %q", o.deployment)
 	}


### PR DESCRIPTION
New option `--deployment local` that runs hack/local-up-cluster.sh
script

Please see #6696 for context, looks like this will fix https://github.com/kubernetes/test-infra/issues/3328 too