### PR TITLE
update janitor deployment to pick up logsink fix

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20171209-206236aa6
+        image: gcr.io/k8s-testimages/janitor:v20180315-843b952c0
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project,ingress-project


### PR DESCRIPTION
picks up https://github.com/kubernetes/test-infra/pull/7304

/hold
wait for a ci-pull-janitor run