### PR TITLE
add prometheus metrics to greenhouse

### DIFF
--- a/greenhouse/BUILD.bazel
+++ b/greenhouse/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
         "//greenhouse/diskcache:go_default_library",
         "//greenhouse/diskutil:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/greenhouse/README.md
+++ b/greenhouse/README.md
@@ -27,3 +27,6 @@ We use this with [Prow](./../prow), to set it up we do the following:
    <!--TODO(bentheelder): make this easier to consume by other users?-->
    - NOTE: other uses will likely need to tweak this step to their needs
 
+
+Optional Setup:
+- tweak `metrics-service.yaml` and point prometheus at this service to collect metrics

--- a/greenhouse/deployment.yaml
+++ b/greenhouse/deployment.yaml
@@ -32,6 +32,8 @@ spec:
         ports:
         - name: cache
           containerPort: 8080
+        - name: metrics
+          containerPort: 9090
         args:
         - --dir=/data
         - --remount

--- a/greenhouse/diskcache/cache.go
+++ b/greenhouse/diskcache/cache.go
@@ -197,7 +197,8 @@ func (c *Cache) MonitorDiskAndEvict(
 	minPercentBlocksFree, evictUntilPercentBlocksFree float64,
 ) {
 	// forever check if usage is past thresholds and evict
-	for range time.Tick(interval) {
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
 		blocksFree, _, _, err := diskutil.GetDiskUsage(c.diskRoot)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to get disk usage!")

--- a/greenhouse/diskutil/diskutil.go
+++ b/greenhouse/diskutil/diskutil.go
@@ -70,16 +70,17 @@ func Remount(device, mountPoint, options string) error {
 	return err
 }
 
-// GetDiskUsage wraps syscall.Statfs
-func GetDiskUsage(path string) (percentBlocksFree, percentFilesFree float64, err error) {
+// GetDiskUsage wraps syscall.Statfs for usage in GCing the disk
+func GetDiskUsage(path string) (percentBlocksFree float64, bytesFree, bytesUsed uint64, err error) {
 	var stat syscall.Statfs_t
 	err = syscall.Statfs(path, &stat)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	percentBlocksFree = float64(stat.Bfree) / float64(stat.Blocks) * 100
-	percentFilesFree = float64(stat.Ffree) / float64(stat.Files) * 100
-	return percentBlocksFree, percentFilesFree, nil
+	bytesFree = stat.Bfree * uint64(stat.Bsize)
+	bytesUsed = (stat.Blocks - stat.Bfree) * uint64(stat.Bsize)
+	return percentBlocksFree, bytesFree, bytesUsed, nil
 }
 
 // GetATime the atime for a file, logging errors instead of failing

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -249,7 +249,9 @@ func cacheHandler(cache *diskcache.Cache) http.Handler {
 // helper to update disk metrics
 func updateMetrics(interval time.Duration, diskRoot string) {
 	logger := logrus.WithField("sync-loop", "updateMetrics")
-	for range time.Tick(interval) {
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
+		logger.Info("tick")
 		_, bytesFree, bytesUsed, err := diskutil.GetDiskUsage(diskRoot)
 		if err != nil {
 			logger.WithError(err).Error("Failed to get disk metrics")

--- a/greenhouse/metrics-service.yaml
+++ b/greenhouse/metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazel-cache-metrics
+  namespace: default
+spec:
+  selector:
+    app: bazel-cache
+  ports:
+  - name: default
+    protocol: TCP
+    port: 80
+    targetPort: 9090
+  loadBalancerIP: 35.225.115.154
+  type: LoadBalancer


### PR DESCRIPTION
- add metrics ...  also drop the file count eviction, this metric is usless to monitor, it stays constant, tracking disk blocks should be plenty
- add a service / static IP pointed at the metrics endpoint, expose this (NOT the cache)

Follow Up:
- deploy
- configure veldrome to scrape these metrics 
- create dashboard