### PR TITLE
Checkout sources for ci-kubernetes-local-e2e

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9922,6 +9922,7 @@
     "args": [
       "--deployment=local",
       "--extract=ci/latest",
+      "--extract-sources",
       "--ginkgo-parallel=1",
       "--provider=local",
       "--test_args=--ginkgo.focus=\\[Feature:Conformance\\]",


### PR DESCRIPTION
oops looks like the downloaded tars do not have source files etc.