### PR TITLE
 Create a pull-kubernetes-bazel-test-integration-canary job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1345,6 +1345,50 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  - name: pull-kubernetes-bazel-test-integration-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-test-integration-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-test-integration-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-test-integration-canary,?(\\s+|$)"
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--test=//test/integration/..."
+        - "--test-args=--config=integration"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-kubernetes-cross
     agent: kubernetes
     context: pull-kubernetes-cross
@@ -3250,6 +3294,49 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test pull-security-kubernetes-bazel-test-canary,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-bazel-test-integration-canary
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test-integration-canary
+    rerun_command: /test pull-security-kubernetes-bazel-test-integration-canary
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --
+        - --test=//test/integration/...
+        - --test-args=--config=integration
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-test-integration-canary,?(\s+|$)
   - agent: kubernetes
     always_run: false
     cluster: security

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1143,7 +1143,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
         env:
@@ -1318,7 +1317,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
         - "--test=//... -//build/... -//vendor/..."
         - "--manual-test=//hack:verify-all"
         - "--test-args=--config=unit"
@@ -3041,7 +3039,6 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --
-        - --batch
         - --build=//... -//vendor/...
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build-canary
@@ -3227,7 +3224,6 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --
-        - --batch
         - --test=//... -//build/... -//vendor/...
         - --manual-test=//hack:verify-all
         - --test-args=--config=unit
@@ -5571,7 +5567,6 @@ postsubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
         - "--build=//..."
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."
@@ -13649,7 +13644,6 @@ periodics:
       - "--service-account=/etc/service-account/service-account.json"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--" # end bootstrap args, scenario args below
-      - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
       - "--build=//..."
       - "--install=gubernator/test_requirements.txt"
       - "--test=//..."

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1756,6 +1756,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test-canary
   days_of_results: 1
   num_columns_recent: 20
+- name: pull-kubernetes-bazel-test-integration-canary
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test-integration-canary
+  days_of_results: 1
+  num_columns_recent: 20
 - name: pull-kubernetes-cross
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-cross
   days_of_results: 1
@@ -4587,6 +4591,8 @@ dashboards:
     test_group_name: pull-kubernetes-bazel-build-canary
   - name: bazel-test-canary
     test_group_name: pull-kubernetes-bazel-test-canary
+  - name: bazel-test-integration-canary
+    test_group_name: pull-kubernetes-bazel-test-integration-canary
   - name: pull-kubernetes-verify-prow
     test_group_name: pull-kubernetes-verify-prow
   - name: pull-kubernetes-unit-prow


### PR DESCRIPTION
This job basically clones pull-kubernetes-bazel-test-canary, but uses the integration bazel config instead.

I also removed all of the `--batch` arguments from the various bazel canary jobs, which I guess we don't need anymore.

/assign @BenTheElder 
/cc @mikedanese 
/hold