### PR TITLE
Fix containerd repo test.

### DIFF
--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -1,8 +1,8 @@
 ### job-env
 # Envs for containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd


### PR DESCRIPTION
We should not use the same latest file for containerd and cri-containerd together.
Download containerd test tarball to a different bucket cri-containerd-staging/containerd.

/hold

Depend on https://github.com/containerd/cri/pull/675

Signed-off-by: Lantao Liu <lantaol@google.com>