### PR TITLE
support extract from arbitrary gcs filepointer

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -458,9 +458,12 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		}
 		return getKube(url, release, extractSrc)
 	case gcs:
-		// strip gs://foo -> /foo
-		withoutGS := e.option[3:]
-		url := "https://storage.googleapis.com" + path.Dir(withoutGS)
+		// strip gs://foo -> foo
+		withoutGS := e.option[5:]
+		if strings.HasSuffix(e.option, ".txt") {
+			return setReleaseFromGcs(path.Dir(withoutGS), e.option, extractSrc)
+		}
+		url := "https://storage.googleapis.com" + "/" + path.Dir(withoutGS)
 		return getKube(url, path.Base(withoutGS), extractSrc)
 	case load:
 		return loadState(e.option, extractSrc)

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -130,6 +130,11 @@ func TestExtractStrategies(t *testing.T) {
 			"https://storage.googleapis.com/kubernetes-release-gke/release",
 			"v1.2.3+abcde",
 		},
+		{
+			"gs://whatever-bucket/ci/latest.txt",
+			"https://storage.googleapis.com/whatever-bucket/ci",
+			"v1.2.3+abcde",
+		},
 	}
 
 	var gotURL string


### PR DESCRIPTION
so that we can do `--extract=gs://whatever/latest.txt`

/area kubetest
/assign @BenTheElder 