### PR TITLE
Fix broken milestone munger

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -62,7 +62,7 @@ const (
 )
 
 var (
-	releaseMilestoneRE = regexp.MustCompile(`^v[\d]+.[\d]$`)
+	releaseMilestoneRE = regexp.MustCompile(`^v[\d]+.[\d]+$`)
 	priorityLabelRE    = regexp.MustCompile(`priority/[pP]([\d]+)`)
 	fixesIssueRE       = regexp.MustCompile(`(?i)(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[\s]+#([\d]+)`)
 	reviewableFooterRE = regexp.MustCompile(`(?s)<!-- Reviewable:start -->.*<!-- Reviewable:end -->`)

--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -289,13 +289,8 @@ func dayPhrase(days int) string {
 	return fmt.Sprintf("%d %s", days, dayString)
 }
 
-func durationToMinDays(duration time.Duration) string {
-	days := int(math.Floor(duration.Hours() / 24))
-	return dayPhrase(days)
-}
-
 func durationToMaxDays(duration time.Duration) string {
-	days := int(math.Floor(duration.Hours() / 24))
+	days := int(math.Ceil(duration.Hours() / 24))
 	return dayPhrase(days)
 }
 

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -41,7 +41,7 @@ const milestoneTestBotName = "test-bot"
 //
 // TODO(marun) Enable testing of comment deletion
 func TestMilestoneMaintainer(t *testing.T) {
-	activeMilestone := "v1.8"
+	activeMilestone := "v1.10"
 	milestone := &githubapi.Milestone{Title: &activeMilestone, Number: intPtr(1)}
 	m := MilestoneMaintainer{
 		milestoneModeMap:    map[string]string{activeMilestone: milestoneModeDev},
@@ -116,7 +116,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 @user @kubernetes/sig-foo-misc
 
 
-**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 3 days, the issue will be moved out of the v1.8 milestone.
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 3 days, the issue will be moved out of the v1.10 milestone.
 <details>
 <summary>Issue Labels</summary>
 

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -116,7 +116,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 @user @kubernetes/sig-foo-misc
 
 
-**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 2 days, the issue will be moved out of the v1.8 milestone.
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 3 days, the issue will be moved out of the v1.8 milestone.
 <details>
 <summary>Issue Labels</summary>
 
@@ -205,7 +205,7 @@ _**sig owner**_: Must specify at least one label prefixed with ` + "`sig/`." + `
 			expectedSections: sets.NewString("warnIncompleteLabels"),
 			expectedState:    milestoneNeedsLabeling,
 			expectedBody: `
-**Action required**: This issue requires label changes. If the required changes are not made within 2 days, the issue will be moved out of the v1.8 milestone.
+**Action required**: This issue requires label changes. If the required changes are not made within 3 days, the issue will be moved out of the v1.8 milestone.
 ` + incompleteLabels,
 		},
 		"Incomplete labels outside of grace period": {
@@ -246,7 +246,7 @@ _**sig owner**_: Must specify at least one label prefixed with ` + "`sig/`." + `
 			expectedSections: sets.NewString("summarizeLabels", "warnUnapproved"),
 			expectedState:    milestoneNeedsApproval,
 			expectedBody: `
-**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 6 days, the issue will be moved out of the v1.8 milestone.
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 7 days, the issue will be moved out of the v1.8 milestone.
 <details>` + nonBlockerCompleteLabels,
 		},
 		"Complete labels, not approved, non-blocker, outside of grace period": {


### PR DESCRIPTION
2 for 1: 
- Fix release milestone regex to support vx+.x+ (e.g. v1.10) instead of just vx+.x
- Use Ceil instead of Floor to compute days (e.g. grace period of 3 days should appear as 3 days instead of 2 in comments)

cc: @jdumars @jberkus 

Fixes: #7080