### PR TITLE
prow: plank: support initcontainers in PodSpec better

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -150,6 +150,14 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	// Set environment variables in each container in the pod spec. We don't
 	// want to update the spec in place, since that will update the ProwJob
 	// spec. Instead, create a copy.
+	spec.InitContainers = []v1.Container{}
+	for i := range pj.Spec.PodSpec.InitContainers {
+		spec.InitContainers = append(spec.InitContainers, pj.Spec.PodSpec.InitContainers[i])
+		if spec.InitContainers[i].Name == "" {
+			spec.InitContainers[i].Name = fmt.Sprintf("%s-%d", pj.ObjectMeta.Name, i)
+		}
+		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, kubeEnv(env)...)
+	}
 	spec.Containers = []v1.Container{}
 	for i := range pj.Spec.PodSpec.Containers {
 		spec.Containers = append(spec.Containers, pj.Spec.PodSpec.Containers[i])

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -153,7 +153,9 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	spec.Containers = []v1.Container{}
 	for i := range pj.Spec.PodSpec.Containers {
 		spec.Containers = append(spec.Containers, pj.Spec.PodSpec.Containers[i])
-		spec.Containers[i].Name = fmt.Sprintf("%s-%d", pj.ObjectMeta.Name, i)
+		if spec.Containers[i].Name == "" {
+			spec.Containers[i].Name = fmt.Sprintf("%s-%d", pj.ObjectMeta.Name, i)
+		}
 		spec.Containers[i].Env = append(spec.Containers[i].Env, kubeEnv(env)...)
 	}
 	podLabels := make(map[string]string)


### PR DESCRIPTION
Only overwrite container names if they are unset

As soon as user-specified container names are actually useful and there
are more containers and initcontainers that just one, we should not
overwrite the names unless we aren't given one in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Propagate environment to initcontainers as well

Plank needs to propagate environment variables to the init containers in
the PodSpec as well as the Containers so that they can all use the
`$JOB_SPEC` interface.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/area prow
/kind enhancement
/cc @kargakis @cjwagner 
/assign @BenTheElder 