### PR TITLE
Enable plugins to let K8s bot manage reviews for Kubeflow.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -142,30 +142,22 @@ plugins:
   google/cadvisor:
   - trigger
 
-  kubeflow/examples:
-  - lgtm
-  - size
-  - trigger
-
-  kubeflow/kubeflow:
-  - lgtm
-  - size
-  - trigger
-
-  kubeflow/reporting:
-  - lgtm
-  - size
-  - trigger
-
-  kubeflow/testing:
-  - lgtm
-  - size
-  - trigger
-
-  kubeflow/tf-operator:
-  - lgtm
-  - size
-  - trigger
+  kubeflow:
+    # Enable /approve and /assign commands.
+    - approve
+    - assign
+    - help
+    - hold
+    - label
+    - lgtm
+    # Lets PRs & issues be flagged as stale
+    - lifecycle
+    - size
+    # Allows cleaning up stale commit statuses
+    - skip
+    # Applies a label to PRs with wip in the title to block merge
+    - wip
+    - trigger
 
   kubernetes/charts:
   - approve


### PR DESCRIPTION
* Kubeflow would like to use the K8s bot to assign reviewers and manage PRs.
* So we enable the plugins to support this.
* We enable this for the kubeflow org as opposed to individual repositories
  since we want to apply it to all repositories.

Related to
  kubeflow/community#10