### PR TITLE
Fix gcs_prefix for istio daily jobs on testgrid

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2172,31 +2172,31 @@ test_groups:
   num_failures_to_alert: 1
 # Istio daily releases
 - name: daily-e2e-rbac-no_auth
-  gcs_prefix: istio-prow/daily-e2e-rbac-no_auth
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-no_auth
   num_failures_to_alert: 1
 - name: daily-e2e-rbac-no_auth-default
-  gcs_prefix: istio-prow/daily-e2e-rbac-no_auth-default
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-no_auth-default
   num_failures_to_alert: 1
 - name: daily-e2e-rbac-no_auth-skew
-  gcs_prefix: istio-prow/daily-e2e-rbac-no_auth-skew
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-no_auth-skew
   num_failures_to_alert: 1
 - name: daily-e2e-rbac-auth
-  gcs_prefix: istio-prow/daily-e2e-rbac-auth
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-auth
   num_failures_to_alert: 1
 - name: daily-e2e-rbac-auth-default
-  gcs_prefix: istio-prow/daily-e2e-rbac-auth-default
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-auth-default
   num_failures_to_alert: 1
 - name: daily-e2e-rbac-auth-skew
-  gcs_prefix: istio-prow/daily-e2e-rbac-auth-skew
+  gcs_prefix: istio-prow/directory/daily-e2e-rbac-auth-skew
   num_failures_to_alert: 1
 - name: daily-e2e-cluster_wide-auth
-  gcs_prefix: istio-prow/daily-e2e-cluster_wide-auth
+  gcs_prefix: istio-prow/directory/daily-e2e-cluster_wide-auth
   num_failures_to_alert: 1
 - name: daily-e2e-cluster_wide-auth-default
-  gcs_prefix: istio-prow/daily-e2e-cluster_wide-auth-default
+  gcs_prefix: istio-prow/directory/daily-e2e-cluster_wide-auth-default
   num_failures_to_alert: 1
 - name: daily-e2e-cluster_wide-auth-skew
-  gcs_prefix: istio-prow/daily-e2e-cluster_wide-auth-skew
+  gcs_prefix: istio-prow/directory/daily-e2e-cluster_wide-auth-skew
   num_failures_to_alert: 1
 - name: istio-periodic-e2e-gke-addon
   gcs_prefix: kubernetes-jenkins/logs/istio-periodic-e2e-gke-addon


### PR DESCRIPTION
Testgrid has been complaining stale results for jobs I added in https://github.com/kubernetes/test-infra/pull/7177. My investigation shows that testgrid works for the istio prow jobs added before https://github.com/kubernetes/test-infra/pull/7177 because those jobs run on postsubmits and their _artifacts are uploaded to, for example, `/istio-prow/e2e-suite-rbac-no_auth/{some_run_number}/` but the daily release jobs I added in https://github.com/kubernetes/test-infra/pull/7177 run on presubmit and are uploaded to, for example, `/istio-prow/pull/istio-releases_daily-release/{pr_number}/daily-e2e-cluster_wide-auth/{run_number}/`.

Here I try to match all `{pr_number}` for the same job using the wildcard. I am not sure if this works as I have not seen similar approach in this `config.yaml`. Need some insights from the awesome k8s team.