### PR TITLE
Fix SetMilestone Github client function.

### DIFF
--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180302-5519b614a
+        image: gcr.io/k8s-prow/hook:v20180302-cadaa0672
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180302-5519b614a
+        image: gcr.io/k8s-prow/hook:v20180302-cadaa0672
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1580,12 +1580,14 @@ func (c *Client) ClearMilestone(org, repo string, num int) error {
 func (c *Client) SetMilestone(org, repo string, issueNum, milestoneNum int) error {
 	c.log("SetMilestone", org, repo, issueNum, milestoneNum)
 
-	m := &Issue{Milestone: Milestone{Number: milestoneNum}}
+	issue := &struct {
+		Milestone int `json:"milestone"`
+	}{Milestone: milestoneNum}
 
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("%s/repos/%v/%v/issues/%d", c.base, org, repo, issueNum),
-		requestBody: &m,
+		requestBody: &issue,
 		exitCodes:   []int{200},
 	}, nil)
 	return err

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1364,11 +1364,17 @@ func TestSetMilestone(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not read request body: %v", err)
 		}
-		var issue Issue
+		var issue struct {
+			Milestone *int `json:"milestone,omitempty"`
+		}
 		if err := json.Unmarshal(b, &issue); err != nil {
-			t.Errorf("Could not unmarshal request: %v", err)
-		} else if issue.Milestone.Number != newMilestone {
-			t.Errorf("Milestone not set %d.  Instead set to: %d", newMilestone, issue.Milestone.Number)
+			t.Fatalf("Could not unmarshal request: %v", err)
+		}
+		if issue.Milestone == nil {
+			t.Fatal("Milestone was not set.")
+		}
+		if *issue.Milestone != newMilestone {
+			t.Errorf("Expected milestone to be set to %d, but got %d.", newMilestone, *issue.Milestone)
 		}
 	}))
 	defer ts.Close()


### PR DESCRIPTION
The SetMilestone Github client function was sending an entire Milestone struct in the `milestone` field when it should have been sending just an integer.
https://developer.github.com/v3/issues/#edit-an-issue

/area prow
/kind bug
/cc @grodrigues3 @BenTheElder @liggitt  
/hold