### PR TITLE
Security repo: disable bazel remote cache

### DIFF
--- a/maintenance/fixconfig/main.go
+++ b/maintenance/fixconfig/main.go
@@ -139,8 +139,12 @@ func stripCache(j *config.Presubmit) {
 	// filter cache related env
 	filteredEnv := []kube.EnvVar{}
 	for _, env := range container.Env {
-		// don't keep bazel cache directory env
+		// don't keep bazel *local* cache directory env
+		// TODO(bentheelder): we can probably allow this env in certain cases
 		if env.Name == "TEST_TMPDIR" {
+			continue
+		}
+		if env.Name == "BAZEL_REMOTE_CACHE_ENABLED" {
 			continue
 		}
 		filteredEnv = append(filteredEnv, env)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3127,9 +3127,6 @@ presubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build-canary
         - --gcs-shared=gs://kubernetes-security-prow/bazel
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         name: ""
@@ -3180,9 +3177,6 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180228-dabde9ed5-master
         name: ""
         resources:
@@ -3312,9 +3306,6 @@ presubmits:
         - --
         - make
         - bazel-test
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         name: ""
@@ -3355,9 +3346,6 @@ presubmits:
         - --
         - --test=//test/integration/...
         - --test-args=--config=integration
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
this *should* be fine either way, but it's probably best to explicitly not-enable this for the security repo

/area jobs