### PR TITLE
Updating args to pass the args to make instead of execute.py

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -622,6 +622,7 @@
   "ci-kubemci-image-push": {
     "args": [
       "make",
+      "--",
       "-C",
       "images/kubemci",
       "push"


### PR DESCRIPTION
Adding "--" so that args are passed to make instead of execute.py.

The job is failing right now.
From http://prow.k8s.io/log?job=ci-kubemci-image-push&id=4
```
I0214 22:09:14.273] Call:  /workspace/./test-infra/jenkins/../scenarios/execute.py make -C images/kubemci push
W0214 22:09:14.299] usage: execute.py [-h] [--env ENV] cmd [args [args ...]]
W0214 22:09:14.300] execute.py: error: unrecognized arguments: -C images/kubemci push
E0214 22:09:14.301] Command failed
```

cc @krzyzacy @BenTheElder 