### PR TITLE
clonerefs: handle the case where we're on the target ref

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -55,6 +55,13 @@ func Run(refs kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 	} else {
 		target = "FETCH_HEAD"
 	}
+	// we need to be "on" the target branch after the sync
+	// so we need to set the branch to point to the base ref,
+	// but we cannot update a branch we are on, so in case we
+	// are on the branch we are syncing, we check out the SHA
+	// first and reset the branch second, then check out the
+	// branch we just reset to be in the correct final state
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", target))
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "branch", "--force", refs.BaseRef, target))
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", refs.BaseRef))
 


### PR DESCRIPTION
When we already have a cloned repository before we do a sync and we are
already on the target base ref before the sync, `git branch --force`
will fail. We therefore can check out the target SHA and reset the
branch while we're not on it, then checkout the branch again to not
remain in detached `HEAD` state after the sync.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @BenTheElder 
/assign @kargakis 