### PR TITLE
It is UTF-8 not utf8

### DIFF
--- a/hack/coalesce.py
+++ b/hack/coalesce.py
@@ -66,7 +66,7 @@ def result(pkg):
                 if status.tag == 'error' or status.tag == 'failure':
                     failure = ET.Element('failure')
                     with open(pkg + '/test.log') as fp:
-                        text = fp.read().decode('utf8', 'ignore')
+                        text = fp.read().decode('UTF-8', 'ignore')
                         failure.text = sanitize(text)
                     elem.append(failure)
     return elem
@@ -84,7 +84,7 @@ def main():
     except OSError:
         pass
     with open(os.path.join(artifacts_dir, 'junit_bazel.xml'), 'w') as fp:
-        fp.write(ET.tostring(root, 'utf8'))
+        fp.write(ET.tostring(root, 'UTF-8'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per https://stackoverflow.com/a/809643

And Golang [does not know](https://golang.org/pkg/encoding/xml/#Decoder) how to unmarshal "utf8" xml documents:
```
The parser assumes that its input is encoded in UTF-8.
...
// CharsetReader, if non-nil, defines a function to generate
        // charset-conversion readers, converting from the provided
        // non-UTF-8 charset into UTF-8. If CharsetReader is nil or
        // returns an error, parsing stops with an error. 
```