### PR TITLE
Only run milestone plugins on k/k

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -226,6 +226,8 @@ plugins:
   - blockade
   - blunderbuss
   - docs-no-retest
+  - milestone
+  - milestonestatus
   - release-note
   - require-sig
   - trigger
@@ -270,8 +272,6 @@ plugins:
   - label
   - lgtm
   - lifecycle
-  - milestone
-  - milestonestatus
   - shrug
   - sigmention
   - size


### PR DESCRIPTION
The milestone process doesn't apply right now outside of kubernetes/kubernetes, and we haven't communicated org wide about turning on new features. As such, this pulls them out of the org-wide config, and scopes them to just k/k.

cc: @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort @kubernetes/sig-testing-misc @kubernetes/sig-release-members 