### PR TITLE
Display stderr when command fails with kubernetes_e2e scenario

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -103,7 +103,13 @@ def check_env(env, *cmd):
     for key, value in sorted(env.items()):
         print >>sys.stderr, '%s=%s' % (key, value)
     print >>sys.stderr, 'Run:', cmd
-    subprocess.check_call(cmd, env=env)
+    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _, err = proc.communicate()
+    if proc.returncode != 0:
+        err_msg = "Command: {} failed with error code: {} stderr: \n{}".format(
+            cmd, proc.returncode, err
+        )
+        raise RuntimeError(err_msg)
 
 
 def kubekins(tag):


### PR DESCRIPTION
Currently when the kubernetes_e2e scenario fails to run the test command it also fails to display the stderr from that command, which complicates troubleshooting the cause of failure.

This PR adds the stderr output from the command to the raised exception to make troubleshooting test command failures a bit easier.