### PR TITLE
Add cri-containerd daemon log support.

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -5,6 +5,7 @@ KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-contai
 KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/var/run/cri-containerd.sock
+KUBE_CONTAINER_RUNTIME_NAME=cri-containerd
 KUBE_LOAD_IMAGE_COMMAND=/home/cri-containerd/usr/local/bin/ctrcri load
 NETWORK_POLICY_PROVIDER=calico
 NON_MASQUERADE_CIDR=0.0.0.0/0


### PR DESCRIPTION
Add cri-containerd daemon log support after https://github.com/kubernetes/kubernetes/pull/59103 is merged.
Signed-off-by: Lantao Liu <lantaol@google.com>