### PR TITLE
Split autoscaling e2e jobs and organize dashboard tabs.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4531,6 +4531,7 @@
   "ci-kubernetes-e2e-gci-gce-autoscaling": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=ca",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling.env",
       "--extract=ci/latest",
@@ -4539,7 +4540,25 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--runtime-config=scheduling.k8s.io/v1alpha1=true",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\]|\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-autoscaling"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gce-autoscaling-hpa": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=hpa",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-jkns-gci-autoscaling",
+      "--gcp-zone=us-central1-c",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
@@ -4550,6 +4569,7 @@
   "ci-kubernetes-e2e-gci-gce-autoscaling-migs": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=ca",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env",
       "--extract=ci/latest",
@@ -4558,7 +4578,25 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--runtime-config=scheduling.k8s.io/v1alpha1=true",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-autoscaling"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=hpa",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-jkns-gci-autoscaling-migs",
+      "--gcp-zone=us-central1-c",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
@@ -5007,7 +5045,7 @@
   "ci-kubernetes-e2e-gci-gke-autoscaling": {
     "args": [
       "--check-leaked-resources",
-      "--cluster=",
+      "--cluster=ca",
       "--deployment=gke",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -5016,7 +5054,27 @@
       "--gcp-zone=us-central1-f",
       "--gke-environment=test",
       "--provider=gke",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:ClusterSizeAutoscalingScaleWithNAP\\]|\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:ClusterSizeAutoscalingScaleWithNAP\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=420m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-autoscaling"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gke-autoscaling-hpa": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=hpa",
+      "--deployment=gke",
+      "--extract=ci/latest",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-e2e-gci-gke-autoscaling",
+      "--gcp-zone=us-central1-c",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:CustomMetricsAutoscaling\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--timeout=420m"
     ],
     "scenario": "kubernetes_e2e",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -577,6 +577,10 @@ class JobTest(unittest.TestCase):
             # ingress-GCE e2e jobs
             'pull-ingress-gce-e2e': 'e2e-ingress-gce',
             'ci-ingress-gce-e2e': 'e2e-ingress-gce',
+            # sig-autoscaling jobs intentionally share projetcs
+            'ci-kubernetes-e2e-gci-gce-autoscaling-hpa':'ci-kubernetes-e2e-gci-gce-autoscaling',
+            'ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa':'ci-kubernetes-e2e-gci-gce-autoscaling-migs',
+            'ci-kubernetes-e2e-gci-gke-autoscaling-hpa':'ci-kubernetes-e2e-gci-gke-autoscaling',
         }
         for soak_prefix in [
                 'ci-kubernetes-soak-gce-1.5',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9433,7 +9433,33 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=350
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180226-a50c3d6d9-master
+
+- interval: 30m
+  agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=350
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180226-a50c3d6d9-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
   labels:
     preset-service-account: true
     preset-k8s-ssh: true
@@ -9772,6 +9798,19 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-autoscaling
+  labels:
+    preset-gke-alpha-service: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=440
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180226-a50c3d6d9-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
   labels:
     preset-gke-alpha-service: true
     preset-k8s-ssh: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -222,6 +222,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling
 - name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling-migs
+- name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling-hpa
+- name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
 - name: ci-kubernetes-e2e-autoscaling-vpa-recommender
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-autoscaling-vpa-recommender
 - name: ci-kubernetes-e2e-autoscaling-vpa-updater
@@ -375,6 +379,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling
 - name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling-regional
+- name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling-hpa
 - name: ci-kubernetes-e2e-gke-stackdriver
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-stackdriver
 - name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
@@ -3623,7 +3629,7 @@ dashboards:
     description: Presumbit tests for Minigo.
     test_group_name: tf-minigo-presubmit
 
-- name: sig-autoscaling
+- name: sig-autoscaling-cluster-autoscaler
   dashboard_tab:
   - name: gci-gce-autoscaling
     test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling
@@ -3639,6 +3645,18 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling
   - name: gke-ubuntustable1-k8sstable2-autoscaling
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-autoscaling
+
+- name: sig-autoscaling-hpa
+  dashboard_tab:
+  - name: gci-gce-autoscaling-hpa
+    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
+  - name: gci-gce-autoscaling-migs-hpa
+    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
+  - name: gci-gke-autoscaling-hpa
+    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
+
+- name: sig-autoscaling-vpa
+  dashboard_tab:
   - name: autoscaling-vpa-recommender
     test_group_name: ci-kubernetes-e2e-autoscaling-vpa-recommender
   - name: autoscaling-vpa-updater
@@ -5272,3 +5290,9 @@ dashboard_groups:
   - sig-gcp-release-1.8
   - sig-gcp-release-1.7
   - sig-gcp-ubuntu
+
+- name: sig-autoscaling
+  dashboard_names:
+    - sig-autoscaling-cluster-autoscaler
+    - sig-autoscaling-hpa
+    - sig-autoscaling-vpa


### PR DESCRIPTION
We are currently often close to hitting time limits when running autoscaling tests. We want to split the tests into three functionally disjoint sets:
1. Cluster autoscaling tests
2. Horizontal pod autoscaling tests
3. Vertical pod autoscaling tests

This is done firstly by splitting jobs that ran tests from more than one of these sets and secondly organizing the sig-autoscaling dashboard into three tabs (ca, hpa, vpa).