### PR TITLE
check if pod has a valid StartTime before access it

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -186,7 +186,7 @@ func (c *controller) clean() {
 				// deleting the pod now will result in plank creating a brand new pod
 				continue
 			}
-			if time.Since(pod.Status.StartTime.Time) > maxPodAge {
+			if !pod.Status.StartTime.IsZero() && time.Since(pod.Status.StartTime.Time) > maxPodAge {
 				// Delete old completed pods. Don't quit if we fail to delete one.
 				if err := client.DeletePod(pod.ObjectMeta.Name); err == nil {
 					c.logger.WithField("pod", pod.ObjectMeta.Name).Info("Deleted old completed pod.")

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -383,7 +383,7 @@ func (c *Controller) syncPendingJob(pj kube.ProwJob, pm map[string]kube.Pod, rep
 
 		case kube.PodPending:
 			maxPodPending := c.ca.Config().Plank.PodPendingTimeout
-			if time.Since(pod.Status.StartTime.Time) < maxPodPending {
+			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodPending {
 				// Pod is running. Do nothing.
 				c.incrementNumPendingJobs(pj.Spec.Job)
 				return nil


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/fbd570c8621cb3ba07d8ff0aae8526013e3087ec/staging/src/k8s.io/api/core/v1/types.go#L2778-L2781

this will be before kubelet pulling the image, so if pod stuck on imagePullBackoff we will still catch it and abort the prowjob.

Sinker is actually WAI and all ImagePullBackoff pods are already cleaned.

/assign @BenTheElder @ixdy @cjwagner @stevekuznetsov 