### PR TITLE
Adding a ci job to run kubemci ingress conformance tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -609,6 +609,23 @@
       "sig-multicluster"
     ]
   },
+  "ci-kubemci-ingress-conformance": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=ingress-project",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:kubemci\\] --minStartupPods=8",
+      "--timeout=90m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-multicluster"
+    ]
+  },
   "ci-kubernetes-bazel-build": {
     "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
     "args": [],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6256,6 +6256,20 @@ periodics:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
 
+- interval: 60m
+  agent: kubernetes
+  name: ci-kubemci-ingress-conformance
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=110
+      - --bare
+      image: gcr.io/k8s-testimages/e2e-kubemci:latest
+      imagePullPolicy: Always
+
 - name: ci-kubernetes-bazel-build
   interval: 6h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -312,6 +312,8 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress
   alert_stale_results_hours: 24
+- name: ci-kubemci-ingress-conformance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubemci-ingress-conformance
 - name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-manual-network
   alert_stale_results_hours: 24
@@ -3773,6 +3775,8 @@ dashboards:
   dashboard_tab:
   - name: kubemci-image-push
     test_group_name: ci-kubemci-image-push
+  - name: kubemci-ingress-conformance
+    test_group_name: ci-kubemci-ingress-conformance
 
 - name: sig-instrumentation
   dashboard_tab:


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/131

This runs the tests that were added in https://github.com/kubernetes/kubernetes/pull/59234.

This will use the latest image pushed by the `kubemci-image-push` job that was added in https://github.com/kubernetes/test-infra/pull/6799

cc @G-Harmon @csbell @MrHohn @BenTheElder @krzyzacy 