### PR TITLE
Make OwnersClient directory blacklist configurable.

### DIFF
--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -25,7 +25,10 @@ go_test(
         "//prow:configs",
     ],
     embed = [":go_default_library"],
-    deps = ["//prow/plugins:go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
 )
 
 go_library(

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -25,10 +25,7 @@ go_test(
         "//prow:configs",
     ],
     embed = [":go_default_library"],
-    deps = [
-        "//prow/config:go_default_library",
-        "//prow/plugins:go_default_library",
-    ],
+    deps = ["//prow/plugins:go_default_library"],
 )
 
 go_library(
@@ -49,6 +46,7 @@ go_library(
         "//prow/slack:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -174,12 +174,16 @@ func main() {
 
 	pluginAgent := &plugins.PluginAgent{}
 
-	ownersClient := repoowners.NewClient(gitClient, githubClient, pluginAgent.MDYAMLEnabled)
 	ownersDirBlacklistConf := configAgent.Config().OwnersDirBlacklist
-	ownersClient.DirBlacklistDefault = sets.NewString(ownersDirBlacklistConf.Default...)
+	ownersDirBlacklistDefault := sets.NewString(ownersDirBlacklistConf.Default...)
+	ownersDirBlacklistByRepo := make(map[string]sets.String)
 	for orgRepo, blacklist := range ownersDirBlacklistConf.Repos {
-		ownersClient.DirBlacklistByRepo[orgRepo] = sets.NewString(blacklist...)
+		ownersDirBlacklistByRepo[orgRepo] = sets.NewString(blacklist...)
 	}
+	ownersClient := repoowners.NewClient(
+		gitClient, githubClient, pluginAgent.MDYAMLEnabled,
+		ownersDirBlacklistDefault, ownersDirBlacklistByRepo,
+	)
 
 	pluginAgent.PluginClient = plugins.PluginClient{
 		GitHubClient: githubClient,

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -173,12 +173,15 @@ func main() {
 
 	pluginAgent := &plugins.PluginAgent{}
 
+	ownersClient := repoowners.NewClient(gitClient, githubClient, pluginAgent.MDYAMLEnabled)
+	ownersClient.DirBlackList = configAgent.Config().OwnersDirBlacklist
+
 	pluginAgent.PluginClient = plugins.PluginClient{
 		GitHubClient: githubClient,
 		KubeClient:   kubeClient,
 		GitClient:    gitClient,
 		SlackClient:  slackClient,
-		OwnersClient: repoowners.NewClient(gitClient, githubClient, pluginAgent.MDYAMLEnabled),
+		OwnersClient: ownersClient,
 		Logger:       logrus.WithField("agent", "plugin"),
 	}
 	if err := pluginAgent.Start(o.pluginConfig); err != nil {

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -174,7 +174,18 @@ func main() {
 	pluginAgent := &plugins.PluginAgent{}
 
 	ownersClient := repoowners.NewClient(gitClient, githubClient, pluginAgent.MDYAMLEnabled)
-	ownersClient.DirBlackList = configAgent.Config().OwnersDirBlacklist
+	ownersClient.DirBlacklist = func(org, repo string) []string {
+		conf := configAgent.Config().OwnersDirBlacklist
+
+		if list, ok := conf.Repos[org+"/"+repo]; ok {
+			return list
+		}
+		if list, ok := conf.Repos[org]; ok {
+			return list
+		}
+
+		return conf.Default
+	}
 
 	pluginAgent.PluginClient = plugins.PluginClient{
 		GitHubClient: githubClient,

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"testing"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/plugins"
 )
 
@@ -69,13 +68,5 @@ func TestOptions_Validate(t *testing.T) {
 		if !testCase.expectedErr && err != nil {
 			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 		}
-	}
-}
-
-func TestParseConfig(t *testing.T) {
-	cf := "../../config.yaml"
-	_, err := config.Load(cf)
-	if err != nil {
-		t.Fatalf("Could not load prow config: %v.", err)
 	}
 }

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"testing"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/plugins"
 )
 
@@ -68,5 +69,13 @@ func TestOptions_Validate(t *testing.T) {
 		if !testCase.expectedErr && err != nil {
 			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 		}
+	}
+}
+
+func TestParseConfig(t *testing.T) {
+	cf := "../../config.yaml"
+	_, err := config.Load(cf)
+	if err != nil {
+		t.Fatalf("Could not load prow config: %v.", err)
 	}
 }

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -98,7 +98,7 @@ type Config struct {
 //     kubernetes-sig-testing:
 //     - bin
 type OwnersDirBlacklist struct {
-	// Repos configures a direcotry blacklist per repo (or org)
+	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`
 	// Default configures a default blacklist for repos (or orgs) not
 	// specifically configured

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -78,6 +78,8 @@ type Config struct {
 
 	// PushGateway is a prometheus push gateway.
 	PushGateway PushGateway `json:"push_gateway,omitempty"`
+
+	OwnersDirBlacklist []string `json:"owners_dir_blacklist"`
 }
 
 // PushGateway is a prometheus push gateway.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -79,7 +79,30 @@ type Config struct {
 	// PushGateway is a prometheus push gateway.
 	PushGateway PushGateway `json:"push_gateway,omitempty"`
 
-	OwnersDirBlacklist []string `json:"owners_dir_blacklist"`
+	// OwnersDirBlacklist is used to configure which directories to ignore when
+	// searching for OWNERS{,_ALIAS} files in a repo.
+	OwnersDirBlacklist OwnersDirBlacklist `json:"owners_dir_blacklist,omitempty"`
+}
+
+// OwnersDirBlacklist is used to configure which directories to ignore when
+// searching for OWNERS{,_ALIAS} files in a repo.
+//
+// owners_dir_blacklist:
+//   default:
+//   - .git
+//   - vendor
+//   - _output
+//   repos:
+//     kubernetes-sig-testing/frameworks:
+//     - assets
+//     kubernetes-sig-testing:
+//     - bin
+type OwnersDirBlacklist struct {
+	// Repos configures a direcotry blacklist per repo (or org)
+	Repos map[string][]string `json:"repos"`
+	// Default configures a default blacklist for repos (or orgs) not
+	// specifically configured
+	Default []string `json:"default"`
 }
 
 // PushGateway is a prometheus push gateway.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -86,17 +86,6 @@ type Config struct {
 
 // OwnersDirBlacklist is used to configure which directories to ignore when
 // searching for OWNERS{,_ALIAS} files in a repo.
-//
-// owners_dir_blacklist:
-//   default:
-//   - .git
-//   - vendor
-//   - _output
-//   repos:
-//     kubernetes-sig-testing/frameworks:
-//     - assets
-//     kubernetes-sig-testing:
-//     - bin
 type OwnersDirBlacklist struct {
 	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -126,12 +126,12 @@ func TestOwnerDirBlacklist(t *testing.T) {
 		t.Fatalf("Unexpected error loading RepoOwners: %v.", err)
 	}
 
-	for dir, _ := range ro.approvers {
+	for dir := range ro.approvers {
 		if strings.Contains(dir, "src") {
 			t.Errorf("Expected directory %s to be excluded from the approvers map", dir)
 		}
 	}
-	for dir, _ := range ro.reviewers {
+	for dir := range ro.reviewers {
 		if strings.Contains(dir, "src") {
 			t.Errorf("Expected directory %s to be excluded from the reviewers map", dir)
 		}

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -117,7 +117,9 @@ func TestOwnerDirBlacklist(t *testing.T) {
 	}
 	defer cleanup()
 
-	client.DirBlackList = []string{"src"}
+	client.DirBlacklist = func(org, repo string) []string {
+		return []string{"src"}
+	}
 
 	ro, err := client.LoadRepoOwners("org", "repo")
 	if err != nil {
@@ -133,6 +135,18 @@ func TestOwnerDirBlacklist(t *testing.T) {
 		if strings.Contains(dir, "src") {
 			t.Errorf("Expected directory %s to be excluded from the reviewers map", dir)
 		}
+	}
+}
+
+func TestOwnerDirBlacklistWithNoFunc(t *testing.T) {
+	client, cleanup, err := getTestClient(testFiles, true, true)
+	if err != nil {
+		t.Fatalf("Error creating test client: %v.", err)
+	}
+	defer cleanup()
+
+	if _, err := client.LoadRepoOwners("org", "repo"); err != nil {
+		t.Fatalf("Unexpected error loading RepoOwners: %v.", err)
 	}
 }
 


### PR DESCRIPTION
- A list of directories to be ignored can be configured on a per repo / org basis.
- A default for all repos, not specifically configured, can be set.
- The fallback, if nothing is configured at all, is the hardcoded setting as it is right now (`.git`, `_output`).

If there is a specific configuration for a repo (`owners_dir_blacklist[repos][org/repo]`) the configuration for the org (`owners_dir_blacklist[repos][org]`) and the global default (`owners_dir_blacklist[default]`) is ignored, the blacklists are not merged. The more specific configuration always "wins".

Prow's `config.yaml` might look something like this:

```yaml
...
owners_dir_blacklist:
  default:
  - ".git"
  - "_output"
  repos:
    kubernetes/repo1:
    - ignore_dir
    - ignore_another_dir
    kubernetes-sig-something:
    - ignore_on_org_if_not_configured_on_repo
...
```

Closes: #5156