### PR TITLE
Enable the approve plugin and tide on kubernetes/gengo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -49,6 +49,7 @@ tide:
     - kubernetes/dashboard
     - kubernetes/features
     - kubernetes/federation
+    - kubernetes/gengo
     - kubernetes/heapster
     - kubernetes/ingress-nginx
     - kubernetes/kops

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -41,6 +41,7 @@ approve:
   - kubernetes/dashboard
   - kubernetes/features
   - kubernetes/federation
+  - kubernetes/gengo
   - kubernetes/heapster
   - kubernetes/ingress-nginx
   - kubernetes/kops
@@ -198,6 +199,9 @@ plugins:
 
   kubernetes/federation:
   - trigger
+  - approve
+
+  kubernetes/gengo:
   - approve
 
   kubernetes/heapster:


### PR DESCRIPTION
Per request - https://github.com/kubernetes/gengo/pull/102

/assign @BenTheElder 
/cc @thockin