### PR TITLE
No need to --stage builds from pull-kubernetes-local-e2e

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11593,7 +11593,6 @@
       "--deployment=local",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-local-e2e",
       "--test_args=--ginkgo.focus=\\[Conformance\\]",
       "--timeout=120m"
     ],

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -328,21 +328,21 @@ class JobTest(unittest.TestCase):
                     extracts = [a for a in args if '--extract=' in a]
                     shared_builds = [a for a in args if '--use-shared-build' in a]
                     node_e2e = [a for a in args if '--deployment=node' in a]
+                    local_e2e = [a for a in args if '--deployment=local' in a]
                     builds = [a for a in args if '--build' in a]
-                    stages = [a for a in args if '--stage' in a]
                     if shared_builds and extracts:
                         self.fail(('e2e jobs cannot have --use-shared-build'
                                    ' and --extract: %s %s') % (job, args))
                     elif not extracts and not shared_builds and not node_e2e:
                         # we should at least have --build and --stage
-                        if not builds or not stages:
+                        if not builds:
                             self.fail(('e2e job needs --extract or'
                                        ' --use-shared-build or'
-                                       ' --build/--stage: %s %s') % (job, args))
+                                       ' --build: %s %s') % (job, args))
 
                     if shared_builds or node_e2e:
                         expected = 0
-                    elif builds and stages and not extracts:
+                    elif builds and not extracts:
                         expected = 0
                     elif 'ingress' in job:
                         expected = 1
@@ -372,7 +372,7 @@ class JobTest(unittest.TestCase):
                         self.fail('--image-family and --image-project must be'
                                   'both set or unset: %s' % job)
 
-                    if job.startswith('pull-kubernetes-') and not node_e2e:
+                    if job.startswith('pull-kubernetes-') and not node_e2e and not local_e2e:
                         if 'gke' in job:
                             stage = 'gs://kubernetes-release-dev/ci'
                             suffix = True


### PR DESCRIPTION
We do not need to push builds from job to a staging area. We are building stuff to just use in this job.