### PR TITLE
Revert "Make gke-large-deploy manual again"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10436,7 +10436,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-deploy
   labels:


### PR DESCRIPTION
Reverts kubernetes/test-infra#6758

Let's retry again, with gke tests green now - https://k8s-testgrid.appspot.com/google-gke#gci-gke

/cc @wojtek-t 