### PR TITLE
set pure=on for needs-rebase

### DIFF
--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
 go_binary(
     name = "needs-rebase",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/7257

we don't want to build with cgo. most of test-infra should not use cgo at all.