### PR TITLE
fix --extract=gke

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -68,16 +68,16 @@ func (l *extractStrategies) String() string {
 // Converts --extract=release/stable, etc into an extractStrategy{}
 func (l *extractStrategies) Set(value string) error {
 	var strategies = map[string]extractMode{
-		`^(local)`:                           local,
-		`^gke-(default|latest(-\d+.\d+)?)?$`: gke,
-		`^gci/([\w-]+)$`:                     gci,
-		`^gci/([\w-]+)/(.+)$`:                gciCi,
-		`^ci/(.+)$`:                          ci,
-		`^release/(latest.*)$`:               rc,
-		`^release/(stable.*)$`:               stable,
-		`^(v\d+\.\d+\.\d+[\w.\-+]*)$`:        version,
-		`^(gs://.*)$`:                        gcs,
-		`^(bazel/.*)$`:                       bazel,
+		`^(local)`:                            local,
+		`^gke-?(default|latest(-\d+.\d+)?)?$`: gke,
+		`^gci/([\w-]+)$`:                      gci,
+		`^gci/([\w-]+)/(.+)$`:                 gciCi,
+		`^ci/(.+)$`:                           ci,
+		`^release/(latest.*)$`:                rc,
+		`^release/(stable.*)$`:                stable,
+		`^(v\d+\.\d+\.\d+[\w.\-+]*)$`:         version,
+		`^(gs://.*)$`:                         gcs,
+		`^(bazel/.*)$`:                        bazel,
 	}
 
 	if len(*l) == 2 {


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/google-gke-prod#gke-prod-parallel starts to fail since the last bump...

dropped the `?` in https://github.com/kubernetes/test-infra/pull/6769
/shrug
/area kubetest
/priority failing-test
/assign @BenTheElder @ixdy @caesarxuchao 
