### PR TITLE
Add CI node e2e and e2e test for containerd repo.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -35,6 +35,70 @@
       "sig-node"
     ]
   },
+  "ci-containerd-build": {
+    "args": [
+      "/go/src/github.com/containerd/cri/test/build-containerd.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-containerd-e2e-gci-gce": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce.env",
+      "--env-file=jobs/env/ci-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-containerd-e2e-ubuntu-gce": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=ubuntu",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--image-family=ubuntu-gke-1604-lts",
+      "--image-project=ubuntu-os-gke-cloud",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-containerd-node-e2e": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=cri-containerd-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-test-args=--container-runtime=remote --container-runtime-endpoint=/run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/runtime\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\" --flakeAttempts=2",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-cri-containerd-build": {
     "args": [
       "./test/build.sh"

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -583,6 +583,7 @@ class JobTest(unittest.TestCase):
             'ci-cri-containerd-node-e2e-serial': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-flaky': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-benchmark': 'cri-containerd-node-e2e-*',
+            'ci-containerd-node-e2e': 'cri-containerd-node-e2e-*',
             # ci-cri-containerd-e2e-gce-stackdriver intentionally share projects with
             # ci-kubernetes-e2e-gce-stackdriver.
             'ci-kubernetes-e2e-gce-stackdriver': 'k8s-jkns-e2e-gce-stackdriver',

--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -1,0 +1,14 @@
+### job-env
+# Envs for containerd.
+LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni
+KUBE_CONTAINER_RUNTIME=remote
+KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
+KUBE_CONTAINER_RUNTIME_NAME=containerd
+KUBE_LOAD_IMAGE_COMMAND=/home/containerd/usr/local/bin/ctr cri load
+NETWORK_POLICY_PROVIDER=calico
+NON_MASQUERADE_CIDR=0.0.0.0/0
+KUBELET_TEST_ARGS=--runtime-cgroups=/runtime
+# TODO(random-liu): Enable this after kubernetes/kubernetes#55141 is fixed.
+PREPULL_E2E_IMAGES=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6653,6 +6653,66 @@ periodics:
       - name: GOPATH
         value: /go
 
+- name: ci-containerd-build
+  interval: 30m
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180314-34ab1109a-experimental
+      args:
+      - "--repo=github.com/containerd/containerd=master"
+      - "--repo=github.com/containerd/cri=master"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-containerd-e2e-gci-gce
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri=master"
+      - "--timeout=70"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180314-34ab1109a-master
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-containerd-e2e-ubuntu-gce
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/containerd/cri=master"
+      - "--timeout=70"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180314-34ab1109a-master
+
+- name: ci-containerd-node-e2e
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180314-34ab1109a-master
+      args:
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes
+      - --repo=github.com/containerd/cri=master
+      - --timeout=90
+      - --
+      - "--node-args=--image-config-file=test/e2e_node/image-config-containerd.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
+      env:
+      - name: GOPATH
+        value: /go
+
 - name: ci-cri-containerd-build
   interval: 30m
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -84,6 +84,8 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-cri-containerd-build
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-build
+- name: ci-containerd-build
+  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-build
 - name: ci-cri-containerd-e2e-gci-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce
 - name: ci-cri-containerd-e2e-ubuntu-gce
@@ -120,6 +122,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gce-stackdriver
 - name: ci-cri-containerd-e2e-gci-gce-ip-alias
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-ip-alias
+- name: ci-containerd-e2e-gci-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-e2e-gci-gce
+- name: ci-containerd-e2e-ubuntu-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce
 - name: ci-cri-containerd-node-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e
   test_name_config:
@@ -143,6 +149,13 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-cri-containerd-node-e2e-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e-benchmark
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-containerd-node-e2e
+  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e
   test_name_config:
     name_elements:
     - target_config: Tests name
@@ -4340,6 +4353,14 @@ dashboards:
     test_group_name: ci-cri-containerd-e2e-gci-gce
   - name: e2e-ubuntu
     test_group_name: ci-cri-containerd-e2e-ubuntu-gce
+  - name: containerd-build
+    test_group_name: ci-containerd-build
+  - name: containerd-node-e2e
+    test_group_name: ci-containerd-node-e2e
+  - name: containerd-e2e-gci
+    test_group_name: ci-containerd-e2e-gci-gce
+  - name: containerd-e2e-ubuntu
+    test_group_name: ci-containerd-e2e-ubuntu-gce
   - name: e2e-gci-etcd3
     test_group_name: ci-cri-containerd-e2e-gci-gce-etcd3
   - name: e2e-gci-reboot


### PR DESCRIPTION
Setup node e2e and e2e CI test for containerd repo.

Depends on https://github.com/containerd/cri/pull/673.

/hold