### PR TITLE
Remove some deprecated labels

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -13,17 +13,19 @@ labels:
   - color: bfe5bf
     name: 'cla: human-approved'
   - color: e11d21
+    deleteAfter: 2018-03-16T00:00:00Z07:00
     name: 'cla: no'
   - color: bfe5bf
+    deleteAfter: 2018-03-16T00:00:00Z07:00
     name: 'cla: yes'
   - color: d455d0
-    name: 'close/duplicate'
+    name: close/duplicate
   - color: d455d0
-    name: 'close/needs-information'
+    name: close/needs-information
   - color: d455d0
-    name: 'close/not-reproducible'
+    name: close/not-reproducible
   - color: d455d0
-    name: 'close/unresolved'
+    name: close/unresolved
   - color: c0ff4a
     name: committee/conduct
   - color: c0ff4a
@@ -75,6 +77,7 @@ labels:
   - color: ededed
     name: needs-sig
   - color: fbca04
+    deleteAfter: 2018-03-16T00:00:00Z07:00
     name: ok-to-merge
   - color: fef2c0
     name: priority/awaiting-more-evidence
@@ -105,6 +108,7 @@ labels:
   - color: c2e0c6
     name: release-note-none
   - color: d93f0b
+    deleteAfter: 2018-03-16T00:00:00Z07:00
     name: requires-release-czar-attention
   - color: eb6420
     name: retest-not-required
@@ -142,9 +146,6 @@ labels:
     name: sig/instrumentation
   - color: d2b48c
     name: sig/multicluster
-    previously:
-      - name: sig/federation
-      - name: 'sig/federation (deprecated - do not use)'
   - color: d2b48c
     name: sig/network
   - color: d2b48c
@@ -193,207 +194,3 @@ labels:
     name: status/in-progress
   - color: fef2c0
     name: status/in-review
-
-unknown:
-#  - color: 0052cc
-#    name: area/admin
-#  - color: 0052cc
-#    name: area/admission-control
-#  - color: 0052cc
-#    name: area/api
-#  - color: 0052cc
-#    name: area/apiserver
-#  - color: 0052cc
-#    name: area/app-lifecycle
-#  - color: 0052cc
-#    name: area/batch
-#  - color: 0052cc
-#    name: area/build-release
-#  - color: 0052cc
-#    name: area/cadvisor
-#  - color: 0052cc
-#    name: area/client-libraries
-#  - color: 0052cc
-#    name: area/cloudprovider
-#  - color: 0052cc
-#    name: area/configmap-api
-#  - color: 0052cc
-#    name: area/controller-manager
-#  - color: 0052cc
-#    name: area/declarative-configuration
-#  - color: 0052cc
-#    name: area/dns
-#  - color: 0052cc
-#    name: area/docker
-#  - color: 0052cc
-#    name: area/downward-api
-#  - color: 0052cc
-#    name: area/ecosystem
-#  - color: 0052cc
-#    name: area/etcd
-#  - color: 0052cc
-#    name: area/example
-#  - color: 0052cc
-#    name: area/example/cassandra
-#  - color: 0052cc
-#    name: area/extensibility
-#  - color: 0052cc
-#    name: area/HA
-#  - color: 0052cc
-#    name: area/hw-accelerators
-#  - color: 0052cc
-#    name: area/images-registry
-#  - color: 0052cc
-#    name: area/ingress
-#  - color: 0052cc
-#    name: area/introspection
-#  - color: 0052cc
-#    name: area/ipv6
-#  - color: 0052cc
-#    name: area/isolation
-#  - color: 0052cc
-#    name: area/kube-proxy
-#  - color: 0052cc
-#    name: area/kubeadm
-#  - color: 0052cc
-#    name: area/kubectl
-#  - color: 0052cc
-#    name: area/kubelet
-#  - color: 0052cc
-#    name: area/kubelet-api
-#  - color: 0052cc
-#    name: area/logging
-#  - color: 0052cc
-#    name: area/monitoring
-#  - color: 0052cc
-#    name: area/node-e2e
-#  - color: 0052cc
-#    name: area/node-lifecycle
-#  - color: 0052cc
-#    name: area/nodecontroller
-#  - color: d4c5f9
-#    name: area/os/coreos
-#  - color: d4c5f9
-#    name: area/os/fedora
-#  - color: d4c5f9
-#    name: area/os/gci
-#  - color: d4c5f9
-#    name: area/os/ubuntu
-#  - color: d4c5f9
-#    name: area/platform/aws
-#  - color: d4c5f9
-#    name: area/platform/azure
-#  - color: d4c5f9
-#    name: area/platform/gce
-#  - color: d4c5f9
-#    name: area/platform/gke
-#  - color: d4c5f9
-#    name: area/platform/mesos
-#  - color: d4c5f9
-#    name: area/platform/vagrant
-#  - color: d4c5f9
-#    name: area/platform/vsphere
-#  - color: 0052cc
-#    name: area/release-infra
-#  - color: 0052cc
-#    name: area/reliability
-#  - color: 0052cc
-#    name: area/rkt
-#  - color: 0052cc
-#    name: area/secret-api
-#  - color: d93f0b
-#    name: area/security
-#  - color: 0052cc
-#    name: area/stateful-apps
-#  - color: 0052cc
-#    name: area/swagger
-#  - color: 0052cc
-#    name: area/system-requirement
-#  - color: 0052cc
-#    name: area/teardown
-#  - color: 0052cc
-#    name: area/test
-#  - color: 0052cc
-#    name: area/test-infra
-#  - color: 0052cc
-#    name: area/third-party-resource
-#  - color: 0052cc
-#    name: area/ui
-#  - color: 0052cc
-#    name: area/upgrade
-#  - color: 0052cc
-#    name: area/usability
-#  - color: 0052cc
-#    name: area/workload-api/cronjob
-#  - color: 0052cc
-#    name: area/workload-api/daemonset
-#  - color: 0052cc
-#    name: area/workload-api/deployment
-#  - color: 0052cc
-#    name: area/workload-api/job
-#  - color: 0052cc
-#    name: area/workload-api/replicaset
-#  - color: d93f0b
-#    name: beta-blocker
-#  - color: fbca04
-#    name: flake-has-meta
-#  - color: c7def8
-#    name: kind/api-change
-#  - color: c7def8
-#    name: kind/cleanup
-#  - color: c7def8
-#    name: kind/design
-#  - color: c7def8
-#    name: kind/enhancement
-#  - color: f7c6c7
-#    name: kind/flake
-#  - color: c7def8
-#    name: kind/friction
-#  - color: f7c6c7
-#    name: kind/mesos-flake
-#  - color: c7def8
-#    name: kind/new-api
-#  - color: c7def8
-#    name: kind/old-docs
-#  - color: bfe5bf
-#    name: kind/postmortem
-#  - color: eb6420
-#    name: kind/support
-#  - color: c7def8
-#    name: kind/technical-debt
-#  - color: fbca04
-#    name: kind/upgrade-test-failure
-#  - color: ededed
-#    name: needs-ok-to-merge
-#  - color: 0e8a16
-#    name: non-release-blocker
-#  - color: ff0000
-#    name: priority/P0
-#  - color: ededed
-#    name: priority/P1
-#  - color: ededed
-#    name: priority/P2
-#  - color: ededed
-#    name: priority/P3
-#  - color: d93f0b
-#    name: release-blocker
-#  - color: ededed
-#    name: team/api (deprecated - do not use)
-#  - color: ededed
-#    name: team/cluster (deprecated - do not use)
-#  - color: ededed
-#    name: team/control-plane (deprecated - do not use)
-#  - color: d2b48c
-#    name: team/gke
-#  - color: d2b48c
-#    name: team/huawei
-#  - color: d2b48c
-#    name: team/mesosphere
-#  - color: d2b48c
-#    name: team/redhat
-#  - color: ededed
-#    name: team/test-infra
-#  - color: ededed
-#    name: team/ux (deprecated - do not use)
-#  - color: d455d0
-#    name: triaged


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/57911

The rule of thumb was "a prow plugin doesn't use these labels"

Also some other minor cleanup

- dropped quotes form close/foo label names
- dropped `unknown:` field and commented out entries (it's not used and was output from `labeler scan --repo kubernetes/kubernetes` that's now out of date)