### PR TITLE
create DefaultFieldsFormatter and inject component into all prow messages

### DIFF
--- a/experiment/nursery/BUILD.bazel
+++ b/experiment/nursery/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//experiment/nursery/diskcache:go_default_library",
         "//experiment/nursery/diskutil:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/experiment/nursery/main.go
+++ b/experiment/nursery/main.go
@@ -39,6 +39,7 @@ import (
 
 	"k8s.io/test-infra/experiment/nursery/diskcache"
 	"k8s.io/test-infra/experiment/nursery/diskutil"
+	"k8s.io/test-infra/prow/logrusutil"
 
 	"github.com/sirupsen/logrus"
 )
@@ -64,29 +65,10 @@ var diskCheckInterval = flag.Duration("disk-check-interval", time.Minute,
 var remount = flag.Bool("remount", false,
 	"attempt to remount --dir with strictatime,lazyatime to improve eviction")
 
-// DefaultFieldsFormatter wraps another logrus.Formatter, injecting
-// DefaultFields into each Format() call
-type DefaultFieldsFormatter struct {
-	WrappedFormatter logrus.Formatter
-	DefaultFields    logrus.Fields
-}
-
-// Format implements logrus.Formatter's Format
-func (d *DefaultFieldsFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	decorated := entry
-	if entry != nil {
-		decorated = entry.WithFields(d.DefaultFields)
-	}
-	return d.WrappedFormatter.Format(decorated)
-}
-
 func init() {
-	logrus.SetFormatter(&DefaultFieldsFormatter{
-		WrappedFormatter: &logrus.JSONFormatter{},
-		DefaultFields: logrus.Fields{
-			"component": "nursery",
-		},
-	})
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "nursery"}),
+	)
 	logrus.SetOutput(os.Stdout)
 }
 

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -74,6 +74,7 @@ filegroup(
         "//prow/hook:all-srcs",
         "//prow/jenkins:all-srcs",
         "//prow/kube:all-srcs",
+        "//prow/logrusutil:all-srcs",
         "//prow/metrics:all-srcs",
         "//prow/phony:all-srcs",
         "//prow/pjutil:all-srcs",

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/githuboauth:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/tide:go_default_library",

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/pluginhelp/hook:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/cron:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/cron"
 	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
 )
 
@@ -33,7 +34,9 @@ var configPath = flag.String("config-path", "/etc/config/config", "Path to confi
 
 func main() {
 	flag.Parse()
-	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "horologium"}),
+	)
 
 	configAgent := config.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//vendor/github.com/NYTimes/gziphandler:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/plank:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/cmd/splice/BUILD.bazel
+++ b/prow/cmd/splice/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/tide:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -32,7 +32,10 @@ go_library(
     name = "go_default_library",
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
-    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+    deps = [
+        "//prow/logrusutil:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["logrusutil.go"],
+    importpath = "k8s.io/test-infra/prow/logrusutil",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logrusutil implements some helpers for using logrus
+package logrusutil
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// DefaultFieldsFormatter wraps another logrus.Formatter, injecting
+// DefaultFields into each Format() call, existing fields are preserved
+// if they have the same key
+type DefaultFieldsFormatter struct {
+	WrappedFormatter logrus.Formatter
+	DefaultFields    logrus.Fields
+}
+
+// NewDefaultFieldsFormatter returns a DefaultFieldsFormatter,
+// if wrappedFormatter is nil &logrus.JSONFormatter{} will be used instead
+func NewDefaultFieldsFormatter(
+	wrappedFormatter logrus.Formatter, defaultFields logrus.Fields,
+) *DefaultFieldsFormatter {
+	res := &DefaultFieldsFormatter{
+		WrappedFormatter: wrappedFormatter,
+		DefaultFields:    defaultFields,
+	}
+	if res.WrappedFormatter == nil {
+		res.WrappedFormatter = &logrus.JSONFormatter{}
+	}
+	return res
+}
+
+// Format implements logrus.Formatter's Format
+func (d *DefaultFieldsFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	if entry != nil {
+		for k, v := range d.DefaultFields {
+			if _, exists := entry.Data[k]; !exists {
+				entry.Data[k] = v
+			}
+		}
+	}
+	return d.WrappedFormatter.Format(entry)
+}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -125,6 +125,9 @@ type Pool struct {
 
 // NewController makes a Controller out of the given clients.
 func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, ca *config.Agent, gc *git.Client, logger *logrus.Entry) *Controller {
+	if logger == nil {
+		logger = logrus.NewEntry(logrus.StandardLogger())
+	}
 	sc := &statusController{
 		logger:         logger.WithField("controller", "status-update"),
 		ghc:            ghcStatus,


### PR DESCRIPTION
I had this idea when working on the bazel remote cache server:  Wrap the logrus formatter with one that injects default fields so we can use the `logrus.Fields{"component": "tide"}` pattern across *all* log messages within a binary. 

I've created a small package implementing this and migrated all of the prow components to use it and standardized the logging a bit.

/area prow