### PR TITLE
Add testing image for kube-deploy with etcd installed

### DIFF
--- a/images/kube-deploy/Dockerfile
+++ b/images/kube-deploy/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes go, gcloud, and etcd
+FROM gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+LABEL maintainer="krousey@google.com"
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+ENV ETCD_VER=v3.3.0
+ENV ETCD_URL=https://storage.googleapis.com/etcd
+
+RUN wget ${ETCD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz && \
+    mkdir /etcd && \
+    tar xzf etcd-${ETCD_VER}-linux-amd64.tar.gz -C /etcd --strip-components=1 && \
+    rm -f etcd-${ETCD_VER}-linux-amd64.tar.gz
+
+ENV PATH "/etcd:${PATH}"

--- a/images/kube-deploy/Makefile
+++ b/images/kube-deploy/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+IMG="gcr.io/k8s-testimages/kube-deploy"
+
+image:
+	docker build --build-arg "IMAGE_ARG=$(IMG):$(VERSION)" -t "$(IMG):$(VERSION)" .
+
+push: image
+	docker push "$(IMG):$(VERSION)"
+
+.PHONY: image push

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -560,7 +560,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      - image: gcr.io/k8s-testimages/kube-deploy:v20180212-214c99406
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -6119,7 +6119,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+    - image: gcr.io/k8s-testimages/kube-deploy:v20180212-214c99406
       args:
       - "--repo=k8s.io/kube-deploy"
       - "--root=/go/src"


### PR DESCRIPTION
Currently, kube-deploy CI testing is failing because it can't find etcd. With this image, it would be able to run, and I could fix other errors to turn on the PR job.