### PR TITLE
Wrap hack/verify-spelling in a bazel test

### DIFF
--- a/hack/BUILD
+++ b/hack/BUILD
@@ -24,6 +24,16 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "verify-spelling",
+    srcs = ["verify-spelling.sh"],
+    args = ["-m $(location //vendor/github.com/client9/misspell/cmd/misspell)"],
+    data = [
+        "//:all-srcs",
+        "//vendor/github.com/client9/misspell/cmd/misspell",
+    ],
+)
+
 test_suite(
     name = "verify-all",
     tests = [

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11258,15 +11258,6 @@
       "sig-testing"
     ]
   },
-  "pull-test-infra-verify-spelling": {
-    "args": [
-      "./hack/verify-spelling.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "random_job": {
     "scenario": "execute",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4854,25 +4854,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
 
-  - name: pull-test-infra-verify-spelling
-    agent: kubernetes
-    context: pull-test-infra-verify-spelling
-    branches:
-    - master
-    rerun_command: "/test pull-test-infra-verify-spelling"
-    trigger: "/test( all| pull-test-infra-verify-spelling)"
-    always_run: true
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
-
   tensorflow/k8s:
   - name: tf-k8s-presubmit
     context: tf-k8s-presubmit

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1814,10 +1814,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-govet
   days_of_results: 1
   num_columns_recent: 20
-- name: pull-test-infra-verify-spelling
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-spelling
-  days_of_results: 1
-  num_columns_recent: 20
 - name: pull-test-infra-verify-gofmt
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-gofmt
   days_of_results: 1
@@ -5023,9 +5019,6 @@ dashboards:
     base_options: 'width=10'
   - name: verify-govet
     test_group_name: pull-test-infra-verify-govet
-    base_options: 'width=10'
-  - name: verify-spelling
-    test_group_name: pull-test-infra-verify-spelling
     base_options: 'width=10'
   - name: verify-gofmt
     test_group_name: pull-test-infra-verify-gofmt


### PR DESCRIPTION
Followup to #6716, which turns the new spelling verification check into a bazel test.

This also removes the newly created pull-test-infra-verify-spelling job, since the test would run in the bazel-test job instead.

/cc @dixudx 