### PR TITLE
Enable ALLOW_PRIVILEGED for ci-kubernetes-local-e2e job

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -74,8 +74,12 @@ func (n localCluster) Up() error {
 
 	cmd := exec.Command(script)
 	cmd.Env = os.Environ()
+
 	cmd.Env = append(cmd.Env, "ENABLE_DAEMON=true")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("LOG_DIR=%s", n.tempDir))
+
+	// Needed for at least one conformance e2e test. Please see issue #59978
+	cmd.Env = append(cmd.Env, "ALLOW_PRIVILEGED=true")
 
 	// when we are running in a DIND scenario, we should use the ip address of
 	// the docker0 network interface, This ensures that when the pods come up


### PR DESCRIPTION
"HostPath should give a volume the correct mode" e2e test needs
support for privileged containers to pass conformance tests. This is
not ideal, but the current consensus (see 59978) is to leave the
situation as-is.

See https://github.com/kubernetes/kubernetes/issues/59978 for more discussion