### PR TITLE
Thaw 1.10 code freeze.

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -33,5 +33,5 @@ label-file: "/gitrepos/kubernetes/labels.yaml"
 alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 use-reviewers: true
 # milestone-maintainer
-milestone-modes: v1.8=dev,v1.9=dev,v1.10=freeze
+milestone-modes: v1.8=dev,v1.9=dev,v1.10=dev,v1.11=dev
 milestone-freeze-date: "TBD"

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -91,8 +91,8 @@ nonblocking-jobs: "\
   ci-kubernetes-soak-gke-test,\
   ci-kubernetes-integration-master,\
   ci-kubernetes-verify-master"
-do-not-merge-milestones: "v1.11,v1.12,v1.13,next-candidate,NO-MILESTONE"
-additional-required-labels: "status/approved-for-milestone"
+do-not-merge-milestones: ""
+additional-required-labels: ""
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
 history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
I'll be OOO when this needs to be deployed, so someone else will need to roll this out. Here are instructions for deploying:

1. After this PR merges, fetch and checkout the master branch.
1. `cd mungegithub/misc-mungers/deployment/kubernetes/`
1. `make push_config deploy`
1. `cd ../../../submit-queue/deployment/kubernetes/`
1. `make push_config deploy`

Monitor the logs with kubectl or stackdriver after deploying to make sure that the behavior seems appropriate after the pods restart. 

Don't panic:
- The new pods will take a minute to bind to their persistent volumes before they start.
- It is likely that the bot will run out of API tokens during the update. This shouldn't cause any problems besides some down time. The logs will indicate when token limits will be refreshed.
- You can ignore submit-queue errors like "Got a non-success response 404 while reading data for ci-kubernetes-soak-gke-gci-test/latest-build.txt". they aren't important.

/area mungegithub
/cc @krzyzacy @BenTheElder @jdumars 