### PR TITLE
set env for kuberentes bazel periodics to fix caching

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6361,6 +6361,12 @@ periodics:
       env:
       - name: TEST_TMPDIR
         value: /root/.cache/bazel
+      # so we can use the right cache id
+      # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
@@ -6585,6 +6591,11 @@ periodics:
       env:
       - name: BAZEL_REMOTE_CACHE_ENABLED
         value: "true"
+      # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
workaround for #7023 in the short term, we might want to keep this anyhow since it's probably less magical than trying to get the directory /baz/foo/bar -> foo/bar in bash anyhow

/area bazel