### PR TITLE
Configure Deck to refresh tide data every 1 second (was 10s).

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9,6 +9,7 @@ sinker:
   max_pod_age: 30m
 
 deck:
+  tide_update_period: 1s
   hidden_repos:
   - kubernetes-security
   - GoogleCloudPlatform/k8s-tpu-operator


### PR DESCRIPTION
fixes #7087 
/cc @BenTheElder 
/kind velocity-improvement
/area prow