### PR TITLE
Update bazelbuild/rules_go and gazelle to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ versions.check(minimum_bazel_version = "0.10.0")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "bdf2df58c0d352ffa262ae4b36c7a1a2d6e3f0c9",
+    commit = "6b39964af66c98580be4c5ac6cf1d243332f78e4",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/boskos/BUILD.bazel
+++ b/boskos/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 go_binary(
     name = "boskos",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos",
     pure = "on",
 )
 
@@ -19,7 +18,6 @@ go_test(
     srcs = ["boskos_test.go"],
     data = ["resources.json"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos",
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/ranch:go_default_library",

--- a/boskos/client/BUILD.bazel
+++ b/boskos/client/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["client_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/client",
     deps = ["//boskos/common:go_default_library"],
 )
 

--- a/boskos/janitor/BUILD.bazel
+++ b/boskos/janitor/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 go_binary(
     name = "janitor",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/janitor",
     pure = "on",
 )
 
@@ -42,6 +41,5 @@ go_test(
     name = "go_default_test",
     srcs = ["janitor_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/janitor",
     deps = ["//boskos/common:go_default_library"],
 )

--- a/boskos/metrics/BUILD.bazel
+++ b/boskos/metrics/BUILD.bazel
@@ -11,7 +11,6 @@ load(
 go_binary(
     name = "metrics",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/metrics",
     pure = "on",
     tags = ["automanaged"],
 )

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["ranch_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/ranch",
     deps = ["//boskos/common:go_default_library"],
 )
 

--- a/boskos/reaper/BUILD.bazel
+++ b/boskos/reaper/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "reaper",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/boskos/reaper",
     pure = "on",
 )
 

--- a/experiment/bootstrap/BUILD.bazel
+++ b/experiment/bootstrap/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
 go_binary(
     name = "bootstrap",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/bootstrap",
     visibility = ["//visibility:public"],
 )
 
@@ -44,5 +43,4 @@ go_test(
         "repos_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/bootstrap",
 )

--- a/experiment/cherrypicker/BUILD.bazel
+++ b/experiment/cherrypicker/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
 go_binary(
     name = "cherrypicker",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/cherrypicker",
     visibility = ["//visibility:public"],
 )
 
@@ -45,7 +44,6 @@ go_test(
     name = "go_default_test",
     srcs = ["server_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/cherrypicker",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",

--- a/experiment/coverage/BUILD.bazel
+++ b/experiment/coverage/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
 go_binary(
     name = "coverage",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/coverage",
     visibility = ["//visibility:public"],
 )
 
@@ -36,5 +35,4 @@ go_test(
     name = "go_default_test",
     srcs = ["apicoverage_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/coverage",
 )

--- a/experiment/manual-trigger/BUILD.bazel
+++ b/experiment/manual-trigger/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
 go_binary(
     name = "manual-trigger",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/manual-trigger",
     visibility = ["//visibility:public"],
 )
 

--- a/experiment/refresh/BUILD.bazel
+++ b/experiment/refresh/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
 go_binary(
     name = "refresh",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/refresh",
     visibility = ["//visibility:public"],
 )
 

--- a/experiment/tracer/BUILD.bazel
+++ b/experiment/tracer/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
 go_binary(
     name = "tracer",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/tracer",
     visibility = ["//visibility:public"],
 )
 
@@ -28,7 +27,6 @@ go_test(
     name = "go_default_test",
     srcs = ["trace_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/experiment/tracer",
 )
 
 filegroup(

--- a/gcsweb/cmd/gcsweb/BUILD.bazel
+++ b/gcsweb/cmd/gcsweb/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "gcsweb",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     pure = "on",
 )
 

--- a/ghclient/BUILD.bazel
+++ b/ghclient/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "wrappers_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/ghclient",
     tags = ["automanaged"],
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -34,7 +34,7 @@ rm -f ${TESTINFRA_ROOT}/vendor/k8s.io/apimachinery/pkg/util/sets/{BUILD,BUILD.ba
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
-  eaa1e87d2a3ca716780ca6650ef5b9b9663b8773 \
+  a85b63b06c2e0c75931e57c4a1a18d4e566bb6f4 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD.bazel"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -28,7 +28,7 @@ cd "${TESTINFRA_ROOT}"
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
-  eaa1e87d2a3ca716780ca6650ef5b9b9663b8773 \
+  a85b63b06c2e0c75931e57c4a1a18d4e566bb6f4 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD.bazel"

--- a/images/bootstrap/barnacle/BUILD.bazel
+++ b/images/bootstrap/barnacle/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
 go_binary(
     name = "barnacle",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/images/bootstrap/barnacle",
     pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 go_binary(
     name = "kubetest",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/kubetest",
     pure = "on",
 )
 
@@ -77,6 +76,5 @@ go_test(
         "util_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/kubetest",
     deps = ["//kubetest/util:go_default_library"],
 )

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -37,7 +37,6 @@ go_image(
     name = "label_sync-image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/label_sync",
     pure = "on",
     tags = ["automanaged"],
 )
@@ -49,7 +48,6 @@ go_test(
         "//label_sync:test_examples",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/label_sync",
     tags = ["automanaged"],
 )
 
@@ -87,5 +85,4 @@ filegroup(
 go_binary(
     name = "label_sync",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/label_sync",
 )

--- a/logexporter/cmd/BUILD.bazel
+++ b/logexporter/cmd/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "cmd",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/logexporter/cmd",
     pure = "on",
 )
 

--- a/maintenance/aws-janitor/BUILD.bazel
+++ b/maintenance/aws-janitor/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
 go_binary(
     name = "aws-janitor",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/maintenance/aws-janitor",
     visibility = ["//visibility:public"],
 )
 

--- a/maintenance/fixconfig/BUILD.bazel
+++ b/maintenance/fixconfig/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
 go_binary(
     name = "fixconfig",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/maintenance/fixconfig",
     visibility = ["//visibility:public"],
 )
 

--- a/maintenance/migratestatus/BUILD.bazel
+++ b/maintenance/migratestatus/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "migratestatus",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/maintenance/migratestatus",
 )
 
 go_library(

--- a/maintenance/migratestatus/migrator/BUILD.bazel
+++ b/maintenance/migratestatus/migrator/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["migrator_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/maintenance/migratestatus/migrator",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/BUILD.bazel
+++ b/mungegithub/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "mungegithub",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub",
     pure = "on",
 )
 

--- a/mungegithub/example-one-off/BUILD.bazel
+++ b/mungegithub/example-one-off/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "example-one-off",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/example-one-off",
 )
 
 go_library(

--- a/mungegithub/features/BUILD.bazel
+++ b/mungegithub/features/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["repo-updates_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/features",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/github/BUILD.bazel
+++ b/mungegithub/github/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "status_change_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/github",
     deps = [
         "//mungegithub/github/testing:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungers/BUILD.bazel
+++ b/mungegithub/mungers/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
         "//mungegithub:configs",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers",
     race = "off",  # kubernetes/test-infra/issues/3639
     deps = [
         "//mungegithub/features:go_default_library",

--- a/mungegithub/mungers/approvers/BUILD.bazel
+++ b/mungegithub/mungers/approvers/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "owners_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
     deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )
 

--- a/mungegithub/mungers/e2e/BUILD.bazel
+++ b/mungegithub/mungers/e2e/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "resolved_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/e2e",
     deps = [
         "//mungegithub/options:go_default_library",
         "//vendor/k8s.io/contrib/test-utils/utils:go_default_library",

--- a/mungegithub/mungers/flakesync/BUILD.bazel
+++ b/mungegithub/mungers/flakesync/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["cache_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/flakesync",
     deps = ["//vendor/github.com/google/gofuzz:go_default_library"],
 )
 

--- a/mungegithub/mungers/matchers/BUILD.bazel
+++ b/mungegithub/mungers/matchers/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
         "//mungegithub:configs",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/mungers/matchers/comment/BUILD.bazel
+++ b/mungegithub/mungers/matchers/comment/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
         "pinger_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/comment",
 )
 
 go_library(

--- a/mungegithub/mungers/matchers/event/BUILD.bazel
+++ b/mungegithub/mungers/matchers/event/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "finder_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/event",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/mungers/mungerutil/BUILD.bazel
+++ b/mungegithub/mungers/mungerutil/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "util_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/mungers/mungerutil",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/options/BUILD.bazel
+++ b/mungegithub/options/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["options_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/mungegithub/options",
     deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )
 

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
         "protect_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/branchprotector",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
@@ -66,6 +65,5 @@ filegroup(
 go_binary(
     name = "branchprotector",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/branchprotector",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -25,7 +25,6 @@ go_image(
 go_binary(
     name = "clonerefs",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/clonerefs",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/config/BUILD.bazel
+++ b/prow/cmd/config/BUILD.bazel
@@ -16,7 +16,6 @@ go_binary(
     name = "config",
     data = ["//prow:configs"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/config",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -29,7 +29,6 @@ go_image(
 go_binary(
     name = "deck",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/deck",
     pure = "on",
 )
 
@@ -41,7 +40,6 @@ go_test(
         "tide_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/deck",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -15,7 +15,6 @@ go_binary(
         "//prow:configs",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/hook",
     pure = "on",
 )
 
@@ -26,7 +25,6 @@ go_test(
         "//prow:configs",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/hook",
     deps = ["//prow/plugins:go_default_library"],
 )
 

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -17,7 +17,6 @@ go_image(
 go_binary(
     name = "horologium",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/horologium",
     pure = "on",
 )
 
@@ -52,7 +51,6 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/horologium",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
 go_binary(
     name = "initupload",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/initupload",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -53,7 +53,6 @@ filegroup(
 go_binary(
     name = "jenkins-operator",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     pure = "on",
     race = "off",
 )

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -12,7 +12,6 @@ go_binary(
     args = ["--config-path=$(location //prow:config.yaml)"],
     data = ["//prow:config.yaml"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/mkpj",
 )
 
 go_library(

--- a/prow/cmd/phony/BUILD.bazel
+++ b/prow/cmd/phony/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "phony",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/phony",
 )
 
 go_library(

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -13,7 +13,6 @@ go_image(
 go_binary(
     name = "plank",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/plank",
     pure = "on",
 )
 

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -17,7 +17,6 @@ go_image(
 go_binary(
     name = "sinker",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/sinker",
     pure = "on",
 )
 
@@ -25,7 +24,6 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/sinker",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/splice/BUILD.bazel
+++ b/prow/cmd/splice/BUILD.bazel
@@ -17,7 +17,6 @@ go_image(
 go_binary(
     name = "splice",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/splice",
     pure = "on",
 )
 
@@ -25,7 +24,6 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/splice",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
 go_binary(
     name = "tide",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/tide",
     pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -17,7 +17,6 @@ go_image(
 go_binary(
     name = "tot",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/tot",
     pure = "on",
 )
 
@@ -25,7 +24,6 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cmd/tot",
 )
 
 go_library(

--- a/prow/commentpruner/BUILD.bazel
+++ b/prow/commentpruner/BUILD.bazel
@@ -15,7 +15,6 @@ go_test(
     name = "go_default_test",
     srcs = ["commentpruner_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/commentpruner",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
         "//scenarios",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/config",
     deps = [
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cron/BUILD.bazel
+++ b/prow/cron/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
     name = "go_default_test",
     srcs = ["cron_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/cron",
     deps = [
         "//prow/config:go_default_library",
         "//vendor/gopkg.in/robfig/cron.v2:go_default_library",

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
 go_binary(
     name = "needs-rebase",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/external-plugins/needs-rebase",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
     name = "go_default_test",
     srcs = ["plugin_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/external-plugins/needs-rebase/plugin",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/genfiles/BUILD.bazel
+++ b/prow/genfiles/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     name = "go_default_test",
     srcs = ["genfiles_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/genfiles",
 )
 
 filegroup(

--- a/prow/git/BUILD.bazel
+++ b/prow/git/BUILD.bazel
@@ -32,6 +32,5 @@ filegroup(
 go_test(
     name = "go_default_xtest",
     srcs = ["git_test.go"],
-    importpath = "k8s.io/test-infra/prow/git_test",
     deps = ["//prow/git/localgit:go_default_library"],
 )

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -15,7 +15,6 @@ go_test(
         "types_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/github",
 )
 
 go_library(

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "server_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/hook",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/jenkins/BUILD.bazel
+++ b/prow/jenkins/BUILD.bazel
@@ -48,7 +48,6 @@ go_test(
         "jenkins_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/jenkins",
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",

--- a/prow/kube/BUILD.bazel
+++ b/prow/kube/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "prowjob_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/kube",
     deps = ["//vendor/k8s.io/api/core/v1:go_default_library"],
 )
 

--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "pjutil_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/pjutil",
     tags = ["automanaged"],
     deps = [
         "//prow/kube:go_default_library",

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plank",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/pluginhelp/hook/BUILD.bazel
+++ b/prow/pluginhelp/hook/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
     name = "go_default_test",
     srcs = ["hook_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/pluginhelp/hook",
     deps = [
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "respond_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins",
     deps = ["//prow/github:go_default_library"],
 )
 

--- a/prow/plugins/approve/BUILD.bazel
+++ b/prow/plugins/approve/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
         "//prow:configs",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/approve",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/approve/approvers/BUILD.bazel
+++ b/prow/plugins/approve/approvers/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
         "owners_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/approve/approvers",
     deps = [
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/assign/BUILD.bazel
+++ b/prow/plugins/assign/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["assign_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/assign",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/blockade/BUILD.bazel
+++ b/prow/plugins/blockade/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
     name = "go_default_test",
     srcs = ["blockade_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/blockade",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/blunderbuss/BUILD.bazel
+++ b/prow/plugins/blunderbuss/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
     name = "go_default_test",
     srcs = ["blunderbuss_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/blunderbuss",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/buildifier/BUILD.bazel
+++ b/prow/plugins/buildifier/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
     name = "go_default_test",
     srcs = ["buildifier_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/buildifier",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/cat/BUILD.bazel
+++ b/prow/plugins/cat/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["cat_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/yuks",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/cla/BUILD.bazel
+++ b/prow/plugins/cla/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["cla_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/cla",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/docs-no-retest/BUILD.bazel
+++ b/prow/plugins/docs-no-retest/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
     name = "go_default_test",
     srcs = ["docs-no-retest_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/docs-no-retest",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/golint/BUILD.bazel
+++ b/prow/plugins/golint/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["golint_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/golint",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/heart/BUILD.bazel
+++ b/prow/plugins/heart/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     name = "go_default_test",
     srcs = ["heart_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/heart",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/help/BUILD.bazel
+++ b/prow/plugins/help/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     name = "go_default_test",
     srcs = ["help_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/help",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/hold/BUILD.bazel
+++ b/prow/plugins/hold/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     name = "go_default_test",
     srcs = ["hold_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/hold",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/label/BUILD.bazel
+++ b/prow/plugins/label/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["label_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/label",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["lgtm_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/lgtm",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/lifecycle/BUILD.bazel
+++ b/prow/plugins/lifecycle/BUILD.bazel
@@ -14,7 +14,6 @@ go_test(
         "reopen_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/lifecycle",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/milestonestatus/BUILD.bazel
+++ b/prow/plugins/milestonestatus/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
     name = "go_default_test",
     srcs = ["milestonestatus_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/milestonestatus",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/releasenote/BUILD.bazel
+++ b/prow/plugins/releasenote/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["releasenote_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/releasenote",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/requiresig/BUILD.bazel
+++ b/prow/plugins/requiresig/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     name = "go_default_test",
     srcs = ["requiresig_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/requiresig",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/shrug/BUILD.bazel
+++ b/prow/plugins/shrug/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
     name = "go_default_test",
     srcs = ["shurg_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/shrug",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/sigmention/BUILD.bazel
+++ b/prow/plugins/sigmention/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     name = "go_default_test",
     srcs = ["sigmention_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/sigmention",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/size/BUILD.bazel
+++ b/prow/plugins/size/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     name = "go_default_test",
     srcs = ["size_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/size",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/skip/BUILD.bazel
+++ b/prow/plugins/skip/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
     name = "go_default_test",
     srcs = ["skip_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/skip",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/slackevents/BUILD.bazel
+++ b/prow/plugins/slackevents/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["slackevents_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/slackevents",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "pr_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/trigger",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["updateconfig_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/wip/BUILD.bazel
+++ b/prow/plugins/wip/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     name = "go_default_test",
     srcs = ["wip-label_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/wip",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/yuks/BUILD.bazel
+++ b/prow/plugins/yuks/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["yuks_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/plugins/yuks",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/pod-utils/clone/BUILD.bazel
+++ b/prow/pod-utils/clone/BUILD.bazel
@@ -34,6 +34,5 @@ go_test(
     name = "go_default_test",
     srcs = ["parse_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/pod-utils/clone",
     deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -41,7 +41,6 @@ go_test(
         "upload_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/pod-utils/gcs",
     deps = [
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
     name = "go_default_test",
     srcs = ["repoowners_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/repoowners",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/report/BUILD.bazel
+++ b/prow/report/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     name = "go_default_test",
     srcs = ["report_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/report",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     name = "go_default_test",
     srcs = ["tide_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/prow/tide",
     deps = [
         "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -30,7 +30,6 @@ go_image(
     name = "commenter-image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/commenter",
 )
 
 go_library(
@@ -57,7 +56,6 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/commenter",
     deps = ["//prow/github:go_default_library"],
 )
 
@@ -65,5 +63,4 @@ go_test(
 go_binary(
     name = "commenter",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/commenter",
 )

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -33,7 +33,6 @@ go_image(
     name = "issue-creator-image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/issue-creator",
     visibility = ["//visibility:public"],
 )
 
@@ -65,6 +64,5 @@ filegroup(
 go_binary(
     name = "issue-creator",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/issue-creator",
     visibility = ["//visibility:public"],
 )

--- a/robots/issue-creator/creator/BUILD.bazel
+++ b/robots/issue-creator/creator/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     name = "go_default_test",
     srcs = ["creator_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/issue-creator/creator",
     deps = [
         "//robots/issue-creator/testowner:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/robots/issue-creator/sources/BUILD.bazel
+++ b/robots/issue-creator/sources/BUILD.bazel
@@ -23,7 +23,6 @@ go_test(
         "triage-filer_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/issue-creator/sources",
     deps = [
         "//robots/issue-creator/creator:go_default_library",
         "//robots/issue-creator/testowner:go_default_library",

--- a/robots/issue-creator/testowner/BUILD.bazel
+++ b/robots/issue-creator/testowner/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     name = "go_default_test",
     srcs = ["owner_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/robots/issue-creator/testowner",
 )
 
 filegroup(

--- a/testgrid/cmd/updater/BUILD.bazel
+++ b/testgrid/cmd/updater/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
 go_binary(
     name = "updater",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/testgrid/updater",
     pure = "on",
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/velodrome/fetcher/BUILD.bazel
+++ b/velodrome/fetcher/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 go_binary(
     name = "fetcher",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/fetcher",
     pure = "on",
 )
 
@@ -24,7 +23,6 @@ go_test(
         "issues_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/fetcher",
     deps = [
         "//velodrome/sql:go_default_library",
         "//velodrome/sql/testing:go_default_library",

--- a/velodrome/sql/BUILD.bazel
+++ b/velodrome/sql/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "mysql_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/sql",
 )
 
 go_library(

--- a/velodrome/sql/testing/BUILD.bazel
+++ b/velodrome/sql/testing/BUILD.bazel
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = ["sqlite_test.go"],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/sql/testing",
     deps = ["//velodrome/sql:go_default_library"],
 )
 

--- a/velodrome/token-counter/BUILD.bazel
+++ b/velodrome/token-counter/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 go_binary(
     name = "token-counter",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/token-counter",
     pure = "on",
 )
 

--- a/velodrome/transform/BUILD.bazel
+++ b/velodrome/transform/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 go_binary(
     name = "transform",
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/transform",
     pure = "on",
 )
 
@@ -21,7 +20,6 @@ go_test(
         "influx_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/transform",
     deps = [
         "//velodrome/sql:go_default_library",
         "//velodrome/sql/testing:go_default_library",

--- a/velodrome/transform/plugins/BUILD.bazel
+++ b/velodrome/transform/plugins/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
         "type_filter_wrapper_test.go",
     ],
     embed = [":go_default_library"],
-    importpath = "k8s.io/test-infra/velodrome/transform/plugins",
     deps = [
         "//velodrome/sql:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",


### PR DESCRIPTION
We're not vendoring gazelle properly, and some upstream changes to bazelbuild/buildtools are now causing compilation failures:
```
$ hack/update-bazel.sh 
# github.com/bazelbuild/bazel-gazelle/internal/merger
../../internal/merger/fix.go:93:28: too few values in struct initializer
../../internal/merger/merger.go:657:16: too few values in struct initializer
../../internal/merger/merger.go:677:19: too few values in struct initializer
../../internal/merger/merger.go:681:19: too few values in struct initializer
# github.com/bazelbuild/bazel-gazelle/internal/rules
../../internal/rules/generator.go:183:16: too few values in struct initializer
../../internal/rules/sort_labels.go:45:16: too few values in struct initializer
```

The latest gazelle has been updated to compile properly. We'll want to follow up with proper vendoring in a separate PR.

The large swath of BUILD.bazel changes is the removal of the `importpath` attribute.

/assign @BenTheElder 