### PR TITLE
enable k8s-ci-robot for kube_state_metrics

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -54,6 +54,7 @@ tide:
     - kubernetes/ingress-nginx
     - kubernetes/kops
     - kubernetes/kubernetes-template-project
+    - kubernetes/kube-state-metrics
     - kubernetes/kube-deploy
     - kubernetes/minikube
     - kubernetes/repo-infra

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -49,6 +49,7 @@ approve:
   - kubernetes/kubectl
   - kubernetes/kubernetes
   - kubernetes/kubernetes-template-project
+  - kubernetes/kube-state-metrics
   - kubernetes/minikube
   - kubernetes/repo-infra
   - kubernetes/sig-release
@@ -237,6 +238,10 @@ plugins:
 
   kubernetes/kubernetes-template-project:
   - approve
+
+  kubernetes/kube-state-metrics:
+  - approve
+  - blunderbuss
 
   kubernetes/minikube:
   - approve


### PR DESCRIPTION
Cross fix https://github.com/kubernetes/kube-state-metrics/issues/376

This PR will enable k8s-ci-robot for kube-state-metrics.

/cc @cblecker @brancz 