### PR TITLE
Enable Secure, HttpOnly, Path and Expires for some cookies in PR Status

### DIFF
--- a/prow/githuboauth/githuboauth.go
+++ b/prow/githuboauth/githuboauth.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/go-github/github"
 	"github.com/sirupsen/logrus"
@@ -160,14 +161,17 @@ func (ga *GithubOAuthAgent) HandleRedirect(client OAuthClient, getter GithubClie
 			ga.serverError(w, "Save session", err)
 			return
 		}
-
 		ghc := getter.GetGithubClient(token.AccessToken, false)
 		user, err := ghc.GetUser("")
 		if err != nil {
 			ga.serverError(w, "Get user login", err)
 			return
 		}
-		http.SetCookie(w, &http.Cookie{Name: "github_login", Value: *user.Login})
+		http.SetCookie(w, &http.Cookie{
+			Name:    "github_login",
+			Value:   *user.Login,
+			Expires: time.Now().Add(time.Hour * 24 * 30),
+			Path:    "/"})
 		http.Redirect(w, r, ga.gc.FinalRedirectURL, http.StatusFound)
 	}
 }

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -183,8 +183,10 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			http.SetCookie(w, &http.Cookie{
 				Name:    "github_login",
 				Value:   login,
+				Path:    "/",
 				Expires: time.Now().Add(time.Hour * 24 * 30),
-				Path:    "/"})
+				Secure:  true,
+			})
 			session.Values[loginKey] = login
 			if err := session.Save(r, w); err != nil {
 				serverError("Save oauth session", err)

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	gogithub "github.com/google/go-github/github"
 	"github.com/gorilla/sessions"
@@ -179,7 +180,11 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 			// Saves login. We save the login under 2 cookies. One for the use of client to render the
 			// data and one encoded for server to verify the identity of the authenticated user.
-			http.SetCookie(w, &http.Cookie{Name: "github_login", Value: login})
+			http.SetCookie(w, &http.Cookie{
+				Name:    "github_login",
+				Value:   login,
+				Expires: time.Now().Add(time.Hour * 24 * 30),
+				Path:    "/"})
 			session.Values[loginKey] = login
 			if err := session.Save(r, w); err != nil {
 				serverError("Save oauth session", err)


### PR DESCRIPTION
github_login cookie's path should be set to '/' so that the client side can access it.
* Fixes #7234
* Fixes #7233