### PR TITLE
Bump Tide to v20180305-a0d0c9688.

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180302-0064877cc
+        image: gcr.io/k8s-prow/tide:v20180305-a0d0c9688
         args:
         - --dry-run=false
         ports:


### PR DESCRIPTION
This will roll out the fix to make Tide serve valid JSON to deck again.
bump for #7112 
/cc @BenTheElder 
/hold