### PR TITLE
Milestone munger: Skip slush/freeze-only behavior for PRs

### DIFF
--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -660,6 +660,13 @@ func (m *MilestoneMaintainer) issueChangeConfig(obj *github.MungeObject) *issueC
 			return icc
 		}
 
+		if obj.IsPR() {
+			// Status and updates are not required for PRs, and
+			// non-blocking PRs should not be removed from the
+			// milestone.
+			return icc
+		}
+
 		if mode == milestoneModeFreeze && !isBlocker {
 			icc.removeNonBlocker()
 			return icc


### PR DESCRIPTION
PRs don't require status or updates in slush or freeze, and non-blocking PRs should not be removed from the milestone.