### PR TITLE
Ensure that GCS alias files contain full GCS paths

### DIFF
--- a/prow/pod-utils/gcs/options.go
+++ b/prow/pod-utils/gcs/options.go
@@ -141,7 +141,8 @@ func (o *Options) Run(extra map[string]UploadFunc) error {
 	// ensure that an alias exists for any
 	// job we're uploading artifacts for
 	if alias := AliasForSpec(spec); alias != "" {
-		uploadTargets[alias] = DataUpload(strings.NewReader(jobBasePath))
+		fullBasePath := "gs://" + path.Join(o.GcsBucket, jobBasePath)
+		uploadTargets[alias] = DataUpload(strings.NewReader(fullBasePath))
 	}
 
 	if latestBuild := LatestBuildForSpec(spec); latestBuild != "" {


### PR DESCRIPTION
The GCS alias files we use as "symlinks" need to contain the full GCS
path including the bucket name.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @BenTheElder @kargakis @smarterclayton 
/assign @kargakis @smarterclayton 