### PR TITLE
Stop using the `result` field in `finished.json`

### DIFF
--- a/gubernator/OWNERS
+++ b/gubernator/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- rmmh
+- stevekuznetsov

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -51,7 +51,7 @@ def init_build(build_dir, started=True, finished=True,
                finished_has_version=False):
     """Create faked files for a build."""
     start_json = {'timestamp': 1406535800}
-    finish_json = {'result': 'SUCCESS', 'timestamp': 1406536800}
+    finish_json = {'passed': True, 'timestamp': 1406536800}
     (finish_json if finished_has_version else start_json)['version'] = 'v1+56'
     if started:
         write(build_dir + 'started.json', start_json)

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -51,7 +51,7 @@ def init_build(build_dir, started=True, finished=True,
                finished_has_version=False):
     """Create faked files for a build."""
     start_json = {'timestamp': 1406535800}
-    finish_json = {'passed': True, 'timestamp': 1406536800}
+    finish_json = {'passed': True, 'result': 'SUCCESS', 'timestamp': 1406536800}
     (finish_json if finished_has_version else start_json)['version'] = 'v1+56'
     if started:
         write(build_dir + 'started.json', start_json)

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -4,7 +4,7 @@
 {{super()}}
 % if not finished
 <link rel="icon" type="image/png" href="{{'favicon-yellow.png'|static}}" />
-% elif finished and finished['result'] == 'SUCCESS' and not res['failed']
+% elif finished and finished['passed'] and not res['failed']
 <link rel="icon" type="image/png" href="{{'favicon-green.png'|static}}" />
 % endif
 % endblock
@@ -25,7 +25,11 @@
 		% set pl = pr_digest.payload
 		<tr><td>PR<td><a href="/pr/{{pl['author']}}">{{pl['author']}}</a>: {{pl['title']}}
 	% endif
-		% set result = finished['result'] if finished else 'Not Finished'
+		% if finished
+			% set result = finished['result']
+		% else
+			% set result = 'Not Finished'
+		% endif
 		<tr><td>Result<td><span class="build-{{result | slugify}}">{{result}}</span>
 	% if started
 		% if finished

--- a/gubernator/test-gubernator.sh
+++ b/gubernator/test-gubernator.sh
@@ -20,7 +20,8 @@ set -o xtrace
 
 cd "$(dirname "$0")"
 pip install -r test_requirements.txt
-./test.sh --nologcapture
+mkdir -p "${WORKSPACE}/_artifacts"
+./test.sh --nologcapture --with-xunit --xunit-file="${WORKSPACE}/_artifacts/junit_nosetests.xml"
 ./lint.sh
 mocha static/build_test.js
 ./verify_config.sh

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -139,6 +139,15 @@ def build_details(build_dir):
     started = json.loads(started)
     finished = json.loads(finished)
 
+    # we want to allow users pushing to GCS to
+    # provide us either passed or result, but not
+    # require either (or both)
+    if 'result' in finished and 'passed' not in finished:
+        finished['passed'] = finished['result'] == 'SUCCESS'
+
+    if 'passed' in finished and 'result' not in finished:
+        finished['result'] = 'SUCCESS' if finished['passed'] else 'FAILURE'
+
     junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
                    if f.filename.endswith('.xml')]
 

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -125,7 +125,7 @@ def normalize_metadata(started_future, finished_future):
     finished = finished_future.get_result()
     if finished and not started:
         started = 'null'
-    if started and not finished:
+    elif started and not finished:
         finished = 'null'
     elif not (started and finished):
         return None, None
@@ -164,6 +164,9 @@ def build_details(build_dir):
         gcs_async.read(build_dir + '/started.json'),
         gcs_async.read(build_dir + '/finished.json')
     )
+
+    if started is None and finished is None:
+        return started, finished, None
 
     junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
                    if f.filename.endswith('.xml')]

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -112,6 +112,39 @@ def get_running_build_log(job, build, prow_url):
     return None, None
 
 
+def normalize_metadata(started_future, finished_future):
+    """
+    Munge and normalize the output of loading started
+    and finished.json files from a GCS bucket.
+
+    :param started_future: future from gcs_async.read()
+    :param finished_future: future from gcs_async.read()
+    :return: started, finished dictionaries
+    """
+    started = started_future.get_result()
+    finished = finished_future.get_result()
+    if finished and not started:
+        started = 'null'
+    if started and not finished:
+        finished = 'null'
+    elif not (started and finished):
+        return None, None
+    started = json.loads(started)
+    finished = json.loads(finished)
+
+    if finished is not None:
+        # we want to allow users pushing to GCS to
+        # provide us either passed or result, but not
+        # require either (or both)
+        if 'result' in finished and 'passed' not in finished:
+            finished['passed'] = finished['result'] == 'SUCCESS'
+
+        if 'passed' in finished and 'result' not in finished:
+            finished['result'] = 'SUCCESS' if finished['passed'] else 'FAILURE'
+
+    return started, finished
+
+
 @view_base.memcache_memoize('build-details://', expires=60)
 def build_details(build_dir):
     """
@@ -127,26 +160,10 @@ def build_details(build_dir):
                   skipped: [name...],
                   passed: [name...]}
     """
-    started_fut = gcs_async.read(build_dir + '/started.json')
-    finished = gcs_async.read(build_dir + '/finished.json').get_result()
-    started = started_fut.get_result()
-    if finished and not started:
-        started = 'null'
-    if started and not finished:
-        finished = 'null'
-    elif not (started and finished):
-        return
-    started = json.loads(started)
-    finished = json.loads(finished)
-
-    # we want to allow users pushing to GCS to
-    # provide us either passed or result, but not
-    # require either (or both)
-    if 'result' in finished and 'passed' not in finished:
-        finished['passed'] = finished['result'] == 'SUCCESS'
-
-    if 'passed' in finished and 'result' not in finished:
-        finished['result'] = 'SUCCESS' if finished['passed'] else 'FAILURE'
+    started, finished = normalize_metadata(
+        gcs_async.read(build_dir + '/started.json'),
+        gcs_async.read(build_dir + '/finished.json')
+    )
 
     junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
                    if f.filename.endswith('.xml')]
@@ -206,15 +223,14 @@ class BuildHandler(view_base.BaseHandler):
         job_dir = '/%s/%s/' % (prefix, job)
         testgrid_query = testgrid.path_to_query(job_dir)
         build_dir = job_dir + build
-        details = build_details(build_dir)
-        if not details:
+        started, finished, results = build_details(build_dir)
+        if started is None and finished is None:
             logging.warning('unable to load %s', build_dir)
             self.render(
                 'build_404.html',
                 dict(build_dir=build_dir, job_dir=job_dir, job=job, build=build))
             self.response.set_status(404)
             return
-        started, finished, results = details
 
         want_build_log = False
         build_log = ''
@@ -357,13 +373,12 @@ def build_list(job_dir, before):
             for build in builds
         ]
 
-    def resolve(future):
-        res = future.get_result()
-        if res:
-            return json.loads(res)
+    output = []
+    for build, loc, started_future, finished_future in build_futures:
+        started, finished = normalize_metadata(started_future, finished_future)
+        output.append((str(build), loc, started, finished))
 
-    return [(str(build), loc, resolve(started), resolve(finished))
-            for build, loc, started, finished in build_futures]
+    return output
 
 class BuildListHandler(view_base.BaseHandler):
     """Show a list of Builds for a Job."""

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -335,7 +335,7 @@ class BuildTest(main_test.TestBase):
 
     def do_view_build_list_test(self, job_dir='/buck/some-job/', indirect=False):
         sta_result = {'timestamp': 12345}
-        fin_result = {'passed': True}
+        fin_result = {'passed': True, 'result': 'SUCCESS'}
         for n in xrange(120):
             write('%s%d/started.json' % (job_dir, n), sta_result)
             write('%s%d/finished.json' % (job_dir, n), fin_result)

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -225,6 +225,7 @@ class BuildTest(main_test.TestBase):
         self.assertIn('Show 1 Passed Tests', response)
 
     def test_build_optional_log(self):
+        """Test that passing builds do not show logs by default but display them when requested"""
         write(self.BUILD_DIR + 'build-log.txt', 'error or timeout or something')
         response = self.get_build_page()
         self.assertIn('<a href="?log#log">', response)

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -183,7 +183,7 @@ class BuildTest(main_test.TestBase):
         write(self.BUILD_DIR + 'finished.json',
             {
                 'timestamp': 1406536800,
-                'result': 'SUCCESS',
+                'passed': True,
                 'metadata': {
                     'skew-version': 'm11'
                 }
@@ -201,7 +201,7 @@ class BuildTest(main_test.TestBase):
         """Test that builds that failed with no failures show the build log."""
         gcs.delete(self.BUILD_DIR + 'artifacts/junit_01.xml')
         write(self.BUILD_DIR + 'finished.json',
-              {'result': 'FAILURE', 'timestamp': 1406536800})
+              {'passed': False, 'timestamp': 1406536800})
 
         # Unable to fetch build-log.txt, still works.
         response = self.get_build_page()
@@ -334,7 +334,7 @@ class BuildTest(main_test.TestBase):
 
     def do_view_build_list_test(self, job_dir='/buck/some-job/', indirect=False):
         sta_result = {'timestamp': 12345}
-        fin_result = {'result': 'SUCCESS'}
+        fin_result = {'passed': True}
         for n in xrange(120):
             write('%s%d/started.json' % (job_dir, n), sta_result)
             write('%s%d/finished.json' % (job_dir, n), fin_result)

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -23,6 +23,7 @@ import gcs_async
 import github.models as ghm
 import pull_request
 import view_base
+import view_build
 
 
 @view_base.memcache_memoize('pr-details://', expires=60 * 3)
@@ -48,12 +49,7 @@ def pr_builds(path):
 
     jobs = {}
     for job, build, started_fut, finished_fut in futures:
-        started = started_fut.get_result()
-        finished = finished_fut.get_result()
-        if started is not None:
-            started = json.loads(started)
-        if finished is not None:
-            finished = json.loads(finished)
+        started, finished = view_build.normalize_metadata(started_fut, finished_fut)
         jobs.setdefault(job, []).append((build, started, finished))
 
     return jobs

--- a/gubernator/view_pr_test.py
+++ b/gubernator/view_pr_test.py
@@ -16,16 +16,14 @@
 
 import datetime
 import unittest
+from webapp2_extras import securecookie
 
 # TODO(fejta): use non-relative imports
 # https://google.github.io/styleguide/pyguide.html?showone=Packages#Packages
 import gcs_async_test
-from github import models
 import main_test
 import view_pr
-
-from webapp2_extras import securecookie
-
+from github import models
 
 app = main_test.app
 write = gcs_async_test.write
@@ -60,10 +58,14 @@ class PathTest(unittest.TestCase):
 class PRTest(main_test.TestBase):
     BUILDS = {
         'build': [('12', {'version': 'bb', 'timestamp': 1467147654}, None),
-                  ('11', {'version': 'bb', 'timestamp': 1467146654}, {'result': 'PASSED'}),
-                  ('10', {'version': 'aa', 'timestamp': 1467136654}, {'result': 'FAILED'})],
-        'e2e': [('47', {'version': 'bb', 'timestamp': '1467147654'}, {'result': '[UNSET]'}),
-                ('46', {'version': 'aa', 'timestamp': '1467136700'}, {'result': '[UNSET]'})]
+                  ('11', {'version': 'bb', 'timestamp': 1467146654},
+                   {'result': 'PASSED', 'passed': True}),
+                  ('10', {'version': 'aa', 'timestamp': 1467136654},
+                   {'result': 'FAILED', 'passed': False})],
+        'e2e': [('47', {'version': 'bb', 'timestamp': '1467147654'},
+                 {'result': '[UNSET]', 'passed': False}),
+                ('46', {'version': 'aa', 'timestamp': '1467136700'},
+                 {'result': '[UNSET]', 'passed': False})]
     }
 
     def setUp(self):

--- a/gubernator/view_pr_test.py
+++ b/gubernator/view_pr_test.py
@@ -16,14 +16,16 @@
 
 import datetime
 import unittest
-from webapp2_extras import securecookie
 
 # TODO(fejta): use non-relative imports
 # https://google.github.io/styleguide/pyguide.html?showone=Packages#Packages
 import gcs_async_test
+from github import models
 import main_test
 import view_pr
-from github import models
+
+from webapp2_extras import securecookie
+
 
 app = main_test.app
 write = gcs_async_test.write


### PR DESCRIPTION
We always have the `passed` boolean in `finished.json` and should stop
using the Jenkins-style `result` string wherever possible as it contains
the same information and is otherwise useless.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @BenTheElder @cjwagner 
/assign @rmmh 
/area gubernator