### PR TITLE
Migrate lgtm_after_commit munger to prow lgtm plugin

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -973,15 +973,55 @@ func (c *Client) AddLabel(org, repo string, number int, label string) error {
 	return err
 }
 
+// LabelNotFound indicates that a label is not attached to an issue. For example, removing a
+// label from an issue, when the issue does not have that label.
+type LabelNotFound struct {
+	Owner, Repo string
+	Number      int
+	Label       string
+}
+
+func (e *LabelNotFound) Error() string {
+	return fmt.Sprintf("label %q does not exist on %s/%s/%d", e.Label, e.Owner, e.Repo, e.Number)
+}
+
+type githubError struct {
+	Message string `json:"message,omitempty"`
+}
+
 func (c *Client) RemoveLabel(org, repo string, number int, label string) error {
 	c.log("RemoveLabel", org, repo, number, label)
-	_, err := c.request(&request{
+	ge := githubError{}
+	code, err := c.request(&request{
 		method: http.MethodDelete,
 		path:   fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels/%s", c.base, org, repo, number, label),
 		// GitHub sometimes returns 200 for this call, which is a bug on their end.
-		exitCodes: []int{200, 204},
-	}, nil)
-	return err
+		// On 404, do not retry. We will inspect and handle this case appropriately.
+		exitCodes: []int{200, 204, 404},
+	}, &ge)
+
+	// If our code was 200 or 204, no error info.
+	if code != 404 {
+		return nil
+	}
+
+	// If the error was because the label was not found, annotate that error with type information.
+	if ge.Message == "Label does not exist" {
+		return &LabelNotFound{
+			Owner:  org,
+			Repo:   repo,
+			Number: number,
+			Label:  label,
+		}
+	}
+
+	// If we saw an opaque error, pass it up.
+	if err != nil {
+		return err
+	}
+
+	// Otherwise we got some other 404 error.
+	return fmt.Errorf("deleting label 404: %s", ge.Message)
 }
 
 type MissingUsers struct {
@@ -1397,25 +1437,23 @@ func (e UnmergablePRBaseChangedError) Error() string { return string(e) }
 // Merge merges a PR.
 func (c *Client) Merge(org, repo string, pr int, details MergeDetails) error {
 	c.log("Merge", org, repo, pr, details)
-	var res struct {
-		Message string `json:"message"`
-	}
+	ge := githubError{}
 	ec, err := c.request(&request{
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("%s/repos/%s/%s/pulls/%d/merge", c.base, org, repo, pr),
 		requestBody: &details,
 		exitCodes:   []int{200, 405, 409},
-	}, &res)
+	}, &ge)
 	if err != nil {
 		return err
 	}
 	if ec == 405 {
-		if strings.Contains(res.Message, "Base branch was modified") {
-			return UnmergablePRBaseChangedError(res.Message)
+		if strings.Contains(ge.Message, "Base branch was modified") {
+			return UnmergablePRBaseChangedError(ge.Message)
 		}
-		return UnmergablePRError(res.Message)
+		return UnmergablePRError(ge.Message)
 	} else if ec == 409 {
-		return ModifiedHeadError(res.Message)
+		return ModifiedHeadError(ge.Message)
 	}
 
 	return nil

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -391,6 +391,23 @@ func TestRemoveLabel(t *testing.T) {
 	}
 }
 
+func TestRemoveLabelNotFound(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Label does not exist"}`, 404)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	err := c.RemoveLabel("any", "old", 3, "label")
+
+	if err == nil {
+		t.Fatalf("RemoveLabel expected an error, got none")
+	}
+
+	if _, ok := err.(*LabelNotFound); !ok {
+		t.Fatalf("RemoveLabel expected LabelNotFound error, got %v", err)
+	}
+}
+
 func TestAssignIssue(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -37,6 +37,9 @@ var (
 
 func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, func(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+		return handlePullRequest(pc.GitHubClient, pe)
+	}, helpProvider)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -138,5 +141,36 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent) e
 		log.Info("Adding LGTM label.")
 		return gc.AddLabel(org, repo, e.Number, lgtmLabel)
 	}
+	return nil
+}
+
+type ghLabelClient interface {
+	RemoveLabel(owner, repo string, number int, label string) error
+}
+
+func handlePullRequest(gc ghLabelClient, pe github.PullRequestEvent) error {
+	if pe.PullRequest.Merged {
+		return nil
+	}
+
+	if pe.Action != github.PullRequestActionSynchronize {
+		return nil
+	}
+
+	// Don't bother checking if it has the label...it's a race, and we'll have
+	// to handle failure due to not being labeled anyway.
+	if err := gc.RemoveLabel(
+		pe.PullRequest.Base.Repo.Owner.Login,
+		pe.PullRequest.Base.Repo.Name,
+		pe.PullRequest.Number,
+		lgtmLabel,
+	); err != nil {
+		if _, ok := err.(*github.LabelNotFound); !ok {
+			return fmt.Errorf("failed removing lgtm label: %v", err)
+		}
+
+		// If the error is indeed *github.LabelNotFound, consider it a success.
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR migrates the lgtm_after_commit munger into the prow lgtm plugin.

Closes [#3795](https://github.com/kubernetes/test-infra/issues/3795).
Refer to the original PR, [#3821](https://github.com/kubernetes/test-infra/pull/3821), for reference.

/assign @cjwagner 