### PR TITLE
Read instance metadata from file.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -37,7 +37,7 @@
   },
   "ci-containerd-build": {
     "args": [
-      "/go/src/github.com/containerd/cri/test/build-containerd.sh"
+      "/go/src/github.com/containerd/cri/test/containerd/build.sh"
     ],
     "scenario": "execute",
     "sigOwners": [

--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -1,8 +1,8 @@
 ### job-env
 # Envs for containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=/workspace/github.com/containerd/cri/test/containerd/pkg-prefix,deploy-path=/workspace/github.com/containerd/cri/test/containerd/deploy-path
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=/workspace/github.com/containerd/cri/test/containerd/pkg-prefix,deploy-path=/workspace/github.com/containerd/cri/test/containerd/deploy-path
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6737,7 +6737,7 @@ periodics:
       - --repo=github.com/containerd/cri=master
       - --timeout=90
       - --
-      - "--node-args=--image-config-file=test/e2e_node/image-config-containerd.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
+      - "--node-args=--image-config-file=test/containerd/image-config.yaml --image-config-dir=$GOPATH/src/github.com/containerd/cri"
       env:
       - name: GOPATH
         value: /go


### PR DESCRIPTION
Cluster e2e only supports loading instance metadata from file. This PR does that.

Depends on https://github.com/containerd/cri/pull/677.
