### PR TITLE
update gcloud container property name

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -149,7 +149,7 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 	if *gkeCommandGroup == "alpha" || *gkeCommandGroup == "beta" {
 		// By default gcloud {alpha,beta} container is using v1 api.
 		// If we want to use v1alpha1/v1beta1 we need to force it.
-		if err := finishRunning(exec.Command("gcloud", "config", "set", "container/use_v1_api_client", "False")); err != nil {
+		if err := finishRunning(exec.Command("gcloud", "config", "set", "container/use_v1_api", "False")); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The name has been changed from `use_v1_api_client` to `use_v1_api` in cl/185908644.
