### PR TITLE
Rename `cri-containerd` to `cri`.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11775,7 +11775,7 @@
       "--deployment=node",
       "--gcp-project=k8s-c8d-pr-node-e2e",
       "--gcp-zone=us-central1-f",
-      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd",
+      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri",
       "--node-test-args=--container-runtime=remote --container-runtime-endpoint=/run/containerd/containerd.sock --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/runtime\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\"",
       "--node-tests=true",
       "--provider=gce",

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -1,8 +1,8 @@
 ### job-env
 # Envs for containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri-containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri-containerd/test/configure.sh
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -919,7 +919,7 @@ presubmits:
         resources:
           requests:
             memory: "2Gi"
-  containerd/cri-containerd:
+  containerd/cri:
   - name: pull-cri-containerd-build
     agent: kubernetes
     always_run: true
@@ -964,7 +964,7 @@ presubmits:
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=90"
           - "--"
-          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd --node-env=PULL_REFS=$(PULL_REFS)"
+          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri --node-env=PULL_REFS=$(PULL_REFS)"
 
   - name: pull-cri-containerd-verify
     agent: kubernetes
@@ -1569,7 +1569,7 @@ presubmits:
         - --root=/go/src
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
-        - --repo=github.com/containerd/cri-containerd
+        - --repo=github.com/containerd/cri
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --clean
         - --timeout=90
@@ -3005,7 +3005,7 @@ presubmits:
         - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=github.com/containerd/cri-containerd"
+        - "--repo=github.com/containerd/cri"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
@@ -3746,7 +3746,7 @@ presubmits:
         - --root=/go/src
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
-        - --repo=github.com/containerd/cri-containerd
+        - --repo=github.com/containerd/cri
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --clean
         - --timeout=90
@@ -5250,7 +5250,7 @@ presubmits:
         - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=github.com/containerd/cri-containerd
+        - --repo=github.com/containerd/cri
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --timeout=90
@@ -6234,7 +6234,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-experimental
       args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -6247,7 +6247,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=300"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6260,7 +6260,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=170"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6273,7 +6273,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6286,7 +6286,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6299,7 +6299,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=200"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6312,7 +6312,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=110"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6325,7 +6325,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6338,7 +6338,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=200"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6351,7 +6351,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=110"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6364,7 +6364,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6377,7 +6377,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6390,7 +6390,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=200"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6403,7 +6403,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=1340"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6416,7 +6416,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=520"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6429,7 +6429,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=170"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6442,7 +6442,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=110"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6455,7 +6455,7 @@ periodics:
   spec:
     containers:
     - args:
-      - "--repo=github.com/containerd/cri-containerd=master"
+      - "--repo=github.com/containerd/cri=master"
       - "--timeout=70"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180312-a6be97dc1-master
 
@@ -6471,10 +6471,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri-containerd=master
+      - --repo=github.com/containerd/cri=master
       - --timeout=90
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
       env:
       - name: GOPATH
         value: /go
@@ -6491,10 +6491,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri-containerd=master
+      - --repo=github.com/containerd/cri=master
       - --timeout=90
       - --
-      - "--node-args=--image-config-file=test/e2e_node/benchmark-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/benchmark-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
       env:
       - name: GOPATH
         value: /go
@@ -6512,10 +6512,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri-containerd=master
+      - --repo=github.com/containerd/cri=master
       - --timeout=140
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
       env:
       - name: GOPATH
         value: /go
@@ -6532,10 +6532,10 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri-containerd=master
+      - --repo=github.com/containerd/cri=master
       - --timeout=240
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri-containerd"
+      - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
       env:
       - name: GOPATH
         value: /go

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -16,7 +16,7 @@ triggers:
   trusted_org: kubernetes
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
 - repos:
-  - containerd/cri-containerd
+  - containerd/cri
   trusted_org: containerd
   join_org_url: "https://github.com/containerd/containerd/blob/master/MAINTAINERS"
 - repos:
@@ -310,7 +310,7 @@ plugins:
   kubernetes-sigs/scheduling_poseidon:
   - approve
 
-  containerd/cri-containerd:
+  containerd/cri:
   - assign
   - cla
   - label


### PR DESCRIPTION
/hold

We are planning to rename `cri-containerd` repository to `cri`, because it becomes a plugin of containerd now.

Please hold this PR until the actual renaming happens. It will happen soon.

Signed-off-by: Lantao Liu <lantaol@google.com>