### PR TITLE
Setting repo flag for kubemci push job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5099,6 +5099,7 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180212-83c830734-master
         args:
+        - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
         - "--clean"
         - "--timeout=90"


### PR DESCRIPTION
I assumed it will use test-infra by default, but the job is failing as it is a required param
```
'Expected --repo xor --bare:', args.repo, args.bare)
argparse.ArgumentTypeError: ('Expected --repo xor --bare:', None, False)
```
cc @krzyzacy 