### PR TITLE
publish ci/latest-bazel builds

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5348,6 +5348,9 @@ postsubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
+        - "--gcs=gs://kubernetes-release-dev/ci"
+        - "--version-suffix=-bazel"
+        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt"
         env:
         - name: BAZEL_REMOTE_CACHE_ENABLED
           value: "true"
@@ -5406,6 +5409,9 @@ postsubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
+        - "--gcs=gs://kubernetes-release-dev/ci"
+        - "--version-suffix=-bazel"
+        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.10.txt"
         env:
         - name: BAZEL_REMOTE_CACHE_ENABLED
           value: "true"
@@ -5432,6 +5438,9 @@ postsubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
+        - "--gcs=gs://kubernetes-release-dev/ci"
+        - "--version-suffix=-bazel"
+        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.7.txt"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5529,6 +5538,9 @@ postsubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
+        - "--gcs=gs://kubernetes-release-dev/ci"
+        - "--version-suffix=-bazel"
+        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.8.txt"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5653,6 +5665,9 @@ postsubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
+        - "--gcs=gs://kubernetes-release-dev/ci"
+        - "--version-suffix=-bazel"
+        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.9.txt"
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -200,6 +200,8 @@ def main(args):
             res = 1
         else:
             try:
+                if args.version_suffix:
+                    version += args.version_suffix
                 gcs_build = '%s/%s' % (args.gcs, version)
                 bazel.check('run', '//:push-build', '--', gcs_build)
                 # log push-build location to path child jobs can find
@@ -208,6 +210,8 @@ def main(args):
                 gcs_shared = os.path.join(args.gcs_shared, pull_refs, 'bazel-build-location.txt')
                 if pull_refs:
                     upload_string(gcs_shared, gcs_build)
+                if args.publish_version:
+                    upload_string(args.publish_version, version)
             except subprocess.CalledProcessError as exp:
                 res = exp.returncode
 
@@ -241,6 +245,10 @@ def create_parser():
         default="gs://kubernetes-jenkins/shared-results/",
         help='If $PULL_REFS is set push build location to this bucket')
     parser.add_argument(
+        '--publish-version',
+        help='publish GCS file here with the build version, like ci/latest.txt',
+    )
+    parser.add_argument(
         '--test', help='Bazel test target patterns, split by one space')
     parser.add_argument(
         '--manual-test',
@@ -252,6 +260,9 @@ def create_parser():
         '--gcs',
         default='gs://kubernetes-release-dev/bazel',
         help='GCS path for where to push build')
+    parser.add_argument(
+        '--version-suffix',
+        help='version suffix for build pushing')
     parser.add_argument(
         '--batch', action='store_true', help='run Bazel in batch mode')
     return parser


### PR DESCRIPTION
- update `kubernetes_bazel` to allow uploading build with a version suffix
- update `kubernetes_bazel` to support publishing a version pointer to GCS like ci/latest-bazel.txt
- update bazel CI jobs (periodics) to do this
