### PR TITLE
fixconfig: use tempfile in the same directory as the output file

### DIFF
--- a/maintenance/fixconfig/main.go
+++ b/maintenance/fixconfig/main.go
@@ -35,6 +35,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -443,7 +444,7 @@ func main() {
 	}
 
 	// create temp file to write updated config
-	f, err := ioutil.TempFile("", "prow-config")
+	f, err := ioutil.TempFile(filepath.Dir(*configPath), "temp")
 	if err != nil {
 		log.Fatalf("Failed to create temp file: %v", err)
 	}


### PR DESCRIPTION
this should improve the behavior of `hack/update-config.sh`