### PR TITLE
Fix running multiple pull jobs for federation

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10776,7 +10776,7 @@
   "pull-federation-e2e-gce": {
     "args": [
       "--build-federation",
-      "--cluster=jenkins-us-central1-f",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
       "--env-file=jobs/env/pull-federation-e2e-gce.env",


### PR DESCRIPTION
Currently if multiple pull jobs are triggered in parallel, they all fail. The root cause is that we fix the cluster name in pull job. If we didn't specify the cluster name then `kubernetes_e2e` will generate a cluster name for each build, which ideally should segregate all resources within the same GCE project.

The name of cluster was fixed previously to solve an log-dump issue which is anyway failing like below:
```
W0219 16:52:32.818] 2018/02/19 16:52:32 util.go:172: Running: ./cluster/log-dump/log-dump.sh /workspace/_artifacts
W0219 16:52:32.818] Trying to find master named 'jenkins-us-central1-f-master'
W0219 16:52:32.818] Looking for address 'jenkins-us-central1-f-master-ip'
W0219 16:52:33.618] ERROR: (gcloud.compute.addresses.describe) Could not fetch resource:
W0219 16:52:33.619]  - The resource 'projects/k8s-jkns-pr-bldr-e2e-gce-fdrtn/regions/us-central1/addresses/jenkins-us-central1-f-master-ip' was not found
W0219 16:52:33.619] 
W0219 16:52:33.681] Could not detect Kubernetes master node.  Make sure you've launched a cluster with 'kube-up.sh'
I0219 16:52:33.782] Master not detected. Is the cluster up?
I0219 16:52:33.782] Dumping logs from nodes locally to '/workspace/_artifacts'
I0219 16:52:33.783] Detecting nodes in the cluster
I0219 16:52:35.049] No nodes found!
I0219 16:52:35.095] Dumping Federation and DNS pod logs to /workspace/_artifacts
W0219 16:52:35.196] 2018/02/19 16:52:35 util.go:174: Step './cluster/log-dump/log-dump.sh /workspace/_artifacts' finished in 2.417510303s
```
This PR will at least solve running multiple federation pull jobs in parallel.

/cc @irfanurrehman @kubernetes/sig-multicluster-bugs 
/assign @krzyzacy 
