### PR TITLE
flip on the bazel remote cache for more presubmits

### DIFF
--- a/maintenance/fixconfig/main.go
+++ b/maintenance/fixconfig/main.go
@@ -467,9 +467,10 @@ func main() {
 
 	// convert each kubernetes/kubernetes presubmit to a
 	// kubernetes-security/kubernetes presubmit and write to the file
-	cacheLabels := getCacheSSDPresetLabels(parsed)
+	dropLabels := getCacheSSDPresetLabels(parsed)
+	dropLabels.Insert("preset-bazel-remote-cache-enabled: true")
 	for _, job := range parsed.Presubmits["kubernetes/kubernetes"] {
-		convertJobToSecurityJob(&job, cacheLabels, jobsConfig)
+		convertJobToSecurityJob(&job, dropLabels, jobsConfig)
 		jobBytes, err := yaml.Marshal(job)
 		if err != nil {
 			log.Fatalf("Failed to marshal job: %v", err)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -233,7 +233,11 @@ presets:
   volumeMounts:
   - name: bazel-scratch
     mountPath: /bazel-scratch/.cache
-
+- labels:
+    preset-bazel-remote-cache-enabled: true
+  env:
+  - name: BAZEL_REMOTE_CACHE_ENABLED
+    value: "true"
 
 presubmits:
   google/cadvisor:
@@ -630,6 +634,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-experimental
@@ -643,9 +648,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "make"
         - "bazel-build"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -665,6 +667,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-experimental
@@ -678,9 +681,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "make"
         - "bazel-test"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -830,6 +830,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -839,9 +840,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1002,6 +1000,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -1015,9 +1014,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1242,6 +1238,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
@@ -1256,9 +1253,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1280,6 +1274,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -1297,9 +1292,6 @@ presubmits:
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1417,6 +1409,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
@@ -1432,9 +1425,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "make"
         - "bazel-test"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1451,6 +1441,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
@@ -1464,9 +1455,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--test=//test/integration/..."
         - "--test-args=--config=integration"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1606,6 +1594,7 @@ presubmits:
       preset-service-account: true
       preset-k8s-ssh: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - args:
@@ -1619,9 +1608,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
         volumeMounts:
         - mountPath: /root/.cache
@@ -1844,6 +1830,7 @@ presubmits:
       preset-service-account: true
       preset-k8s-ssh: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -1857,9 +1844,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -2257,6 +2241,7 @@ presubmits:
       preset-service-account: true
       preset-aws-ssh: true
       preset-aws-credential: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -2270,9 +2255,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -4075,9 +4057,6 @@ presubmits:
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
         name: ""
         resources:
@@ -4474,9 +4453,6 @@ presubmits:
         - --timeout=75
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
         name: ""
         resources:
@@ -5452,6 +5428,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-experimental
@@ -5464,9 +5441,6 @@ presubmits:
         - "--scenario=kubernetes_execute_bazel"
         - "--" # end bootstrap args, scenario args below
         - "hack/build-then-unit.sh"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5483,6 +5457,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
@@ -5496,9 +5471,6 @@ presubmits:
         - "--scenario=kubernetes_execute_bazel"
         - "--" # end bootstrap args, scenario args below
         - "hack/build-then-unit.sh"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5535,6 +5507,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
@@ -5550,9 +5523,6 @@ presubmits:
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."
         - "--test-args=--config=lint"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5921,6 +5891,7 @@ postsubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -5936,9 +5907,6 @@ postsubmits:
         - "--gcs=gs://kubernetes-release-dev/ci"
         - "--version-suffix=-bazel"
         - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5951,6 +5919,7 @@ postsubmits:
       labels:
         preset-service-account: true
         preset-bazel-scratch-dir: true
+        preset-bazel-remote-cache-enabled: true
       spec:
         containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -5967,9 +5936,6 @@ postsubmits:
           - "--test-args=--build_tag_filters=-e2e,-integration"
           - "--test-args=--test_tag_filters=-e2e,-integration"
           - "--test-args=--flaky_test_attempts=3"
-          env:
-          - name: BAZEL_REMOTE_CACHE_ENABLED
-            value: "true"
           securityContext:
             privileged: true
           resources:
@@ -5982,6 +5948,7 @@ postsubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -5997,9 +5964,6 @@ postsubmits:
         - "--gcs=gs://kubernetes-release-dev/ci"
         - "--version-suffix=-bazel"
         - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.10.txt"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -6042,6 +6006,7 @@ postsubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -6058,9 +6023,6 @@ postsubmits:
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         securityContext:
           privileged: true
         resources:
@@ -6101,6 +6063,7 @@ postsubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-experimental
@@ -6115,9 +6078,6 @@ postsubmits:
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."
         - "--test-args=--test_output=errors"
-        env:
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -6795,6 +6755,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -6811,8 +6772,6 @@ periodics:
       - "--version-suffix=-bazel"
       - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt"
       env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # so we can use the right cache id
       # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
       - name: REPO_OWNER
@@ -6832,6 +6791,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -6847,9 +6807,6 @@ periodics:
       - "--gcs=gs://kubernetes-release-dev/ci"
       - "--version-suffix=-bazel"
       - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.10.txt"
-      env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
@@ -6940,6 +6897,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
@@ -6957,8 +6915,6 @@ periodics:
       - "--test-args=--test_tag_filters=-e2e,-integration"
       - "--test-args=--flaky_test_attempts=3"
       env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
       - name: REPO_OWNER
         value: kubernetes
@@ -14539,6 +14495,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-experimental
@@ -14554,9 +14511,6 @@ periodics:
       - "--install=gubernator/test_requirements.txt"
       - "--test=//..."
       - "--test-args=--test_output=errors"
-      env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
@@ -14742,6 +14696,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -14755,8 +14710,6 @@ periodics:
       - "--build=//... -//vendor/..."
       - "--release=//build/release-tars"
       env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
       - name: REPO_OWNER
         value: kubernetes
@@ -14843,6 +14796,7 @@ periodics:
   labels:
     preset-service-account: true
     preset-bazel-scratch-dir: true
+    preset-bazel-remote-cache-enabled: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.10
@@ -14861,8 +14815,6 @@ periodics:
       - "--test-args=--test_tag_filters=-e2e,-integration"
       - "--test-args=--flaky_test_attempts=3"
       env:
-      - name: BAZEL_REMOTE_CACHE_ENABLED
-        value: "true"
       # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
       - name: REPO_OWNER
         value: kubernetes

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -643,6 +643,9 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "make"
         - "bazel-build"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1012,6 +1015,9 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1590,12 +1596,56 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-gce"
     trigger: "(?m)^/test (all|pull-kubernetes-e2e-gce),?(\\s+|$)"
     always_run: true
-    # TODO(bentheelder): enforce this pattern (skip all releases) or implement
-    # something better like https://github.com/kubernetes/test-infra/pull/4918
+    # TODO(bentheelder): fork 1.10 after release
     skip_branches:
     - release-1.6 # per-release image
     - release-1.7 # per-release image
     - release-1.8 # per-release image
+    - release-1.9 # per-release image
+    labels:
+      preset-service-account: true
+      preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        volumeMounts:
+        - mountPath: /root/.cache
+          name: cache-ssd
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+  - name: pull-kubernetes-e2e-gce
+    agent: kubernetes
+    context: pull-kubernetes-e2e-gce
+    rerun_command: "/test pull-kubernetes-e2e-gce"
+    trigger: "(?m)^/test (all|pull-kubernetes-e2e-gce),?(\\s+|$)"
+    always_run: true
+    # TODO(bentheelder): enforce this pattern (skip all releases) or implement
+    # something better like https://github.com/kubernetes/test-infra/pull/4918
+    branches:
+    - release-1.9 # per-release image
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
@@ -1617,7 +1667,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         volumeMounts:
         - mountPath: /root/.cache
           name: cache-ssd
@@ -1783,6 +1833,53 @@ presubmits:
     - release-1.6  # not supported
     - release-1.7  # not supported
     - release-1.8  # per-release image
+    - release-1.9  # per-release image
+    always_run: true
+    skip_report: false
+    max_concurrency: 12
+    context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: "/test pull-kubernetes-e2e-gce-device-plugin-gpu"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    labels:
+      preset-service-account: true
+      preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-gce-device-plugin-gpu
+    agent: kubernetes
+    branches:
+    - release-1.9 # per-release image
     always_run: true
     skip_report: false
     max_concurrency: 12
@@ -1794,7 +1891,7 @@ presubmits:
       preset-k8s-ssh: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         args:
         - --root=/go/src
         - "--clean"
@@ -2147,9 +2244,10 @@ presubmits:
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     skip_branches:
-    - release-1.6  # runs on Jenkins?
+    - release-1.6  # runs on Jenkins? NOT ANYMORE :D
     - release-1.7  # per-release image
     - release-1.8  # per-release image
+    - release-1.9  # per-release image
     max_concurrency: 12
     always_run: true
     context: pull-kubernetes-e2e-kops-aws
@@ -2162,6 +2260,51 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-kops-aws
+    agent: kubernetes
+    branches:
+    - release-1.9  # per-release image
+    max_concurrency: 12
+    always_run: true
+    context: pull-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    labels:
+      preset-service-account: true
+      preset-aws-ssh: true
+      preset-aws-credential: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         args:
         - --root=/go/src
         - "--clean"
@@ -3647,6 +3790,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -3657,6 +3801,7 @@ presubmits:
     - release-1.6
     - release-1.7
     - release-1.8
+    - release-1.9
     skip_report: false
     spec:
       containers:
@@ -3671,6 +3816,48 @@ presubmits:
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-1.9
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-e2e-gce
+    rerun_command: /test pull-security-kubernetes-e2e-gce
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --clean
+        - --timeout=90
+        - --
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         name: ""
         resources:
           requests:
@@ -3861,6 +4048,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -3871,6 +4059,7 @@ presubmits:
     - release-1.6
     - release-1.7
     - release-1.8
+    - release-1.9
     skip_report: false
     spec:
       containers:
@@ -3886,7 +4075,54 @@ presubmits:
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-1.9
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=90
+        - --
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         name: ""
         resources:
           requests:
@@ -4222,6 +4458,7 @@ presubmits:
     - release-1.6
     - release-1.7
     - release-1.8
+    - release-1.9
     skip_report: false
     spec:
       containers:
@@ -4237,7 +4474,55 @@ presubmits:
         - --timeout=75
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
+        env:
+        - name: BAZEL_REMOTE_CACHE_ENABLED
+          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-1.9
+    cluster: security
+    context: pull-security-kubernetes-e2e-kops-aws
+    labels:
+      preset-aws-credential: "true"
+      preset-aws-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: /test pull-security-kubernetes-e2e-kops-aws
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --clean
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180307-ce8e19913-1.9
         name: ""
         resources:
           requests:


### PR DESCRIPTION
- also fork the e2e's involved for 1.9 using the kubekins-e2e 1.9 image instead of master...
- also migrate this env to a preset instead of setting the env on each job

We have way more cache disk now, and we're seeing big speedups leveraging it in canaries, let's turn this on for more presubmits.

- `pull-kops-bazel-build`
- `pull-kubernetes-bazel-build` 1.10/master
- `pull-kubernetes-e2e-gce` 1.10/master
- `pull-kubernetes-e2e-kops-aws` 1.10/master
- `pull-kubernetes-e2e-gce-device-plugin-gpu` 1.10/master