### PR TITLE
Set credentials for hook's git client.

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -164,6 +164,12 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting git client.")
 	}
+	// Get the bot's name in order to set credentials for the git client.
+	botName, err := githubClient.BotName()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot name.")
+	}
+	gitClient.SetCredentials(botName, oauthSecret)
 
 	pluginAgent := &plugins.PluginAgent{}
 


### PR DESCRIPTION
This should allow the plugins that use a git client to operate on private git repos that the bot has access to.

cc @yguo0905 
/cc @BenTheElder @kargakis 