### PR TITLE
Optional directory in getNamedBinaries

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -183,7 +183,7 @@ func ensureKube() (string, error) {
 }
 
 // Download named binaries for kubernetes
-func getNamedBinaries(url, version, tarball string, retry int) error {
+func getNamedBinaries(url, version, tarball string, dir string, retry int) error {
 	f, err := os.Create(tarball)
 	if err != nil {
 		return err
@@ -210,8 +210,18 @@ func getNamedBinaries(url, version, tarball string, retry int) error {
 		return err
 	}
 	log.Printf("md5sum: %s", o)
-	if err = finishRunning(exec.Command("tar", "-xzf", f.Name())); err != nil {
-		return err
+
+	if dir != "" {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+		if err = finishRunning(exec.Command("tar", "-xzf", f.Name(), "-C", dir)); err != nil {
+			return err
+		}
+	} else {
+		if err = finishRunning(exec.Command("tar", "-xzf", f.Name())); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -244,7 +254,7 @@ var getKube = func(url, version string, getSrc bool) error {
 			return err
 		}
 
-		if err := getNamedBinaries(url, version, "kubernetes-src.tar.gz", 3); err != nil {
+		if err := getNamedBinaries(url, version, "kubernetes-src.tar.gz", "kubernetes", 3); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
kubernetes-src.tar.gz from ci/latest downloads does not really
have a root kubernetes/ directory like the other tar.gz like
(kubernetes-client-linux-amd64.tar.gz
kubernetes-server-linux-amd64.tar.gz
kubernetes-test.tar.gz)

So we need to create a root directory when extracting
kubernetes-src.tar.gz.

Found when looking at logs for ci-kubernetes-local-e2e