### PR TITLE
Update munger for current code slush

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -33,5 +33,5 @@ label-file: "/gitrepos/kubernetes/labels.yaml"
 alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 use-reviewers: true
 # milestone-maintainer
-milestone-modes: v1.8=dev,v1.9=dev,v1.10=dev
+milestone-modes: v1.8=dev,v1.9=dev,v1.10=slush
 milestone-freeze-date: "TBD"


### PR DESCRIPTION
This should have been activated when code slush started.  It will be updated to freeze on Monday 2/26/2018 at 6pm