### PR TITLE
Fix milestone plugin comment formatting.

### DIFF
--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -34,7 +34,7 @@ import (
 const pluginName = "milestone"
 
 var (
-	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+)$`)
+	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
 	mustBeSigLead    = "You must be a member of the [%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	clearKeyword     = "clear"

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -19,9 +19,10 @@ limitations under the License.
 package milestone
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -35,7 +36,7 @@ const pluginName = "milestone"
 var (
 	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+)$`)
 	mustBeSigLead    = "You must be a member of the [%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone."
-	invalidMilestone = "The provided milestone is not valid for this repository.  Here are the available milestones:\n %s"
+	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	clearKeyword     = "clear"
 )
 
@@ -125,12 +126,13 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, m
 	milestoneMap := buildMilestoneMap(milestones)
 	milestoneNumber, ok := milestoneMap[proposedMilestone]
 	if !ok {
-		var buffer bytes.Buffer
-		buffer.WriteString("\t 1." + clearKeyword + "\n")
+		slice := make([]string, 0, len(milestoneMap))
 		for k := range milestoneMap {
-			buffer.WriteString("\t 1." + k + "\n")
+			slice = append(slice, fmt.Sprintf("`%s`", k))
 		}
-		msg := fmt.Sprintf(invalidMilestone, buffer.String())
+		sort.Strings(slice)
+
+		msg := fmt.Sprintf(invalidMilestone, strings.Join(slice, ", "), clearKeyword)
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
 	}
 

--- a/prow/plugins/milestone/milestone_test.go
+++ b/prow/plugins/milestone/milestone_test.go
@@ -89,6 +89,13 @@ func TestMilestoneStatus(t *testing.T) {
 			previousMilestone: 10,
 			expectedMilestone: 10,
 		},
+		{
+			name:              "Multiline comment",
+			body:              "Foo\n/milestone v1.0\r\n/priority critical-urgent",
+			commenter:         "sig-lead",
+			previousMilestone: 10,
+			expectedMilestone: 1,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
fixes #7130 
The list is now sorted and uses bullets instead of a numbered list. The `/milestone clear` command is  listed separately at the end instead of suggesting that `clear` is a valid milestone.

The comment should now look like:
> @cjwagner: The provided milestone is not valid for this repository. Milestones in this repository:
> - next-candidate
> - v1.10
> - v1.11
> - v1.4
> - v1.5
> - v1.6
> - v1.7
> - v1.8
> - v1.9
>
> Use `/milestone clear` to clear the milestone.
> 
> <details>
> 
> In response to [this](https://github.com/kubernetes/test-infra/pull/947#issuecomment-262693732):
> 
> >/milestone foo
> 
> 
> Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/devel/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
> </details>


/cc @krzyzacy @grodrigues3 