### PR TITLE
Fix typo: Update minigo test harness image to v2

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4982,7 +4982,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/minigo-testing/minigo-prow-harness:latest
+      - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
         imagePullPolicy: Always
         args:
         - "--clean"


### PR DESCRIPTION
Accidentally typo'd the image name in the previous commit.