### PR TITLE
Leave detached HEAD state in clonerefs

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -49,13 +49,14 @@ func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, "--tags", "--prune"))
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, refs.BaseRef))
 
-	var checkout string
+	var target string
 	if refs.BaseSHA != "" {
-		checkout = refs.BaseSHA
+		target = refs.BaseSHA
 	} else {
-		checkout = "FETCH_HEAD"
+		target = "FETCH_HEAD"
 	}
-	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", checkout))
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "branch", "--force", refs.BaseRef, target))
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", refs.BaseRef))
 
 	for _, prRef := range refs.Pulls {
 		commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, fmt.Sprintf("pull/%d/head", prRef.Number)))


### PR DESCRIPTION
Most tools do not mind being in detached HEAD state of a repository but
there are some that attempt to introspect the git state that they are
called from and need the current branch as well as tags, etc. We should
be able to leave detached HEAD state and be in the target base ref.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @cjwagner @kargakis @smarterclayton 
/assign @BenTheElder 