### PR TITLE
Add test for kops on centos7

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9845,6 +9845,25 @@
       "sig-aws"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-imagecentos7": {
+    "args": [
+      "--cluster=e2e-kops-aws-imagecentos7.test-cncf-aws.k8s.io",
+      "--deployment=kops",
+      "--env=KUBE_SSH_USER=centos",
+      "--extract=ci/latest",
+      "--ginkgo-parallel",
+      "--kops-args=--image=ami-4bf3d731",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
+      "--kops-zones=us-east-1c",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-imageubuntu1604": {
     "args": [
       "--cluster=e2e-kops-aws-imageubuntu1604.test-cncf-aws.k8s.io",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13713,6 +13713,21 @@ periodics:
 
 - interval: 4h
   agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-imagecentos7
+  labels:
+    preset-service-account: true
+    preset-aws-ssh: true
+    preset-aws-credential: true
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
+- interval: 4h
+  agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
   labels:
     preset-service-account: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1515,6 +1515,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-channelalpha
 - name: ci-kubernetes-e2e-kops-aws-ena-nvme
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ena-nvme
+- name: ci-kubernetes-e2e-kops-aws-imagecentos7
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-imagecentos7
 - name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-imageubuntu1604
 - name: ci-kubernetes-e2e-kops-aws-newrunner
@@ -2797,6 +2799,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
   - name: kops-aws-newrunner
     test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
+  - name: kops-aws-imagecentos7
+    test_group_name: ci-kubernetes-e2e-kops-aws-imagecentos7
   - name: kops-aws-imageubuntu1604
     test_group_name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
 


### PR DESCRIPTION
There was an issue installing docker on centos7, so we want it under
e2e.