### PR TITLE
Remove showAPIType option from apicoverage

### DIFF
--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -39,7 +39,6 @@ var (
 	openAPIFile = flag.String("openapi", "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json", "URL to openapi-spec of Kubernetes")
 	minCoverage = flag.Int("minimum-coverage", 0, "This command fails if the number of covered APIs is less than this option ratio(percent)")
 	restLog     = flag.String("restlog", "", "File path to REST API operation log of Kubernetes")
-	showAPIType = flag.String("apitype", "stable", "API type to show not-tested APIs. The options are stable, alpha, beta and all")
 )
 
 type apiData struct {


### PR DESCRIPTION
showAPIType option was implemented during the prototype, but it has
not been used at all today. So this commit removes it for the code
cleanup.