### PR TITLE
move bazel cache rc creation into images

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -19,6 +19,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# darwin is great
+SED=sed
+if which gsed &>/dev/null; then
+  SED=gsed
+fi
+if ! ($SED --version 2>&1 | grep -q GNU); then
+  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
+  exit 1
+fi
+
 dirty="$(git status --porcelain)"
 if [[ -n ${dirty} ]]; then
   echo "Tree not clean:"
@@ -40,10 +50,10 @@ popd
 
 echo "TAG = ${TAG}"
 
-sed -i "s/DEFAULT_KUBEKINS_TAG = '.*'/DEFAULT_KUBEKINS_TAG = '${TAG}-master'/" "${TREE}/scenarios/kubernetes_e2e.py"
-sed -i "s/\/kubekins-e2e:.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/images/kubeadm/Dockerfile"
-sed -i "s/\/kubekins-e2e:v.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/experiment/generate_tests.py"
-sed -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/experiment/test_config.yaml"
+$SED -i "s/DEFAULT_KUBEKINS_TAG = '.*'/DEFAULT_KUBEKINS_TAG = '${TAG}-master'/" "${TREE}/scenarios/kubernetes_e2e.py"
+$SED -i "s/\/kubekins-e2e:.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/images/kubeadm/Dockerfile"
+$SED -i "s/\/kubekins-e2e:v.*$/\/kubekins-e2e:${TAG}-master/" "${TREE}/experiment/generate_tests.py"
+$SED -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/experiment/test_config.yaml"
 
 pushd "${TREE}"
 bazel run //experiment:generate_tests -- \
@@ -55,7 +65,7 @@ popd
 
 # Scan for kubekins-e2e:v.* as a rudimentary way to avoid
 # replacing :latest.
-sed -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/prow/config.yaml"
+$SED -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/prow/config.yaml"
 git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-(master|releases) (using generate_tests and manual)"
 
 # Bump kubeadm image
@@ -65,5 +75,5 @@ pushd "${TREE}/images/kubeadm"
 make push TAG="${TAG}"
 popd
 
-sed -i "s/\/e2e-kubeadm:v.*$/\/e2e-kubeadm:${TAG}/" "${TREE}/prow/config.yaml"
+$SED -i "s/\/e2e-kubeadm:v.*$/\/e2e-kubeadm:${TAG}/" "${TREE}/prow/config.yaml"
 git commit -am "Bump to e2e-kubeadm:${TAG}"

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -126,7 +126,8 @@ ADD ["./barnacle/barnacle", "/usr/local/bin"]
 
 
 # note the runner is also responsible for making docker in docker function if
-# env DOCKER_IN_DOCKER_ENABLED is set
+# env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
+# .bazelrc files if bazel remote caching is enabled 
 ADD ["runner", \
     "/workspace/"]
 

--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# THIS IS TEMPORARY (!)
-# Once this moves out of experiment/ we will create these files in the bazel
-# images instead (!)
-# TODO(bentheelder): verify that this works and move it into the images
 CACHE_HOST="bazel-cache.default"
 CACHE_PORT="8080"
 

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -17,8 +17,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# get test-infra for latest bootstrap etc
+git clone https://github.com/kubernetes/test-infra
+
+
+# Check if the job has opted-in to bazel remote caching and if so generate 
+# .bazelrc entries pointing to the remote cache
+export BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
+if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
+    echo "Bazel remote cache is enabled, generating .bazelrcs ..."
+    ./test-infra/images/bootstrap/create_bazel_cache_rcs.sh
+fi
+
+
+# runs custom docker data root cleanup binary and debugs remaining resources
 cleanup_dind() {
-    # run custom docker data root cleanup binary
     barnacle || true
     # list what images and volumes remain
     echo "Remaining docker images and volumes are:"
@@ -59,14 +72,14 @@ fi
 
 # disable error exit so we can run post-command cleanup
 set +o errexit
-# Clone test-infra and start bootstrap
-git clone https://github.com/kubernetes/test-infra
+# actually start bootstrap and the job
 ./test-infra/jenkins/bootstrap.py \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     --upload='gs://kubernetes-jenkins/logs' \
     "$@"
 EXIT_VALUE=$?
+
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Cleaning up after docker in docker."
@@ -75,5 +88,6 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     printf '=%.0s' {1..80}; echo
     echo "Done cleaning up after docker in docker."
 fi
+
 # preserve exit value from job / bootstrap
 exit ${EXIT_VALUE}

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+FROM gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
 ENV KUBETEST_IN_DOCKER="true"

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -21,6 +21,12 @@ GO ?= 1.9.3
 BAZEL ?= 0.10.0
 CFSSL ?= R1.2
 
+ifeq ($(K8S), experimental)
+	GO = 1.9.4
+	BAZEL = 0.10.1
+	CFSSL = R1.2
+endif
+
 ifeq ($(K8S), 1.9)
 	GO = 1.9.2
 	BAZEL = 0.8.1

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1390,7 +1390,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+      - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2644,7 +2644,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+      - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -2725,7 +2725,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+      - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -3346,7 +3346,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         name: ""
         resources:
           requests:
@@ -4579,7 +4579,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         name: ""
         resources:
           requests:
@@ -4668,7 +4668,7 @@ presubmits:
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         name: ""
         resources:
           requests:
@@ -5705,7 +5705,7 @@ periodics:
     preset-cadvisor-docker-credential: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --repo=github.com/google/cadvisor
@@ -6073,7 +6073,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6519,7 +6519,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6560,7 +6560,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6600,7 +6600,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6641,7 +6641,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6682,7 +6682,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -6737,7 +6737,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -12621,7 +12621,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -12662,7 +12662,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
       - --git-cache=/root/.cache/git
@@ -12703,7 +12703,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes"
@@ -12735,7 +12735,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.9"
@@ -12767,7 +12767,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.8"
@@ -12799,7 +12799,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.7"
@@ -13335,7 +13335,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes"
@@ -13367,7 +13367,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.9"
@@ -13399,7 +13399,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.8"
@@ -13431,7 +13431,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.7"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1137,8 +1137,9 @@ presubmits:
         - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
-        - "--experimental-add-caching-configs"
         env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         - name: TEST_TMPDIR
           value: /scratch/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
@@ -1357,8 +1358,9 @@ presubmits:
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
-        - "--experimental-add-caching-configs"
         env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
@@ -3111,9 +3113,11 @@ presubmits:
         - --batch
         - --build=//... -//vendor/...
         - --release=//build/release-tars
-        - --experimental-add-caching-configs
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build-canary
         - --gcs-shared=gs://kubernetes-security-prow/bazel
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
         name: ""
@@ -3298,7 +3302,9 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        - --experimental-add-caching-configs
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
         name: ""
@@ -4798,8 +4804,9 @@ presubmits:
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."
         - "--test-args=--test_output=errors"
-        - "--experimental-add-caching-configs"
         env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         - name: TEST_TMPDIR
           value: /scratch/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1125,7 +1125,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
         - "--clean"
@@ -1341,7 +1341,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
         - "--clean"
@@ -3118,7 +3118,7 @@ presubmits:
         env:
         - name: BAZEL_REMOTE_CACHE_ENABLED
           value: "true"
-        image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         name: ""
         resources:
@@ -3305,7 +3305,7 @@ presubmits:
         env:
         - name: BAZEL_REMOTE_CACHE_ENABLED
           value: "true"
-        image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         name: ""
         resources:
@@ -4791,7 +4791,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
         - "--clean"

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -135,9 +135,6 @@ def clean_file_in_dir(dirname, filename):
 def main(args):
     """Trigger a bazel build/test run, and upload results."""
     # pylint:disable=too-many-branches, too-many-statements, too-many-locals
-    if args.experimental_add_caching_configs:
-        check(test_infra('experiment', 'nursery', 'create_bazel_cache_rcs.sh'))
-
     if args.install:
         for install in args.install:
             if not os.path.isfile(install):
@@ -257,10 +254,6 @@ def create_parser():
         help='GCS path for where to push build')
     parser.add_argument(
         '--batch', action='store_true', help='run Bazel in batch mode')
-    # TODO(bentheelder): remove this
-    parser.add_argument(
-        '--experimental-add-caching-configs', action='store_true', help='experimental, do not use'
-    )
     return parser
 
 def parse_args(args=None):


### PR DESCRIPTION
- update bootstrap runner to have bazelrc creation behind an opt-in env
- switch to using this for test / experimental jobs
- bump bootstrap
- patch e2e image bump for darwin (longstanding bug...)
- create experimental/bleeding edge kubekins-e2e variant (to go with k8s release branch variants)
- bump kubekins-e2e for experimental jobs (note: this is pushed so it should not break, but these aren't blocking anyhow)