### PR TITLE
Reduce repetitive code in trigger plugin and fix bug with branch sharded jobs.

### DIFF
--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -22,9 +22,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -152,4 +155,98 @@ func isUserTrusted(ghc githubClient, user, trustedOrg, org string) (bool, error)
 		}
 	}
 	return orgMember, nil
+}
+
+func runOrSkipRequested(c client, pr *github.PullRequest, requestedJobs []config.Presubmit, forceRunContexts map[string]bool, body, eventGUID string) error {
+	org := pr.Base.Repo.Owner.Login
+	repo := pr.Base.Repo.Name
+	number := pr.Number
+
+	baseSHA, err := c.GitHubClient.GetRef(org, repo, "heads/"+pr.Base.Ref)
+	if err != nil {
+		return err
+	}
+
+	getChanges := fileChangesGetter(c.GitHubClient, org, repo, number)
+	// shouldRun indicates if a job should actually run.
+	shouldRun := func(j config.Presubmit) (bool, error) {
+		if !j.RunsAgainstBranch(pr.Base.Ref) {
+			return false, nil
+		}
+		if j.RunIfChanged == "" || forceRunContexts[j.Context] || j.TriggerMatches(body) {
+			return true, nil
+		}
+		changes, err := getChanges()
+		if err != nil {
+			return false, err
+		}
+		return j.RunsAgainstChanges(changes), nil
+	}
+
+	// For each job determine if any sharded version of the job runs.
+	// This in turn determines which jobs to run and which contexts to mark as "Skipped".
+	//
+	// Note: Job sharding is achieved with presubmit configurations that overlap on
+	// name, but run under disjoint circumstances. For example, a job 'foo' can be
+	// sharded to have different pod specs for different branches by
+	// creating 2 presubmit configurations with the name foo, but different pod
+	// specs, and specifying different branches for each job.
+	var toRunJobs []config.Presubmit
+	toRun := sets.NewString()
+	toSkip := sets.NewString()
+	for _, job := range requestedJobs {
+		runs, err := shouldRun(job)
+		if err != nil {
+			return err
+		}
+		if runs {
+			toRunJobs = append(toRunJobs, job)
+			toRun.Insert(job.Context)
+		} else if !job.SkipReport {
+			toSkip.Insert(job.Context)
+		}
+	}
+	// 'Skip' any context that is requested, but doesn't have any job shards that
+	// will run.
+	for _, context := range toSkip.Difference(toRun).List() {
+		if err := c.GitHubClient.CreateStatus(org, repo, pr.Head.SHA, github.Status{
+			State:       github.StatusSuccess,
+			Context:     context,
+			Description: "Skipped",
+		}); err != nil {
+			return err
+		}
+	}
+
+	var errors []error
+	for _, job := range toRunJobs {
+		c.Logger.Infof("Starting %s build.", job.Name)
+		kr := kube.Refs{
+			Org:     org,
+			Repo:    repo,
+			BaseRef: pr.Base.Ref,
+			BaseSHA: baseSHA,
+			Pulls: []kube.Pull{
+				{
+					Number: number,
+					Author: pr.User.Login,
+					SHA:    pr.Head.SHA,
+				},
+			},
+		}
+		labels := make(map[string]string)
+		for k, v := range job.Labels {
+			labels[k] = v
+		}
+		labels[github.EventGUID] = eventGUID
+		pj := pjutil.NewProwJob(pjutil.PresubmitSpec(job, kr), labels)
+		c.Logger.WithFields(pjutil.ProwJobFields(&pj)).Info("Creating a new prowjob.")
+		if _, err := c.KubeClient.CreateProwJob(pj); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("errors starting jobs: %v", errors)
+	}
+	return nil
 }


### PR DESCRIPTION
The bug is a problem with skipping branch sharded jobs that affects the `buildAll` function used to handle `pull_request` events. (`/test` and `/retest` commands are working properly.)
Specifically each job that didn't need to run would mark the status context as skipped before the shard that actually runs sets the status to "Job triggered".  In addition to being confusing to users, this wastes API tokens, and is a potential race if requests arrive to Github in the wrong order. Switching `buildAll` to share the logic from comment handling fixes this.

/area prow
/kind bug