### PR TITLE
add job-state icons back to prow status

### DIFF
--- a/prow/cmd/deck/static/.gitignore
+++ b/prow/cmd/deck/static/.gitignore
@@ -2,3 +2,4 @@ data.js
 plugin-help.js
 tide.js
 branding.js
+user-data.js

--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -549,30 +549,37 @@ function createRerunCell(modal, rerun_command, prowjob) {
 
 function stateCell(state) {
     const c = document.createElement("td");
-    c.className = state;
+    c.classList.add("icon-cell");
 
     let displayState = "";
+    let displayIcon = "";
     switch (state) {
         case "pending":
             displayState = "Pending";
+            displayIcon = "access_time";
             break;
         case "success":
-            displayState = "Successful";
+            displayState = "Succeded";
+            displayIcon = "check_circle";
             break;
         case "failure":
             displayState = "Failed";
+            displayIcon = "error";
             break;
         case "aborted":
             displayState = "Aborted";
+            displayIcon = "clear";
             break;
         case "error":
             displayState = "Error";
+            displayIcon = "warning";
             break;
     }
-    const stateIndicator = document.createElement("DIV");
-    stateIndicator.classList.add(...["state", state]);
+    const stateIndicator = document.createElement("I");
+    stateIndicator.classList.add("material-icons", "state", state);
+    stateIndicator.innerText = displayIcon;
     c.appendChild(stateIndicator);
-    c.title = displayState + " job";
+    c.title = displayState;
 
     return c;
 }

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -114,28 +114,28 @@ th {
     width: 32px;
 }
 /**
- * State style
+ * ProwJob State style
  */
-.state {
-    border-radius: 2px;
-    width: 12px;
-    height: 12px;
+i.state {
+    width: 24px;
+    height: 24px;
+    vertical-align: middle;
 }
 
 .state.triggered, .state.pending {
-    background-color: #FFCA28;
+    color: #FFCA28;
 }
 
 .state.success {
-    background-color: #66BB6A;
+    color: #66BB6A;
 }
 
 .state.failure {
-    background-color: #EF5350;
+    color: #EF5350;
 }
 
 state.error, .state.aborted {
-    background-color: #BDBDBD;
+    color: #BDBDBD;
 }
 
 #rerun {


### PR DESCRIPTION
just using colors + hover text isn't the most accessible, this brings back using icons as well, though material icons this time.

<img width="1621" alt="screen shot 2018-02-20 at 11 03 16 pm" src="https://user-images.githubusercontent.com/917931/36467157-58881662-1692-11e8-8f73-264e5398ee22.png">


I also fixed `.gitignore`ing the user-data