### PR TITLE
Add framework for testing with image families on GKE

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -80,6 +80,8 @@ type gkeDeployer struct {
 	subnetwork                  string
 	subnetworkRegion            string
 	image                       string
+	imageFamily                 string
+	imageProject                string
 	commandGroup                []string
 	createCommand               []string
 	singleZoneNodeInstanceGroup bool
@@ -98,7 +100,7 @@ type ig struct {
 
 var _ deployer = &gkeDeployer{}
 
-func newGKE(provider, project, zone, region, network, image, cluster string, testArgs *string, upgradeArgs *string) (*gkeDeployer, error) {
+func newGKE(provider, project, zone, region, network, image, imageFamily, imageProject, cluster string, testArgs *string, upgradeArgs *string) (*gkeDeployer, error) {
 	if provider != "gke" {
 		return nil, fmt.Errorf("--provider must be 'gke' for GKE deployment, found %q", provider)
 	}
@@ -135,6 +137,13 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 	if image == "" {
 		return nil, fmt.Errorf("--gcp-node-image must be set for GKE deployment")
 	}
+	if strings.ToUpper(image) == "CUSTOM" {
+		if imageFamily == "" || imageProject == "" {
+			return nil, fmt.Errorf("--image-family and --image-project must be set for GKE deployment if --gcp-node-image=CUSTOM")
+		}
+	}
+	g.imageFamily = imageFamily
+	g.imageProject = imageProject
 	g.image = image
 
 	g.additionalZones = *gkeAdditionalZones
@@ -297,6 +306,10 @@ func (g *gkeDeployer) Up() error {
 		"--num-nodes="+strconv.Itoa(def.Nodes),
 		"--network="+g.network,
 	)
+	if strings.ToUpper(g.image) == "CUSTOM" {
+		args = append(args, "--image-family="+g.imageFamily)
+		args = append(args, "--image-project="+g.imageProject)
+	}
 	if g.subnetwork != "" {
 		args = append(args, "--subnetwork="+g.subnetwork)
 	}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -75,6 +75,8 @@ type options struct {
 	gcpMasterImage      string
 	gcpNetwork          string
 	gcpNodeImage        string
+	gcpImageFamily      string
+	gcpImageProject     string
 	gcpNodes            string
 	gcpProject          string
 	gcpProjectType      string
@@ -141,6 +143,8 @@ func defineFlags() *options {
 	flag.StringVar(&o.gcpNetwork, "gcp-network", "", "Cluster network. Must be set for --deployment=gke (TODO: other deployments).")
 	flag.StringVar(&o.gcpMasterImage, "gcp-master-image", "", "Master image type (cos|debian on GCE, n/a on GKE)")
 	flag.StringVar(&o.gcpNodeImage, "gcp-node-image", "", "Node image type (cos|container_vm on GKE, cos|debian on GCE)")
+	flag.StringVar(&o.gcpImageFamily, "image-family", "", "Node image family from which to use the latest image, required when --gcp-node-image=CUSTOM")
+	flag.StringVar(&o.gcpImageProject, "image-project", "", "Project containing node image family, required when --gcp-node-image=CUSTOM")
 	flag.StringVar(&o.gcpNodes, "gcp-nodes", "", "(--provider=gce only) Number of nodes to create.")
 	flag.StringVar(&o.kubecfg, "kubeconfig", "", "The location of a kubeconfig file.")
 	flag.BoolVar(&o.kubemark, "kubemark", false, "If true, run kubemark tests.")
@@ -227,7 +231,7 @@ func getDeployer(o *options) (deployer, error) {
 	case "dind":
 		return dind.NewDeployer(o.kubecfg, o.dindImage, &o.testArgs, control)
 	case "gke":
-		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpRegion, o.gcpNetwork, o.gcpNodeImage, o.cluster, &o.testArgs, &o.upgradeArgs)
+		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpRegion, o.gcpNetwork, o.gcpNodeImage, o.gcpImageFamily, o.gcpImageProject, o.cluster, &o.testArgs, &o.upgradeArgs)
 	case "kops":
 		return newKops(o.provider, o.gcpProject, o.cluster)
 	case "kubernetes-anywhere":


### PR DESCRIPTION
cc @yguo0905 @abgworrall 
We currently have [tests on gce](https://github.com/kubernetes/test-infra/blob/master/jobs/config.json#L1642) which run tests against a specific gce image family.  This change allows doing the same on gke.
To do this for a test job, specify:
`--gcp-node-image=CUSTOM`
`--image-family=cos-beta`
`--image-project=cos-cloud`
`--gke-environment=test`
`--provider=gke`

/assign @krzyzacy  