### PR TITLE
Print the expected and actual values in error messages for --provider=gke

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -694,13 +694,13 @@ func prepareGcp(o *options) error {
 			o.deployment = "gke"
 		}
 		if o.deployment != "gke" {
-			return fmt.Errorf("--provider=gke implies --deployment=gke")
+			return fmt.Errorf("expected --deployment=gke for --provider=gke, found --deployment=%s", o.deployment)
 		}
 		if o.gcpNodeImage == "" {
 			return fmt.Errorf("--gcp-node-image must be set for GKE")
 		}
 		if o.gcpMasterImage != "" {
-			return fmt.Errorf("--gcp-master-image cannot be set on GKE")
+			return fmt.Errorf("expected --gcp-master-image to be empty for --provider=gke, found --gcp-master-image=%s", o.gcpMasterImage)
 		}
 		if o.gcpNodes != "" {
 			return fmt.Errorf("--gcp-nodes cannot be set on GKE, use --gke-shape instead")


### PR DESCRIPTION
I cant find good documention on how to run e2e tests on an existing GKE cluster.

https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#testing-against-local-clusters only has instructions on running e2e tests with a local cluster.
Let me know if there is an easy command I can use.

In the meanting, finding documention via error messages :)

cc @krzyzacy @BenTheElder 