### PR TITLE
Turning on PR testing for kube-deploy

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -552,7 +552,6 @@ presubmits:
   - name: pull-kube-deploy-test
     agent: kubernetes
     always_run: true
-    skip_report: true
     context: pull-kube-deploy-test
     rerun_command: "/test pull-kube-deploy-test"
     trigger: "/test( all| pull-kube-deploy-test)"


### PR DESCRIPTION
will wait until CI goes green
/hold