### PR TITLE
rename confusingly named integration testing job

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -36,7 +36,7 @@ jobs:
   - pull-kubernetes-e2e-gce
   - pull-kubernetes-e2e-gce-device-plugin-gpu
   - pull-kubernetes-e2e-kops-aws
+  - pull-kubernetes-integration
   - pull-kubernetes-kubemark-e2e-gce
   - pull-kubernetes-node-e2e
-  - pull-kubernetes-unit
   - pull-kubernetes-verify

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11362,6 +11362,26 @@
       "sig-cluster-lifecycle"
     ]
   },
+  "pull-kubernetes-integration": {
+    "args": [
+      "--branch=${PULL_BASE_REF}",
+      "--prow"
+    ],
+    "scenario": "kubernetes_verify",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
+  "pull-kubernetes-integration-prow": {
+    "args": [
+      "--branch=${PULL_BASE_REF}",
+      "--prow"
+    ],
+    "scenario": "kubernetes_verify",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-kubernetes-kubemark-e2e-gce": {
     "args": [
       "--build=bazel",
@@ -11476,26 +11496,6 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
-    ]
-  },
-  "pull-kubernetes-unit": {
-    "args": [
-      "--branch=${PULL_BASE_REF}",
-      "--prow"
-    ],
-    "scenario": "kubernetes_verify",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
-  "pull-kubernetes-unit-prow": {
-    "args": [
-      "--branch=${PULL_BASE_REF}",
-      "--prow"
-    ],
-    "scenario": "kubernetes_verify",
-    "sigOwners": [
-      "sig-testing"
     ]
   },
   "pull-kubernetes-verify": {

--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -20,9 +20,9 @@ required-retest-contexts: "\
   pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
+  pull-kubernetes-integration,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\
-  pull-kubernetes-unit,\
   pull-kubernetes-verify"
 
 # munger specific options.

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -18,9 +18,9 @@ required-retest-contexts: "\
   pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
+  pull-kubernetes-integration,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\
-  pull-kubernetes-unit,\
   pull-kubernetes-verify"
 
 # submit-queue options. Keep job lists sorted!

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2103,6 +2103,87 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-kubernetes-integration
+    agent: kubernetes
+    always_run: true
+    context: pull-kubernetes-integration
+    rerun_command: "/test pull-kubernetes-integration"
+    trigger: "(?m)^/test( all| pull-kubernetes-integration),?(\\s+|$)"
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=60"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-integration-prow
+    agent: kubernetes
+    always_run: false
+    context: pull-kubernetes-integration-prow
+    rerun_command: "/test pull-kubernetes-integration-prow"
+    trigger: "(?m)^/test pull-kubernetes-integration-prow,?(\\s+|$)"
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:latest
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=60"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
@@ -2643,87 +2724,6 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-kubernetes-unit
-    agent: kubernetes
-    always_run: true
-    context: pull-kubernetes-unit
-    rerun_command: "/test pull-kubernetes-unit"
-    trigger: "(?m)^/test( all| pull-kubernetes-unit),?(\\s+|$)"
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
-        args:
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=60"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: docker-graph
-          mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            cpu: 4
-      volumes:
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
-  - name: pull-kubernetes-unit-prow
-    agent: kubernetes
-    always_run: false
-    context: pull-kubernetes-unit-prow
-    rerun_command: "/test pull-kubernetes-unit-prow"
-    trigger: "(?m)^/test pull-kubernetes-unit-prow,?(\\s+|$)"
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:latest
-        imagePullPolicy: Always
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=60"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: true
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        - name: docker-graph
-          mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-        resources:
-          requests:
-            cpu: 4
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-      - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
   - name: pull-kubernetes-verify
     agent: kubernetes
     always_run: true
@@ -4046,6 +4046,95 @@ presubmits:
   - agent: kubernetes
     always_run: true
     cluster: security
+    context: pull-security-kubernetes-integration
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-integration
+    rerun_command: /test pull-security-kubernetes-integration
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=60
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+        - mountPath: /docker-graph
+          name: auto-generated-docker-graph-volume-mount
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+      - emptyDir: {}
+        name: auto-generated-docker-graph-volume-mount
+    trigger: (?m)^/test( all| pull-security-kubernetes-integration),?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-integration-prow
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-integration-prow
+    rerun_command: /test pull-security-kubernetes-integration-prow
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=60
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        image: gcr.io/k8s-testimages/bootstrap:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+        - mountPath: /docker-graph
+          name: auto-generated-docker-graph-volume-mount
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+      - emptyDir: {}
+        name: auto-generated-docker-graph-volume-mount
+    trigger: (?m)^/test pull-security-kubernetes-integration-prow,?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
     labels:
       preset-k8s-ssh: "true"
@@ -4567,95 +4656,6 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\s+|$)
-  - agent: kubernetes
-    always_run: true
-    cluster: security
-    context: pull-security-kubernetes-unit
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 0
-    name: pull-security-kubernetes-unit
-    rerun_command: /test pull-security-kubernetes-unit
-    run_if_changed: ""
-    skip_report: false
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --clean
-        - --job=$(JOB_NAME)
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=60
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
-        name: ""
-        resources:
-          requests:
-            cpu: "4"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-        - mountPath: /docker-graph
-          name: auto-generated-docker-graph-volume-mount
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-      - emptyDir: {}
-        name: auto-generated-docker-graph-volume-mount
-    trigger: (?m)^/test( all| pull-security-kubernetes-unit),?(\s+|$)
-  - agent: kubernetes
-    always_run: false
-    cluster: security
-    context: pull-security-kubernetes-unit-prow
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 0
-    name: pull-security-kubernetes-unit-prow
-    rerun_command: /test pull-security-kubernetes-unit-prow
-    run_if_changed: ""
-    skip_report: false
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --clean
-        - --job=$(JOB_NAME)
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=60
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: "4"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-        - mountPath: /docker-graph
-          name: auto-generated-docker-graph-volume-mount
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-      - emptyDir: {}
-        name: auto-generated-docker-graph-volume-mount
-    trigger: (?m)^/test pull-security-kubernetes-unit-prow,?(\s+|$)
   - agent: kubernetes
     always_run: true
     cluster: security

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1849,14 +1849,14 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
-- name: pull-kubernetes-unit
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-unit
+- name: pull-kubernetes-integration
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-integration
   days_of_results: 1
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
-- name: pull-kubernetes-unit-prow
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-unit-prow
+- name: pull-kubernetes-integration-prow
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-integration-prow
   days_of_results: 1
   num_columns_recent: 20
   alert_stale_results_hours: 24
@@ -4683,8 +4683,8 @@ dashboards:
     test_group_name: pull-kubernetes-bazel-test-integration-canary
   - name: pull-kubernetes-verify-prow
     test_group_name: pull-kubernetes-verify-prow
-  - name: pull-kubernetes-unit-prow
-    test_group_name: pull-kubernetes-unit-prow
+  - name: pull-kubernetes-integration-prow
+    test_group_name: pull-kubernetes-integration-prow
   - name: pull-kubernetes-cross-prow
     test_group_name: pull-kubernetes-cross-prow
 
@@ -5125,8 +5125,8 @@ dashboards:
     base_options: 'width=10'
     alert_options:
       alert_mail_to_addresses: 'michelle.192837+alerts@gmail.com, lusensjtu+alerts@gmail.com'
-  - name: pull-kubernetes-unit
-    test_group_name: pull-kubernetes-unit
+  - name: pull-kubernetes-integration
+    test_group_name: pull-kubernetes-integration
     base_options: 'width=10'
     alert_options:
       alert_mail_to_addresses: 'michelle.192837+alerts@gmail.com, lusensjtu+alerts@gmail.com'


### PR DESCRIPTION
the CI equivalent was already renamed
/hold
Next steps:
- update the submit-queue and misc-mungers deployments
- run migratestatus