### PR TITLE
flip timestamp and age hover

### DIFF
--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -171,7 +171,7 @@ window.onload = function () {
     setInterval(() => {
         timeCells.forEach(timeCell => {
             var origin = parseInt(timeCell.getAttribute("data-time"));
-            timeCell.textContent = moment.unix(origin).fromNow();
+            timeCell.textContent = moment.unix(origin).toString();
         }, 60000);
     });
 };
@@ -492,15 +492,15 @@ function createTimeCell(id, time) {
     var momentTime = moment.unix(time);
     var tid = "time-cell-" + id;
     var main = document.createElement("div");
-    var localTime = momentTime.fromNow();
-    main.textContent = localTime;
+    var age = momentTime.fromNow();
+    var timeString = momentTime.toString();
+    main.textContent = timeString;
     main.id = tid;
     main.setAttribute("data-time", time);
     main.classList.add("time-cell");
 
-    var utcTime = momentTime.toString();
     var tooltip = document.createElement("div");
-    tooltip.textContent = utcTime;
+    tooltip.textContent = age;
     tooltip.setAttribute("data-mdl-for", tid);
     tooltip.classList.add("mdl-tooltip");
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/917931/36877886-4b4ed716-1d71-11e8-8e96-370d70e44544.png)

This is a bit wider, but tabs can get stale and I can't copy the timestamp from hover, so I swapped the hover behavior to show the age instead. In the future we should consider if we want to keep the age up to date / lazily compute it when users hover.

/area prow