### PR TITLE
Revert "Use streaming mode of ginkgo."

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3032,7 +3032,7 @@
       "--gcp-zone=us-east1-a",
       "--ginkgo-parallel=30",
       "--provider=gce",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.stream --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
       "--timeout=390m",
       "--use-logexporter"
     ],
@@ -3394,7 +3394,7 @@
       "--gcp-zone=us-east1-a",
       "--ginkgo-parallel=30",
       "--provider=gce",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.stream --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=90m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=90m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
       "--timeout=570m",
       "--use-logexporter"
     ],
@@ -6661,7 +6661,7 @@
       "--gke-environment=test",
       "--gke-shape={\"default\":{\"Nodes\":2000,\"MachineType\":\"g1-small\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-8\"}}",
       "--provider=gke",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.stream --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8",
       "--timeout=450m",
       "--use-logexporter"
     ],
@@ -6912,7 +6912,7 @@
       "--gke-environment=test",
       "--gke-shape={\"default\":{\"Nodes\":3999,\"MachineType\":\"g1-small\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-16\"}}",
       "--provider=gke",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.stream --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=40 --node-schedulable-timeout=90m --minStartupPods=8",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=40 --node-schedulable-timeout=90m --minStartupPods=8",
       "--timeout=630m",
       "--use-logexporter"
     ],


### PR DESCRIPTION
Reverts kubernetes/test-infra#6845

This change seems to cause failure of our jobs with:

```
I0215 22:33:16.112] [3] flag provided but not defined: -ginkgo.stream
I0215 22:33:16.112] [3] Usage of /workspace/kubernetes/platforms/linux/amd64/e2e.test:
```

ref: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/74

fyi - @porridge 