### PR TITLE
Add run-time logging to clonerefs tool

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/logrusutil"
 
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
@@ -97,6 +98,10 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "clonerefs"}),
+	)
+
 	jobRefs, err := pjutil.ResolveSpecFromEnv()
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not determine job refs")
@@ -117,4 +122,6 @@ func main() {
 			logrus.WithError(err).Fatal("Failed to write clone records")
 		}
 	}
+
+	logrus.Info("Finished cloning refs")
 }

--- a/prow/pod-utils/clone/BUILD.bazel
+++ b/prow/pod-utils/clone/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/pod-utils/clone",
     visibility = ["//visibility:public"],
-    deps = ["//prow/kube:go_default_library"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -23,10 +23,12 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/kube"
 )
 
 func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
+	logrus.WithFields(logrus.Fields{"refs": refs}).Infof("Cloning refs")
 	repositoryURL := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
 	cloneDir := fmt.Sprintf("%s/src/github.com/%s/%s", dir, refs.Org, refs.Repo)
 	record := Record{Refs: refs}
@@ -67,6 +69,7 @@ func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 
 	for _, command := range commands {
 		formattedCommand, output, err := command()
+		logrus.WithFields(logrus.Fields{"command": formattedCommand, "output": output, "error": err}).Infof("Ran clone command")
 		message := ""
 		if err != nil {
 			message = err.Error()


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @BenTheElder 

QOL change, was a little annoying for it to be silent the whole time when cloning.