### PR TITLE
 tot uses prow config to determine fallback GCS path 

### DIFF
--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -50,6 +50,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/cmd/tot/fallbackcheck:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -23,7 +23,9 @@ go_binary(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    data = ["//prow:configs"],
     embed = [":go_default_library"],
+    deps = ["//prow/config:go_default_library"],
 )
 
 go_library(
@@ -31,7 +33,10 @@ go_library(
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//prow/pod-utils/gcs:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/cmd/tot/fallbackcheck/BUILD.bazel
+++ b/prow/cmd/tot/fallbackcheck/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/tot/fallbackcheck",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//prow/pod-utils/gcs:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "fallbackcheck",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/tot/fallbackcheck/main.go
+++ b/prow/cmd/tot/fallbackcheck/main.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// fallbackcheck reports whether jobs in the provided prow
+// deployment have fallback build numbers in GCS.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/pod-utils/gcs"
+)
+
+type options struct {
+	prowURL string
+	bucket  string
+}
+
+func gatherOptions() options {
+	o := options{}
+
+	// TODO: Support reading from a local file.
+	flag.StringVar(&o.prowURL, "prow-url", "", "Prow frontend URL.")
+	flag.StringVar(&o.bucket, "bucket", "", "Top-level GCS bucket where job artifacts are pushed.")
+
+	flag.Parse()
+	return o
+}
+
+func (o *options) Validate() error {
+	if o.prowURL == "" {
+		return errors.New("you need to provide a URL to a live prow deployment")
+	}
+	if o.bucket == "" {
+		return errors.New("you need to provide the GCS bucket where all job artifacts are pushed")
+	}
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	// TODO: Retries
+	resp, err := http.Get(o.prowURL + "/config")
+	if err != nil {
+		logrus.Fatalf("cannot get prow config: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		logrus.Fatalf("status code not 2XX: %v", resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Fatalf("cannot read request body: %v", err)
+	}
+
+	cfg := &config.Config{}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		logrus.Fatalf("cannot unmarshal data from prow: %v", err)
+	}
+
+	var notFound bool
+	for _, pre := range cfg.AllPresubmits(nil) {
+		spec := pjutil.PresubmitToJobSpec(pre)
+		nf, err := getJobFallbackNumber(o.bucket, spec)
+		if err != nil {
+			logrus.Fatalf("cannot get fallback number: %v", err)
+		}
+		notFound = notFound || nf
+	}
+	for _, post := range cfg.AllPostsubmits(nil) {
+		spec := pjutil.PostsubmitToJobSpec(post)
+		nf, err := getJobFallbackNumber(o.bucket, spec)
+		if err != nil {
+			logrus.Fatalf("cannot get fallback number: %v", err)
+		}
+		notFound = notFound || nf
+	}
+
+	for _, per := range cfg.AllPeriodics() {
+		spec := pjutil.PeriodicToJobSpec(per)
+		nf, err := getJobFallbackNumber(o.bucket, spec)
+		if err != nil {
+			logrus.Fatalf("cannot get fallback number: %v", err)
+		}
+		notFound = notFound || nf
+	}
+
+	if notFound {
+		os.Exit(1)
+	}
+}
+
+func getJobFallbackNumber(bucket string, spec *pjutil.JobSpec) (bool, error) {
+	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(bucket, "/"), gcs.LatestBuildForSpec(spec))
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		fmt.Printf("OK: %s\n", spec.Job)
+		return false, nil
+	case http.StatusNotFound:
+		fmt.Printf("NOT FOUND: %s\n", spec.Job)
+		return true, nil
+	default:
+		return false, fmt.Errorf("unexpected status for %s: %v", spec.Job, resp.Status)
+	}
+}

--- a/prow/pjutil/jobspec.go
+++ b/prow/pjutil/jobspec.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -58,6 +59,36 @@ func NewJobSpec(spec kube.ProwJobSpec, buildId, prowJobId string) JobSpec {
 		ProwJobId: prowJobId,
 		Refs:      spec.Refs,
 		agent:     spec.Agent,
+	}
+}
+
+// PresubmitToJobSpec generates a JobSpec out of a Presubmit.
+// Useful for figuring out GCS paths when parsing jobs out
+// of a prow config.
+func PresubmitToJobSpec(pre config.Presubmit) *JobSpec {
+	return &JobSpec{
+		Type: kube.PresubmitJob,
+		Job:  pre.Name,
+	}
+}
+
+// PostsubmitToJobSpec generates a JobSpec out of a Postsubmit.
+// Useful for figuring out GCS paths when parsing jobs out
+// of a prow config.
+func PostsubmitToJobSpec(post config.Postsubmit) *JobSpec {
+	return &JobSpec{
+		Type: kube.PostsubmitJob,
+		Job:  post.Name,
+	}
+}
+
+// PeriodicToJobSpec generates a JobSpec out of a Periodic.
+// Useful for figuring out GCS paths when parsing jobs out
+// of a prow config.
+func PeriodicToJobSpec(periodic config.Periodic) *JobSpec {
+	return &JobSpec{
+		Type: kube.PeriodicJob,
+		Job:  periodic.Name,
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/7056

I also wrote a cli tool that checks all the expected GCS paths that need to exist given a live prow deployment and a GCS bucket.

/cc @stevekuznetsov @rmmh @BenTheElder 
/area prow