### PR TITLE
Set hairpin mode to hairpin-veth for ipvs tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4793,6 +4793,7 @@
     "args": [
       "--check-leaked-resources",
       "--env=KUBE_PROXY_MODE=ipvs",
+      "--env=HAIRPIN_MODE=hairpin-veth",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",


### PR DESCRIPTION
This will help determine how many test failures are caused by the ebtables rules.