### PR TITLE
Introduce a test job for Core DNS.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4662,7 +4662,7 @@
       "--ginkgo-parallel=1",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=320m"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4650,6 +4650,25 @@
       "sig-autoscaling"
     ]
   },
+  "ci-kubernetes-e2e-gci-gce-coredns": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:latest",
+      "--env=CLUSTER_DNS_CORE_DNS=true",
+      "--extract=ci/latest",
+      "--gcp-project-type=ingress-project",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=1",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce-es-logging": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9823,6 +9823,19 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180305-98b9ccd6e-master
 
+- interval: 60m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-coredns
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180305-98b9ccd6e-master
+
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-es-logging

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -317,6 +317,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ip-alias
 - name: ci-kubernetes-e2e-gci-gce-ipvs
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ipvs
+- name: ci-kubernetes-e2e-gci-gce-coredns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-coredns
 - name: ci-kubernetes-e2e-gce-alpha-api
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
@@ -4117,6 +4119,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-ipvs
     base_options: 'include-filter-by-regex=\[sig-network\]'
     description: 'network gci-gce e2e tests in ipvs proxier mode'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-coredns
+    test_group_name: ci-kubernetes-e2e-gci-gce-coredns
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gce tests with CoreDNS'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gce-alpha-api


### PR DESCRIPTION
This job will run all e2e tests with the cluster DNS set to CoreDNS rather than kube-dns

The testgrid will display the results for the sig-network tests

/assign @krzyzacy 