### PR TITLE
Add a test for V100 against the GKE staging endpoint.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7676,6 +7676,27 @@
       "sig-gcp"
     ]
   },
+  "ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--env=NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/k8s-1.9/nvidia-driver-installer/cos/daemonset-preloaded.yaml",
+      "--extract=gke-latest",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-gke-gpu-boskos-v100",
+      "--gcp-zone=us-central1-f",
+      "--gke-create-command=beta container clusters create --accelerator=type=nvidia-tesla-v100,count=8 --num-nodes=2",
+      "--gke-environment=staging",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:GPUDevicePlugin\\] --minStartupPods=8",
+      "--timeout=80m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
   "ci-kubernetes-e2e-gke-staging-latest-parallel": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11823,6 +11823,19 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
 
+- name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100
+  interval: 12h #expensive test
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=100
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-latest-parallel

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -461,6 +461,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   alert_stale_results_hours: 24
   num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours.
+- name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100
+  alert_stale_results_hours: 36
+  num_failures_to_alert: 3 # Runs every 12h. Alert when it's been failing for 36h.
 - name: ci-kubernetes-e2e-gke-updown
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-updown
 - name: ci-kubernetes-e2e-gci-gke-updown
@@ -2732,6 +2736,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-staging-default-parallel
   - name: gke-staging-latest-device-plugin-gpu
     test_group_name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
+  - name: gke-staging-latest-device-plugin-gpu-v100
+    test_group_name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100
   - name: gke-staging-1-7-1-8-upgrade-master
     test_group_name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-master
   - name: gke-staging-1-7-1-8-upgrade-cluster
@@ -3636,6 +3642,11 @@ dashboards:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gke-staging-latest-device-plugin-gpu
     test_group_name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gke-staging-latest-device-plugin-gpu-v100
+    test_group_name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu-v100
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'


### PR DESCRIPTION
We use 8 V100 per node because that's the supported configuration currently.