### PR TITLE
start to seperate lint and unit test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
 build --workspace_status_command=./print-workspace-status.sh
 run --workspace_status_command=./print-workspace-status.sh
 test --features=race --test_output=errors
+
+# you can run only lint tests with:
+# bazel test //... --config=lint
+test:lint --test_tag_filters=lint
+
+# you can run non-lint tests with:
+# bazel test //... --config=unit
+test:unit --test_tag_filters=-lint

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -13,6 +13,7 @@ py_test(
     name = "verify_boilerplate",
     srcs = ["verify_boilerplate.py"],
     data = ["//:all-srcs"],
+    tags = ["lint"],
 )
 
 sh_test(
@@ -22,6 +23,7 @@ sh_test(
         ":pylint_bin",
         "//:all-srcs",
     ],
+    tags = ["lint"],
 )
 
 sh_test(
@@ -32,10 +34,12 @@ sh_test(
         "//:all-srcs",
         "//vendor/github.com/client9/misspell/cmd/misspell",
     ],
+    tags = ["lint"],
 )
 
 test_suite(
     name = "verify-all",
+    tags = ["lint"],
     tests = [
         "verify-pylint",
         "verify_boilerplate",
@@ -45,6 +49,7 @@ test_suite(
 py_binary(
     name = "pylint_bin",
     srcs = ["pylint_bin.py"],
+    tags = ["lint"],
     # NOTE: this should only contain direct third party imports and pylint
     deps = [
         "@influxdb",

--- a/hack/build-then-unit.sh
+++ b/hack/build-then-unit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# used in presubmits / CI testing
+# bazel build then unit test, exiting non-zero if either failed
+
+local res=0
+
+bazel build //...
+if [[ $? -ne 0 ]]; then
+    res=1
+fi
+
+bazel test //... --config=unit
+if [[ $? -ne 0 ]]; then
+    res=1
+fi
+
+exit $res

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4800,8 +4800,6 @@ presubmits:
   - name: pull-test-infra-bazel-canary
     agent: kubernetes
     context: pull-test-infra-bazel-canary
-    branches:
-    - master
     always_run: false
     rerun_command: "/test pull-test-infra-bazel-canary"
     trigger: "(?m)^/test pull-test-infra-bazel-canary,?(\\s+|$)"
@@ -4818,11 +4816,9 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
         - "--" # end bootstrap args, scenario args below
-        - "--build=//..."
-        - "--install=gubernator/test_requirements.txt"
-        - "--test=//..."
-        - "--test-args=--test_output=errors"
+        - "hack/build-then-unit.sh"
         env:
         - name: BAZEL_REMOTE_CACHE_ENABLED
           value: "true"
@@ -4862,6 +4858,42 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+
+  - name: pull-test-infra-lint
+    agent: kubernetes
+    context: pull-test-infra-lint
+    # TODO(bentheelder): set always_run once we've switched over to use --config=unit for the bazel job
+    always_run: false
+    rerun_command: "/test pull-test-infra-lint"
+    trigger: "(?m)^/test pull-test-infra-lint,?(\\s+|$)"
+    labels:
+      preset-service-account: true
+      preset-bazel-scratch-dir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_bazel"
+        - "--" # end bootstrap args, scenario args below
+        - "--install=gubernator/test_requirements.txt"
+        - "--test=//..."
+        - "--test-args=--config=lint"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        resources:
+          requests:
+            memory: "2Gi"
 
   - name: pull-test-infra-verify-bazel
     agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1856,6 +1856,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
   days_of_results: 1
   num_columns_recent: 20
+- name: pull-test-infra-lint
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
+  days_of_results: 1
+  num_columns_recent: 20
 - name: pull-test-infra-gubernator
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-gubernator
   days_of_results: 1
@@ -5076,6 +5080,11 @@ dashboards:
   dashboard_tab:
   - name: bazel
     test_group_name: pull-test-infra-bazel
+    base_options: 'width=10'
+    alerts_options:
+      alert_mail_to_addresses: 'bentheelder+alerts@google.com'
+  - name: lint
+    test_group_name: pull-test-infra-lint
     base_options: 'width=10'
     alerts_options:
       alert_mail_to_addresses: 'bentheelder+alerts@google.com'


### PR DESCRIPTION
`bazel test //...` will still run *all* bazel tests, however now you can run `bazel test //... --config=unit` to ignore our not-quite-hermetic lint tests, and `bazel test //... --config=lint` to only do lint. 

This will let us split these `pull-test-infra-bazel` job into one job with build+unit tests and another that only does lints. The former should be  a 100% cacheable presubmit and I expect this job to take ~one minute after this change. We'll have another job to install python deps and perform linting in ~2 minutes.

xref: #6865 #6808 