### PR TITLE
add typecheck presubmit

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -39,4 +39,5 @@ jobs:
   - pull-kubernetes-integration
   - pull-kubernetes-kubemark-e2e-gce
   - pull-kubernetes-node-e2e
+  - pull-kubernetes-typecheck
   - pull-kubernetes-verify

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11498,6 +11498,15 @@
       "sig-node"
     ]
   },
+  "pull-kubernetes-typecheck": {
+    "args": [
+      "hack/verify-typecheck.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-kubernetes-verify": {
     "args": [
       "--branch=${PULL_BASE_REF}",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2724,6 +2724,29 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-kubernetes-typecheck
+    agent: kubernetes
+    always_run: true
+    skip_report: true
+    context: pull-kubernetes-typecheck
+    rerun_command: "/test pull-kubernetes-typecheck"
+    trigger: "(?m)^/test( all| pull-kubernetes-typecheck),?(\\s+|$)"
+    branches:
+    - master
+    - release-1.10
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180226-a50c3d6d9-master
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+
   - name: pull-kubernetes-verify
     agent: kubernetes
     always_run: true
@@ -2799,7 +2822,6 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
-
   kubernetes-security/kubernetes:
   - agent: kubernetes
     always_run: true
@@ -4656,6 +4678,42 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    - release-1.10
+    cluster: security
+    context: pull-security-kubernetes-typecheck
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-typecheck
+    rerun_command: /test pull-security-kubernetes-typecheck
+    run_if_changed: ""
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180226-a50c3d6d9-master
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-typecheck),?(\s+|$)
   - agent: kubernetes
     always_run: true
     cluster: security

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1873,6 +1873,12 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
+- name: pull-kubernetes-typecheck
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-typecheck
+  days_of_results: 1
+  num_columns_recent: 20
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 10
 - name: pull-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel
   days_of_results: 1
@@ -5158,6 +5164,9 @@ dashboards:
     base_options: 'width=10'
   - name: pull-kubernetes-kubemark-e2e-gce-scale
     test_group_name: pull-kubernetes-kubemark-e2e-gce-scale
+    base_options: 'width=10'
+  - name: pull-kubernetes-typecheck
+    test_group_name: pull-kubernetes-typecheck
     base_options: 'width=10'
 
 - name: presubmits-test-infra


### PR DESCRIPTION
adds a new silent / non-blocking presubmit for https://github.com/kubernetes/kubernetes/pull/59289

TODO (follow up): 
- we should make this non-silent once the things it would have caught are patched again :/
- we should consider having many of our build-based scenarios first run this tool with `--cross=false` to typecheck in ~20s and fail out quickly instead of spinning up docker / bazel etc for the builds and then failing.