### PR TITLE
add missing ginkgo skips to 1.7-1.8 upgrade

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7457,7 +7457,7 @@
       "--gke-environment=staging",
       "--provider=gke",
       "--skew",
-      "--test_args=--ginkgo.skip=Initializers|Dashboard",
+      "--test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
     ],
@@ -7478,7 +7478,7 @@
       "--gcp-zone=us-central1-f",
       "--gke-environment=staging",
       "--provider=gke",
-      "--test_args=--ginkgo.skip=Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
     ],


### PR DESCRIPTION
issue here in https://k8s-testgrid.appspot.com/google-gke-staging#gke-staging-1-7-1-8-upgrade-master:

https://github.com/kubernetes/test-infra/pull/6925 adds a new ginkgo.skip to the suites, however, we have a default ginkgo.skip set to `\[Flaky\\]|\\[Feature:.+\\]`, this overwrites the default, and start to run unexpected tests after upgrade happens.

/assign @caesarxuchao 