### PR TITLE
Trim all whitespace from `gcloud container get-server-config`

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -588,7 +588,7 @@ func getLatestGKEVersion(project, zone, releasePrefix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	versions := strings.Split(string(res), ";")
+	versions := strings.Split(strings.TrimSpace(string(res)), ";")
 	latestValid := ""
 	for _, version := range versions {
 		if strings.HasPrefix(version, releasePrefix) {


### PR DESCRIPTION
The GKE upgrade jobs have been failing for a while, e.g. 
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-master/52

Mysteriously `v1.8.7-gke.1` is working, but `v1.7.12-gke.1` is failing:
```
W0213 08:08:35.814] 2018/02/13 08:08:35 util.go:172: Running: gcloud container get-server-config --project=k8s-gke-gci-1-5-1-6-ctl-skew --zone=us-central1-f --format=value(validMasterVersions)
W0213 08:08:36.451] Fetching server config for us-central1-f
W0213 08:08:36.584] 2018/02/13 08:08:36 util.go:174: Step 'gcloud container get-server-config --project=k8s-gke-gci-1-5-1-6-ctl-skew --zone=us-central1-f --format=value(validMasterVersions)' finished in 770.881043ms
W0213 08:08:36.585] 2018/02/13 08:08:36 extract_k8s.go:276: U=https://storage.googleapis.com/kubernetes-release-gke/release R=v1.7.12-gke.1
W0213 08:08:36.585]  get-kube.sh
W0213 08:08:36.585] 2018/02/13 08:08:36 util.go:172: Running: ./get-kube.sh
W0213 08:08:36.590] Version doesn't match regexp
W0213 08:08:36.590] 2018/02/13 08:08:36 util.go:174: Step './get-kube.sh' finished in 6.636404ms
W0213 08:08:36.591] 2018/02/13 08:08:36 extract_k8s.go:286: U=https://storage.googleapis.com/kubernetes-release-gke/release R=v1.7.12-gke.1
W0213 08:08:36.591]  get-kube.sh failed: error during ./get-kube.sh: exit status 1
W0213 08:08:36.591] 2018/02/13 08:08:36 util.go:172: Running: ./get-kube.sh
W0213 08:08:36.596] Version doesn't match regexp
W0213 08:08:36.597] 2018/02/13 08:08:36 util.go:174: Step './get-kube.sh' finished in 6.40438ms
W0213 08:08:36.597] 2018/02/13 08:08:36 extract_k8s.go:286: U=https://storage.googleapis.com/kubernetes-release-gke/release R=v1.7.12-gke.1
W0213 08:08:36.597]  get-kube.sh failed: error during ./get-kube.sh: exit status 1
W0213 08:08:37.597] 2018/02/13 08:08:37 util.go:172: Running: ./get-kube.sh
W0213 08:08:37.604] Version doesn't match regexp
W0213 08:08:37.604] 2018/02/13 08:08:37 util.go:174: Step './get-kube.sh' finished in 7.23279ms
W0213 08:08:37.605] 2018/02/13 08:08:37 main.go:240: Saved XML output to /workspace/_artifacts/junit_runner.xml.
W0213 08:08:37.607] 2018/02/13 08:08:37 main.go:317: Something went wrong: failed to acquire k8s binaries: U=https://storage.googleapis.com/kubernetes-release-gke/release R=v1.7.12-gke.1
W0213 08:08:37.607]  get-kube.sh failed: error during ./get-kube.sh: exit status 1
```

Looking very carefully, I realized that it was actually asking for `v1.7.12-gke.1\n`. This PR fixes that.

(Still need to bump kubekins-e2e with this fix - should I do that in this PR?)