### PR TITLE
greenhouse: add disk eviction metric, update owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
-bootstrap/** @bentheelder
 boskos/** @krzyzacy
+experiment/bootstrap/** @bentheelder
+greenhouse/** @bentheelder
 gubernator/** @rmmh
 images/** @bentheelder @krzyzacy
 images/bazelbuild/** @bentheelder @ixdy

--- a/greenhouse/BUILD.bazel
+++ b/greenhouse/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "eviction.go",
         "main.go",
         "prometheus.go",
     ],

--- a/greenhouse/OWNERS
+++ b/greenhouse/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - BenTheElder

--- a/greenhouse/eviction.go
+++ b/greenhouse/eviction.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sort"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/greenhouse/diskcache"
+	"k8s.io/test-infra/greenhouse/diskutil"
+)
+
+// monitorDiskAndEvict loops monitoring the disk, evicting cache entries
+// when the disk passes either minPercentBlocksFree until the disk is above
+// evictUntilPercentBlocksFree
+func monitorDiskAndEvict(
+	c *diskcache.Cache,
+	interval time.Duration,
+	minPercentBlocksFree, evictUntilPercentBlocksFree float64,
+) {
+	diskRoot := c.DiskRoot()
+	// forever check if usage is past thresholds and evict
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
+		blocksFree, _, _, err := diskutil.GetDiskUsage(diskRoot)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to get disk usage!")
+			continue
+		}
+		logger := logrus.WithFields(logrus.Fields{
+			"sync-loop":   "MonitorDiskAndEvict",
+			"blocks-free": blocksFree,
+		})
+		logger.Info("tick")
+		// if we are past the threshold, start evicting
+		if blocksFree < minPercentBlocksFree {
+			logger.Warn("Eviction triggered")
+			// get all cache entries and sort by lastaccess
+			// so we can pop entries until we have evicted enough
+			files := c.GetEntries()
+			sort.Slice(files, func(i, j int) bool {
+				return files[i].LastAccess.Before(files[j].LastAccess)
+			})
+			// evict until we pass the safe threshold so we don't thrash at the eviction trigger
+			for blocksFree < evictUntilPercentBlocksFree {
+				if len(files) < 1 {
+					logger.Fatal("Failed to find entries to evict!")
+				}
+				// pop entry and delete
+				var entry diskcache.EntryInfo
+				entry, files = files[0], files[1:]
+				err = c.Delete(c.PathToKey(entry.Path))
+				if err != nil {
+					logger.WithError(err).Errorf("Error deleting entry at path: %v", entry.Path)
+				} else {
+					promMetrics.FilesEvicted.Inc()
+				}
+				// get new disk usage
+				blocksFree, _, _, err = diskutil.GetDiskUsage(diskRoot)
+				logger = logrus.WithFields(logrus.Fields{
+					"sync-loop":   "MonitorDiskAndEvict",
+					"blocks-free": blocksFree,
+				})
+				if err != nil {
+					logrus.WithError(err).Error("Failed to get disk usage!")
+					continue
+				}
+			}
+			logger.Info("Done evicting")
+		}
+	}
+}

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -104,8 +104,8 @@ func main() {
 	}
 
 	cache := diskcache.NewCache(*dir)
-	go cache.MonitorDiskAndEvict(
-		*diskCheckInterval,
+	go monitorDiskAndEvict(
+		cache, *diskCheckInterval,
 		*minPercentBlocksFree, *evictUntilPercentBlocksFree,
 	)
 

--- a/greenhouse/prometheus.go
+++ b/greenhouse/prometheus.go
@@ -25,6 +25,7 @@ type prometheusMetrics struct {
 	DiskFree          prometheus.Gauge
 	DiskUsed          prometheus.Gauge
 	DiskTotal         prometheus.Gauge
+	FilesEvicted      prometheus.Counter
 	ActionCacheHits   prometheus.Counter
 	CASHits           prometheus.Counter
 	ActionCacheMisses prometheus.Counter
@@ -44,6 +45,10 @@ func initMetrics() *prometheusMetrics {
 		DiskTotal: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "bazel_cache_disk_total",
 			Help: "Total gb on bazel cache disk",
+		}),
+		FilesEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "bazel_cache_evicted_files",
+			Help: "number of files evicted since last server start",
 		}),
 		ActionCacheHits: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "bazel_cache_cas_hits",
@@ -65,6 +70,7 @@ func initMetrics() *prometheusMetrics {
 	prometheus.MustRegister(metrics.DiskFree)
 	prometheus.MustRegister(metrics.DiskUsed)
 	prometheus.MustRegister(metrics.DiskTotal)
+	prometheus.MustRegister(metrics.FilesEvicted)
 	prometheus.MustRegister(metrics.ActionCacheHits)
 	prometheus.MustRegister(metrics.CASHits)
 	prometheus.MustRegister(metrics.ActionCacheMisses)


### PR DESCRIPTION
- move eviction logic to main package since it's not super reusable / it's pretty application specific
- add a prometheus counter for files evicted so we can see when evictions occur on the dashboard
- add greenhouse to CODEOWNERS/OWNERS
  - also fix bootstrap location in CODEOWNERS