### PR TITLE
Enforces code freeze for v1.10

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -33,5 +33,5 @@ label-file: "/gitrepos/kubernetes/labels.yaml"
 alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 use-reviewers: true
 # milestone-maintainer
-milestone-modes: v1.8=dev,v1.9=dev,v1.10=slush
+milestone-modes: v1.8=dev,v1.9=dev,v1.10=freeze
 milestone-freeze-date: "TBD"

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -91,8 +91,8 @@ nonblocking-jobs: "\
   ci-kubernetes-soak-gke-test,\
   ci-kubernetes-integration-master,\
   ci-kubernetes-verify-master"
-do-not-merge-milestones: ""
-additional-required-labels: ""
+do-not-merge-milestones: "v1.4,v1.5,v1.6,v1.7,v1.8,v1.9,v1.11,v1.12,v1.13,next-candidate,NO-MILESTONE"
+additional-required-labels: "status/approved-for-milestone"
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
 history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
Following the [published timeline][] this should take effect
18:00 PST 26 February 2018

[published timeline]: https://goo.gl/MKzGPo