### PR TITLE
Upload the ProwJob spec from initupload

### DIFF
--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -28,6 +28,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -90,6 +91,7 @@ func main() {
 	uploadTargets := map[string]gcs.UploadFunc{
 		"clone-log.txt":      gcs.DataUpload(&buildLog),
 		"clone-records.json": gcs.FileUpload(o.cloneLog),
+		"job-spec.json":      gcs.DataUpload(strings.NewReader(os.Getenv("JOB_SPEC"))),
 	}
 
 	started := struct {


### PR DESCRIPTION
Exposing the configuration metadata used to run the job to GCS allows
for downstream tools to use it for meta-analysis.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind feature
/area prow
/cc @cjwagner 
/assign @BenTheElder 

We've talked about this a bunch.