### PR TITLE
Change dind to gcr.io/k8s-testimages

### DIFF
--- a/dind/base/Makefile
+++ b/dind/base/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 # TAG is the version to build and push to.
-PREFIX = gcr.io/qlee-dev
+PREFIX = gcr.io/k8s-testimages
 NAME = dind-test-base
 ARCH = amd64
 TAG = 0.1

--- a/dind/cluster/Dockerfile
+++ b/dind/cluster/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/qlee-dev/dind-test-base-amd64:0.1
+FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.1
 
 # Get our short startup scripts first, because they're least likely to change.
 COPY init-wrapper.sh /init-wrapper.sh

--- a/dind/node/Dockerfile
+++ b/dind/node/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/qlee-dev/dind-test-base-amd64:0.1
+FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.1
 
 # Get our short startup scripts first, because they're least likely to change.
 COPY init-wrapper.sh /init-wrapper.sh


### PR DESCRIPTION
This bucket seems to be the sanest home.