### PR TITLE
more image cleanup, move test-infra to bazel 0.10.1

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -42,6 +42,7 @@ DATE="$(date +v%Y%m%d)"
 TAG="${DATE}-$(git describe --tags --always --dirty)"
 pushd "${TREE}/images/kubekins-e2e"
 make push
+K8S=experimental make push
 K8S=1.9 make push
 K8S=1.8 make push
 K8S=1.7 make push
@@ -66,7 +67,7 @@ popd
 # Scan for kubekins-e2e:v.* as a rudimentary way to avoid
 # replacing :latest.
 $SED -i "s/\/kubekins-e2e:v.*-\(.*\)$/\/kubekins-e2e:${TAG}-\1/" "${TREE}/prow/config.yaml"
-git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-(master|releases) (using generate_tests and manual)"
+git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-(master|experimental|releases) (using generate_tests and manual)"
 
 # Bump kubeadm image
 

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -66,14 +66,6 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
-# TODO(bentheelder): remove this once we are no longer using Jenkins
-# Get docker client binary for use with our jenkins nodes, and put it in it's
-# own bin dir. The runner will add this to the path if dind mode is not enabled.
-# Note: 1.11+ changes the tarball format
-RUN mkdir /docker-no-dind-bin/ && \
-    curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
-    | tar -C /docker-no-dind-bin -xvzf- --strip-components=3 usr/local/bin/docker
-
 
 #
 # BEGIN: DOCKER IN DOCKER SETUP

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -64,10 +64,6 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     cleanup_dind
     printf '=%.0s' {1..80}; echo
     echo "Done setting up docker in docker."
-else
-# TODO(bentheelder): remove this once we are no longer using Jenkins
-# If not, make sure `docker` points to the old one compatible with our Jenkins
-    export PATH=/docker-no-dind-bin/:$PATH
 fi
 
 # disable error exit so we can run post-command cleanup

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4746,7 +4746,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-90c54ef53-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4882,7 +4882,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-90c54ef53-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -4917,7 +4917,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-90c54ef53-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -5572,7 +5572,7 @@ postsubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-90c54ef53-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5642,7 +5642,7 @@ postsubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.10.0
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -13507,7 +13507,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-90c54ef53-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180216-306463dae-experimental
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
- remove kubekins / docker related junk :tada:
- add experimental config to experiment/bump_e2e_image.sh

WIP:
- bump test-infra to stable kubekins-e2e:date-sha-experimental tag for bazel `0.10.1.`