### PR TITLE
Use bazel build mode for scalability presubmits

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11380,7 +11380,7 @@
   },
   "pull-kubernetes-e2e-gce-100-performance": {
     "args": [
-      "--build",
+      "--build=bazel",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env",
@@ -11400,7 +11400,7 @@
   },
   "pull-kubernetes-e2e-gce-big-performance": {
     "args": [
-      "--build",
+      "--build=bazel",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-big-performance.env",
@@ -11442,7 +11442,7 @@
   },
   "pull-kubernetes-e2e-gce-large-performance": {
     "args": [
-      "--build",
+      "--build=bazel",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-large-performance.env",


### PR DESCRIPTION
To fix https://github.com/kubernetes/kubernetes/pull/60891#issuecomment-371481070

@dims Thanks for the pointer.