### PR TITLE
let 1.10 kubelet job run more often

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13912,7 +13912,7 @@ periodics:
         value: /go
 
 - name: ci-kubernetes-node-kubelet-beta
-  interval: 48h
+  interval: 1h
   agent: kubernetes
   labels:
     preset-service-account: true


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/sig-release-1.10-blocking#kubelet-1.10
looks flaky and I forgot to reset the interval

/assign @BenTheElder 