### PR TITLE
add bazel-cache metrics to velodrome

### DIFF
--- a/velodrome/config.yaml
+++ b/velodrome/config.yaml
@@ -105,6 +105,11 @@ projects:
             static_configs:
               - targets:
                   - 104.197.27.114
+          - job_name: kubernetes-bazel-cache
+            metrics_path: /prometheus
+            static_configs:
+              - targets:
+                  - 35.225.115.154
           - job_name: kubernetes-misc-mungers
             metrics_path: /prometheus
             static_configs:


### PR DESCRIPTION
the endpoint appears to be up and running smoothly now, let's get velodrome importing it