### PR TITLE
Revert "Merge pull request #5403 from stevekuznetsov/skuznets/tighter-spec-validation"

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -258,14 +258,8 @@ func parseConfig(c *Config) error {
 		name := v.Name
 		agent := v.Agent
 		// Ensure that k8s presubmits have a pod spec.
-		if agent == string(kube.KubernetesAgent) {
-			if v.Spec == nil {
-				return fmt.Errorf("job %s has no spec", name)
-			} else {
-				if len(v.Spec.Containers) > 1 {
-					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
-				}
-			}
+		if agent == string(kube.KubernetesAgent) && v.Spec == nil {
+			return fmt.Errorf("job %s has no spec", name)
 		}
 		// Ensure agent is a known value.
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
@@ -287,14 +281,9 @@ func parseConfig(c *Config) error {
 	for _, j := range c.AllPostsubmits(nil) {
 		name := j.Name
 		agent := j.Agent
-		if agent == string(kube.KubernetesAgent) {
-			if j.Spec == nil {
-				return fmt.Errorf("job %s has no spec", name)
-			} else {
-				if len(j.Spec.Containers) > 1 {
-					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
-				}
-			}
+		// Ensure that k8s postsubmits have a pod spec.
+		if agent == string(kube.KubernetesAgent) && j.Spec == nil {
+			return fmt.Errorf("job %s has no spec", name)
 		}
 		// Ensure agent is a known value.
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
@@ -316,14 +305,8 @@ func parseConfig(c *Config) error {
 	for _, p := range c.AllPeriodics() {
 		name := p.Name
 		agent := p.Agent
-		if agent == string(kube.KubernetesAgent) {
-			if p.Spec == nil {
-				return fmt.Errorf("job %s has no spec", name)
-			} else {
-				if len(p.Spec.Containers) > 1 {
-					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
-				}
-			}
+		if agent == string(kube.KubernetesAgent) && p.Spec == nil {
+			return fmt.Errorf("job %s has no spec", name)
 		}
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
 			return fmt.Errorf("job %s has invalid agent (%s), it needs to be one of the following: %s %s",


### PR DESCRIPTION
This reverts commit 2834c187478fa1228909896afec09edcd6cffabf, reversing
changes made to 8aaff58561b0753da6b5a44bd916461957564c28.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @cjwagner 
/assign @BenTheElder 

We need this to test the pod utilities externally to Plank -- with raw PodSpecs that have sidecars and initcontainers. Having more than one test container in a test pod is still generally undefined behavior but we can figure out what to do with that later.