### PR TITLE
Fix pr dashboard test status display with /retest-ed PRs.

### DIFF
--- a/prow/cmd/deck/static/pr-script.js
+++ b/prow/cmd/deck/static/pr-script.js
@@ -437,7 +437,7 @@ function createJobStatus(builds) {
             stateIcon = "check_circle";
             break;
         case "failed":
-            statusText = failedJobs.length + " test(s) failed";
+            statusText = failedJobs.length + " test" + (failedJobs.length === 1 ? "" : "s") + " failed";
             stateIcon = "error";
             break;
         case "unknown":


### PR DESCRIPTION
Before, it would collect all builds for each PR. If a job had flaked
(failed then passed), it would display the job as failed.