### PR TITLE
Don't show BeforeSuite in the dashboard.

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3461,8 +3461,9 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gke-device-plugin-gpu-cri-containerd
+  - name: gce-device-plugin-gpu-cri-containerd
     test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-gpu-1.7


### PR DESCRIPTION
It only shows up when there's failure, so we keep getting alerted for no reason.
It was suggested that if we don't show this in the dashboard, then we won't be alerted.
Trying it on one suite to see if that's correct.