### PR TITLE
Revert "Make large scale tests manual temporarily"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4757,8 +4757,6 @@ presubmits:
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --timeout=140
-        - --
-        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-local-e2e
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
@@ -8952,7 +8950,7 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180301-32170552d-master
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- cron: '1 6 * * 2,4,6' # Run at 22:01PST on Mon,Wed,Fri (06:01 UTC Tue,Thur,Sat)
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-large-correctness
   labels:
@@ -8997,7 +8995,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- cron: '1 13 * * 2,4,6' # Run at 5:01PST (13:01 UTC) on even days
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-large-performance
   tags:
@@ -9213,7 +9211,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- cron: '1 22 * * 2,4,6' # Run at 14:01PST (22:01 UTC) on even days
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-scale-correctness
   labels:
@@ -9230,7 +9228,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- cron: '1 8 * * 1,3,5' # Run at 00:01PST (8:01 UTC) on odd days (except sunday)
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:


### PR DESCRIPTION
Reverts kubernetes/test-infra#7131

As that change doesn't seem needed for manual scale-testing.