### PR TITLE
Follow kubernetes-sig-testing/frameworks repo transfer

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,13 +32,11 @@ branch-protection:
       protect-by-default: true
       require-contexts:
       - cla/linuxfoundation
-    kubernetes-sig-testing:
       repos:
-        frameworks:
-          protect-by-default: true
+        testing_frameworks:
           require-contexts:
-          - continuous-integration/travis-ci
           - cla/linuxfoundation
+          - continuous-integration/travis-ci
 
 tide:
   queries:
@@ -100,7 +98,7 @@ tide:
     - do-not-merge/work-in-progress
     reviewApprovedRequired: true
   - repos:
-    - kubernetes-sig-testing/frameworks
+    - kubernetes-sigs/testing_frameworks
     labels:
     - lgtm
     - approved
@@ -5395,7 +5393,7 @@ presubmits:
       - emptyDir: {}
         name: auto-generated-docker-graph-volume-mount
     trigger: (?m)^/test pull-security-kubernetes-verify-prow,?(\s+|$)
-  kubernetes-sig-testing/frameworks:
+  kubernetes-sigs/testing_frameworks:
   - name: pull-frameworks-test
     context: pull-frameworks-test
     agent: kubernetes

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,7 +8,6 @@ triggers:
   - kubernetes-incubator
   - kubernetes-security
   - kubernetes-sigs
-  - kubernetes-sig-testing
   - google/cadvisor
   - tensorflow/k8s
   - tensorflow/minigo
@@ -59,7 +58,6 @@ approve:
   implicit_self_approve: true
 - repos:
   - kubernetes-sigs
-  - kubernetes-sig-testing
   implicit_self_approve: true
 
 blockades:
@@ -306,26 +304,8 @@ plugins:
   - wip
   - yuks
 
-  kubernetes-sig-testing:
-  - assign
+  kubernetes-sigs/testing_frameworks:
   - approve
-  - blunderbuss
-  - cat
-  - cla
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - shrug
-  - size
-  - skip
-  - trigger
-  - wip
-  - yuks
 
   containerd/cri-containerd:
   - assign


### PR DESCRIPTION
We moved kubernetes-sig-testing/frameworks to
kubernetes-sigs/testing_frameworks to follow the new world order
as spelling out in kubernetes/community/kubernetes-repositories.md

/cc @timothysc