### PR TITLE
fix kops-build image

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5987,7 +5987,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180205-d99d9c246-master
       args:
       - --clean
       - --git-cache=/root/.cache/git


### PR DESCRIPTION
👀 and find a 🔥 
🤦‍♂️ `/bin/sh: 1: go: not found`

/assign @BenTheElder @justinsb 