### PR TITLE
Move local ssd config to serial suite

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4843,6 +4843,7 @@
   "ci-kubernetes-e2e-gci-gce-serial": {
     "args": [
       "--check-leaked-resources",
+      "--env=NODE_LOCAL_SSDS_EXT=1,scsi,fs",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",

--- a/jobs/env/ci-kubernetes-e2e-gci-gce.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce.env
@@ -8,6 +8,3 @@ TEST_ETCD_VERSION=2.2.1
 
 # Enable the PodSecurityPolicy in tests.
 ENABLE_POD_SECURITY_POLICY=true
-
-# Add one local SSD for local PV tests
-NODE_LOCAL_SSDS_EXT=1,scsi,fs


### PR DESCRIPTION
gce local ssd tests have to be serial since it's only one disk per node