### PR TITLE
Add validation for repo sync config in clonerefs

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -46,4 +47,5 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/cmd/clonerefs/main_test.go
+++ b/prow/cmd/clonerefs/main_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"k8s.io/test-infra/prow/kube"
+)
 
 func TestOptions_Validate(t *testing.T) {
 	var testCases = []struct {
@@ -43,6 +47,42 @@ func TestOptions_Validate(t *testing.T) {
 			name: "missing log location",
 			input: options{
 				srcRoot: "test",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "separate repos",
+			input: options{
+				srcRoot: "test",
+				log:     "thing",
+				refs: gitRefs{gitRefs: []kube.Refs{
+					{
+						Repo: "repo1",
+						Org:  "org1",
+					},
+					{
+						Repo: "repo2",
+						Org:  "org2",
+					},
+				}},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "duplicate repos",
+			input: options{
+				srcRoot: "test",
+				log:     "thing",
+				refs: gitRefs{gitRefs: []kube.Refs{
+					{
+						Repo: "repo",
+						Org:  "org",
+					},
+					{
+						Repo: "repo",
+						Org:  "org",
+					},
+				}},
 			},
 			expectedErr: true,
 		},


### PR DESCRIPTION
Multiple `--repo` flags should not give conflicting or overlapping
instructions for what to sync, and `--repo` flags should not overlap
with the Prow-provided `$JOB_SPEC`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @kargakis 
/assign @BenTheElder 
fixes https://github.com/kubernetes/test-infra/issues/7036