### PR TITLE
Minor bugfixes for pod utilities

### DIFF
--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -100,11 +100,13 @@ func main() {
 
 	if failed {
 		finished := struct {
-			Timestamp int64 `json:"timestamp"`
-			Passed    bool  `json:"passed"`
+			Timestamp int64  `json:"timestamp"`
+			Passed    bool   `json:"passed"`
+			Result    string `json:"result"`
 		}{
 			Timestamp: time.Now().Unix(),
 			Passed:    false,
+			Result:    "FAILURE",
 		}
 		finishedData, err := json.Marshal(&finished)
 		if err != nil {

--- a/prow/pod-utils/clone/format.go
+++ b/prow/pod-utils/clone/format.go
@@ -26,7 +26,7 @@ import (
 func FormatRecord(record Record) string {
 	output := bytes.Buffer{}
 	if record.Failed {
-		fmt.Fprint(&output, "# FAILED!")
+		fmt.Fprintln(&output, "# FAILED!")
 	}
 	fmt.Fprintf(&output, "# Cloning %s/%s at %s", record.Refs.Org, record.Refs.Repo, record.Refs.BaseRef)
 	if record.Refs.BaseSHA != "" {


### PR DESCRIPTION
Pass both `result` and `passed` in finished.json

Until Gubernator and other tools stop requiring these two fields that
hold identical information in different formats, we should pass both
whenever we upload a `finished.json` file.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Add a newline to clone record output formatting

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/area prow
/cc @cjwagner @BenTheElder @rmmh 
/assign @BenTheElder 


We really need to fix the `finished.json` bit next ... yuck.