### PR TITLE
Change configuration for k/community repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -34,7 +34,6 @@ approve:
 - repos:
   - kubernetes/charts
   - kubernetes/cluster-registry
-  - kubernetes/community
   - kubernetes/contrib
   - kubernetes/dashboard
   - kubernetes/examples


### PR DESCRIPTION
This does ~~two~~ one thing(s):
- Disables implicit self-approve by the author (the author would have to manually /approve if they intend to approve it)
- ~~Changes the merge method to squash. This creates a more concise git history for a repo that is mostly documentation. The commit will also more clearly link back to the PR that created it.~~