### PR TITLE
prow/pr_status: get user login after exchange the token

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -254,7 +254,7 @@ func prodOnlyMain(o options, mux *http.ServeMux) {
 		// Handles login request.
 		mux.Handle("/github-login", goa.HandleLogin(oauthClient))
 		// Handles redirect from Github OAuth server.
-		mux.Handle("/github-login/redirect", goa.HandleRedirect(oauthClient))
+		mux.Handle("/github-login/redirect", goa.HandleRedirect(oauthClient, githuboauth.NewGithubClientGetter()))
 	}
 
 	// optionally inject http->https redirect handler when behind loadbalancer

--- a/prow/githuboauth/BUILD.bazel
+++ b/prow/githuboauth/BUILD.bazel
@@ -6,7 +6,9 @@ go_library(
     importpath = "k8s.io/test-infra/prow/githuboauth",
     visibility = ["//visibility:public"],
     deps = [
+        "//ghclient:go_default_library",
         "//prow/config:go_default_library",
+        "//vendor/github.com/google/go-github/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/net/xsrftoken:go_default_library",
@@ -34,6 +36,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
+        "//vendor/github.com/google/go-github/github:go_default_library",
         "//vendor/github.com/gorilla/securecookie:go_default_library",
         "//vendor/github.com/gorilla/sessions:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",


### PR DESCRIPTION
* This fixes pr status does not has the user's login to request after being redirected back from authentication