### PR TITLE
Add plugins README

### DIFF
--- a/prow/plugins/README.md
+++ b/prow/plugins/README.md
@@ -1,0 +1,7 @@
+# prow plugins
+
+Most plugins lack README's but instead provide `PluginHelp` structs during init
+
+Please see https://prow.k8s.io/plugins for a list of all deployed plugins, what they do, and what commands they offer
+
+For an alternate view, please see https://prow.k8s.io/command-help to see all of the commands offered by the deployed plugins


### PR DESCRIPTION
Someone looking to find out about what prow plugins we have to offer might think they're totally undocumented if they don't know about prow.k8s.io/plugins