### PR TITLE
Make bootstrap keep git ssh config for the duration of testing.

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -821,7 +821,7 @@ def gubernator_uri(paths):
 
 
 @contextlib.contextmanager
-def choose_ssh_key(ssh):
+def configure_ssh_key(ssh):
     """Creates a script for GIT_SSH that uses -i ssh if set."""
     if not ssh:  # Nothing to do
         yield
@@ -867,21 +867,20 @@ def setup_root(call, root, repos, ssh, git_cache, clean):
     # under the sun assumes $GOPATH/src/k8s.io/kubernetes so... :(
     # after this method is called we've already computed the upload paths
     # etc. so we can just swap it out for the desired path on disk
-    with choose_ssh_key(ssh):
-        for repo, (branch, pull) in repos.items():
-            os.chdir(root_dir)
-            # for k-s/k these are different, for the rest they are the same
-            # TODO(bentheelder,cjwagner,stevekuznetsov): in the integrated
-            # prow checkout support remapping checkouts and kill this monstrosity
-            repo_path = repo
-            if repo == "github.com/kubernetes-security/kubernetes":
-                repo_path = "k8s.io/kubernetes"
-            logging.info(
-                'Checkout: %s %s to %s',
-                os.path.join(root_dir, repo),
-                pull and pull or branch,
-                os.path.join(root_dir, repo_path))
-            checkout(call, repo, repo_path, branch, pull, ssh, git_cache, clean)
+    for repo, (branch, pull) in repos.items():
+        os.chdir(root_dir)
+        # for k-s/k these are different, for the rest they are the same
+        # TODO(bentheelder,cjwagner,stevekuznetsov): in the integrated
+        # prow checkout support remapping checkouts and kill this monstrosity
+        repo_path = repo
+        if repo == "github.com/kubernetes-security/kubernetes":
+            repo_path = "k8s.io/kubernetes"
+        logging.info(
+            'Checkout: %s %s to %s',
+            os.path.join(root_dir, repo),
+            pull and pull or branch,
+            os.path.join(root_dir, repo_path))
+        checkout(call, repo, repo_path, branch, pull, ssh, git_cache, clean)
     # switch out the main repo for the actual path on disk if we are k-s/k
     # from this point forward this is the path we want to use for everything
     if repos.main == "github.com/kubernetes-security/kubernetes":
@@ -977,24 +976,25 @@ def bootstrap(args):
     exc_type = None
 
     try:
-        setup_root(call, args.root, repos, args.ssh, args.git_cache, args.clean)
-        logging.info('Configure environment...')
-        if repos:
-            version = find_version(call)
-        else:
-            version = ''
-        setup_magic_environment(job)
-        setup_credentials(call, args.service_account, upload)
-        logging.info('Start %s at %s...', build, version)
-        if upload:
-            start(gsutil, paths, started, node(), version, repos)
-        success = False
-        try:
-            call(job_script(job, args.scenario, args.extra_job_args))
-            logging.info('PASS: %s', job)
-            success = True
-        except subprocess.CalledProcessError:
-            logging.error('FAIL: %s', job)
+        with configure_ssh_key(args.ssh):
+            setup_root(call, args.root, repos, args.ssh, args.git_cache, args.clean)
+            logging.info('Configure environment...')
+            if repos:
+                version = find_version(call)
+            else:
+                version = ''
+            setup_magic_environment(job)
+            setup_credentials(call, args.service_account, upload)
+            logging.info('Start %s at %s...', build, version)
+            if upload:
+                start(gsutil, paths, started, node(), version, repos)
+            success = False
+            try:
+                call(job_script(job, args.scenario, args.extra_job_args))
+                logging.info('PASS: %s', job)
+                success = True
+            except subprocess.CalledProcessError:
+                logging.error('FAIL: %s', job)
     except Exception:  # pylint: disable=broad-except
         exc_type, exc_value, exc_traceback = sys.exc_info()
         logging.exception('unexpected error')

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -283,19 +283,19 @@ class PullRefsTest(unittest.TestCase):
         )
 
 
-class ChooseSshKeyTest(unittest.TestCase):
-    """Tests for choose_ssh_key()."""
+class ConfigureSshKeyTest(unittest.TestCase):
+    """Tests for configure_ssh_key()."""
     def test_empty(self):
         """Do not change environ if no ssh key."""
         fake_env = {}
         with Stub(os, 'environ', fake_env):
-            with bootstrap.choose_ssh_key(''):
+            with bootstrap.configure_ssh_key(''):
                 self.assertFalse(fake_env)
 
     def test_full(self):
         fake_env = {}
         with Stub(os, 'environ', fake_env):
-            with bootstrap.choose_ssh_key('hello there'):
+            with bootstrap.configure_ssh_key('hello there'):
                 self.assertIn('GIT_SSH', fake_env)
                 with open(fake_env['GIT_SSH']) as fp:
                     buf = fp.read()
@@ -308,7 +308,7 @@ class ChooseSshKeyTest(unittest.TestCase):
         fake_env = {'GIT_SSH': 'random-value'}
         old_env = dict(fake_env)
         with Stub(os, 'environ', fake_env):
-            with bootstrap.choose_ssh_key('hello there'):
+            with bootstrap.configure_ssh_key('hello there'):
                 self.assertNotEqual(old_env, fake_env)
             self.assertEquals(old_env, fake_env)
 


### PR DESCRIPTION
Previously, bootstrap configured ssh for git only while checking out repos and then restored the git config to its previous state before running the tests. This PR removes the logic that restores the git config so that git remains configured to use the ssh key for the duration of the actual test. This will provide support for things like bazel dependencies on private Github repositories.

This change doesn't affect the secrecy of the ssh key. It is already available to the actual tests because the bootstrap script runs in the same container as the tests. This just makes it so that the jobs don't have to reconfigure the ssh key themselves after bootstrap already has.

The only existing jobs this should affect are the security repo jobs and the 2 jobs for GoogleCloudPlatform/k8s-tpu-operator so this should be fine to merge directly if we keep an eye on those jobs.

cc @adrcunha
/cc @BenTheElder @krzyzacy 
