### PR TITLE
Cleaup of logging in kops-e2e-runner

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -32,9 +32,6 @@ RUN mkdir -p /go/src/k8s.io/kubernetes \
 
 # preinstall graphviz package for graphing profiles
 RUN apt-get install -y graphviz
-# preinstall this for kops tests xref kubetest prepareAws(...)
-# TODO(bentheelder,krzyzacy,justisb,chrislovecnm): remove this
-RUN pip install awscli
 
 # install cfssl to prevent https://github.com/kubernetes/kubernetes/issues/55589
 # The invocation at the end is to prevent download failures downloads as in the bug.
@@ -63,7 +60,6 @@ RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-# everything below will be triggered on every new image tag ...
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "kubetest", \

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -808,7 +808,7 @@ func prepareAws(o *options) error {
 	if err := activateServiceAccount(o.gcpServiceAccount); err != nil {
 		return err
 	}
-	return control.FinishRunning(exec.Command("pip", "install", "awscli"))
+	return nil
 }
 
 // Activate GOOGLE_APPLICATION_CREDENTIALS if set or do nothing.

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -805,10 +805,7 @@ func prepareGcp(o *options) error {
 
 func prepareAws(o *options) error {
 	// gcloud creds may have changed
-	if err := activateServiceAccount(o.gcpServiceAccount); err != nil {
-		return err
-	}
-	return nil
+	return activateServiceAccount(o.gcpServiceAccount)
 }
 
 // Activate GOOGLE_APPLICATION_CREDENTIALS if set or do nothing.


### PR DESCRIPTION
We are now using kops for dumping logs rather than the log dumper
script.  Removing the requirement for aws cli installation and removing
the log dumper helper shell function.

/assign @krzyzacy 

@krzyzacy will probably need some help testing this PR, not certain how to test outside of our test infrastructure.