### PR TITLE
Allow approve label and merge for scheduling_poseidon

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -99,6 +99,7 @@ tide:
     reviewApprovedRequired: true
   - repos:
     - kubernetes-sigs/testing_frameworks
+    - kubernetes-sigs/scheduling_poseidon
     labels:
     - lgtm
     - approved

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -307,6 +307,9 @@ plugins:
   kubernetes-sigs/testing_frameworks:
   - approve
 
+  kubernetes-sigs/scheduling_poseidon:
+  - approve
+
   containerd/cri-containerd:
   - assign
   - cla


### PR DESCRIPTION
Add merge-bot and /approve lable capability for scheduling_poseidon projects in `kubernetes-sigs`

cc @timothysc @deepak-vij 