### PR TITLE
Add a gcsupload utility binary and image

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -52,6 +52,7 @@ filegroup(
         "//prow/cmd/clonerefs:all-srcs",
         "//prow/cmd/config:all-srcs",
         "//prow/cmd/deck:all-srcs",
+        "//prow/cmd/gcsupload:all-srcs",
         "//prow/cmd/hook:all-srcs",
         "//prow/cmd/horologium:all-srcs",
         "//prow/cmd/initupload:all-srcs",

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -44,6 +44,8 @@ TIDE_VERSION             ?= $(TAG)
 CLONEREFS_VERSION        ?= $(TAG)
 # INITUPLOAD_VERSION is the version of the initupload image
 INITUPLOAD_VERSION       ?= $(TAG)
+# GCSUPLOAD_VERSION is the version of the gcsupload image
+GCSUPLOAD_VERSION        ?= $(TAG)
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow
@@ -216,4 +218,9 @@ initupload-image: alpine-image
 	docker build -t "$(REGISTRY)/$(PROJECT)/initupload:$(INITUPLOAD_VERSION)" $(DOCKER_LABELS) cmd/initupload
 	$(PUSH) "$(REGISTRY)/$(PROJECT)/initupload:$(INITUPLOAD_VERSION)"
 
-.PHONY: clonerefs-image initupload-image
+gcsupload-image: alpine-image
+	CGO_ENABLED=0 go build -o cmd/gcsupload/gcsupload k8s.io/test-infra/prow/cmd/gcsupload
+	docker build -t "$(REGISTRY)/$(PROJECT)/gcsupload:$(GCSUPLOAD_VERSION)" $(DOCKER_LABELS) cmd/gcsupload
+	$(PUSH) "$(REGISTRY)/$(PROJECT)/gcsupload:$(GCSUPLOAD_VERSION)"
+
+.PHONY: clonerefs-image initupload-image gcsupload-image

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/gcsupload",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/pod-utils/gcs:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "gcsupload",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/gcsupload/Dockerfile
+++ b/prow/cmd/gcsupload/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-prow/alpine:0.1
+LABEL maintainer="skuznets@redhat.com"
+
+COPY gcsupload /gcsupload
+ENTRYPOINT ["/gcsupload"]

--- a/prow/cmd/gcsupload/OWNERS
+++ b/prow/cmd/gcsupload/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- stevekuznetsov

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// gcsupload uploads the files and folders specified
+// to GCS using the Prow-defined job configuration
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/pod-utils/gcs"
+)
+
+func main() {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	o := gcs.BindOptions(fs)
+	fs.Parse(os.Args[1:])
+	o.Complete(fs.Args())
+
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	if err := o.Run(map[string]gcs.UploadFunc{}); err != nil {
+		logrus.WithError(err).Fatal("Failed to upload to GCS")
+	}
+}

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -14,12 +14,9 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/initupload",
     visibility = ["//visibility:private"],
     deps = [
-        "//prow/pjutil:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
-        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 
@@ -48,4 +45,5 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/pod-utils/gcs:go_default_library"],
 )

--- a/prow/cmd/initupload/main_test.go
+++ b/prow/cmd/initupload/main_test.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"testing"
+
+	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
 
 func TestOptions_Validate(t *testing.T) {
@@ -29,48 +31,21 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "minimal set ok",
 			input: options{
-				cloneLog:     "testing",
-				dryRun:       true,
-				pathStrategy: pathStrategyExplicit,
+				cloneLog: "testing",
+				gcsOptions: &gcs.Options{
+					DryRun:       true,
+					PathStrategy: "explicit",
+				},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "missing clone log",
 			input: options{
-				dryRun:       true,
-				pathStrategy: pathStrategyExplicit,
-			},
-			expectedErr: true,
-		},
-		{
-			name: "push to GCS, ok",
-			input: options{
-				cloneLog:           "testing",
-				dryRun:             false,
-				gcsBucket:          "seal",
-				gceCredentialsFile: "secrets",
-				pathStrategy:       pathStrategyExplicit,
-			},
-			expectedErr: false,
-		},
-		{
-			name: "push to GCS, missing bucket",
-			input: options{
-				cloneLog:           "testing",
-				dryRun:             false,
-				gceCredentialsFile: "secrets",
-				pathStrategy:       pathStrategyExplicit,
-			},
-			expectedErr: true,
-		},
-		{
-			name: "push to GCS, missing credentials",
-			input: options{
-				cloneLog:     "testing",
-				dryRun:       false,
-				gcsBucket:    "seal",
-				pathStrategy: pathStrategyExplicit,
+				gcsOptions: &gcs.Options{
+					DryRun:       true,
+					PathStrategy: "explicit",
+				},
 			},
 			expectedErr: true,
 		},
@@ -83,92 +58,6 @@ func TestOptions_Validate(t *testing.T) {
 		}
 		if !testCase.expectedErr && err != nil {
 			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
-		}
-	}
-}
-
-func TestValidatePathOptions(t *testing.T) {
-	var testCases = []struct {
-		name        string
-		strategy    string
-		org         string
-		repo        string
-		expectedErr bool
-	}{
-		{
-			name:        "invalid strategy",
-			strategy:    "whatever",
-			expectedErr: true,
-		},
-		{
-			name:        "explicit strategy, no defaults",
-			strategy:    "explicit",
-			expectedErr: false,
-		},
-		{
-			name:        "legacy strategy, no defaults",
-			strategy:    "legacy",
-			expectedErr: true,
-		},
-		{
-			name:        "legacy strategy, no default repo",
-			strategy:    "legacy",
-			org:         "org",
-			expectedErr: true,
-		},
-		{
-			name:        "legacy strategy, no default org",
-			strategy:    "legacy",
-			repo:        "repo",
-			expectedErr: true,
-		},
-		{
-			name:        "legacy strategy, with defaults",
-			strategy:    "legacy",
-			org:         "org",
-			repo:        "repo",
-			expectedErr: false,
-		},
-		{
-			name:        "single strategy, no defaults",
-			strategy:    "single",
-			expectedErr: true,
-		},
-		{
-			name:        "single strategy, no default repo",
-			strategy:    "single",
-			org:         "org",
-			expectedErr: true,
-		},
-		{
-			name:        "single strategy, no default org",
-			strategy:    "single",
-			repo:        "repo",
-			expectedErr: true,
-		},
-		{
-			name:        "single strategy, with defaults",
-			strategy:    "single",
-			org:         "org",
-			repo:        "repo",
-			expectedErr: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		o := options{
-			cloneLog:     "dummy",
-			dryRun:       true,
-			pathStrategy: testCase.strategy,
-			defaultOrg:   testCase.org,
-			defaultRepo:  testCase.repo,
-		}
-		err := o.Validate()
-		if err != nil && !testCase.expectedErr {
-			t.Errorf("%s: expected no err but got %v", testCase.name, err)
-		}
-		if err == nil && testCase.expectedErr {
-			t.Errorf("%s: expected err but got none", testCase.name)
 		}
 	}
 }

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -70,6 +70,7 @@ func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 		message := ""
 		if err != nil {
 			message = err.Error()
+			record.Failed = true
 		}
 		record.Commands = append(record.Commands, Command{Command: formattedCommand, Output: output, Error: message})
 		if err != nil {

--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "options.go",
         "target.go",
         "upload.go",
     ],
@@ -14,6 +15,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 
@@ -34,6 +36,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "options_test.go",
         "target_test.go",
         "upload_test.go",
     ],

--- a/prow/pod-utils/gcs/options.go
+++ b/prow/pod-utils/gcs/options.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+type pathStrategyType string
+
+const (
+	pathStrategyLegacy   pathStrategyType = "legacy"
+	pathStrategyExplicit                  = "explicit"
+	pathStrategySingle                    = "single"
+)
+
+// BindOptions adds flags to the FlagSet that populate
+// the GCS upload options struct returned.
+func BindOptions(fs *flag.FlagSet) *Options {
+	o := Options{}
+	fs.StringVar(&o.SubDir, "sub-dir", "", "Optional sub-directory of the job's path to which artifacts are uploaded")
+
+	fs.StringVar(&o.PathStrategy, "path-strategy", pathStrategyExplicit, "how to encode org and repo into GCS paths")
+	fs.StringVar(&o.DefaultOrg, "default-org", "", "optional default org for GCS path encoding")
+	fs.StringVar(&o.DefaultRepo, "default-repo", "", "optional default repo for GCS path encoding")
+
+	fs.StringVar(&o.GcsBucket, "gcs-bucket", "", "GCS bucket to upload into")
+	fs.StringVar(&o.GceCredentialsFile, "gcs-credentials-file", "", "file where Google Cloud authentication credentials are stored")
+	fs.BoolVar(&o.DryRun, "dry-run", true, "do not interact with GCS")
+	return &o
+}
+
+// Options exposes the configuration necessary
+// for defining where in GCS an upload will land.
+type Options struct {
+	// Items are files or directories to upload
+	Items []string
+
+	// SubDir is appended to the resolved GCS path
+	SubDir string
+
+	// PathStrategy and the default Org and Repo
+	// determine how the GCS path is resolved from
+	// Prow-specified environment variables
+	PathStrategy string
+	DefaultOrg   string
+	DefaultRepo  string
+
+	GcsBucket          string
+	GceCredentialsFile string
+	DryRun             bool
+}
+
+// Complete internalizes command line arguments
+func (o *Options) Complete(args []string) {
+	o.Items = args
+}
+
+// Validate ensures that the set of options are
+// self-consistent and valid
+func (o *Options) Validate() error {
+	if !o.DryRun {
+		if o.GcsBucket == "" {
+			return errors.New("GCS upload was requested but required flag --gcs-bucket was unset")
+		}
+
+		if o.GceCredentialsFile == "" {
+			return errors.New("GCS upload was requested but required flag --gcs-credentials-file was unset")
+		}
+	}
+
+	strategy := pathStrategyType(o.PathStrategy)
+	if strategy != pathStrategyLegacy && strategy != pathStrategyExplicit && strategy != pathStrategySingle {
+		return fmt.Errorf("GCS path strategy must be one of %q, %q, or %q", pathStrategyLegacy, pathStrategyExplicit, pathStrategySingle)
+	}
+
+	if strategy != pathStrategyExplicit && (o.DefaultOrg == "" || o.DefaultRepo == "") {
+		return fmt.Errorf("default org and repo must be provided for GCS strategy %q", strategy)
+	}
+
+	return nil
+}
+
+// Run will upload files to GCS as prescribed by
+// the options. Any extra files can be passed as
+// a parameter and will have the prefix prepended
+// to their destination in GCS, so the caller can
+// operate relative to the base of the GCS dir.
+func (o *Options) Run(extra map[string]UploadFunc) error {
+	var builder RepoPathBuilder
+	switch pathStrategyType(o.PathStrategy) {
+	case pathStrategyExplicit:
+		builder = NewExplicitRepoPathBuilder()
+	case pathStrategyLegacy:
+		builder = NewLegacyRepoPathBuilder(o.DefaultOrg, o.DefaultRepo)
+	case pathStrategySingle:
+		builder = NewSingleDefaultRepoPathBuilder(o.DefaultOrg, o.DefaultRepo)
+	}
+
+	spec, err := pjutil.ResolveSpecFromEnv()
+	if err != nil {
+		return fmt.Errorf("could not resolve job spec: %v", err)
+	}
+
+	gcsPath := PathForSpec(spec, builder)
+	if o.SubDir != "" {
+		gcsPath = path.Join(gcsPath, o.SubDir)
+	}
+
+	uploadTargets := map[string]UploadFunc{}
+	for _, item := range o.Items {
+		info, err := os.Stat(item)
+		if err != nil {
+			logrus.Warnf("Encountered error in resolving items to upload for %s: %v", item, err)
+			continue
+		}
+		if info.IsDir() {
+			gatherArtifacts(item, gcsPath, info.Name(), uploadTargets)
+		} else {
+			destination := path.Join(gcsPath, info.Name())
+			if _, exists := uploadTargets[destination]; exists {
+				logrus.Warnf("Encountered duplicate upload of %s, skipping...", destination)
+				continue
+			}
+			uploadTargets[destination] = FileUpload(item)
+		}
+	}
+
+	for destination, upload := range extra {
+		uploadTargets[path.Join(gcsPath, destination)] = upload
+	}
+
+	if !o.DryRun {
+		ctx := context.Background()
+		gcsClient, err := storage.NewClient(ctx, option.WithCredentialsFile(o.GceCredentialsFile))
+		if err != nil {
+			return fmt.Errorf("could not connect to GCS: %v", err)
+		}
+
+		if err := Upload(gcsClient.Bucket(o.GcsBucket), uploadTargets); err != nil {
+			return fmt.Errorf("failed to upload to GCS: %v", err)
+		}
+	} else {
+		for destination := range uploadTargets {
+			logrus.WithField("dest", destination).Info("Would upload")
+		}
+	}
+
+	return nil
+}
+
+func gatherArtifacts(artifactDir, gcsPath, subDir string, uploadTargets map[string]UploadFunc) {
+	logrus.Printf("Gathering artifacts from artifact directory: %s", artifactDir)
+	filepath.Walk(artifactDir, func(fspath string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+
+		// we know path will be below artifactDir, but we can't
+		// communicate that to the filepath module. We can ignore
+		// this error as we can be certain it won't occur and best-
+		// effort upload is OK in any case
+		if relPath, err := filepath.Rel(artifactDir, fspath); err == nil {
+			destination := path.Join(subDir, relPath)
+			if _, exists := uploadTargets[destination]; exists {
+				logrus.Warnf("Encountered duplicate upload of %s, skipping...", destination)
+				return nil
+			}
+			logrus.Printf("Found %s in artifact directory. Uploading as %s\n", fspath, destination)
+			uploadTargets[path.Join(gcsPath, destination)] = FileUpload(fspath)
+		} else {
+			logrus.Warnf("Encountered error in relative path calculation for %s under %s: %v", fspath, artifactDir, err)
+		}
+		return nil
+	})
+}

--- a/prow/pod-utils/gcs/options_test.go
+++ b/prow/pod-utils/gcs/options_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"testing"
+)
+
+func TestOptions_Validate(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		input       Options
+		expectedErr bool
+	}{
+		{
+			name: "minimal set ok",
+			input: Options{
+				DryRun:       true,
+				PathStrategy: pathStrategyExplicit,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "push to GCS, ok",
+			input: Options{
+				DryRun:             false,
+				GcsBucket:          "seal",
+				GceCredentialsFile: "secrets",
+				PathStrategy:       pathStrategyExplicit,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "push to GCS, missing bucket",
+			input: Options{
+				DryRun:             false,
+				GceCredentialsFile: "secrets",
+				PathStrategy:       pathStrategyExplicit,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "push to GCS, missing credentials",
+			input: Options{
+				DryRun:       false,
+				GcsBucket:    "seal",
+				PathStrategy: pathStrategyExplicit,
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.input.Validate()
+		if testCase.expectedErr && err == nil {
+			t.Errorf("%s: expected an error but got none", testCase.name)
+		}
+		if !testCase.expectedErr && err != nil {
+			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+		}
+	}
+}
+
+func TestValidatePathOptions(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		strategy    string
+		org         string
+		repo        string
+		expectedErr bool
+	}{
+		{
+			name:        "invalid strategy",
+			strategy:    "whatever",
+			expectedErr: true,
+		},
+		{
+			name:        "explicit strategy, no defaults",
+			strategy:    "explicit",
+			expectedErr: false,
+		},
+		{
+			name:        "legacy strategy, no defaults",
+			strategy:    "legacy",
+			expectedErr: true,
+		},
+		{
+			name:        "legacy strategy, no default repo",
+			strategy:    "legacy",
+			org:         "org",
+			expectedErr: true,
+		},
+		{
+			name:        "legacy strategy, no default org",
+			strategy:    "legacy",
+			repo:        "repo",
+			expectedErr: true,
+		},
+		{
+			name:        "legacy strategy, with defaults",
+			strategy:    "legacy",
+			org:         "org",
+			repo:        "repo",
+			expectedErr: false,
+		},
+		{
+			name:        "single strategy, no defaults",
+			strategy:    "single",
+			expectedErr: true,
+		},
+		{
+			name:        "single strategy, no default repo",
+			strategy:    "single",
+			org:         "org",
+			expectedErr: true,
+		},
+		{
+			name:        "single strategy, no default org",
+			strategy:    "single",
+			repo:        "repo",
+			expectedErr: true,
+		},
+		{
+			name:        "single strategy, with defaults",
+			strategy:    "single",
+			org:         "org",
+			repo:        "repo",
+			expectedErr: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		o := Options{
+			DryRun:       true,
+			PathStrategy: testCase.strategy,
+			DefaultOrg:   testCase.org,
+			DefaultRepo:  testCase.repo,
+		}
+		err := o.Validate()
+		if err != nil && !testCase.expectedErr {
+			t.Errorf("%s: expected no err but got %v", testCase.name, err)
+		}
+		if err == nil && testCase.expectedErr {
+			t.Errorf("%s: expected err but got none", testCase.name)
+		}
+	}
+}

--- a/prow/pod-utils/gcs/target.go
+++ b/prow/pod-utils/gcs/target.go
@@ -49,7 +49,7 @@ func AliasForSpec(spec *pjutil.JobSpec) string {
 	case kube.PeriodicJob, kube.PostsubmitJob, kube.BatchJob:
 		return ""
 	case kube.PresubmitJob:
-		return path.Join("pr-logs", "directory", spec.Job, spec.BuildId)
+		return path.Join("pr-logs", "directory", spec.Job, fmt.Sprintf("%s.txt", spec.BuildId))
 	default:
 		logrus.Fatalf("unknown job spec type: %v", spec.Type)
 	}

--- a/prow/pod-utils/gcs/target_test.go
+++ b/prow/pod-utils/gcs/target_test.go
@@ -149,7 +149,7 @@ func TestAliasForSpec(t *testing.T) {
 				Job:     "job",
 				BuildId: "number",
 			},
-			expected: "pr-logs/directory/job/number",
+			expected: "pr-logs/directory/job/number.txt",
 		},
 	}
 


### PR DESCRIPTION
The logic used to determine the GCS destination directory for upload is
complicated. This patch adds a `gcsupload` utility that allows a user to
manually upload files to the "correct" location for a test when those
artifacts need to be uploaded outside of the normal init/finalize flow.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis @fejta 
/assign @cjwagner @BenTheElder 

@BenTheElder is this in line with what you expected from the `FlagSet` stuff? This GCS option struct is going to be useful for a couple of commands.