### PR TITLE
Add e2e-node test job for alpha features

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10356,6 +10356,23 @@
       "sig-node"
     ]
   },
+  "ci-kubernetes-node-kubelet-alpha": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml",
+      "--node-test-args=--feature-gates=AllAlpha=true,RotateKubeletServerCertificate=false --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-kubernetes-node-kubelet-benchmark": {
     "args": [
       "--deployment=node",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -573,6 +573,7 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-node-kubelet-stable1': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-stable2': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-stable3': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-alpha': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-beta': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-non-cri-1-6': 'ci-kubernetes-node-kubelet-*',
             # The cri-containerd validation node e2e jobs intentionally share projects.

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14053,6 +14053,23 @@ periodics:
       - name: GOPATH
         value: /go
 
+- name: ci-kubernetes-node-kubelet-alpha
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180305-98b9ccd6e-master
+      args:
+      - --repo=k8s.io/kubernetes=release-1.10
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOPATH
+        value: /go
+
 - name: ci-kubernetes-node-kubelet-benchmark
   interval: 2h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -561,6 +561,13 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-large-deploy
 - name: ci-kubernetes-cross-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-cross-build
+- name: ci-kubernetes-node-kubelet-alpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-alpha
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
 - name: ci-kubernetes-node-kubelet-beta
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-beta
   test_name_config:
@@ -4496,6 +4503,8 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-serial
   - name: kubelet-flaky-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-flaky
+  - name: kubelet-alpha
+    test_group_name: ci-kubernetes-node-kubelet-alpha
   - name: kubelet-conformance-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-conformance
   - name: kubelet-1.9


### PR DESCRIPTION
This feature gate is required for test added in kubernetes/kubernetes#60509. I'm not sure which jobs should be updated, so I guessed.

/area jobs
/sig node