### PR TITLE
make janitor.py can run with latest gcloud

### DIFF
--- a/boskos/janitor/janitor.py
+++ b/boskos/janitor/janitor.py
@@ -53,7 +53,8 @@ DEMOLISH_ORDER = [
     Resource('compute', 'routes', None, None, None, False),
 
     # logging resources
-    Resource('logging', 'sinks', None, None, None, False),
+    # sinks does not have creationTimestamp yet
+    #Resource('logging', 'sinks', None, None, None, False),
 ]
 
 
@@ -267,7 +268,7 @@ if __name__ == '__main__':
         help='Clean items more than --hours old (added to --days)')
     PARSER.add_argument(
         '--filter',
-        default='NOT tags.items:do-not-delete AND NOT name ~ ^default',
+        default='name !~ ^default',
         help='Filter down to these instances')
     PARSER.add_argument(
         '--dryrun',

--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -26,12 +26,21 @@ RUN apt-get update && apt-get install -y \
     wget && \
     apt-get clean
 
-ENV GCLOUD_VERSION 163.0.0
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
-    tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz -C / && \
-    rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
-    /google-cloud-sdk/install.sh
-ENV PATH "/google-cloud-sdk/bin:${PATH}"
+# Install gcloud
+
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud components install alpha beta kubectl && \
+    gcloud info | tee /workspace/gcloud-info.txt
 
 WORKDIR /workspace
 ADD runner /


### PR DESCRIPTION
and unpin gcloud version in gcloud-in-go image

updated --filter, we don't really mark anything as do-not-delete anymore, that was for jenkins vms

disabled cleaning logging sinks because of https://github.com/kubernetes/test-infra/issues/7295#issuecomment-373571541

/assign @BenTheElder 