### PR TITLE
apicoverage: Add output-covered-apis option

### DIFF
--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -36,9 +36,10 @@ import (
 )
 
 var (
-	openAPIFile = flag.String("openapi", "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json", "URL to openapi-spec of Kubernetes")
-	minCoverage = flag.Int("minimum-coverage", 0, "This command fails if the number of covered APIs is less than this option ratio(percent)")
-	restLog     = flag.String("restlog", "", "File path to REST API operation log of Kubernetes")
+	openAPIFile       = flag.String("openapi", "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json", "URL to openapi-spec of Kubernetes")
+	outputCoveredAPIs = flag.Bool("output-covered-apis", false, "Output the list of covered APIs")
+	minCoverage       = flag.Int("minimum-coverage", 0, "This command fails if the number of covered APIs is less than this option ratio(percent)")
+	restLog           = flag.String("restlog", "", "File path to REST API operation log of Kubernetes")
 )
 
 type apiData struct {
@@ -246,4 +247,9 @@ func main() {
 	apisLogs := getAPILog(*restLog)
 	apisTested := getTestedAPIs(apisOpenapi, apisLogs)
 	outputCoverage(apisOpenapi, apisTested)
+	if *outputCoveredAPIs {
+		for _, openapi := range apisTested {
+			fmt.Printf("%s %s\n", openapi.Method, openapi.URL)
+		}
+	}
 }


### PR DESCRIPTION
As the sig-testing discussion [1], it is important to know which APIs
are covered on tests. So this adds the corresponding option to the
tool.

fixes #7012 