### PR TITLE
Create new labels to identify issues as close candidates

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -16,6 +16,14 @@ labels:
     name: 'cla: no'
   - color: bfe5bf
     name: 'cla: yes'
+  - color: d455d0
+    name: 'close/duplicate'
+  - color: d455d0
+    name: 'close/needs-information'
+  - color: d455d0
+    name: 'close/not-reproducible'
+  - color: d455d0
+    name: 'close/unresolved'
   - color: c0ff4a
     name: committee/conduct
   - color: c0ff4a


### PR DESCRIPTION
The need for these new labels has been already discussed at various
places like on the kubernetes-dev mailing list, with ContribEx SIG
etc with approval to create them. The labels will not close the
issue but will identify close candidates with reasoning. To close
issue, the current close command is required. The color coding for
these labels are same as what we have today for Triaged label.

The open discussion on proposal for these lables can be found at,
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-dev/c8J8VOYeDB8/39kYEYkrBwAJ
https://docs.google.com/document/d/1Bl965KDJb8xrVmf3o90aRQdwZZ9XU9g0lLkwmA8M1YQ/edit