### PR TITLE
fix(*): fix nil point dereference when do request return error

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -300,7 +300,7 @@ func (c *Client) requestRetry(method, path, accept string, body interface{}) (*h
 	var err error
 	backoff := initialDelay
 	for retries := 0; retries < maxRetries; retries++ {
-		if retries > 0 {
+		if retries > 0 && resp != nil {
 			resp.Body.Close()
 		}
 		resp, err = c.doRequest(method, path, accept, body)


### PR DESCRIPTION
The method `doRequest ` can return nil response, which leads to nil point dereference.