### PR TITLE
fix kubeadm ci path logic

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -143,11 +143,12 @@ func initializeKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, er
 
 	kubeletVersion := *kubernetesAnywhereKubeletVersion
 	if *kubernetesAnywhereKubeletCIVersion != "" {
+		// resolvedVersion is EG v1.11.0-alpha.0.1031+d37460147ec956-bazel
 		resolvedVersion, err := resolveCIVersion(*kubernetesAnywhereKubeletCIVersion)
 		if err != nil {
 			return nil, err
 		}
-		kubeletVersion = bazelBuildPath(resolvedVersion)
+		kubeletVersion = fmt.Sprintf("gs://kubernetes-release-dev/ci/%v/bin/linux/amd64/", resolvedVersion)
 	}
 
 	// preserve backwards compatibility for e2e tests which never provided cni name
@@ -201,22 +202,8 @@ func newKubernetesAnywhere(project, zone string) (deployer, error) {
 }
 
 func resolveCIVersion(version string) (string, error) {
-	if strings.HasPrefix(version, "v") {
-		return version, nil
-	}
 	file := fmt.Sprintf("gs://kubernetes-release-dev/ci/%v.txt", version)
 	return readGSFile(file)
-}
-
-func bazelBuildPath(version string) string {
-	// This replicates the logic from scenarios/kubernetes_e2e.py, to
-	// accommodate the fact that bazel artifacts are stored in a different
-	// location for 1.6 builds.
-	if strings.HasPrefix(version, "v1.6.") {
-		return fmt.Sprintf("gs://kubernetes-release-dev/bazel/%v/build/debs/", version)
-	} else {
-		return fmt.Sprintf("gs://kubernetes-release-dev/bazel/%v/bin/linux/amd64/", version)
-	}
 }
 
 // Implemented as a function var for testing.

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -88,55 +88,27 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 			name:              "kubeadm with ci kubelet version",
 			phase2:            "kubeadm",
 			kubeadmVersion:    "unstable",
-			kubeletCIVersion:  "vfoo",
-			kubernetesVersion: "latest-1.6",
+			kubeletCIVersion:  "latest-bazel",
+			kubernetesVersion: "latest-bazel",
 			expectConfigLines: []string{
 				".phase2.provider=\"kubeadm\"",
 				".phase2.kubeadm.version=\"unstable\"",
-				".phase2.kubernetes_version=\"latest-1.6\"",
-				".phase2.kubelet_version=\"gs://kubernetes-release-dev/bazel/vfoo/bin/linux/amd64/\"",
+				".phase2.kubernetes_version=\"latest-bazel\"",
+				".phase2.kubelet_version=\"gs://kubernetes-release-dev/ci/v1.11.0-alpha.0.1031+d37460147ec956-bazel/bin/linux/amd64/\"",
 				".phase3.cni=\"weave\"",
 			},
 		},
 		{
-			name:              "kubeadm with ci kubelet version",
+			name:              "kubeadm with 1.9 ci kubelet version",
 			phase2:            "kubeadm",
 			kubeadmVersion:    "unstable",
-			kubeletCIVersion:  "latest",
-			kubernetesVersion: "latest-1.6",
+			kubeletCIVersion:  "latest-bazel-1.9",
+			kubernetesVersion: "latest-bazel-1.9",
 			expectConfigLines: []string{
 				".phase2.provider=\"kubeadm\"",
 				".phase2.kubeadm.version=\"unstable\"",
-				".phase2.kubernetes_version=\"latest-1.6\"",
-				".phase2.kubelet_version=\"gs://kubernetes-release-dev/bazel/vbar/bin/linux/amd64/\"",
-				".phase3.cni=\"weave\"",
-			},
-		},
-		{
-			name:              "kubeadm with 1.6 ci kubelet version",
-			phase2:            "kubeadm",
-			kubeadmVersion:    "unstable",
-			kubeletCIVersion:  "latest-1.6",
-			kubernetesVersion: "latest-1.6",
-			expectConfigLines: []string{
-				".phase2.provider=\"kubeadm\"",
-				".phase2.kubeadm.version=\"unstable\"",
-				".phase2.kubernetes_version=\"latest-1.6\"",
-				".phase2.kubelet_version=\"gs://kubernetes-release-dev/bazel/v1.6.12-beta.0.2+a03873b40780a3/build/debs/\"",
-				".phase3.cni=\"weave\"",
-			},
-		},
-		{
-			name:              "kubeadm with 1.7 ci kubelet version",
-			phase2:            "kubeadm",
-			kubeadmVersion:    "unstable",
-			kubeletCIVersion:  "latest-1.7",
-			kubernetesVersion: "latest-1.7",
-			expectConfigLines: []string{
-				".phase2.provider=\"kubeadm\"",
-				".phase2.kubeadm.version=\"unstable\"",
-				".phase2.kubernetes_version=\"latest-1.7\"",
-				".phase2.kubelet_version=\"gs://kubernetes-release-dev/bazel/v1.7.8-beta.0.22+9243a03f5fecc5/bin/linux/amd64/\"",
+				".phase2.kubernetes_version=\"latest-bazel-1.9\"",
+				".phase2.kubelet_version=\"gs://kubernetes-release-dev/ci/v1.9.4-beta.0.53+326c7c181909a8-bazel/bin/linux/amd64/\"",
 				".phase3.cni=\"weave\"",
 			},
 		},
@@ -192,8 +164,8 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 	}
 
 	mockGSFiles := map[string]string{
-		"gs://kubernetes-release-dev/ci/latest-1.6.txt": "v1.6.12-beta.0.2+a03873b40780a3",
-		"gs://kubernetes-release-dev/ci/latest-1.7.txt": "v1.7.8-beta.0.22+9243a03f5fecc5",
+		"gs://kubernetes-release-dev/ci/latest-bazel.txt":     "v1.11.0-alpha.0.1031+d37460147ec956-bazel",
+		"gs://kubernetes-release-dev/ci/latest-bazel-1.9.txt": "v1.9.4-beta.0.53+326c7c181909a8-bazel",
 	}
 
 	originalReadGSFile := readGSFile

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -137,7 +137,7 @@ def kubeadm_version(mode, shared_build_gcs_path):
         version = status.group(1)
 
         # The path given here should match ci-kubernetes-bazel-build
-        return 'gs://kubernetes-release-dev/%s-bazel/bin/linux/amd64/' % version
+        return 'gs://kubernetes-release-dev/ci/%s-bazel/bin/linux/amd64/' % version
 
     elif mode == 'pull':
         # The format of shared_build_gcs_path looks like:

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -136,14 +136,8 @@ def kubeadm_version(mode, shared_build_gcs_path):
             raise ValueError('STABLE_BUILD_SCM_REVISION not found')
         version = status.group(1)
 
-        # Work-around for release-1.6 jobs, which still upload debs to an older
-        # location (without os/arch prefixes).
-        # TODO(pipejakob): remove this when we no longer support 1.6.x.
-        if version.startswith('v1.6.'):
-            return 'gs://kubernetes-release-dev/bazel/%s/build/debs/' % version
-
-        # The path given here should match jobs/ci-kubernetes-bazel-build.sh
-        return 'gs://kubernetes-release-dev/bazel/%s/bin/linux/amd64/' % version
+        # The path given here should match ci-kubernetes-bazel-build
+        return 'gs://kubernetes-release-dev/%s-bazel/bin/linux/amd64/' % version
 
     elif mode == 'pull':
         # The format of shared_build_gcs_path looks like:

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -274,7 +274,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
                 kubernetes_e2e.main(args)
 
         self.assertNotIn('E2E_OPT', self.envs)
-        version = 'gs://kubernetes-release-dev/bazel/v1.7.0-alpha.0.1320+599539dc0b9997/bin/linux/amd64/'  # pylint: disable=line-too-long
+        version = 'gs://kubernetes-release-dev/ci/v1.7.0-alpha.0.1320+599539dc0b9997-bazel/bin/linux/amd64/'  # pylint: disable=line-too-long
         self.assertIn('--kubernetes-anywhere-kubeadm-version=%s' % version, self.callstack[-1])
         called = False
         for call in self.callstack:
@@ -315,25 +315,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
                 kubernetes_e2e.main(args)
 
         self.assertNotIn('E2E_OPT', self.envs)
-        version = 'gs://kubernetes-release-dev/bazel/v1.7.0-alpha.0.1320+599539dc0b9997/bin/linux/amd64/'  # pylint: disable=line-too-long
-        self.assertIn('--kubernetes-anywhere-kubeadm-version=%s' % version, self.callstack[-1])
-        called = False
-        for call in self.callstack:
-            self.assertFalse(call.startswith('docker'))
-            if call == 'hack/print-workspace-status.sh':
-                called = True
-        self.assertTrue(called)
-
-    def test_kubeadm_periodic_v1_6(self):
-        """Make sure kubeadm periodic mode has correct version on v1.6"""
-        args = kubernetes_e2e.parse_args(['--kubeadm=periodic'])
-        self.assertEqual(args.kubeadm, 'periodic')
-        with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
-            with Stub(kubernetes_e2e, 'check_output', self.fake_output_work_status_v1_6):
-                kubernetes_e2e.main(args)
-
-        self.assertNotIn('E2E_OPT', self.envs)
-        version = 'gs://kubernetes-release-dev/bazel/v1.6.4-beta.0.18+84febd4537dd19/build/debs/'
+        version = 'gs://kubernetes-release-dev/ci/v1.7.0-alpha.0.1320+599539dc0b9997-bazel/bin/linux/amd64/'  # pylint: disable=line-too-long
         self.assertIn('--kubernetes-anywhere-kubeadm-version=%s' % version, self.callstack[-1])
         called = False
         for call in self.callstack:


### PR DESCRIPTION
- drop dead 1.6 support
- correct some paths in kubetest and kubernetes_e2e.py related to kubernetes anywhere / kubeadm

Note CI bazel builds are now at EG:
```
$ gsutil cat gs://kubernetes-release-dev/ci/latest-bazel.txt
v1.11.0-alpha.0.1031+d37460147ec956-bazel
```
Fixing presubmits will come separately. We'll also need to bump kubetest and we should reconfigure all of the jobs to use the `latest-bazel(-release1.x)?` tags as well as no `run_after_success`.