### PR TITLE
bump deck to v20180302-949b16f57

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180302-0064877cc
+        image: gcr.io/k8s-prow/deck:v20180302-949b16f57
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -220,7 +220,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180302-0064877cc
+        image: gcr.io/k8s-prow/deck:v20180302-949b16f57
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:


### PR DESCRIPTION
picks up fixes to the timestamp display, which is currently outright wrong for the minutes

/area prow