### PR TITLE
bind docker credential to cadvisor-canarypush job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -170,6 +170,22 @@ presets:
   - name: aws-cred
     mountPath: /etc/aws-cred
     readOnly: true
+- labels:
+    preset-cadvisor-docker-credential: true
+  env:
+  - name: DOCKER_USER
+    value: /etc/cadvisor-cred/username
+  - name: DOCKER_PASSWORD
+    value: /etc/cadvisor-cred/password
+  volumes:
+  - name: cadvisor-cred
+    secret:
+      defaultMode: 0400
+      secretName: cadvisor-docker-credential
+  volumeMounts:
+  - name: cadvisor-cred
+    mountPath: /etc/cadvisor-cred
+    readOnly: true
 
 presubmits:
   google/cadvisor:
@@ -5475,6 +5491,7 @@ periodics:
   agent: kubernetes
   labels:
     preset-service-account: true
+    preset-cadvisor-docker-credential: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
@@ -5499,7 +5516,6 @@ periodics:
     - name: docker-graph
       hostPath:
         path: /mnt/disks/ssd0/docker-graph
-
 
 - name: ci-cadvisor-e2e
   interval: 8h

--- a/scenarios/canarypush.py
+++ b/scenarios/canarypush.py
@@ -50,8 +50,19 @@ def main(target, buildfile):
     )
     check_with_log('docker', 'inspect', target)
 
-    user = os.environ.get('DOCKER_USER')
-    pwd = os.environ.get('DOCKER_PASSWORD')
+    user = None
+    if os.path.exists(os.environ.get('DOCKER_USER')):
+        with open(os.environ.get('DOCKER_USER'), 'r') as content_file:
+            user = content_file.read()
+
+    pwd = None
+    if os.path.exists(os.environ.get('DOCKER_PASSWORD')):
+        with open(os.environ.get('DOCKER_PASSWORD'), 'r') as content_file:
+            pwd = content_file.read()
+
+    if not user or not pwd:
+        print >>sys.stderr, 'Logging info not exist'
+        sys.exit(1)
     print >>sys.stderr, 'Logging in as %r' % user
     check_no_log('docker', 'login', '--username=%s' % user, '--password=%s' % pwd)
 


### PR DESCRIPTION
using the same legacy Jenkins credential
and the `canarypush.py` scenario is only using by this job

/assign @dashpole @BenTheElder 