### PR TITLE
set --gcp-node-image to 'custom'

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -927,7 +927,7 @@ images:
     args:
     - --image-family=ubuntu-gke-1604-lts-1
     - --image-project=ubuntu-os-gke-cloud-devel
-    - --gcp-node-image=CUSTOM
+    - --gcp-node-image=custom
   ubuntudev:
     args:
     - --image-family=ubuntu-gke-1604-lts-1


### PR DESCRIPTION
I expect we can use `custom` for both GCE and GKE tests, when https://github.com/kubernetes/kubernetes/pull/61235 is merged and cherry-picked.

/assign @krzyzacy 