### PR TITLE
Correct time format for deleteAfter

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -2,7 +2,7 @@
 ---
 labels:
   # Keys for each item: color, name, deleteAfter, previously
-  #   deleteAfter: 2006-01-02T15:04:05Z07:00 (rfc3339)
+  #   deleteAfter: 2006-01-02T15:04:05Z (rfc3339)
   #   previously: list of previous labels (color name deleteAfter, previously)
   - color: 0ffa16
     name: approved
@@ -13,10 +13,10 @@ labels:
   - color: bfe5bf
     name: 'cla: human-approved'
   - color: e11d21
-    deleteAfter: 2018-03-16T00:00:00Z07:00
+    deleteAfter: 2018-03-16T00:00:00Z
     name: 'cla: no'
   - color: bfe5bf
-    deleteAfter: 2018-03-16T00:00:00Z07:00
+    deleteAfter: 2018-03-16T00:00:00Z
     name: 'cla: yes'
   - color: d455d0
     name: close/duplicate
@@ -77,7 +77,7 @@ labels:
   - color: ededed
     name: needs-sig
   - color: fbca04
-    deleteAfter: 2018-03-16T00:00:00Z07:00
+    deleteAfter: 2018-03-16T00:00:00Z
     name: ok-to-merge
   - color: fef2c0
     name: priority/awaiting-more-evidence
@@ -108,7 +108,7 @@ labels:
   - color: c2e0c6
     name: release-note-none
   - color: d93f0b
-    deleteAfter: 2018-03-16T00:00:00Z07:00
+    deleteAfter: 2018-03-16T00:00:00Z
     name: requires-release-czar-attention
   - color: eb6420
     name: retest-not-required


### PR DESCRIPTION
Noticed that the sig/vmware label from #7225 hasn't shown up, 
tried running locally and discovered the docs for the 
timestamp format have a typo.