### PR TITLE
Update Minigo-prow config so that we can use bootstrap.py

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11367,5 +11367,32 @@
     "sigOwners": [
       "sig-big-data"
     ]
+  },
+  "tf-minigo-periodic": {
+    "args": [
+      "./test.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-big-data"
+    ]
+  },
+  "tf-minigo-postsubmit": {
+    "args": [
+      "./test.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-big-data"
+    ]
+  },
+  "tf-minigo-presubmit": {
+    "args": [
+      "./test.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-big-data"
+    ]
   }
 }

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4984,6 +4984,12 @@ presubmits:
       containers:
       - image: gcr.io/minigo-testing/minigo-prow-harness:latest
         imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=tensorflow/minigo=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
 
 postsubmits:
   kubeflow/examples:
@@ -5619,8 +5625,14 @@ postsubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/minigo-testing/minigo-prow-harness:latest
+      - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
         imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=tensorflow/minigo=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
 
 periodics:
 - name: ci-benchmark-scheduler-master
@@ -14250,6 +14262,11 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/minigo-testing/minigo-prow-harness:latest
+    - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
       imagePullPolicy: Always
-
+      args:
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=tensorflow/minigo=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"


### PR DESCRIPTION
This updates the minigo-prow config to enable us to use bootstrap.py.

Corresponding minigo change: https://github.com/tensorflow/minigo/pull/79