### PR TITLE
Actually omit prowjobspec parts when empty

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -158,7 +158,7 @@ func main() {
 	spec := kube.ProwJobSpec{
 		Type: kube.PresubmitJob,
 		Job:  o.jobName,
-		Refs: kube.Refs{
+		Refs: &kube.Refs{
 			Org:     o.org,
 			Repo:    o.repo,
 			BaseRef: pr.Base.Ref,

--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -207,10 +207,6 @@ func (ja *JobAgent) update() error {
 		buildID := j.Status.BuildID
 		nj := Job{
 			Type:    string(j.Spec.Type),
-			Repo:    fmt.Sprintf("%s/%s", j.Spec.Refs.Org, j.Spec.Refs.Repo),
-			Refs:    j.Spec.Refs.String(),
-			BaseRef: j.Spec.Refs.BaseRef,
-			BaseSHA: j.Spec.Refs.BaseSHA,
 			Job:     j.Spec.Job,
 			Context: j.Spec.Context,
 			Agent:   j.Spec.Agent,
@@ -232,10 +228,16 @@ func (ja *JobAgent) update() error {
 			duration -= duration % time.Second // strip fractional seconds
 			nj.Duration = duration.String()
 		}
-		if len(j.Spec.Refs.Pulls) == 1 {
-			nj.Number = j.Spec.Refs.Pulls[0].Number
-			nj.Author = j.Spec.Refs.Pulls[0].Author
-			nj.PullSHA = j.Spec.Refs.Pulls[0].SHA
+		if j.Spec.Refs != nil {
+			nj.Repo = fmt.Sprintf("%s/%s", j.Spec.Refs.Org, j.Spec.Refs.Repo)
+			nj.Refs = j.Spec.Refs.String()
+			nj.BaseRef = j.Spec.Refs.BaseRef
+			nj.BaseSHA = j.Spec.Refs.BaseSHA
+			if len(j.Spec.Refs.Pulls) == 1 {
+				nj.Number = j.Spec.Refs.Pulls[0].Number
+				nj.Author = j.Spec.Refs.Pulls[0].Author
+				nj.PullSHA = j.Spec.Refs.Pulls[0].SHA
+			}
 		}
 		njs = append(njs, nj)
 		if nj.PodName != "" {

--- a/prow/cmd/deck/jobs_test.go
+++ b/prow/cmd/deck/jobs_test.go
@@ -106,7 +106,7 @@ func TestProwJobs(t *testing.T) {
 			Spec: kube.ProwJobSpec{
 				Agent: kube.KubernetesAgent,
 				Job:   "job",
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Org:  "kubernetes",
 					Repo: "test-infra",
 				},

--- a/prow/cmd/splice/main_test.go
+++ b/prow/cmd/splice/main_test.go
@@ -189,7 +189,7 @@ func fakeProwJob(context string, jobType kube.ProwJobType, completed bool, state
 		},
 		Spec: kube.ProwJobSpec{
 			Context: context,
-			Refs:    refs,
+			Refs:    &refs,
 			Type:    jobType,
 		},
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -749,7 +749,7 @@ func TestURLTemplate(t *testing.T) {
 			Spec: kube.ProwJobSpec{
 				Type: tc.jobType,
 				Job:  tc.job,
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Pulls: []kube.Pull{{}},
 					Org:   tc.org,
 					Repo:  tc.repo,
@@ -807,7 +807,7 @@ func TestReportTemplate(t *testing.T) {
 		var b bytes.Buffer
 		if err := c.Plank.ReportTemplate.Execute(&b, &kube.ProwJob{
 			Spec: kube.ProwJobSpec{
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Org:  tc.org,
 					Repo: tc.repo,
 					Pulls: []kube.Pull{

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -239,7 +239,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Pulls: []kube.Pull{{
 							Number: 1,
 							SHA:    "fake-sha",
@@ -443,7 +443,7 @@ func TestSyncPendingJobs(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Type: kube.PresubmitJob,
 					Job:  "test-job",
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Pulls: []kube.Pull{{
 							Number: 1,
 							SHA:    "fake-sha",
@@ -675,7 +675,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-e2e",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{
@@ -697,7 +697,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-bazel-build",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{
@@ -724,7 +724,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-bazel-build",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -83,14 +83,14 @@ type ProwJobSpec struct {
 	Agent   ProwJobAgent `json:"agent,omitempty"`
 	Cluster string       `json:"cluster,omitempty"`
 	Job     string       `json:"job,omitempty"`
-	Refs    Refs         `json:"refs,omitempty"`
+	Refs    *Refs        `json:"refs,omitempty"`
 
 	Report         bool   `json:"report,omitempty"`
 	Context        string `json:"context,omitempty"`
 	RerunCommand   string `json:"rerun_command,omitempty"`
 	MaxConcurrency int    `json:"max_concurrency,omitempty"`
 
-	PodSpec v1.PodSpec `json:"pod_spec,omitempty"`
+	PodSpec *v1.PodSpec `json:"pod_spec,omitempty"`
 
 	RunAfterSuccess []ProwJobSpec `json:"run_after_success,omitempty"`
 }

--- a/prow/pjutil/jobspec.go
+++ b/prow/pjutil/jobspec.go
@@ -52,12 +52,16 @@ type JobSpec struct {
 }
 
 func NewJobSpec(spec kube.ProwJobSpec, buildId, prowJobId string) JobSpec {
+	refs := kube.Refs{}
+	if spec.Refs != nil {
+		refs = *spec.Refs
+	}
 	return JobSpec{
 		Type:      spec.Type,
 		Job:       spec.Job,
 		BuildId:   buildId,
 		ProwJobId: prowJobId,
-		Refs:      spec.Refs,
+		Refs:      refs,
 		agent:     spec.Agent,
 	}
 }

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -43,7 +43,7 @@ func TestProwJobToPod(t *testing.T) {
 				Type:  kube.PresubmitJob,
 				Job:   "job-name",
 				Agent: kube.KubernetesAgent,
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Org:     "org-name",
 					Repo:    "repo-name",
 					BaseRef: "base-ref",
@@ -54,7 +54,7 @@ func TestProwJobToPod(t *testing.T) {
 						SHA:    "pull-sha",
 					}},
 				},
-				PodSpec: v1.PodSpec{
+				PodSpec: &v1.PodSpec{
 					Containers: []v1.Container{
 						{
 							Image: "tester",
@@ -277,7 +277,7 @@ func TestGetLatestProwJobs(t *testing.T) {
 						Type:  kube.PresubmitJob,
 						Agent: kube.JenkinsAgent,
 						Job:   "test_pull_request_origin_extended_networking_minimal",
-						Refs: kube.Refs{
+						Refs: &kube.Refs{
 							Org:     "openshift",
 							Repo:    "origin",
 							BaseRef: "master",
@@ -311,7 +311,7 @@ func TestGetLatestProwJobs(t *testing.T) {
 						Type:  kube.PresubmitJob,
 						Agent: kube.JenkinsAgent,
 						Job:   "test_pull_request_origin_extended_networking_minimal",
-						Refs: kube.Refs{
+						Refs: &kube.Refs{
 							Org:     "openshift",
 							Repo:    "origin",
 							BaseRef: "master",

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -205,7 +205,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
@@ -216,7 +216,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
@@ -227,7 +227,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-2 * time.Hour)),
@@ -238,7 +238,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime:      metav1.NewTime(now.Add(-3 * time.Hour)),
@@ -250,7 +250,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j2",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
@@ -261,7 +261,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j2",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
@@ -272,7 +272,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j3",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
@@ -283,7 +283,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j3",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
@@ -305,7 +305,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
@@ -316,7 +316,7 @@ func TestTerminateDupes(t *testing.T) {
 					Spec: kube.ProwJobSpec{
 						Type: kube.PresubmitJob,
 						Job:  "j1",
-						Refs: kube.Refs{Pulls: []kube.Pull{{}}},
+						Refs: &kube.Refs{Pulls: []kube.Pull{{}}},
 					},
 					Status: kube.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
@@ -422,8 +422,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Name: "blabla",
 				},
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PeriodicJob,
+					Job:     "boop",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -443,6 +444,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Job:            "same",
 					Type:           kube.PeriodicJob,
 					MaxConcurrency: 1,
+					PodSpec:        new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -474,6 +476,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Type:           kube.PeriodicJob,
 					Cluster:        "trusted",
 					MaxConcurrency: 1,
+					PodSpec:        new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -508,6 +511,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Type:           kube.PeriodicJob,
 					Cluster:        "trusted",
 					MaxConcurrency: 1,
+					PodSpec:        new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -539,8 +543,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Name: "beer",
 				},
 				Spec: kube.ProwJobSpec{
-					Job:  "same",
-					Type: kube.PeriodicJob,
+					Job:     "same",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -557,8 +562,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Name: "beer",
 				},
 				Spec: kube.ProwJobSpec{
-					Job:  "same",
-					Type: kube.PeriodicJob,
+					Job:     "same",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -576,8 +582,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			name: "unprocessable prow job",
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PeriodicJob,
+					Job:     "boop",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -593,8 +600,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			name: "conflict error starting pod",
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PeriodicJob,
+					Job:     "boop",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -608,8 +616,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			name: "unknown error starting pod",
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PeriodicJob,
+					Job:     "boop",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -626,8 +635,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PeriodicJob,
+					Job:     "boop",
+					Type:    kube.PeriodicJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -770,7 +780,8 @@ func TestSyncPendingJob(t *testing.T) {
 					Name: "boop-41",
 				},
 				Spec: kube.ProwJobSpec{
-					Type: kube.PostsubmitJob,
+					Type:    kube.PostsubmitJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State:   kube.PendingState,
@@ -846,7 +857,7 @@ func TestSyncPendingJob(t *testing.T) {
 				},
 				Spec: kube.ProwJobSpec{
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org: "kubernetes", Repo: "kubernetes",
 						BaseRef: "baseref", BaseSHA: "basesha",
 						Pulls: []kube.Pull{{Number: 100, Author: "me", SHA: "sha"}},
@@ -966,8 +977,9 @@ func TestSyncPendingJob(t *testing.T) {
 					Name: "jose",
 				},
 				Spec: kube.ProwJobSpec{
-					Job:  "boop",
-					Type: kube.PostsubmitJob,
+					Job:     "boop",
+					Type:    kube.PostsubmitJob,
+					PodSpec: new(kube.PodSpec),
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.PendingState,
@@ -1012,6 +1024,7 @@ func TestSyncPendingJob(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
+		t.Logf("Running test case %q", tc.name)
 		totServ := httptest.NewServer(http.HandlerFunc(handleTot))
 		defer totServ.Close()
 		pm := make(map[string]kube.Pod)
@@ -1102,12 +1115,11 @@ func TestPeriodic(t *testing.T) {
 		pendingJobs: make(map[string]int),
 		lock:        sync.RWMutex{},
 	}
-
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on first sync: %v", err)
 	}
-	if fc.prowjobs[0].Spec.PodSpec.Containers[0].Name != "" {
-		t.Fatal("Sync step updated the TPR spec.")
+	if len(fc.prowjobs[0].Spec.PodSpec.Containers) != 1 || fc.prowjobs[0].Spec.PodSpec.Containers[0].Name != "" {
+		t.Fatalf("Sync step updated the pod spec: %#v", fc.prowjobs[0].Spec.PodSpec)
 	}
 	if len(fc.pods) != 1 {
 		t.Fatal("Didn't create pod on first sync.")
@@ -1160,7 +1172,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-e2e",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{
@@ -1182,7 +1194,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-bazel-build",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{
@@ -1209,7 +1221,7 @@ func TestRunAfterSuccessCanRun(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  "test-bazel-build",
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{
+					Refs: &kube.Refs{
 						Org:  "kubernetes",
 						Repo: "kubernetes",
 						Pulls: []kube.Pull{
@@ -1263,6 +1275,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 						Job:            "test-bazel-build",
 						Type:           kube.PostsubmitJob,
 						MaxConcurrency: 1,
+						PodSpec:        new(kube.PodSpec),
 					},
 					Status: kube.ProwJobStatus{
 						State: kube.TriggeredState,
@@ -1273,6 +1286,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 						Job:            "test-bazel-build",
 						Type:           kube.PostsubmitJob,
 						MaxConcurrency: 1,
+						PodSpec:        new(kube.PodSpec),
 					},
 					Status: kube.ProwJobStatus{
 						State: kube.TriggeredState,
@@ -1290,6 +1304,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 						Job:            "test-bazel-build",
 						Type:           kube.PostsubmitJob,
 						MaxConcurrency: 2,
+						PodSpec:        new(kube.PodSpec),
 					},
 					Status: kube.ProwJobStatus{
 						State: kube.TriggeredState,
@@ -1300,6 +1315,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 						Job:            "test-bazel-build",
 						Type:           kube.PostsubmitJob,
 						MaxConcurrency: 2,
+						PodSpec:        new(kube.PodSpec),
 					},
 					Status: kube.ProwJobStatus{
 						State: kube.TriggeredState,
@@ -1339,6 +1355,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		t.Logf("Running scenario %q", test.name)
 		jobs := make(chan kube.ProwJob, len(test.pjs))
 		for _, pj := range test.pjs {
 			jobs <- pj

--- a/prow/report/report_test.go
+++ b/prow/report/report_test.go
@@ -176,7 +176,7 @@ func TestParseIssueComment(t *testing.T) {
 		pj := kube.ProwJob{
 			Spec: kube.ProwJobSpec{
 				Context: tc.context,
-				Refs:    kube.Refs{Pulls: []kube.Pull{{}}},
+				Refs:    &kube.Refs{Pulls: []kube.Pull{{}}},
 			},
 			Status: kube.ProwJobStatus{
 				State: kube.ProwJobState(tc.state),
@@ -324,7 +324,7 @@ func TestReportStatus(t *testing.T) {
 			Spec: kube.ProwJobSpec{
 				Context: "parent",
 				Report:  report,
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Org:  "k8s",
 					Repo: "test-infra",
 					Pulls: []kube.Pull{{

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -158,6 +158,7 @@ func TestAccumulateBatch(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  pj.job,
 					Type: kube.BatchJob,
+					Refs: new(kube.Refs),
 				},
 				Status: kube.ProwJobStatus{State: pj.state},
 			}
@@ -306,7 +307,7 @@ func TestAccumulate(t *testing.T) {
 				Spec: kube.ProwJobSpec{
 					Job:  pj.job,
 					Type: kube.PresubmitJob,
-					Refs: kube.Refs{Pulls: []kube.Pull{{Number: pj.prNumber}}},
+					Refs: &kube.Refs{Pulls: []kube.Pull{{Number: pj.prNumber}}},
 				},
 				Status: kube.ProwJobStatus{State: pj.state},
 			})
@@ -719,7 +720,7 @@ func TestDividePool(t *testing.T) {
 		pjs = append(pjs, kube.ProwJob{
 			Spec: kube.ProwJobSpec{
 				Type: pj.jobType,
-				Refs: kube.Refs{
+				Refs: &kube.Refs{
 					Org:     pj.org,
 					Repo:    pj.repo,
 					BaseRef: pj.baseRef,


### PR DESCRIPTION
Fix the prowjob API to actually omit fields when empty.
Also fix some mutations in the plank controller that
will bite us back once we switch to informers w/ caches.