### PR TITLE
Setup blunderbuss and tide for Kubeflow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -42,6 +42,21 @@ branch-protection:
 tide:
   queries:
   - repos:
+    - kubeflow/community
+    - kubeflow/examples
+    - kubeflow/kubeflow
+    - kubeflow/testing
+    - kubeflow/tf-operator
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+  - repos:
     - kubernetes/charts
     - kubernetes/cluster-registry
     - kubernetes/community
@@ -102,6 +117,7 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
   merge_method:
+    kubeflow: squash
     kubernetes/charts: squash
     kubernetes/dashboard: squash
     kubernetes/website: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -147,6 +147,7 @@ plugins:
     # Enable /approve and /assign commands.
     - approve
     - assign
+    - blunderbuss
     - help
     - hold
     - label


### PR DESCRIPTION
*  We want to use blunderbuss to start assigning reviewers
* We want to use tide to start automerging approved PRs.

Related to kubeflow/community#19
Related to kubeflow/community#20