### PR TITLE
Bump kubernetes-anywhere version for kubeadm to include k-a PR #514

### DIFF
--- a/images/kubeadm/runner
+++ b/images/kubeadm/runner
@@ -26,7 +26,7 @@ if [ ! -e kubernetes-anywhere ]; then
 
   # Explicitly version this dependency so that upstream commits can't
   # immediately break e2e jobs, and we have control over upgrading/downgrading.
-  git -C kubernetes-anywhere checkout d978bfc7c945cfbdf20c4cb8fad69b0622df2d4a
+  git -C kubernetes-anywhere checkout 3ea5e1f14e57c1eb8c21455348d9825f277be350
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332


### PR DESCRIPTION
Trying to resolve k/k issue # 59762 by bumping up the kubernetes-anywhere
version to include:
    https://github.com/kubernetes/kubernetes-anywhere/pull/514

Fixes issue #6906