### PR TITLE
Set up OWNERS support for Heapster

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -49,6 +49,7 @@ tide:
     - kubernetes/dashboard
     - kubernetes/features
     - kubernetes/federation
+    - kubernetes/heapster
     - kubernetes/ingress-nginx
     - kubernetes/kops
     - kubernetes/kubernetes-template-project

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -41,6 +41,7 @@ approve:
   - kubernetes/dashboard
   - kubernetes/features
   - kubernetes/federation
+  - kubernetes/heapster
   - kubernetes/ingress-nginx
   - kubernetes/kops
   - kubernetes/kube-deploy
@@ -199,6 +200,8 @@ plugins:
   - approve
 
   kubernetes/heapster:
+  - approve
+  - blunderbuss
   - trigger
 
   kubernetes/kops:


### PR DESCRIPTION
This adds approve/blunderbuss/tide-auto-merging for the
kubernetes/heapster repository.