### PR TITLE
fixup greenhouse BUILD

### DIFF
--- a/greenhouse/BUILD.bazel
+++ b/greenhouse/BUILD.bazel
@@ -22,8 +22,9 @@ go_library(
 )
 
 go_binary(
-    name = "nursery",
+    name = "greenhouse",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 
@@ -48,7 +49,7 @@ filegroup(
 go_image(
     name = "image",
     base = "@alpine-base//image",
-    binary = ":nursery",
+    binary = ":greenhouse",
     visibility = ["//visibility:public"],
 )
 
@@ -60,10 +61,4 @@ k8s_object(
     },
     kind = "deployment",
     template = ":deployment.yaml",
-)
-
-go_binary(
-    name = "greenhouse",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- set pure mode for alpine (this was auto enabled before because I was cross compiling, it should have been explicitly on before)
- drop duplicate binary under old name and point image to new name :grimacing: 

/area greenhouse