### PR TITLE
Improve Kubernetes client logging

### DIFF
--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -416,7 +416,13 @@ func (c *Client) DeletePod(name string) error {
 }
 
 func (c *Client) CreateProwJob(j ProwJob) (ProwJob, error) {
-	c.log("CreateProwJob", j)
+	var representation string
+	if out, err := json.Marshal(j); err == nil {
+		representation = string(out[:])
+	} else {
+		representation = fmt.Sprintf("%v", j)
+	}
+	c.log("CreateProwJob", representation)
 	var retJob ProwJob
 	err := c.request(&request{
 		method:      http.MethodPost,


### PR DESCRIPTION
When we create a ProwJob, the current imeplementation of the log
attempts to shove the full ProwJob struct into the message string, which
is very difficult to read. Instead, try to marshal it into JSON and if
that fails fall back to the current implementation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind enhancement
/area prow
/cc @cjwagner @kargakis 
/assign @BenTheElder 

Motivated by crap lines like:

```
{"client":"kube","component":"hook","level":"debug","msg":"CreateProwJob({prow.k8s.io/v1 ProwJob {aca53dea-24a1-11e8-8a1c-0a58ac1011a4      0 0001-01-01 00:00:00 +0000 UTC \u003cnil\u003e \u003cnil\u003e map[master:ci.openshift.redhat.com event-GUID:ac9851e6-24a1-11e8-950f-f1d037727da7] map[] [] nil [] } {postsubmit jenkins  test_branch_origin_web_console_server_e2e master:59d825892cb12ef97a7ea802685d89a9978d2a14 false   0 {[] [] []  \u003cnil\u003e \u003cnil\u003e  map[]   \u003cnil\u003e  false false false nil []   nil  [] []  \u003cnil\u003e nil} []} {2018-03-10 20:29:03.96451689 +0000 UTC m=+5341.534127141 \u003cnil\u003e triggered     }})","time":"2018-03-10T20:29:03Z"}
```