### PR TITLE
ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan: shorten cluster name

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9865,7 +9865,7 @@
   },
   "ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan": {
     "args": [
-      "--cluster=e2e-kops-aws-networking-kopeio-vxlan.test-cncf-aws.k8s.io",
+      "--cluster=e2e-kops-aws-kopeio-vxlan.test-cncf-aws.k8s.io",
       "--deployment=kops",
       "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",


### PR DESCRIPTION
We have a bug where we don't validate very long cluster names:
https://github.com/kubernetes/kops/issues/4729

Until that is fixed, use a shorter cluster name.