### PR TITLE
bazel remote cache: add eviction

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,6 +130,12 @@
   revision = "9ce5d979ffdaca6385988d7ad1079a33ec942d20"
 
 [[projects]]
+  name = "github.com/djherbis/atime"
+  packages = ["."]
+  revision = "8e47e0e01d08df8b9f840d74299c8ab70a024a30"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
@@ -732,6 +738,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "72dabeb79700dbfff9b8a833a3ae82c5085d42b305db04957caa7235fb7ec5f9"
+  inputs-digest = "b86dae268553febc5570e09d43e11ad454f04fde01da3d3b91995209423997c6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/experiment/nursery/BUILD.bazel
+++ b/experiment/nursery/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//experiment/nursery/diskcache:go_default_library",
+        "//experiment/nursery/diskutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
@@ -31,6 +32,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//experiment/nursery/diskcache:all-srcs",
+        "//experiment/nursery/diskutil:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/experiment/nursery/BUILD.bazel
+++ b/experiment/nursery/BUILD.bazel
@@ -38,6 +38,7 @@ filegroup(
 
 go_image(
     name = "image",
+    base = "@alpine-base//image",
     binary = ":nursery",
     visibility = ["//visibility:public"],
 )

--- a/experiment/nursery/deployment.yaml
+++ b/experiment/nursery/deployment.yaml
@@ -34,10 +34,14 @@ spec:
           containerPort: 8080
         args:
         - --dir=/data
-      # mount the local ssd
+        - --remount
+        # mount the local ssd
         volumeMounts:
         - name: cache
           mountPath: /data
+        # --remount needs privileges to remount the disk *shrug*
+        securityContext:
+          privileged: true
       volumes:
       - name: cache
         hostPath:

--- a/experiment/nursery/diskcache/BUILD.bazel
+++ b/experiment/nursery/diskcache/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["cache.go"],
     importpath = "k8s.io/test-infra/experiment/nursery/diskcache",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+    deps = [
+        "//experiment/nursery/diskutil:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(
@@ -26,4 +29,5 @@ go_test(
     name = "go_default_test",
     srcs = ["cache_test.go"],
     embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )

--- a/experiment/nursery/diskutil/BUILD.bazel
+++ b/experiment/nursery/diskutil/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["diskutil.go"],
+    importpath = "k8s.io/test-infra/experiment/nursery/diskutil",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/nursery/diskutil/BUILD.bazel
+++ b/experiment/nursery/diskutil/BUILD.bazel
@@ -5,6 +5,10 @@ go_library(
     srcs = ["diskutil.go"],
     importpath = "k8s.io/test-infra/experiment/nursery/diskutil",
     visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/djherbis/atime:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(

--- a/experiment/nursery/diskutil/diskutil.go
+++ b/experiment/nursery/diskutil/diskutil.go
@@ -71,12 +71,15 @@ func Remount(device, mountPoint, options string) error {
 }
 
 // GetDiskUsage wraps syscall.Statfs
-func GetDiskUsage(path string) (percentBlocksFree, percentFilesFree float64) {
+func GetDiskUsage(path string) (percentBlocksFree, percentFilesFree float64, err error) {
 	var stat syscall.Statfs_t
-	syscall.Statfs(path, &stat)
+	err = syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, 0, err
+	}
 	percentBlocksFree = float64(stat.Bfree) / float64(stat.Blocks) * 100
 	percentFilesFree = float64(stat.Ffree) / float64(stat.Files) * 100
-	return percentBlocksFree, percentFilesFree
+	return percentBlocksFree, percentFilesFree, nil
 }
 
 // GetATime the atime for a file, logging errors instead of failing

--- a/experiment/nursery/diskutil/diskutil.go
+++ b/experiment/nursery/diskutil/diskutil.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package diskutil implements disk related utilities for nursery
+package diskutil
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/djherbis/atime"
+	log "github.com/sirupsen/logrus"
+)
+
+// exec command and returns lines of combined output
+func commandLines(cmd []string) (lines []string, err error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	b, err := c.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(b), "\n"), nil
+}
+
+// FindMountForPath wraps `mount` to find the device / mountpoint
+// on which path is mounted
+func FindMountForPath(path string) (device, mountPoint string, err error) {
+	mounts, err := commandLines([]string{"mount"})
+	if err != nil {
+		return "", "", err
+	}
+	// these lines are like:
+	// $fs on $mountpoint type $fs_type ($mountopts)
+	device, mountPoint = "", ""
+	for _, mount := range mounts {
+		parts := strings.Fields(mount)
+		if len(parts) >= 3 {
+			currDevice := parts[0]
+			currMount := parts[2]
+			// we want the longest matching mountpoint
+			if strings.HasPrefix(path, currMount) && len(currMount) > len(mountPoint) {
+				device, mountPoint = currDevice, currMount
+			}
+		}
+	}
+	return device, mountPoint, nil
+}
+
+// Remount `wraps mount -o remount,options device mountPoint`
+func Remount(device, mountPoint, options string) error {
+	_, err := commandLines([]string{
+		"mount", "-o", fmt.Sprintf("remount,%s", options), device, mountPoint,
+	})
+	return err
+}
+
+// GetDiskUsage wraps syscall.Statfs
+func GetDiskUsage(path string) (percentBlocksFree, percentFilesFree float64) {
+	var stat syscall.Statfs_t
+	syscall.Statfs(path, &stat)
+	percentBlocksFree = float64(stat.Bfree) / float64(stat.Blocks) * 100
+	percentFilesFree = float64(stat.Ffree) / float64(stat.Files) * 100
+	return percentBlocksFree, percentFilesFree
+}
+
+// GetATime the atime for a file, logging errors instead of failing
+// and returning defaultTime instead
+func GetATime(path string, defaultTime time.Time) time.Time {
+	at, err := atime.Stat(path)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get atime for %s", path)
+		return defaultTime
+	}
+	return at
+}

--- a/experiment/nursery/main.go
+++ b/experiment/nursery/main.go
@@ -51,14 +51,16 @@ var port = flag.Int("port", 8080, "port to listen on")
 var minPercentBlocksFree = flag.Float64("min-percent-blocks-free", 10,
 	"minimum percent of blocks free on --dir's disk before evicting entries")
 var minPercentFilesFree = flag.Float64("min-percent-files-free", 10,
-	"minimum percent of blocks free on --dir's disk before evicting entries")
+	"minimum percent of files free on --dir's disk before evicting entries")
 var diskCheckInterval = flag.Duration("disk-check-interval", time.Minute,
 	"interval between checking disk usage (and potentially evicting entries)")
 
 // NOTE: remount is a bit of a hack, unfortunately the kubernetes volumes
 // don't really support this and to cleanly track entry access times we
-// want to use a volume with lazyatime (and not noatime or relatime)
+// want to use a volume with strictatime,lazytime (and not noatime or relatime)
 // so that file access times *are* recorded but are lazily flushed to the disk
+// https://lwn.net/Articles/621046/
+// https://unix.stackexchange.com/questions/276858/why-is-ext4-filesystem-mounted-with-both-relatime-and-lazytime
 var remount = flag.Bool("remount", false,
 	"attempt to remount --dir with strictatime,lazyatime to improve eviction")
 

--- a/experiment/nursery/main.go
+++ b/experiment/nursery/main.go
@@ -64,7 +64,7 @@ var remount = flag.Bool("remount", false,
 	"attempt to remount --dir with strictatime,lazyatime to improve eviction")
 
 func init() {
-	log.SetFormatter(&log.TextFormatter{})
+	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
 }
 
@@ -90,6 +90,7 @@ func main() {
 			if err != nil {
 				logger.WithError(err).Error("Failed to remount with lazyatime!")
 			}
+			logger.Info("Remount complete")
 		}
 	}
 

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
         "//vendor/github.com/boltdb/bolt:all-srcs",
         "//vendor/github.com/bwmarrin/snowflake:all-srcs",
         "//vendor/github.com/client9/misspell:all-srcs",
+        "//vendor/github.com/djherbis/atime:all-srcs",
         "//vendor/github.com/docker/distribution/digestset:all-srcs",
         "//vendor/github.com/docker/distribution/reference:all-srcs",
         "//vendor/github.com/docker/docker/api:all-srcs",

--- a/vendor/github.com/djherbis/atime/.travis.yml
+++ b/vendor/github.com/djherbis/atime/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+go:
+- 1.5
+before_install:
+  - go get github.com/golang/lint/golint
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+  - '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || $HOME/gopath/bin/goveralls -service=travis-ci -repotoken $COVERALLS_TOKEN'
+  - $HOME/gopath/bin/golint ./...
+  - go vet
+  - go test -v ./...
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+env:
+  global:
+    secure: MnwmqgePnDx0t5Ehrp2kLqnuaOh8JxQ9ebaA3KFE3q1TAGVJlv6mHJGFsP+gtC6DIpqosPlZf4JeuMHN+9eLOpa/8E+c9Rl0gctgMpZssgNEAfsqwy7+KBhqLsWKa9NetSB3ZhZit9KLknx8AmjpQCYUcc+n2KN6W4bkbebIp3o=

--- a/vendor/github.com/djherbis/atime/BUILD.bazel
+++ b/vendor/github.com/djherbis/atime/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "stat.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "atime_darwin.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "atime_dragonfly.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "atime_freebsd.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "atime_linux.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "atime_nacl.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "atime_netbsd.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "atime_openbsd.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "atime_plan9.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "atime_solaris.go",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "atime_windows.go",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "github.com/djherbis/atime",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/djherbis/atime/LICENSE
+++ b/vendor/github.com/djherbis/atime/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Dustin H
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/djherbis/atime/README.md
+++ b/vendor/github.com/djherbis/atime/README.md
@@ -1,0 +1,39 @@
+atime 
+==========
+
+[![GoDoc](https://godoc.org/github.com/djherbis/atime?status.svg)](https://godoc.org/github.com/djherbis/atime)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE.txt)
+[![Build Status](https://travis-ci.org/djherbis/atime.svg?branch=master)](https://travis-ci.org/djherbis/atime)
+[![Coverage Status](https://coveralls.io/repos/djherbis/atime/badge.svg?branch=master)](https://coveralls.io/r/djherbis/atime?branch=master)
+
+Usage
+------------
+File Access Times for #golang
+
+Looking for ctime or btime? Checkout https://github.com/djherbis/times
+
+Go has a hidden atime function for most platforms, this repo makes it accessible.
+
+```go
+package main
+
+import (
+  "log"
+
+  "github.com/djherbis/atime"
+)
+
+func main() {
+  at, err := atime.Stat("myfile")
+  if err != nil {
+    log.Fatal(err.Error())
+  }
+  log.Println(at)
+}
+```
+
+Installation
+------------
+```sh
+go get github.com/djherbis/atime
+```

--- a/vendor/github.com/djherbis/atime/atime_darwin.go
+++ b/vendor/github.com/djherbis/atime/atime_darwin.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_darwin.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atimespec)
+}

--- a/vendor/github.com/djherbis/atime/atime_dragonfly.go
+++ b/vendor/github.com/djherbis/atime/atime_dragonfly.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_dragonfly.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
+}

--- a/vendor/github.com/djherbis/atime/atime_freebsd.go
+++ b/vendor/github.com/djherbis/atime/atime_freebsd.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_freebsd.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atimespec)
+}

--- a/vendor/github.com/djherbis/atime/atime_linux.go
+++ b/vendor/github.com/djherbis/atime/atime_linux.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_linux.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
+}

--- a/vendor/github.com/djherbis/atime/atime_nacl.go
+++ b/vendor/github.com/djherbis/atime/atime_nacl.go
@@ -1,0 +1,22 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_nacl.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(sec, nsec int64) time.Time {
+	return time.Unix(sec, nsec)
+}
+
+func atime(fi os.FileInfo) time.Time {
+	st := fi.Sys().(*syscall.Stat_t)
+	return timespecToTime(st.Atime, st.AtimeNsec)
+}

--- a/vendor/github.com/djherbis/atime/atime_netbsd.go
+++ b/vendor/github.com/djherbis/atime/atime_netbsd.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_netbsd.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atimespec)
+}

--- a/vendor/github.com/djherbis/atime/atime_openbsd.go
+++ b/vendor/github.com/djherbis/atime/atime_openbsd.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_openbsd.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
+}

--- a/vendor/github.com/djherbis/atime/atime_plan9.go
+++ b/vendor/github.com/djherbis/atime/atime_plan9.go
@@ -1,0 +1,16 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_plan9.go
+
+package atime
+
+import (
+	"os"
+	"time"
+)
+
+func atime(fi os.FileInfo) time.Time {
+	return time.Unix(int64(fi.Sys().(*syscall.Dir).Atime), 0)
+}

--- a/vendor/github.com/djherbis/atime/atime_solaris.go
+++ b/vendor/github.com/djherbis/atime/atime_solaris.go
@@ -1,0 +1,21 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_solaris.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}
+
+func atime(fi os.FileInfo) time.Time {
+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
+}

--- a/vendor/github.com/djherbis/atime/atime_windows.go
+++ b/vendor/github.com/djherbis/atime/atime_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// http://golang.org/src/os/stat_windows.go
+
+package atime
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func atime(fi os.FileInfo) time.Time {
+	return time.Unix(0, fi.Sys().(*syscall.Win32FileAttributeData).LastAccessTime.Nanoseconds())
+}

--- a/vendor/github.com/djherbis/atime/stat.go
+++ b/vendor/github.com/djherbis/atime/stat.go
@@ -1,0 +1,21 @@
+// Package atime provides a platform-independent way to get atimes for files.
+package atime
+
+import (
+	"os"
+	"time"
+)
+
+// Get returns the Last Access Time for the given FileInfo
+func Get(fi os.FileInfo) time.Time {
+	return atime(fi)
+}
+
+// Stat returns the Last Access Time for the given filename
+func Stat(name string) (time.Time, error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return atime(fi), nil
+}


### PR DESCRIPTION
- add `--remount` which will attempt to remount the storage device with `strictatime,lazyatime` which will have the filesystem track access times for entries with lazy flushing to disk
  - this takes advantage of the fact that `ext4` supports `lazyatime` which should have better characteristics than just enabling `atime`
  - We are doing this because Linux defaults to `relatime` which is not very useful for us since it only updates at most once every 24 hours or when the file is modified, but access time tracking via `atime` is simple and durable
- add eviction based on access time

also vendors [a small library](https://github.com/djherbis/atime) for getting atime cross platform, go's stdlib leaves this as entirely system dependent even though most (all?) platforms support this.

xref: #6808 

/area bazel
/area kinda-hacky 😬 