### PR TITLE
For ingress upgrade test, start cluster with glbc 0.9.7

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -527,6 +527,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/google_containers/glbc:0.9.7",
       "--extract=ci/latest",
       "--gcp-project-type=ingress-project",
       "--gcp-zone=us-central1-f",


### PR DESCRIPTION
Now that version 0.9.8-alpha.1 of glbc is released, configure the upgrade test to start the cluster with glbc 0.9.7. 

cc @MrHohn 
/assign @krzyzacy 