### PR TITLE
don't enforce --gcp-zone for gke-latest tests

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -398,9 +398,6 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		if project == "" {
 			return fmt.Errorf("--gcp-project unset")
 		}
-		if zone == "" {
-			return fmt.Errorf("--gcp-zone unset")
-		}
 		if e.value == "gke" {
 			log.Print("*** --extract=gke is deprecated, migrate to --extract=gke-default ***")
 		}
@@ -415,6 +412,11 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 				return fmt.Errorf("failed to get latest gke version: %s", err)
 			}
 			return getKube("https://storage.googleapis.com/kubernetes-release-gke/release", version, extractSrc)
+		}
+
+		// TODO(krzyzacy): clean up gke-default logic
+		if zone == "" {
+			return fmt.Errorf("--gcp-zone unset")
 		}
 
 		// get default cluster version for default extract strategy


### PR DESCRIPTION
following up https://github.com/kubernetes/test-infra/pull/7158
it's still failing on 
```
2018/03/07 22:25:33 main.go:292: Something went wrong: failed to acquire k8s binaries: --gcp-zone unset
```

move the zone check down as gke-latest does not require it anymore.
I'll probably do a follow up clean up the gke-default logic next.

/area kubetest
/assign @BenTheElder @wojtek-t 