### PR TITLE
For docs repo, no self approve, no issue required.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -53,10 +53,6 @@ approve:
   - kubernetes/test-infra
   implicit_self_approve: true
 - repos:
-  - kubernetes/website
-  issue_required: false
-  implicit_self_approve: false
-- repos:
   - kubernetes-sigs
   - kubernetes-sig-testing
   implicit_self_approve: true

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -51,8 +51,11 @@ approve:
   - kubernetes/sig-release
   - kubernetes/steering
   - kubernetes/test-infra
-  - kubernetes/website
   implicit_self_approve: true
+- repos:
+  - kubernetes/website
+  issue_required: false
+  implicit_self_approve: false
 - repos:
   - kubernetes-sigs
   - kubernetes-sig-testing


### PR DESCRIPTION
In the docs repo (kubernetes/website) we would like to turn off implicit_self_approve.