### PR TITLE
Fix check for the SSH key for the project being set up.

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -777,7 +777,7 @@ func prepareGcp(o *options) error {
 		return err
 	} else if b, err := ioutil.ReadFile(pk); err != nil {
 		return err
-	} else if !strings.Contains(string(b), string(out)) {
+	} else if !strings.Contains(string(out), string(b)) {
 		log.Print("Uploading public ssh key to project metadata...")
 		if err = finishRunning(exec.Command("gcloud", "compute", "--project="+o.gcpProject, "config-ssh")); err != nil {
 			return err


### PR DESCRIPTION
This prevents running `config-ssh` when it is not actually needed.

This was actually intended, however the check had a bug in that the order of arguments to strings.Contain() was incorrect. :-)

Tested: manually by running kubetest --up with the appropriate arguments and checking that my ~/.ssh/config wasn't touched afterwards.

@BenTheElder 