### PR TITLE
Change GKE scale jobs schedule

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6633,7 +6633,7 @@
       "--gke-shape={\"default\":{\"Nodes\":1999,\"MachineType\":\"n1-standard-1\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-8\"}}",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m",
-      "--timeout=570m",
+      "--timeout=510m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -6832,7 +6832,7 @@
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",
-      "--gcp-project=k8s-scale-testing",
+      "--gcp-project=kubernetes-scale",
       "--gcp-zone=us-east1-a",
       "--ginkgo-parallel=30",
       "--gke-custom-subnet=gke-scale-cluster-custom-subnet --region=us-east1 --range=10.0.0.0/19",
@@ -6840,7 +6840,7 @@
       "--gke-shape={\"default\":{\"Nodes\":3999,\"MachineType\":\"g1-small\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-16\"}}",
       "--provider=gke",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=40 --node-schedulable-timeout=90m --minStartupPods=8",
-      "--timeout=990m",
+      "--timeout=630m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10530,7 +10530,7 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180212-83c830734-master
 
-- cron: '1 23 * * 0' # Run at 15:01PST (23:01UTC) on sunday
+- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-correctness
   labels:
@@ -10561,7 +10561,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
-- cron: '1 13 * * 0' # Run at 05:01PST (13:01UTC) on sunday
+- cron: '1 8 * * 0' # Run at 00:01PST (8:01 UTC) on sunday
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-performance
   tags:
@@ -10572,7 +10572,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=600
+      - --timeout=540
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180212-83c830734-master
       resources:
@@ -10698,7 +10698,7 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180212-83c830734-master
 
-- interval: 6h
+- cron: '1 17 * * 0' # Run at 9:01PST (17:01 UTC) on sunday
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-scale-correctness
   labels:
@@ -10707,7 +10707,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=1020
+      - --timeout=660
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180212-83c830734-master
       resources:


### PR DESCRIPTION
This changes the job schedule to run GKE 5k-node correctness instead of 2k-node correctness on sundays.
2k-node performance job continue to run on sundays.

/cc @wojtek-t 