### PR TITLE
Istio Test Command in Gubernator to Avoid `hack/e2e.go`

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -94,6 +94,8 @@ def do_testcmd(name):
             logging.error('Unexpected Go unit test name %r', name)
             return name
         return 'go test -v %s -run %s$' % (pkg, name)
+    elif name.startswith('istio.io/'):
+        return ''
     elif name.startswith('//'):
         return 'bazel test %s' % name
     else:


### PR DESCRIPTION
Istio now has junit results on Prow. It shows command like `go run hack/e2e.go -v --test --test_args=‘--ginkgo.focus=istio\.io\/istio\/pilot\/pkg\/config\/kube\/crd\sTestControllerCacheFreshness$` under each failed test case, which is a message that does not apply to istio. This PR aims to reduce the confusion of istio dev on this test command by handling istio case explicitly. 

Istio now relies on complicated makefiles to trigger testing. Due to the crazy amount of flags and envs that are not available from the function generating the test cmd, I rephrase the message with a reference to the makefile. 

Fixes https://github.com/istio/istio/issues/3982