### PR TITLE
Make tide set a more useful status.

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -128,3 +128,14 @@ func (tqs TideQueries) AllPRsSince(t time.Time) string {
 	}
 	return strings.Join(toks, " ")
 }
+
+// ByRepo returns a mapping from "org/repo" -> TideQueries that apply to that repo.
+func (tqs TideQueries) ByRepo() map[string]TideQueries {
+	res := make(map[string]TideQueries)
+	for _, tq := range tqs {
+		for _, repo := range tq.Repos {
+			res[repo] = append(res[repo], tq)
+		}
+	}
+	return res
+}


### PR DESCRIPTION
This PR adds 3 things to @spxtr's work here: https://github.com/spxtr/test-infra/tree/seethrustatus
1. Limit the status description length:
   1. Limit the character count of the list of labels (but ensure at least 1 label is included).
   1. Only mention one class of requirements (e.g. only mention required labels that are missing or only mention forbidden labels that exist, not both).
1. If multiple queries exist for the repo a PR is in, consider all the queries and use the one with the smallest requirement diff count to generate the status description.
1. Tests

I also changed the status context description prefixes to reference "merge pool" instead of "tide pool" to make it clear that the status context is a merge automation context.

fixes #6145 
/cc @spxtr @stevekuznetsov @kargakis 