### PR TITLE
Stop running config-ssh as part of kubetest

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -772,18 +772,6 @@ func prepareGcp(o *options) error {
 		return err
 	}
 
-	log.Printf("Checking presence of public key in %s", o.gcpProject)
-	if out, err := output(exec.Command("gcloud", "compute", "--project="+o.gcpProject, "project-info", "describe")); err != nil {
-		return err
-	} else if b, err := ioutil.ReadFile(pk); err != nil {
-		return err
-	} else if !strings.Contains(string(b), string(out)) {
-		log.Print("Uploading public ssh key to project metadata...")
-		if err = finishRunning(exec.Command("gcloud", "compute", "--project="+o.gcpProject, "config-ssh")); err != nil {
-			return err
-		}
-	}
-
 	// Install custom gcloud version if necessary
 	if o.gcpCloudSdk != "" {
 		for i := 0; i < 3; i++ {


### PR DESCRIPTION
Can we stop running `gcloud config-ssh` as part of kubetest?

I find it extremely annoying... I really don't want it messing with my `~/.ssh/config`.

Lately, it started giving me even more grief than before.

A recent run today:

```
ERROR: (gcloud.compute.config-ssh) Found more than one Google Compute Engine section in [/usr/local/google/home/filbranden/.ssh/config]. You can either delete [/usr/local/google/home/filbranden/.ssh/config] and let this command recreate it for you or you can manually delete all sections marked with [# Google Compute Engine Section] and [# End of Google Compute Engine Section].
```

And earlier this week I had some other more criptic errors about `NoneType`.

Can we just ditch it?

(NOTE: I haven't done extensive tests with removing it from kubetest, so I don't really know if something depends on it being there to be able to SSH to machines... In that case, couldn't we prefer to use `gcloud compute ssh` that doesn't require it instead?)

Thanks!
Filipe
