### PR TITLE
Require that clone aliases are set per-repo

### DIFF
--- a/prow/pod-utils/clone/parse.go
+++ b/prow/pod-utils/clone/parse.go
@@ -98,7 +98,7 @@ type PathResolver struct {
 // Resolve returns an override clone path if the org and
 // repo match the settings in in the resolver
 func (r *PathResolver) Resolve(org, repo string) string {
-	if r.org == org && (r.repo == "" || r.repo == repo) {
+	if r.org == org && r.repo == repo {
 		return r.path
 	}
 
@@ -106,13 +106,7 @@ func (r *PathResolver) Resolve(org, repo string) string {
 }
 
 func (r *PathResolver) String() string {
-	var prefix string
-	if r.repo == "" {
-		prefix = r.org
-	} else {
-		prefix = fmt.Sprintf("%s,%s", r.org, r.repo)
-	}
-	return fmt.Sprintf("%s=%s", prefix, r.path)
+	return fmt.Sprintf("%s,%s=%s", r.org, r.repo, r.path)
 }
 
 // ParseAliases parses a human-provided string into a
@@ -120,10 +114,9 @@ func (r *PathResolver) String() string {
 // $GOPATH/src directory where the repository should
 // be cloned. The format for the human-provided string
 // is:
-//   org[,repo]=path
-// The repository is optional and if not set, all repos
-// for the org will be captured. Exmaples:
-//   kubernetes=k8s.io
+//   org,repo=path
+// Examples:
+//   kubernetes,test-infra=k8s.io/test-infra
 //   myorg,non-go-project=somewhere/else
 func ParseAliases(value string) (PathResolver, error) {
 	var resolver PathResolver
@@ -136,14 +129,11 @@ func ParseAliases(value string) (PathResolver, error) {
 
 	infoValues := strings.SplitN(info, ",", 2)
 	switch len(infoValues) {
-	case 1:
-		resolver.org = infoValues[0]
-		return resolver, nil
 	case 2:
 		resolver.org = infoValues[0]
 		resolver.repo = infoValues[1]
 		return resolver, nil
 	default:
-		return resolver, fmt.Errorf("path override %s invalid: does not contain 'org[,repo]' as prefix", value)
+		return resolver, fmt.Errorf("path override %s invalid: does not contain 'org,repo' as prefix", value)
 	}
 }

--- a/prow/pod-utils/clone/parse_test.go
+++ b/prow/pod-utils/clone/parse_test.go
@@ -134,7 +134,7 @@ func TestParseRefs(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "malformed pull nuber",
+			name:      "malformed pull number",
 			value:     "org,repo=branch:sha,NaN:sha",
 			expectErr: true,
 		},
@@ -173,13 +173,9 @@ func TestParseAliases(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:  "only org provided",
-			value: "org=path",
-			expected: PathResolver{
-				org:  "org",
-				path: "path",
-			},
-			expectErr: false,
+			name:      "only org provided",
+			value:     "org=path",
+			expectErr: true,
 		},
 		{
 			name:      "no org or repo",
@@ -239,21 +235,12 @@ func TestPathResolver_Resolve(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "matching resolver for org",
-			org:  "org",
-			repo: "repo",
-			resolver: PathResolver{
-				org:  "org",
-				path: "path",
-			},
-			expected: "path",
-		},
-		{
 			name: "not matching resolver for org",
 			org:  "org2",
 			repo: "repo",
 			resolver: PathResolver{
 				org:  "org",
+				repo: "repo",
 				path: "path",
 			},
 			expected: "",


### PR DESCRIPTION
Instead of trying to be clever and support org-wide overrides that can
use the repo name dynamically, we can just force users to give us an
override per-repo and make the overrides static.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @kargakis @cjwagner 
/assign @BenTheElder 

Realized the first implementation was not the best. Since we expect this alias to consume the org and repo, the alias itself should be able to use those bits of information to format the clone path. 