### PR TITLE
Add a success message to GCS upload code

### DIFF
--- a/prow/pod-utils/gcs/options.go
+++ b/prow/pod-utils/gcs/options.go
@@ -182,6 +182,7 @@ func (o *Options) Run(extra map[string]UploadFunc) error {
 		}
 	}
 
+	logrus.Info("Finished upload to GCS")
 	return nil
 }
 

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -40,12 +40,13 @@ func Upload(bucket *storage.BucketHandle, uploadTargets map[string]UploadFunc) e
 	for dest, upload := range uploadTargets {
 		obj := bucket.Object(dest)
 		logrus.WithField("dest", dest).Info("Queued for upload")
-		go func(f UploadFunc, obj *storage.ObjectHandle) {
+		go func(f UploadFunc, obj *storage.ObjectHandle, name string) {
 			defer group.Done()
 			if err := f(obj); err != nil {
 				errCh <- err
 			}
-		}(upload, obj)
+			logrus.WithField("dest", name).Info("Finished upload")
+		}(upload, obj, dest)
 	}
 	group.Wait()
 	close(errCh)


### PR DESCRIPTION
It's hard to tell that the program finished successfully as we only have
logging on the beginning of uploads, not the end. This adds logging to
the end of uploads.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind enhancement
/cc @kargakis 
/assign @BenTheElder 