### PR TITLE
append gs:// to gcs path

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -65,7 +65,8 @@ def check_build_exists(gcs, suffix):
 
     if version:
         if not gcs:
-            gcs = 'gs://kubernetes-release-dev'
+            gcs = 'kubernetes-release-dev'
+        gcs = 'gs://' + gcs
         mode = 'ci'
         if suffix:
             mode += suffix


### PR DESCRIPTION
```
W0302 03:39:00.203] Run: ('gsutil', 'ls', 'kubernetes-release-gke-internal/ci/v1.11.0-alpha.0.821+b79fe107301790')
W0302 03:39:02.141] gcs path kubernetes-release-gke-internal/ci/v1.11.0-alpha.0.821+b79fe107301790 does not exist yet, continue
```

`--release` flag does not include `gs://`

/shrug
/assign @BenTheElder 