### PR TITLE
ci job refactoring

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9174,6 +9174,27 @@
       "sig-network"
     ]
   },
+  "ci-kubernetes-e2e-kubeadm-gce-selfhosting": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-bazel",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=ci",
+      "--kubernetes-anywhere-dump-cluster-logs=true",
+      "--kubernetes-anywhere-kubeadm-feature-gates=SelfHosting=true",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-kubeadm-gce-stable-on-master": {
     "args": [
       "--cluster=",
@@ -9187,6 +9208,75 @@
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=release/latest-1.8",
+      "--extract=ci/latest-bazel-1.7",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.7",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.7",
+      "--kubernetes-anywhere-upgrade-method=upgrade",
+      "--provider=kubernetes-anywhere",
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.8"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=release/latest-1.9",
+      "--extract=ci/latest-bazel-1.8",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.8",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.8",
+      "--kubernetes-anywhere-upgrade-method=upgrade",
+      "--provider=kubernetes-anywhere",
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.9"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=release/latest-1.10",
+      "--extract=ci/latest-bazel-1.9",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.9",
+      "--kubernetes-anywhere-upgrade-method=upgrade",
+      "--provider=kubernetes-anywhere",
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.10"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -10878,172 +10968,6 @@
       "./tests/e2e/pinned_releases.sh"
     ],
     "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-1-10": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-bazel-1.10",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=ci",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.10",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-1-7": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-bazel-1.7",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.7",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.7",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-1-8": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-bazel-1.8",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.8",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.8",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-1-9": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-bazel-1.9",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=ci",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.9",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-selfhosting": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-bazel",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=ci",
-      "--kubernetes-anywhere-dump-cluster-logs=true",
-      "--kubernetes-anywhere-kubeadm-feature-gates=SelfHosting=true",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=release/latest-1.8",
-      "--extract=ci/latest-bazel-1.7",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.7",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.7",
-      "--kubernetes-anywhere-upgrade-method=upgrade",
-      "--provider=kubernetes-anywhere",
-      "--skew",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.8"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=release/latest-1.9",
-      "--extract=ci/latest-bazel-1.8",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.8",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.8",
-      "--kubernetes-anywhere-upgrade-method=upgrade",
-      "--provider=kubernetes-anywhere",
-      "--skew",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.9"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=release/latest-1.10",
-      "--extract=ci/latest-bazel-1.9",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-1.9",
-      "--kubernetes-anywhere-upgrade-method=upgrade",
-      "--provider=kubernetes-anywhere",
-      "--skew",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.10"
-    ],
-    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-cluster-lifecycle"
     ]

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5822,35 +5822,22 @@ postsubmits:
     name: ci-federation-release
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
           # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "2Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build
@@ -5952,12 +5939,12 @@ postsubmits:
     - release-1.9
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5968,91 +5955,12 @@ postsubmits:
         - "--gcs=gs://kubernetes-release-dev/ci"
         - "--version-suffix=-bazel"
         - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.9.txt"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-    run_after_success:
-    - name: ci-kubernetes-bazel-test-1-9
-      agent: kubernetes
-      labels:
-        preset-service-account: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
-          args:
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--job=$(JOB_NAME)"
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--" # end bootstrap args, scenario args below
-          - "--test=//... -//build/... -//vendor/..."
-          - "--manual-test=//hack:verify-all"
-          - "--test-args=--build_tag_filters=-e2e,-integration"
-          - "--test-args=--test_tag_filters=-e2e,-integration"
-          - "--test-args=--flaky_test_attempts=3"
-          env:
-          - name: TEST_TMPDIR
-            value: /root/.cache/bazel
-          securityContext:
-            privileged: true
-          volumeMounts:
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-          resources:
-            requests:
-              memory: "6Gi"
-        volumes:
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
-    - name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-      agent: kubernetes
-      labels:
-        preset-service-account: true
-        preset-k8s-ssh: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-          args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--clean"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-    - name: ci-kubernetes-e2e-kubeadm-gce-1-9
-      agent: kubernetes
-      labels:
-        preset-service-account: true
-        preset-k8s-ssh: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-          args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--clean"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-
   - name: ci-kubernetes-bazel-test-1-10
     agent: kubernetes
     branches:
@@ -6084,33 +5992,32 @@ postsubmits:
         resources:
           requests:
             memory: "6Gi"
-    run_after_success:
-    - name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-      agent: kubernetes
-      labels:
-        preset-service-account: true
-        preset-k8s-ssh: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-          args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--clean"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-    - name: ci-kubernetes-e2e-kubeadm-gce-1-10
-      agent: kubernetes
-      labels:
-        preset-service-account: true
-        preset-k8s-ssh: true
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-          args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--clean"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
+
+  - name: ci-kubernetes-bazel-test-1-9
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+      preset-bazel-scratch-dir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--test=//... -//build/... -//vendor/..."
+        - "--manual-test=//hack:verify-all"
+        - "--test-args=--build_tag_filters=-e2e,-integration"
+        - "--test-args=--test_tag_filters=-e2e,-integration"
+        - "--test-args=--flaky_test_attempts=3"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
 
   kubernetes/test-infra:
   - name: ci-test-infra-bazel
@@ -6833,7 +6740,7 @@ periodics:
 
 
 - name: ci-kubernetes-bazel-build
-  interval: 6h
+  interval: 5m
   agent: kubernetes
   labels:
     preset-service-account: true
@@ -6868,164 +6775,6 @@ periodics:
       resources:
         requests:
           memory: "6Gi"
-  run_after_success:
-  - name: ci-kubernetes-e2e-kubeadm-gce-ipvs
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-  - name: periodic-kubernetes-e2e-kubeadm-gce-selfhosting
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
-  - name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
-    agent: kubernetes
-    labels:
-      preset-service-account: true
-      preset-k8s-ssh: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-        args:
-        - "--repo=k8s.io/kubernetes=master"
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--timeout=320"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
 - name: ci-kubernetes-bazel-build-1-7
   interval: 24h
@@ -12841,6 +12590,22 @@ periodics:
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
+- name: ci-kubernetes-e2e-kubeadm-gce-1-10
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.10"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+
 - name: ci-kubernetes-e2e-kubeadm-gce-1-7
   interval: 12h
   agent: kubernetes
@@ -12851,7 +12616,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
       args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes=release-1.7"
       - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
@@ -12866,7 +12631,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
       args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes=release-1.8"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -12883,7 +12648,197 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
       args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes=release-1.8"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
+  interval: 12h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.9"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-1-9
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.9"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.10"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+- name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+- name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-ipvs
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+- name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+- name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.7"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.9"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=release-1.10"
+      - "--clean"
+      - "--timeout=320"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
+  interval: 6h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
+      args:
+      - "--repo=k8s.io/kubernetes=master"
       - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
@@ -14980,117 +14935,6 @@ periodics:
       - --repo=k8s.io/kubeadm=master
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-10
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.10"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-7
-  interval: 12h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.7"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      env:
-      - name: REPO_NAME
-        value: kubernetes=release-1.7
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-8
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.8"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      env:
-      - name: REPO_NAME
-        value: kubernetes=release-1.8
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-9
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.9"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.8"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.9"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
-
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-  interval: 6h
-  agent: kubernetes
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180306-1db99ab1d
-      args:
-      - "--repo=k8s.io/kubernetes=release-1.10"
-      - "--clean"
-      - "--timeout=320"
-      - "--upload=gs://kubernetes-jenkins/logs"
 
 - name: periodic-test-infra-close
   interval: 1h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1145,8 +1145,8 @@ test_groups:
 # kubeadm tests
 - name: ci-kubernetes-e2e-kubeadm-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce
-- name: periodic-kubernetes-e2e-kubeadm-gce-selfhosting
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-selfhosting
+- name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-selfhosting
 - name: ci-kubernetes-e2e-kubeadm-gce-ipvs
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-ipvs
 - name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
@@ -1180,12 +1180,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
 - name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -1200,14 +1200,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/issue-creator
 - name: metrics-bigquery
   gcs_prefix: kubernetes-jenkins/logs/metrics-bigquery
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-7
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-1-7
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-8
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-1-8
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-9
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-1-9
-- name: periodic-kubernetes-e2e-kubeadm-gce-1-10
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-1-10
 - name: periodic-kubernetes-bazel-test-1-7
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-7
 - name: periodic-kubernetes-bazel-test-1-8
@@ -2933,7 +2925,7 @@ dashboards:
   - name: kubeadm-gce
     test_group_name: ci-kubernetes-e2e-kubeadm-gce
   - name: kubeadm-gce-selfhosting
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-selfhosting
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
 
 - name: sig-release-1.10-all
   dashboard_tab:
@@ -3027,10 +3019,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-beta
   - name: gce-kubeadm-1.9-on-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  - name: periodic-gce-kubeadm-1.10
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-10
+  - name: ci-gce-kubeadm-1.10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
   - name: gce-kubeadm-upgrade-1.9-1.10
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
 
 - name: sig-release-1.10-blocking
   dashboard_tab:
@@ -3086,8 +3078,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-beta
   - name: gce-kubeadm-1.9-on-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  - name: periodic-gce-kubeadm-1.10
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-10
+  - name: ci-gce-kubeadm-1.10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
 
 - name: sig-release-1.9-all
   dashboard_tab:
@@ -3107,10 +3099,10 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-test-1-9
   - name: gce-kubeadm-1.8-on-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-  - name: periodic-gce-kubeadm-1.9
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-9
-  - name: gce-kubeadm-upgrade-1.8-1.9
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+  - name: ci-gce-kubeadm-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
+  - name: ci-gce-kubeadm-upgrade-1.8-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
   - name: periodic-kubernetes-e2e-debs-pushed
     test_group_name: periodic-kubernetes-e2e-debs-pushed
   - name: gci-gce-1.9
@@ -3202,8 +3194,8 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-test-1-9
   - name: gce-kubeadm-1.8-on-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-  - name: periodic-gce-kubeadm-1.9
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-9
+  - name: ci-gce-kubeadm-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
   - name: gci-gce-1.9
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-default
   - name: gci-gce-slow-1.9
@@ -3289,8 +3281,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
   - name: gke-1.9-1.8-downgrade-cluster-parallel
     test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
-  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1.7-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1.7-1.8
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
 
 - name: sig-release-misc
   dashboard_tab:
@@ -3319,10 +3311,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
   - name: gce-kubeadm-1.7-on-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
-  - name: periodic-gce-kubeadm-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-8
-  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1.7-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  - name: ci-gce-kubeadm-1.8
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
+  - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1.7-1.8
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: federation-build-1.8
     test_group_name: ci-kubernetes-federation-build-1-8
   - name: federation-test-1.8
@@ -3375,8 +3367,8 @@ dashboards:
     test_group_name: ci-kubernetes-integration-stable2
   - name: gce-kubeadm-1.7-on-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
-  - name: periodic-gce-kubeadm-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-8
+  - name: ci-gce-kubeadm-1.8
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
   - name: federation-build-1.8
     test_group_name: ci-kubernetes-federation-build-1-8
   - name: federation-test-1.8
@@ -3442,8 +3434,6 @@ dashboards:
     test_group_name: ci-kubernetes-bazel-build-1-7
   - name: ci-bazel-test-1.7
     test_group_name: ci-kubernetes-bazel-test-1-7
-  - name: periodic-gce-kubeadm-1.7
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
   - name: periodic-bazel-build-1.7
     test_group_name: periodic-kubernetes-bazel-build-1-7
   - name: periodic-bazel-test-1.7
@@ -3505,8 +3495,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-slow-release-1-7
   - name: gce-reboot-release-1.7
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-7
-  - name: periodic-gce-kubeadm-1.7
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
+  - name: ci-gce-kubeadm-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-stable3
   - name: gci-gce-ingress-1.7
@@ -3892,32 +3882,24 @@ dashboards:
   dashboard_tab:
   - name: kubeadm-gce-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
-  - name: periodic-kubeadm-gce-1.7
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
   - name: kubeadm-gce-1.7-on-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
   - name: kubeadm-gce-upgrade-1.7-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: kubeadm-gce-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
-  - name: periodic-kubeadm-gce-1.8
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-8
   - name: kubeadm-gce-1.8-on-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
   - name: kubeadm-gce-upgrade-1.8-1.9
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
   - name: kubeadm-gce-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
-  - name: periodic-kubeadm-gce-1.9
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-9
   - name: kubeadm-gce-1.9-on-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
   - name: kubeadm-gce-upgrade-1.9-1.10
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
   - name: kubeadm-gce-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  - name: periodic-kubeadm-gce-1.10
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-10
   - name: periodic-kubernetes-e2e-debs-pushed
     test_group_name: periodic-kubernetes-e2e-debs-pushed
   - name: kubeadm-gce-stable-on-master
@@ -3927,7 +3909,7 @@ dashboards:
   - name: kubeadm-gce
     test_group_name: ci-kubernetes-e2e-kubeadm-gce
   - name: kubeadm-gce-selfhosting
-    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-selfhosting
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
   - name: kubeadm-gce-cni-calico
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
   - name: kubeadm-gce-cni-flannel


### PR DESCRIPTION
- fix some jobs's --repo flags
- converge ci/periodic to periodic jobs named "ci" to match our other e2es (post-submit should not run e2e's, since we need the build anyhow and only build in the build jobs..., we're getting rid of run_after_succes / shared builds for these jobs)
- drop more host ports / un-necessary host path caching
- update testgrid to match