### PR TITLE
[prow] milestone maintainers can set milestone

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -37,6 +37,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *March 1, 2018* `MilestoneStatus` has been removed from the plugins Configuration
+   in favor of the `Milestone` which is shared between two plugins: 1) `milestonestatus`
+   and 2) `milestone`.  The milestonestatus plugin now uses the `Milestone` object to
+   get the maintainers team ID
  - *February 27, 2018* `jenkins-operator` does not use `$BUILD_ID` as a fallback
    to `$PROW_JOB_ID` anymore.
  - *February 15, 2018* `jenkins-operator` can now accept the `--tot-url` flag

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -57,6 +57,10 @@ type FakeClient struct {
 	// org/repo#number:assignee
 	AssigneesAdded []string
 
+	// org/repo#number:milestone (represents the milestone for a specific issue)
+	Milestone    int
+	MilestoneMap map[string]int
+
 	// Fake remote git storage. File name are keys
 	// and values map SHA to content
 	RemoteFiles map[string]map[string]string
@@ -269,4 +273,25 @@ func (f *FakeClient) ListCollaborators(org, repo string) ([]github.User, error) 
 		result = append(result, github.User{Login: login})
 	}
 	return result, nil
+}
+
+func (f *FakeClient) ClearMilestone(org, repo string, issueNum int) error {
+	f.Milestone = 0
+	return nil
+}
+
+func (f *FakeClient) SetMilestone(org, repo string, issueNum, milestoneNum int) error {
+	if milestoneNum < 0 {
+		return fmt.Errorf("Milestone Numbers Cannot Be Negative")
+	}
+	f.Milestone = milestoneNum
+	return nil
+}
+
+func (f *FakeClient) ListMilestones(org, repo string) ([]github.Milestone, error) {
+	milestones := []github.Milestone{}
+	for k, v := range f.MilestoneMap {
+		milestones = append(milestones, github.Milestone{Title: k, Number: v})
+	}
+	return milestones, nil
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -549,5 +549,6 @@ type GenericCommentEvent struct {
 
 // Milestone is a milestone defined on a github repository
 type Milestone struct {
-	Title string `json:"title"`
+	Title  string `json:"title"`
+	Number int    `json:"number"`
 }

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -133,6 +133,13 @@ milestonestatus:
   # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
   maintainers_id: 2460384
 
+milestone:
+  # You can curl the following endpoint in order to determine the github ID of your team
+  # responsible for maintaining the milestones:
+  # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+  maintainers_id: 2460384
+  maintainers_team: kubernetes-milestone-maintainers
+
 config_updater:
   maps:
     label_sync/labels.yaml: label-config

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -127,12 +127,6 @@ slack:
     whitelist:
     - k8s-ci-robot
 
-milestonestatus:
-  # You can curl the following endpoint in order to determine the github ID of your team
-  # responsible for maintaining the milestones:
-  # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
-  maintainers_id: 2460384
-
 milestone:
   # You can curl the following endpoint in order to determine the github ID of your team
   # responsible for maintaining the milestones:

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -64,6 +64,7 @@ filegroup(
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",
+        "//prow/plugins/milestone:all-srcs",
         "//prow/plugins/milestonestatus:all-srcs",
         "//prow/plugins/owners-label:all-srcs",
         "//prow/plugins/releasenote:all-srcs",

--- a/prow/plugins/milestone/BUILD.bazel
+++ b/prow/plugins/milestone/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["milestone.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/milestone",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["milestone_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package setmilestone implements the `/milestone` command which allows members of the milestone
+// maintainers team to specify a milestone to be applied to an Issue or PR.
+package milestone
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "milestone"
+
+var (
+	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+)$`)
+	mustBeSigLead    = "You must be a member of the [%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone."
+	invalidMilestone = "The provided milestone is not valid for this repository.  Here are the available milestones:\n %s"
+	clearKeyword     = "clear"
+)
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	ClearMilestone(org, repo string, num int) error
+	SetMilestone(org, repo string, issueNum, milestoneNum int) error
+	ListTeamMembers(id int) ([]github.TeamMember, error)
+	ListMilestones(org, repo string) ([]github.Milestone, error)
+}
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The milestone plugin allows members of a configurable GitHub team to set the milestone on an issue or pull request.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/milestone <version> or /milestone clear",
+		Description: "Updates the milestone for an issue or PR",
+		Featured:    false,
+		WhoCanUse:   "Members of the milestone maintainers GitHub team can use the '/milestone' command.",
+		Examples:    []string{"/milestone v1.10", "/milestone v1.9", "/milestone clear"},
+	})
+	return pluginHelp, nil
+}
+
+func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.Milestone.MaintainersID, pc.PluginConfig.Milestone.MaintainersTeam)
+}
+
+func buildMilestoneMap(milestones []github.Milestone) map[string]int {
+	m := make(map[string]int)
+	for _, ms := range milestones {
+		m[ms.Title] = ms.Number
+	}
+	return m
+}
+func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, maintainersID int, maintainersName string) error {
+	if e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	milestoneMatch := milestoneRegex.FindStringSubmatch(e.Body)
+	if len(milestoneMatch) != 2 {
+		return nil
+	}
+
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+
+	milestoneMaintainers, err := gc.ListTeamMembers(maintainersID)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, person := range milestoneMaintainers {
+		login := github.NormLogin(e.User.Login)
+		if github.NormLogin(person.Login) == login {
+			found = true
+			break
+		}
+	}
+	if !found {
+		// not in the milestone maintainers team
+		msg := fmt.Sprintf(mustBeSigLead, maintainersName, org, maintainersName)
+		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
+	}
+
+	milestones, err := gc.ListMilestones(org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Error listing the milestones in the %s/%s repo", org, repo)
+		return err
+	}
+	proposedMilestone := milestoneMatch[1]
+
+	// special case, if the clear keyword is used
+	if proposedMilestone == clearKeyword {
+		if err := gc.ClearMilestone(org, repo, e.Number); err != nil {
+			log.WithError(err).Errorf("Error clearing the milestone for %s/%s#%d.", org, repo, e.Number)
+		}
+		return nil
+	}
+
+	milestoneMap := buildMilestoneMap(milestones)
+	milestoneNumber, ok := milestoneMap[proposedMilestone]
+	if !ok {
+		var buffer bytes.Buffer
+		buffer.WriteString("\t 1." + clearKeyword + "\n")
+		for k := range milestoneMap {
+			buffer.WriteString("\t 1." + k + "\n")
+		}
+		msg := fmt.Sprintf(invalidMilestone, buffer.String())
+		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
+	}
+
+	if err := gc.SetMilestone(org, repo, e.Number, milestoneNumber); err != nil {
+		log.WithError(err).Errorf("Error adding the milestone %s to %s/%s#%d.", proposedMilestone, org, repo, e.Number)
+	}
+
+	return nil
+}

--- a/prow/plugins/milestone/milestone_test.go
+++ b/prow/plugins/milestone/milestone_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package milestone
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func formatLabels(labels ...string) []string {
+	r := []string{}
+	for _, l := range labels {
+		r = append(r, fmt.Sprintf("%s/%s#%d:%s", "org", "repo", 1, l))
+	}
+	if len(r) == 0 {
+		return nil
+	}
+	return r
+}
+
+func TestMilestoneStatus(t *testing.T) {
+	type testCase struct {
+		name              string
+		body              string
+		commenter         string
+		previousMilestone int
+		expectedMilestone int
+	}
+	var milestonesMap = map[string]int{"v1.0": 1}
+	testcases := []testCase{
+		{
+			name:              "Update the milestone when a sig-lead uses the command",
+			body:              "/milestone v1.0",
+			commenter:         "sig-lead",
+			previousMilestone: 0,
+			expectedMilestone: 1,
+		},
+		{
+			name:              "Don't update the milestone if a sig-lead enters an invalid milestone",
+			body:              "/milestone v2.0",
+			commenter:         "sig-lead",
+			previousMilestone: 0,
+			expectedMilestone: 0,
+		},
+		{
+			name:              "Don't update the milestone when a sig-lead uses the command with an invalid milestone",
+			body:              "/milestone abc",
+			commenter:         "sig-lead",
+			previousMilestone: 0,
+			expectedMilestone: 0,
+		},
+		{
+			name:              "Don't update the milestone if a sig-follow enters a valid milestone",
+			body:              "/milestone v1.0",
+			commenter:         "sig-follow",
+			previousMilestone: 0,
+			expectedMilestone: 0,
+		},
+		{
+			name:              "Clear the milestone if a sig lead tries to clear",
+			body:              "/milestone clear",
+			commenter:         "sig-lead",
+			previousMilestone: 1,
+			expectedMilestone: 0,
+		},
+		{
+			name:              "Don't clear the milestone if a sig follow tries to clear",
+			body:              "/milestone clear",
+			commenter:         "sig-follow",
+			previousMilestone: 10,
+			expectedMilestone: 10,
+		},
+	}
+
+	for _, tc := range testcases {
+		fakeClient := &fakegithub.FakeClient{IssueComments: make(map[int][]github.IssueComment), MilestoneMap: milestonesMap}
+		fakeClient.Milestone = tc.previousMilestone
+
+		maintainersID := 42
+		maintainersName := "fake-maintainers-team"
+		e := &github.GenericCommentEvent{
+			Action: github.GenericCommentActionCreated,
+			Body:   tc.body,
+			Number: 1,
+			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			User:   github.User{Login: tc.commenter},
+		}
+
+		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, maintainersID, maintainersName); err != nil {
+			t.Errorf("(%s): Unexpected error from handle: %v.", tc.name, err)
+			continue
+		}
+
+		// Check that the milestone was set if it was supposed to be set
+		if fakeClient.Milestone != tc.expectedMilestone {
+			t.Errorf("Expected the milestone to be updated for the issue for %s.  Expected Milestone %v, Actual Milestone %v.", tc.name, tc.expectedMilestone, fakeClient.Milestone)
+		}
+	}
+}

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -56,7 +56,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The milestonestatus plugin allows members of the milestone maintainers Github team to specify the 'status/*' label that should apply to a pull request.",
 		Config: map[string]string{
-			"": fmt.Sprintf("The milestone maintainers team is the Github team with ID: %d.", config.MilestoneStatus.MaintainersID),
+			"": fmt.Sprintf("The milestone maintainers team is the Github team with ID: %d.", config.Milestone.MaintainersID),
 		},
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
@@ -70,7 +70,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 }
 
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.MilestoneStatus.MaintainersID)
+	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.Milestone.MaintainersID)
 }
 
 func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, maintainersID int) error {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -160,6 +160,7 @@ type Configuration struct {
 	Triggers        []Trigger       `json:"triggers,omitempty"`
 	Heart           Heart           `json:"heart,omitempty"`
 	MilestoneStatus MilestoneStatus `json:"milestonestatus,omitempty"`
+	Milestone       Milestone       `json:"milestone,omitempty"`
 	Slack           Slack           `json:"slack,omitempty"`
 	ConfigUpdater   ConfigUpdater   `json:"config_updater,omitempty"`
 	Blockades       []Blockade      `json:"blockades,omitempty"`
@@ -328,6 +329,16 @@ type MilestoneStatus struct {
 	// responsible for maintaining the milestones:
 	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
 	MaintainersID int `json:"maintainers_id,omitempty"`
+}
+
+// MilestoneStatus contains the configuration options for the milestone plugin.
+type Milestone struct {
+	// ID of the github team for the milestone maintainers (used for setting status labels)
+	// You can curl the following endpoint in order to determine the github ID of your team
+	// responsible for maintaining the milestones:
+	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+	MaintainersID   int    `json:"maintainers_id,omitempty"`
+	MaintainersTeam string `json:"maintainers_team,omitempty"`
 }
 
 type Slack struct {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -157,18 +157,17 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
-	Triggers        []Trigger       `json:"triggers,omitempty"`
-	Heart           Heart           `json:"heart,omitempty"`
-	MilestoneStatus MilestoneStatus `json:"milestonestatus,omitempty"`
-	Milestone       Milestone       `json:"milestone,omitempty"`
-	Slack           Slack           `json:"slack,omitempty"`
-	ConfigUpdater   ConfigUpdater   `json:"config_updater,omitempty"`
-	Blockades       []Blockade      `json:"blockades,omitempty"`
-	Approve         []Approve       `json:"approve,omitempty"`
-	Blunderbuss     Blunderbuss     `json:"blunderbuss,omitempty"`
-	RequireSIG      RequireSIG      `json:"requiresig,omitempty"`
-	SigMention      SigMention      `json:"sigmention,omitempty"`
-	Cat             Cat             `json:"cat,omitempty"`
+	Triggers      []Trigger     `json:"triggers,omitempty"`
+	Heart         Heart         `json:"heart,omitempty"`
+	Milestone     Milestone     `json:"milestone,omitempty"`
+	Slack         Slack         `json:"slack,omitempty"`
+	ConfigUpdater ConfigUpdater `json:"config_updater,omitempty"`
+	Blockades     []Blockade    `json:"blockades,omitempty"`
+	Approve       []Approve     `json:"approve,omitempty"`
+	Blunderbuss   Blunderbuss   `json:"blunderbuss,omitempty"`
+	RequireSIG    RequireSIG    `json:"requiresig,omitempty"`
+	SigMention    SigMention    `json:"sigmention,omitempty"`
+	Cat           Cat           `json:"cat,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -320,15 +319,6 @@ type Heart struct {
 	// Adorees is a list of GitHub logins for members
 	// for whom we will add emojis to comments
 	Adorees []string `json:"adorees,omitempty"`
-}
-
-// MilestoneStatus contains the configuration options for the milestonestatus plugin.
-type MilestoneStatus struct {
-	// ID of the github team for the milestone maintainers (used for setting status labels)
-	// You can curl the following endpoint in order to determine the github ID of your team
-	// responsible for maintaining the milestones:
-	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
-	MaintainersID int `json:"maintainers_id,omitempty"`
 }
 
 // MilestoneStatus contains the configuration options for the milestone plugin.


### PR DESCRIPTION
Fixes #5344 

It's not perfect, but it should work for now.

The big thing missing is that it requires people to know the milestone number which is accessible through the URL.  Eg. [v1.10 for K8s maps to 37.](https://github.com/kubernetes/kubernetes/milestone/37)

Edit: changed the functionality so that users can type 
`/milestone v1.0` 

And the plugin with lookup the mapping between v1.0 and the number using the https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository endpoint