### PR TITLE
kinflate: fun with $GOPATH

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -602,7 +602,7 @@
       "--provider=gke",
       "--test=false",
       "--test-cmd=../cmd/kinflate/test/main.sh",
-      "--test-cmd-args=/go/src/example-ldap-repo",
+      "--test-cmd-args=/go/src/github.com/kinflate/example-ldap-repo",
       "--test-cmd-name=kinflate-integration",
       "--timeout=120m"
     ],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7120,7 +7120,7 @@ periodics:
       - "--clean"
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
-      - "--repo=github.com/kubernetes/kubectl"
+      - "--repo=k8s.io/kubectl"
       - "--repo=github.com/kinflate/example-ldap-customized"
       - "--repo=github.com/kinflate/example-ldap"
       - "--upload=gs://kubernetes-jenkins/logs/"


### PR DESCRIPTION
in jenkins/bootstrap.py we magically map k8s.io/foo back to github.com/foo to do the checkout then back again on disk...

this should work

:this_is_fine: