### PR TITLE
Stopping AWS Janitor from removing default IGW

### DIFF
--- a/maintenance/aws-janitor/Makefile
+++ b/maintenance/aws-janitor/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE ?= gcr.io/k8s-test-infra-aws/aws-janitor
-VERSION ?= 0.3
+VERSION ?= 0.4
 
 image:
 	CGO_ENABLED=0 go build k8s.io/test-infra/maintenance/aws-janitor

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13780,7 +13780,7 @@ periodics:
       env:
       - name: AWS_SHARED_CREDENTIALS_FILE
         value: /workspace/.aws/credentials
-      image: gcr.io/k8s-test-infra-aws/aws-janitor:0.3
+      image: gcr.io/k8s-test-infra-aws/aws-janitor:0.4
       volumeMounts:
       - mountPath: /workspace/.aws
         name: aws-cred


### PR DESCRIPTION
This PR fixes the AWS Janitor so that it does not remove the Internet
Gateway for the default VPC.

Fixes https://github.com/kubernetes/test-infra/issues/6573