### PR TITLE
Greenhouse: switch to pd-ssd, drop --remount

### DIFF
--- a/greenhouse/README.md
+++ b/greenhouse/README.md
@@ -18,17 +18,18 @@ We use this with [Prow](./../prow), to set it up we do the following:
 
  - Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [bazel](https://bazel.build/) and Point `KUBECONFIG` at your cluster.
    - for k8s.io use `make -C prow get-build-cluster-credentials`
- - Create a dedicated node. We use a GKE node-pool with a single node. Tag this node with label `dedicated=bazel-cache` and taint `dedicated=bazel-cache:NoSchedule` so your other tasks don't schedule on it.
+ - Create a dedicated node. We use a GKE node-pool with a single node. Tag this node with label `dedicated=greenhouse` and taint `dedicated=greenhouse:NoSchedule` so your other tasks don't schedule on it.
    - for k8s.io this is:
    ```
-   gcloud beta container node-pools create bazel-cache --cluster=prow --project=k8s-prow-builds --zone=us-central1-f --node-taints dedicated=bazel-cache:NoSchedule --machine-type=n1-standard-8 --num-nodes=1 --local-ssd-count=1
-   kubectl label nodes $(kubectl get no | grep cache | cut -d" " -f1) dedicated=bazel-cache
-   kubectl taint nodes $(kubectl get no | grep cache | cut -d" " -f1) dedicated=bazel-cache:NoSchedule
+   gcloud beta container node-pools create greenhouse --cluster=prow --project=k8s-prow-builds --zone=us-central1-f --node-taints dedicated=greenhouse:NoSchedule --machine-type=n1-standard-32 --num-nodes=1
+   kubectl label nodes $(kubectl get no | grep greenhouse | cut -d" " -f1) dedicated=greenhouse
+   kubectl taint nodes $(kubectl get no | grep greenhouse | cut -d" " -f1) dedicated=greenhouse:NoSchedule
    ```
  - Create the Kubernetes service so jobs can talk to it conveniently: `kubectl apply -f greenhouse/service.yaml`
+ - Create a `StorageClass` / `PersistentVolumeClaim` for fast cache storage, we use `kubectl apply -f greenhouse/gce-fast-storage.yaml` for 3TB of pd-ssd storage
  - Finally build, push, and deploy with `bazel run //greenhouse:production.apply --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64`
    <!--TODO(bentheelder): make this easier to consume by other users?-->
-   - NOTE: other uses will likely need to tweak this step to their needs
+   - NOTE: other uses will likely need to tweak this step to their needs, particular the service and storage definitions
 
 
 ## Optional Setup:

--- a/greenhouse/deployment.yaml
+++ b/greenhouse/deployment.yaml
@@ -15,18 +15,18 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: bazel-cache
+  name: greenhouse
   labels:
-    app: bazel-cache
+    app: greenhouse
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: bazel-cache
+        app: greenhouse
     spec:
       containers:
-      - name: bazel-cache
+      - name: greenhouse
         image: gcr.io/k8s-testimages/greenhouse:latest
         imagePullPolicy: Always
         ports:
@@ -36,23 +36,18 @@ spec:
           containerPort: 9090
         args:
         - --dir=/data
-        - --remount
-        # mount the local ssd
         volumeMounts:
         - name: cache
           mountPath: /data
-        # --remount needs privileges to remount the disk *shrug*
-        securityContext:
-          privileged: true
       volumes:
       - name: cache
-        hostPath:
-          path: /mnt/disks/ssd0/cache
+        persistentVolumeClaim:
+          claimName: greenhouse
       # run on our dedicated node
       tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "bazel-cache"
+        value: "greenhouse"
         effect: "NoSchedule"
       nodeSelector:
-        dedicated: "bazel-cache"
+        dedicated: "greenhouse"

--- a/greenhouse/gce-storage.yaml
+++ b/greenhouse/gce-storage.yaml
@@ -1,0 +1,27 @@
+# storage class used by greenhouse for GKE / GCE we use persistent SSD
+# previously we also used local SSDs via hostPath which are *great* but
+# "only" ~375 GB
+# https://cloud.google.com/compute/docs/disks/
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: greenhouse
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+# so we can get accurat eviction, note that lazytime only works on ext4
+mountOptions: ["strictatime", "lazytime"]
+---
+# 3TB of SSD :-)
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: greenhouse
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3000Gi
+  storageClassName: greenhouse
+---

--- a/greenhouse/gce-storage.yaml
+++ b/greenhouse/gce-storage.yaml
@@ -9,7 +9,10 @@ metadata:
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd
-# so we can get accurat eviction, note that lazytime only works on ext4
+# we want to use a volume with strictatime,lazytime (and not noatime or relatime)
+# so that file access times *are* recorded but are lazily flushed to the disk
+# https://lwn.net/Articles/621046/
+# https://unix.stackexchange.com/questions/276858/why-is-ext4-filesystem-mounted-with-both-relatime-and-lazytime
 mountOptions: ["strictatime", "lazytime"]
 ---
 # 3TB of SSD :-)

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -60,15 +60,6 @@ var evictUntilPercentBlocksFree = flag.Float64("evict-until-percent-blocks-free"
 var diskCheckInterval = flag.Duration("disk-check-interval", time.Second*10,
 	"interval between checking disk usage (and potentially evicting entries)")
 
-// NOTE: remount is a bit of a hack, unfortunately the kubernetes volumes
-// don't really support this and to cleanly track entry access times we
-// want to use a volume with strictatime,lazytime (and not noatime or relatime)
-// so that file access times *are* recorded but are lazily flushed to the disk
-// https://lwn.net/Articles/621046/
-// https://unix.stackexchange.com/questions/276858/why-is-ext4-filesystem-mounted-with-both-relatime-and-lazytime
-var remount = flag.Bool("remount", false,
-	"attempt to remount --dir with strictatime,lazyatime to improve eviction")
-
 // global metrics object, see prometheus.go
 var promMetrics *prometheusMetrics
 
@@ -84,23 +75,6 @@ func main() {
 	flag.Parse()
 	if *dir == "" {
 		logrus.Fatal("--dir must be set!")
-	}
-	if *remount {
-		device, mount, err := diskutil.FindMountForPath(*dir)
-		if err != nil {
-			logrus.WithError(err).Errorf("Failed to find mountpoint for %s", *dir)
-		} else {
-			logrus.Warnf(
-				"Attempting to remount %s on %s with 'strictatime,lazyatime'",
-				device, mount,
-			)
-			err = diskutil.Remount(device, mount, "strictatime,lazytime")
-			if err != nil {
-				logrus.WithError(err).Error("Failed to remount with lazyatime!")
-			} else {
-				logrus.Info("Remount complete")
-			}
-		}
 	}
 
 	cache := diskcache.NewCache(*dir)

--- a/greenhouse/metrics-service.yaml
+++ b/greenhouse/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   selector:
-    app: bazel-cache
+    app: greenhouse
   ports:
   - name: default
     protocol: TCP

--- a/greenhouse/service.yaml
+++ b/greenhouse/service.yaml
@@ -23,4 +23,4 @@ spec:
   - port: 8080
     protocol: TCP
   selector:
-    app: bazel-cache
+    app: greenhouse


### PR DESCRIPTION
- switch to PersistentVolumeClaim + GCE pd-ssd based StorageClass for storage
  - this gives us access to way more disk space, but we can still get comparable IOPs by having enough vCPU and enough GB of disk allocated (since it's actually network attached)
- drop --remount and associated code (we can supply the mount options on the PVC)
- rename deployment to greenhouse (not strictly necessary, but also helped switch to the new deployment while leaving the old one available w/ the local ssd etc.)
- update README to reflect new deployment details

/area greenhouse