### PR TITLE
Fix typecheck to output to _artifacts/ instead of artifacts/

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11625,7 +11625,7 @@
       "make",
       "verify",
       "WHAT=typecheck",
-      "KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts"
+      "KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts"
     ],
     "scenario": "execute",
     "sigOwners": [


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/60519/pull-kubernetes-typecheck/368/build-log.txt

has the line: "W0302 21:46:51.968] Missing local artifacts : /workspace/_artifacts"

/shrug