### PR TITLE
remove pull-kubernetes-e2e-kubeadm-gce-canary

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11044,26 +11044,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "pull-kubernetes-e2e-kubeadm-gce-canary": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel=30",
-      "--kubeadm=pull",
-      "--kubernetes-anywhere-dump-cluster-logs=true",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\] --minStartupPods=8",
-      "--timeout=55m",
-      "--use-shared-build=bazel"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "pull-kubernetes-kubemark-e2e-gce": {
     "args": [
       "--build=bazel",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1154,42 +1154,6 @@ presubmits:
       volumes:
       - name: bazel-scratch
         emtpyDir: {}
-    run_after_success:
-    - name: pull-kubernetes-e2e-kubeadm-gce-canary
-      agent: kubernetes
-      context: pull-kubernetes-e2e-kubeadm-gce-canary
-      max_concurrency: 8
-      skip_report: false
-      # use standard (pull-kubernetes-cross) regex we normally make sure
-      # to trigger on dummy / canary testing PRs
-      run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
-      rerun_command: "/test pull-kubernetes-e2e-kubeadm-gce-canary"
-      trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
-      labels:
-        preset-service-account: true
-        preset-k8s-ssh: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180216-4b63e5c46
-          args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--upload=gs://kubernetes-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
-          - "--timeout=75"
-          - "--clean"
-          env:
-          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-            value: true
-          volumeMounts:
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
@@ -3060,44 +3024,6 @@ presubmits:
     max_concurrency: 0
     name: pull-security-kubernetes-bazel-build-canary
     rerun_command: /test pull-security-kubernetes-bazel-build-canary
-    run_after_success:
-    - agent: kubernetes
-      always_run: false
-      cluster: security
-      context: pull-security-kubernetes-e2e-kubeadm-gce-canary
-      labels:
-        preset-k8s-ssh: "true"
-        preset-service-account: "true"
-      max_concurrency: 8
-      name: pull-security-kubernetes-e2e-kubeadm-gce-canary
-      rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce-canary
-      run_if_changed: ^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$
-      skip_report: false
-      spec:
-        containers:
-        - args:
-          - --ssh=/etc/ssh-security/ssh-security
-          - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-          - --upload=gs://kubernetes-security-prow/pr-logs
-          - --timeout=75
-          - --clean
-          - --
-          - --gcs-shared=gs://kubernetes-security-prow/bazel
-          env:
-          - name: SKIP_RELEASE_VALIDATION
-            value: "true"
-          image: gcr.io/k8s-testimages/e2e-kubeadm:v20180216-4b63e5c46
-          name: ""
-          resources: {}
-          volumeMounts:
-          - mountPath: /etc/ssh-security
-            name: ssh-security
-        volumes:
-        - name: ssh-security
-          secret:
-            defaultMode: 256
-            secretName: ssh-security
-      trigger: (?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\s+|$)
     run_if_changed: ""
     skip_report: false
     spec:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1728,10 +1728,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-build-canary
   days_of_results: 1
   num_columns_recent: 20
-- name: pull-kubernetes-e2e-kubeadm-gce-canary
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kubeadm-gce-canary
-  days_of_results: 1
-  num_columns_recent: 20
 - name: pull-kubernetes-bazel-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test
   days_of_results: 1
@@ -4558,8 +4554,6 @@ dashboards:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: bazel-build-canary
     test_group_name: pull-kubernetes-bazel-build-canary
-  - name: kubeadm-canary
-    test_group_name: pull-kubernetes-e2e-kubeadm-gce-canary
   - name: bazel-test-canary
     test_group_name: pull-kubernetes-bazel-test-canary
   - name: pull-kubernetes-verify-prow


### PR DESCRIPTION
this job is just failing and creating noise, we're not using it for anything currently so I'd rather just remove it for the moment. we can test run_after_success in other ways if we want to work on it more