### PR TITLE
Add prow jobs for new Kubeflow repositories:

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -224,6 +224,22 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  kubeflow/examples:
+  - name: kubeflow-examples-presubmit
+    context: kubeflow-examples-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-examples-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-examples-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
   kubeflow/kubeflow:
   - name: kubeflow-presubmit
     context: kubeflow-presubmit
@@ -238,6 +254,54 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        imagePullPolicy: Always
+
+  kubeflow/reporting:
+  - name: kubeflow-reporting-presubmit
+    context: kubeflow-reporting-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-reporting-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-reporting-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/testing:
+  - name: kubeflow-testing-presubmit
+    context: kubeflow-testing-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-testing-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-testing-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-presubmit
+    context: kubeflow-tf-operator-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-tf-operator-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-tf-operator-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
   kubernetes/charts:
@@ -4904,22 +4968,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
 
-  tensorflow/k8s:
-  - name: tf-k8s-presubmit
-    context: tf-k8s-presubmit
-    agent: kubernetes
-    always_run: true         # Run for every PR, or only when requested.
-    rerun_command: "/test tf-k8s-presubmit"
-    trigger: "(?m)^/test( all| tf-k8s-presubmit),?(\\s+|$)"
-    branches:
-    - master
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
-      - image: gcr.io/mlkube-testing/builder:latest
-        imagePullPolicy: Always
 
   tensorflow/minigo:
   - name: tf-minigo-presubmit
@@ -4938,6 +4986,18 @@ presubmits:
         imagePullPolicy: Always
 
 postsubmits:
+  kubeflow/examples:
+  - name: kubeflow-examples-postsubmit
+    agent: kubernetes
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
   kubeflow/kubeflow:
   - name: kubeflow-postsubmit
     agent: kubernetes
@@ -4948,6 +5008,42 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        imagePullPolicy: Always
+
+  kubeflow/reporting:
+  - name: kubeflow-reporting-postsubmit
+    agent: kubernetes
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/testing:
+  - name: kubeflow-testing-postsubmit
+    agent: kubernetes
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-postsubmit
+    agent: kubernetes
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
   kubernetes/ingress-gce:
@@ -5477,18 +5573,6 @@ postsubmits:
           requests:
             memory: "1Gi"
 
-  tensorflow/k8s:
-  - name: tf-k8s-postsubmit
-    agent: kubernetes
-    branches:
-    - master
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
-      - image: gcr.io/mlkube-testing/builder:latest
-        imagePullPolicy: Always
 
   tensorflow/minigo:
   - name: tf-minigo-postsubmit
@@ -14123,17 +14207,6 @@ periodics:
     - name: docker-graph
       hostPath:
         path: /mnt/disks/ssd0/docker-graph
-
-- interval: 8h
-  agent: kubernetes
-  name: tf-k8s-periodic
-  labels:
-    preset-service-account: true
-  spec:
-    containers:
-    # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
-    - image: gcr.io/mlkube-testing/builder:latest
-      imagePullPolicy: Always
 
 - name: tf-minigo-periodic
   interval: 8h

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -134,7 +134,27 @@ plugins:
   google/cadvisor:
   - trigger
 
+  kubeflow/examples:
+  - lgtm
+  - size
+  - trigger
+
   kubeflow/kubeflow:
+  - lgtm
+  - size
+  - trigger
+
+  kubeflow/reporting:
+  - lgtm
+  - size
+  - trigger
+
+  kubeflow/testing:
+  - lgtm
+  - size
+  - trigger
+
+  kubeflow/tf-operator:
   - lgtm
   - size
   - trigger

--- a/testgrid/cmd/config/config_test.go
+++ b/testgrid/cmd/config/config_test.go
@@ -353,7 +353,11 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 	// Also check k/k presubmit, prow postsubmit and periodic jobs
 	for _, job := range prowConfig.AllPresubmits([]string{
 		"google/cadvisor",
+		"kubeflow/examples",
 		"kubeflow/kubeflow",
+		"kubeflow/reporting",
+		"kubeflow/testing",
+		"kubeflow/tf-operator",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",
@@ -362,7 +366,6 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes/heapster",
 		"kubernetes/charts",
 		"kubernetes/kube-deploy",
-		"tensorflow/k8s",
 		"tensorflow/minigo",
 	}) {
 		jobs[job.Name] = false

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1663,14 +1663,27 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-presubmit
   num_columns_recent: 30
 - name: kubeflow-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/google_kubeflow/kubeflow-postsubmit
-- name: tf-k8s-periodic
-  gcs_prefix: kubernetes-jenkins/logs/tf-k8s-periodic
-- name: tf-k8s-presubmit
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/tf-k8s-presubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_kubeflow/kubeflow-postsubmit
+- name: kubeflow-examples-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-examples-presubmit
   num_columns_recent: 30
-- name: tf-k8s-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/tensorflow_k8s/tf-k8s-postsubmit
+- name: kubeflow-examples-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_kubeflow/kubeflow-examples-postsubmit
+- name: kubeflow-reporting-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-reporting-presubmit
+  num_columns_recent: 30
+- name: kubeflow-reporting-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_reporting/kubeflow-reporting-postsubmit
+- name: kubeflow-testing-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-testing-presubmit
+  num_columns_recent: 30
+- name: kubeflow-testing-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_testing/kubeflow-testing-postsubmit
+- name: kubeflow-tf-operator-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-tf-operator-presubmit
+  num_columns_recent: 30
+- name: kubeflow-tf-operator-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_tf-operator/kubeflow-tf-operator-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -3568,15 +3581,30 @@ dashboards:
   - name: kubeflow-presubmit
     description: Presubmit tests for Kubeflow.
     test_group_name: kubeflow-presubmit
-  - name: tf-k8s-periodic
-    description: Periodic builds and testing of TfJob CRD at head running on stable GKE.
-    test_group_name: tf-k8s-periodic
-  - name: tf-k8s-postsubmit
-    description: Postsubmit tests of TfJob CRD running on stable GKE.
-    test_group_name: tf-k8s-postsubmit
-  - name: tf-k8s-presubmit
-    description: Presubmit tests of TfJob CRD running on stable GKE.
-    test_group_name: tf-k8s-presubmit
+  - name: kubeflow-examples-postsubmit
+    description: Postsubmit kubeflow/examples.
+    test_group_name: kubeflow-examples-postsubmit
+  - name: kubeflow-examples-presubmit
+    description: Presubmits for kubeflow/examples.
+    test_group_name: kubeflow-examples-presubmit
+  - name: kubeflow-reporting-postsubmit
+    description: Postsubmit kubeflow/reporting.
+    test_group_name: kubeflow-reporting-postsubmit
+  - name: kubeflow-reporting-presubmit
+    description: Presubmits for kubeflow/reporting.
+    test_group_name: kubeflow-reporting-presubmit
+  - name: kubeflow-testing-postsubmit
+    description: Postsubmit kubeflow/testing.
+    test_group_name: kubeflow-testing-postsubmit
+  - name: kubeflow-testing-presubmit
+    description: Presubmits for kubeflow/testing.
+    test_group_name: kubeflow-testing-presubmit
+  - name: kubeflow-tf-operator-postsubmit
+    description: Postsubmit kubeflow/tf-operator.
+    test_group_name: kubeflow-tf-operator-postsubmit
+  - name: kubeflow-tf-operator-presubmit
+    description: Presubmits for kubeflow/tf-operator.
+    test_group_name: kubeflow-tf-operator-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke


### PR DESCRIPTION
Define pre and postsubmit jobs for the following repositories.

kubeflow/examples
kubeflow/testing
kubeflow/tf-operator
kubeflow/reporting

* remove tensorflow/k8s because this has been moved to kubeflow/tf-operator.
  https://github.com/tensorflow/k8s/issues/350

* We don't add periodic jobs right now; we might add these in the future.