### PR TITLE
fix kubemark canary

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9780,7 +9780,6 @@
       "--kubemark",
       "--kubemark-nodes=100",
       "--provider=gce",
-      "--tag=latest-master",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=240m"


### PR DESCRIPTION
fixes https://k8s-testgrid.appspot.com/sig-testing-canaries#kubemark-canary
the `--tag` flag was for jenkins

/shrug
/assign @BenTheElder 