### PR TITLE
migratestatus: change --modify to --dry-run and update docs

### DIFF
--- a/maintenance/migratestatus/README.md
+++ b/maintenance/migratestatus/README.md
@@ -1,6 +1,10 @@
 # Status Context Migrator
 The migratestatus tool is a maintenance utility used to safely switch a repo from one status context to another.
+
 For example if there is a context named "CI tests" that needs to be moved by "CI tests v2" this tool can be used to copy every "CI tests" status into a "CI tests v2" status context and then mark every "CI tests" context as passing and retired. This ensures that no PRs are ever passing when they shouldn't be and doesn't block PRs that should be passing. The copy and retire phases can be run separately or together at once in move mode.
+
+By default, this tool runs in dry-run mode and doesn't make any modifications.
+Pass `--dry-run=false` to actually change statuses.
 
 ### Usage
 ###### Modes
@@ -15,6 +19,9 @@ This tool runs in one of three modes. Each mode is defined as a set of condition
 	- `$ ./migratestatus --move="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
 ###### Flags
 The migratestatus binary is run locally and can be built by running `go build` from this directory. The binary accepts the following parameters:
+- `--dry-run` Whether to perform modifying actions. Defaults to true.
+- `--logtostderr` Print logging to stderr. Recommended if you want to see what's
+  happening.
 - `--tokenfile` The file containing the github authentication token to use.
 - `--org` The organization that owns the repository to migrate contexts in. (Kubernetes)
 - `--repo` The repository to migrate contexts in.

--- a/maintenance/migratestatus/migrate-many.sh
+++ b/maintenance/migratestatus/migrate-many.sh
@@ -22,7 +22,7 @@ migrate() {
     exit 1
   fi
   bazel-bin/maintenance/migratestatus/migratestatus \
-    --modify --alsologtostderr \
+    --dry-run=false --alsologtostderr \
     --org=kubernetes \
     --repo=kubernetes \
     --tokenfile ~/github-token \

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -29,12 +29,12 @@ import (
 
 func main() {
 	var tokenFile, org, repo, copyContext, moveContext, retireContext, destContext string
-	var modify, continueOnError bool
+	var continueOnError, dryRun bool
 
 	flag.StringVar(&tokenFile, "tokenfile", "", "The file containing the token to use for authentication.")
 	flag.StringVar(&org, "org", "", "The organization that owns the repo.")
 	flag.StringVar(&repo, "repo", "", "The repo needing status migration.")
-	flag.BoolVar(&modify, "modify", false, "Perform modifying actions when set, otherwise dry-run.")
+	flag.BoolVar(&dryRun, "dry-run", true, "Run in dry-run mode, performing no modifying actions.")
 	flag.BoolVar(&continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
 
 	flag.StringVar(&copyContext, "copy", "", "Indicates copy mode and specifies the context to copy.")
@@ -84,7 +84,6 @@ func main() {
 
 	// Note that continueOnError is false by default so that errors can be addressed when they occur
 	// instead of blindly continuing to the next PR, possibly continuing to error.
-	dryRun := !modify
 	m := migrator.New(*mode, strings.TrimSpace(string(tokenData)), org, repo, dryRun, continueOnError)
 
 	prOptions := &github.PullRequestListOptions{}


### PR DESCRIPTION
`--dry-run` is a much more common flag name than `--modify`. We still default to dry-run mode.

/assign @cjwagner @fejta 