### PR TITLE
Avoid chdir for --extract-source

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -62,11 +62,7 @@ func (n localCluster) getScript(scriptPath string) (string, error) {
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}
-	path = filepath.Join(cwd, "kubernetes", scriptPath)
-	if _, err := os.Stat(path); err == nil {
-		return path, nil
-	}
-	return "", fmt.Errorf("unable to find script : %v", scriptPath)
+	return "", fmt.Errorf("unable to find script %v in directory %v", scriptPath, cwd)
 }
 
 func (n localCluster) Up() error {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -379,8 +379,11 @@ func complete(o *options) error {
 		return fmt.Errorf("failed to acquire federation binaries: %v", err)
 	}
 	if o.extract.Enabled() {
-		if err := os.Chdir("kubernetes"); err != nil {
-			return fmt.Errorf("failed to chdir to kubernetes dir: %v", err)
+		// If we specified `--extract-source` we will already be in the correct directory
+		if !o.extractSource {
+			if err := os.Chdir("kubernetes"); err != nil {
+				return fmt.Errorf("failed to chdir to kubernetes dir: %v", err)
+			}
 		}
 	}
 	if err := validWorkingDirectory(); err != nil {


### PR DESCRIPTION
in getKube (extract_k8s.go), we already do a mkdir/chdir into a
kubernetes directory and untar the contents of the source tar there.
So we should avoid yet another chdir.

tested on local docker, and updating the kubetest binary inside it 
```
docker run -i -t --entrypoint=/bin/bash gcr.io/k8s-testimages/kubekins-e2e:v20180217-a8631bf16-master
```
used environment etc from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-local-e2e/103/build-log.txt