### PR TITLE
Updating kubemci-image-push job to push latest image as well

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -625,7 +625,7 @@
       "--",
       "-C",
       "images/kubemci",
-      "push"
+      "push-latest"
     ],
     "scenario": "execute",
     "sigOwners": [


### PR DESCRIPTION
latest tag is what the kubemci e2e test job uses.
cc @BenTheElder @krzyzacy 