### PR TITLE
Fix extract gke regex to allow --extract=gke-latest-1.7

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -68,16 +68,16 @@ func (l *extractStrategies) String() string {
 // Converts --extract=release/stable, etc into an extractStrategy{}
 func (l *extractStrategies) Set(value string) error {
 	var strategies = map[string]extractMode{
-		`^(local)`:                    local,
-		`^gke-?(default|latest)?$`:    gke,
-		`^gci/([\w-]+)$`:              gci,
-		`^gci/([\w-]+)/(.+)$`:         gciCi,
-		`^ci/(.+)$`:                   ci,
-		`^release/(latest.*)$`:        rc,
-		`^release/(stable.*)$`:        stable,
-		`^(v\d+\.\d+\.\d+[\w.\-+]*)$`: version,
-		`^(gs://.*)$`:                 gcs,
-		`^(bazel/.*)$`:                bazel,
+		`^(local)`:                           local,
+		`^gke-(default|latest(-\d+.\d+)?)?$`: gke,
+		`^gci/([\w-]+)$`:                     gci,
+		`^gci/([\w-]+)/(.+)$`:                gciCi,
+		`^ci/(.+)$`:                          ci,
+		`^release/(latest.*)$`:               rc,
+		`^release/(stable.*)$`:               stable,
+		`^(v\d+\.\d+\.\d+[\w.\-+]*)$`:        version,
+		`^(gs://.*)$`:                        gcs,
+		`^(bazel/.*)$`:                       bazel,
 	}
 
 	if len(*l) == 2 {


### PR DESCRIPTION
follow up https://github.com/kubernetes/test-infra/pull/6735
/shrug

format it should support:
```
--extract=gke
--extract=gke-default
--extract=gke-latest
--extract=gke-latest-1.7
```

/assign @BenTheElder @caesarxuchao 