### PR TITLE
make push-build.sh path configurable

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -130,7 +130,7 @@ def main(args):
         check('make', 'quick-release')
     else:
         check('make', 'release')
-    check('../release/push-build.sh', *push_build_args)
+    check(args.push_build_script, *push_build_args)
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(
@@ -155,5 +155,7 @@ if __name__ == '__main__':
         '--extra-publish-file', help='Additional version file uploads to')
     PARSER.add_argument(
         '--allow-dup', action='store_true', help='Allow overwriting if the build exists on gcs')
+    PARSER.add_argument(
+        '--push-build-script', default='../release/push-build.sh', help='location of push-build.sh')
     ARGS = PARSER.parse_args()
     main(ARGS)


### PR DESCRIPTION
kubernetes can be from a different org, while we always use k8s.io/release for push-build - just make the location of push-build.sh configurable

/area scenarios
/assign @BenTheElder @ixdy 