### PR TITLE
 initupload pushes latest-build.txt for every job 

### DIFF
--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -85,13 +85,15 @@ the different types of jobs:
 
 ```
 .
-├── logs                 # periodic and postsubmit jobs live here
-│   └── other_job_name   # contains all the builds of a job
-│       └── build_number # contains job artifacts, as above
+├── logs                    # periodic and postsubmit jobs live here
+│   └── other_job_name      # contains all the builds of a job
+│      ├── build_number     # contains job artifacts, as above
+│      └── latest-build.txt # contains the latest build id of a job
 └── pr-logs
     ├── directory                # symlinks for builds live here
     │   └── job_name             # contains all symlinks for a job
-    │       └── build_number.txt # contains one line: location of artifacts for the build
+    │       ├── build_number.txt # contains one line: location of artifacts for the build
+    │       └── latest-build.txt # contains the latest build id of a job
     └── pull
         ├── batch                # batch jobs live here
         │   └── job_name         # contains all the builds of a job

--- a/prow/pod-utils/gcs/options.go
+++ b/prow/pod-utils/gcs/options.go
@@ -144,6 +144,10 @@ func (o *Options) Run(extra map[string]UploadFunc) error {
 		uploadTargets[alias] = DataUpload(strings.NewReader(jobBasePath))
 	}
 
+	if latestBuild := LatestBuildForSpec(spec); latestBuild != "" {
+		uploadTargets[latestBuild] = DataUpload(strings.NewReader(spec.BuildId))
+	}
+
 	for _, item := range o.Items {
 		info, err := os.Stat(item)
 		if err != nil {

--- a/prow/pod-utils/gcs/target.go
+++ b/prow/pod-utils/gcs/target.go
@@ -56,6 +56,20 @@ func AliasForSpec(spec *pjutil.JobSpec) string {
 	return ""
 }
 
+// LatestBuildForSpec determines the GCS path for storing the latest
+// build id for a job.
+func LatestBuildForSpec(spec *pjutil.JobSpec) string {
+	switch spec.Type {
+	case kube.PeriodicJob, kube.PostsubmitJob:
+		return path.Join("logs", spec.Job, "latest-build.txt")
+	case kube.PresubmitJob, kube.BatchJob:
+		return path.Join("pr-logs", "directory", spec.Job, "latest-build.txt")
+	default:
+		logrus.Errorf("unknown job spec type: %v", spec.Type)
+	}
+	return ""
+}
+
 // RepoPathBuilder builds GCS path segments and embeds defaulting behavior
 type RepoPathBuilder func(org, repo string) string
 

--- a/prow/pod-utils/gcs/target_test.go
+++ b/prow/pod-utils/gcs/target_test.go
@@ -160,6 +160,41 @@ func TestAliasForSpec(t *testing.T) {
 	}
 }
 
+func TestLatestBuildForSpec(t *testing.T) {
+	testCases := []struct {
+		name     string
+		spec     *pjutil.JobSpec
+		expected string
+	}{
+		{
+			name:     "presubmit",
+			spec:     &pjutil.JobSpec{Type: kube.PresubmitJob, Job: "pull-kubernetes-unit"},
+			expected: "pr-logs/directory/pull-kubernetes-unit/latest-build.txt",
+		},
+		{
+			name:     "batch",
+			spec:     &pjutil.JobSpec{Type: kube.BatchJob, Job: "pull-kubernetes-unit"},
+			expected: "pr-logs/directory/pull-kubernetes-unit/latest-build.txt",
+		},
+		{
+			name:     "postsubmit",
+			spec:     &pjutil.JobSpec{Type: kube.PostsubmitJob, Job: "ci-kubernetes-unit"},
+			expected: "logs/ci-kubernetes-unit/latest-build.txt",
+		},
+		{
+			name:     "periodic",
+			spec:     &pjutil.JobSpec{Type: kube.PeriodicJob, Job: "ci-kubernetes-periodic"},
+			expected: "logs/ci-kubernetes-periodic/latest-build.txt",
+		},
+	}
+
+	for _, test := range testCases {
+		if expected, actual := test.expected, LatestBuildForSpec(test.spec); expected != actual {
+			t.Errorf("%s: expected alias %q but got %q", test.name, expected, actual)
+		}
+	}
+}
+
 func TestNewLegacyRepoPathBuilder(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Updates `initupload` to push `latest-build.txt` for every job in
its top-level GCS directory based on its type and the documented
GCS layout.

I am not familiar with the layout that Gubernator expects, let me
know if this is the correct one to follow.

Ref https://github.com/kubernetes/test-infra/issues/7056

/area prow

/cc @stevekuznetsov @rmmh @BenTheElder 

