### PR TITLE
Use 'squash' to merge PRs in k/dashboard.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -91,6 +91,7 @@ tide:
     - needs-ok-to-test
   merge_method:
     kubernetes/charts: squash
+    kubernetes/dashboard: squash
     kubernetes/website: squash
   target_url: https://prow.k8s.io/tide.html
 


### PR DESCRIPTION
The repo is configured to disallow merge commits, but Tide was not configured to use a different merge method.
ref https://github.com/kubernetes/dashboard/issues/2846
cc @floreks @spiffxp 