### PR TITLE
Disable initializer test for 1.7 -> 1.8 gke master upgrade test

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7276,7 +7276,7 @@
       "--gcp-zone=us-central1-f",
       "--gke-environment=staging",
       "--provider=gke",
-      "--test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
     ],
@@ -7298,6 +7298,7 @@
       "--gke-environment=staging",
       "--provider=gke",
       "--skew",
+      "--test_args=--ginkgo.skip=Initializers",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
     ],
@@ -7318,7 +7319,7 @@
       "--gcp-zone=us-central1-f",
       "--gke-environment=staging",
       "--provider=gke",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--ginkgo.skip=Initializers --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
     ],


### PR DESCRIPTION
1.8 apiserver has the initializer feature gate which breaks the initializer tests when disabled.

After all, It's an alpha feature, so it doesn't need to survive upgrade.

