### PR TITLE
Require boilerplate on Dockerfiles, Makefiles, and Bazel Skylark sources

### DIFF
--- a/gubernator/Makefile
+++ b/gubernator/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 PROJECT ?= k8s-gubernator
 

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include ../common.mk  # defines TAG build push all
-
-IMG = gcr.io/k8s-testimages/queue-health-graph

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include ../common.mk  # defines TAG build push all
-
-IMG = gcr.io/k8s-testimages/queue-health-graph

--- a/hack/boilerplate/boilerplate.bzl.txt
+++ b/hack/boilerplate/boilerplate.bzl.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include ../common.mk  # defines TAG build push all
-
-IMG = gcr.io/k8s-testimages/queue-health-graph

--- a/image.bzl
+++ b/image.bzl
@@ -1,3 +1,17 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # tags appends default tags to name
 #
 # In particular, names is a {image_prefix: image_target} mapping, which gets

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y tzdata curl pv time sqlite3 python-pip && apt-get clean

--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 all: container
 
 # Path Prefix: the path the the mungegithub directory.

--- a/mungegithub/cherrypick/deployment/kubernetes/Makefile
+++ b/mungegithub/cherrypick/deployment/kubernetes/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/mungegithub/issue_labeler/Dockerfile
+++ b/mungegithub/issue_labeler/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu
 LABEL maintainer="Garrett Rodrigues grod@google.com"
 RUN apt-get update

--- a/mungegithub/misc-mungers/deployment/kubernetes/Makefile
+++ b/mungegithub/misc-mungers/deployment/kubernetes/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/mungegithub/submit-queue/Makefile
+++ b/mungegithub/submit-queue/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 KUBECONFIG ?= $(HOME)/.kube/config
 
 push-nginx:

--- a/mungegithub/submit-queue/deployment/community/Makefile
+++ b/mungegithub/submit-queue/deployment/community/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/mungegithub/submit-queue/deployment/contrib/Makefile
+++ b/mungegithub/submit-queue/deployment/contrib/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/mungegithub/submit-queue/deployment/kops/Makefile
+++ b/mungegithub/submit-queue/deployment/kops/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/mungegithub/submit-queue/deployment/kubernetes/Makefile
+++ b/mungegithub/submit-queue/deployment/kubernetes/Makefile
@@ -1,1 +1,15 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../../../path.mk

--- a/prow/prow.bzl
+++ b/prow/prow.bzl
@@ -1,11 +1,29 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
-load("//:image.bzl", docker_tags = "tags")
+load(
+    "//:image.bzl",
+    docker_tags = "tags",
+)
 
 MULTI_KIND = None
-CORE_CLUSTER = "{STABLE_PROW_CLUSTER}"  # For components like hook
-BUILD_CLUSTER = "{STABLE_BUILD_CLUSTER}"  # For untrusted test code
 
+CORE_CLUSTER = "{STABLE_PROW_CLUSTER}"  # For components like hook
+
+BUILD_CLUSTER = "{STABLE_BUILD_CLUSTER}"  # For untrusted test code
 
 # image returns the image prefix for the command.
 #
@@ -38,7 +56,6 @@ def target(cmd):
 def tags(*cmds):
   # Create :YYYYmmdd-commitish :latest :latest-USER tags
   return docker_tags(**{prefix(cmd): target(cmd) for cmd in cmds})
-
 
 def object(name, cluster=CORE_CLUSTER, **kwargs):
   k8s_object(

--- a/queue_health/base/Makefile
+++ b/queue_health/base/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../common.mk  # defines TAG build push all
 
 IMG = gcr.io/k8s-testimages/queue-health-base

--- a/queue_health/poll/Makefile
+++ b/queue_health/poll/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include ../common.mk  # defines TAG build push all
 
 IMG = gcr.io/k8s-testimages/queue-health-poll

--- a/test_infra.bzl
+++ b/test_infra.bzl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def _http_archive_with_pkg_path_impl(ctx):
     """Implements the http_archive_with_pkg_path build rule."""
     ctx.execute(["mkdir", "-p", ctx.attr.pkg_path])
@@ -11,12 +25,12 @@ def _http_archive_with_pkg_path_impl(ctx):
 # http_archive_with_pkg_path extends the built-in new_http_archive with a
 # pkg_path field, which can be used to specify the package installation path.
 http_archive_with_pkg_path = repository_rule(
-    implementation = _http_archive_with_pkg_path_impl,
     attrs = {
-        "build_file_content": attr.string(mandatory=True),
-        "pkg_path": attr.string(mandatory=True),
+        "build_file_content": attr.string(mandatory = True),
+        "pkg_path": attr.string(mandatory = True),
         "sha256": attr.string(),
-        "strip_prefix": attr.string(mandatory=True),
-        "url": attr.string(mandatory=True),
+        "strip_prefix": attr.string(mandatory = True),
+        "url": attr.string(mandatory = True),
     },
+    implementation = _http_archive_with_pkg_path_impl,
 )

--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM jamiehewland/alpine-pypy:2
 
 RUN apk add --no-cache jq

--- a/velodrome/fetcher/Dockerfile
+++ b/velodrome/fetcher/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/velodrome/fetcher/Makefile
+++ b/velodrome/fetcher/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Please set IMG
 TAG := $(shell date +v%Y%m%d-%H%M%S)
 IMG ?= gcr.io/google-containers/github-fetcher

--- a/velodrome/token-counter/Dockerfile
+++ b/velodrome/token-counter/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/velodrome/token-counter/Makefile
+++ b/velodrome/token-counter/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Please set IMG
 TAG := $(shell date +v%Y%m%d-%H%M%S)
 IMG ?= gcr.io/google-containers/github-token-counter

--- a/velodrome/transform/Dockerfile
+++ b/velodrome/transform/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/velodrome/transform/Makefile
+++ b/velodrome/transform/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Please set IMG
 TAG := $(shell date +v%Y%m%d-%H%M%S)
 IMG ?= gcr.io/google-containers/github-transform


### PR DESCRIPTION
This is the same list of source files that other kubernetes repos require, so we should maybe be consistent?

/shrug