### PR TITLE
Enable golint and trigger plugins for kubernetes-sig-testing/frameworks

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -300,6 +300,7 @@ plugins:
   - cat
   - cla
   - dog
+  - golint
   - heart
   - help
   - hold
@@ -309,6 +310,7 @@ plugins:
   - shrug
   - size
   - skip
+  - trigger
   - wip
   - yuks
 


### PR DESCRIPTION
Following #6902 
- enable `triggers` plugin to enable the `/test` command
- enable `golint` plugin because the repo is mostly golang