### PR TITLE
Add prow job to test kubernetes-sig-testing/frameworks

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10786,6 +10786,15 @@
       "sig-multicluster"
     ]
   },
+  "pull-frameworks-test": {
+    "args": [
+      "./bin/test-on-prow.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-heapster-e2e": {
     "scenario": "kubernetes_heapster",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4669,6 +4669,8 @@ presubmits:
     skip_report: true # for initial testing of new job
     trigger: "/test pull-frameworks-test"
     rerun_command: "/test pull-frameworks-test"
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
@@ -4677,16 +4679,6 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   kubernetes/test-infra:
   - name: pull-test-infra-bazel

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4659,6 +4659,35 @@ presubmits:
       - emptyDir: {}
         name: auto-generated-docker-graph-volume-mount
     trigger: (?m)^/test pull-security-kubernetes-verify-prow,?(\s+|$)
+  kubernetes-sig-testing/frameworks:
+  - name: pull-frameworks-test
+    context: pull-frameworks-test
+    agent: kubernetes
+    branches:
+    - master
+    always_run: false # for initial testing of new job
+    skip_report: true # for initial testing of new job
+    trigger: "/test pull-frameworks-test"
+    rerun_command: "/test pull-frameworks-test"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--clean"
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   kubernetes/test-infra:
   - name: pull-test-infra-bazel
     agent: kubernetes


### PR DESCRIPTION
We want to have the integration test framework tested on prow. The test script to run is introduced in the PR https://github.com/kubernetes-sig-testing/frameworks/pull/45 .

We are not too familiar with prow. Thus we used the `pull-community-verify` job as a reference as suggested in https://github.com/kubernetes/test-infra/pull/6363#issuecomment-359629246.

Closes: https://github.com/kubernetes-sig-testing/frameworks/issues/16