### PR TITLE
fix user dashboard endpoints

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=prow.k8s.io
-        - --oauth-url=/user-dashboard
+        - --oauth-url=/github-login
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/github

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -47,9 +47,7 @@ go_test(
         "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/tide:go_default_library",
-        "//prow/userdashboard:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
-        "//vendor/github.com/shurcooL/githubql:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
     ],
 )

--- a/prow/userdashboard/userdashboard.go
+++ b/prow/userdashboard/userdashboard.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/shurcooL/githubql"
@@ -155,7 +156,13 @@ func (da *DashboardAgent) HandleUserDashboard(queryHandler PullRequestQueryHandl
 			da.log.WithError(err).Error("Error with marshalling user data.")
 		}
 
-		w.Write(marshaledData)
+		if v := r.URL.Query().Get("var"); v != "" {
+			fmt.Fprintf(w, "var %s = ", v)
+			w.Write(marshaledData)
+			io.WriteString(w, ";")
+		} else {
+			w.Write(marshaledData)
+		}
 	}
 }
 


### PR DESCRIPTION
cleans up the endpoints so we have:

- `/github-login` (login handler)
- `/github-login/redirect` (oauth redirect handler)
- `/user-data.js` (authed data endpoint)


we'll need to update the config, but I wanted to at least bikeshed the login urls now since I hope prow is inherently github only forever..