### PR TITLE
Re-enable audit logging in scale tests

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
@@ -20,7 +20,5 @@ CONTROLLER_MANAGER_TEST_ARGS=--concurrent-service-syncs=5
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
-# Turn off advanced audit until we implement streaming of audit logs.
-ENABLE_APISERVER_ADVANCED_AUDIT=false
 
 ### test-env

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
@@ -25,7 +25,5 @@ APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-infligh
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
-# Turn off advanced audit until we implement streaming of audit logs.
-ENABLE_APISERVER_ADVANCED_AUDIT=false
 
 ### test-env


### PR DESCRIPTION
This PR reverts https://github.com/kubernetes/test-infra/pull/5870

It will become possible to re-enable audit logging in tests when https://github.com/kubernetes/kubernetes/pull/60237 is merged.