### PR TITLE
Make require-sig plugin ignore label events for non-sig labels.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -258,6 +258,8 @@ type IssueEvent struct {
 	Action IssueEventAction `json:"action"`
 	Issue  Issue            `json:"issue"`
 	Repo   Repo             `json:"repository"`
+	// Label is specified for IssueActionLabeled and IssueActionUnlabeled events.
+	Label Label `json:"label"`
 
 	// GUID is included in the header of the request received by Github.
 	GUID string


### PR DESCRIPTION
fixes #6829 
@mml 
Other label commands before the `/sig` command were causing label events that the require-sig plugin reacted to. If the `/sig` command hadn't been processed yet, there was not yet a sig label on the issue so the require-sig plugin would add the `needs-sig` label incorrectly.

/king bug
/area prow
/cc @kargakis @BenTheElder 