### PR TITLE
Run `git config` after `git init` in clonerefs

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -39,13 +39,13 @@ func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 		},
 	}
 
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "init"))
 	if gitUserName != "" {
 		commands = append(commands, shellCloneCommand(cloneDir, "git", "config", "user.name", gitUserName))
 	}
 	if gitUserEmail != "" {
 		commands = append(commands, shellCloneCommand(cloneDir, "git", "config", "user.email", gitUserEmail))
 	}
-	commands = append(commands, shellCloneCommand(cloneDir, "git", "init"))
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, refs.BaseRef))
 
 	var checkout string


### PR DESCRIPTION
In the cases where `clonerefs` was creating a new directory to clone
source into, it would try to configure the git repository before
initializing it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @kargakis 