### PR TITLE
Temporarily make ci-ingress-gce-e2e run serially

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -510,7 +510,7 @@
       "--extract=ci/latest",
       "--gcp-project-type=ingress-project",
       "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel",
+      "--ginkgo-parallel=1",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
       "--timeout=320m"


### PR DESCRIPTION
To avoid wrong signal from https://k8s-testgrid.appspot.com/sig-network-gce#ingress-gce-e2e, temporarily make ci-ingress-gce-e2e run serially until https://github.com/kubernetes/kubernetes/issues/59778 is fixed.

cc @nicksardo @nikhiljindal 