### PR TITLE
Reponame is changed from kubernetes-sigs/scheduling_poseidon ==> kubernet…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -100,7 +100,7 @@ tide:
     reviewApprovedRequired: true
   - repos:
     - kubernetes-sigs/testing_frameworks
-    - kubernetes-sigs/scheduling_poseidon
+    - kubernetes-sigs/poseidon
     labels:
     - lgtm
     - approved

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -307,7 +307,7 @@ plugins:
   kubernetes-sigs/testing_frameworks:
   - approve
 
-  kubernetes-sigs/scheduling_poseidon:
+  kubernetes-sigs/poseidon:
   - approve
 
   containerd/cri:


### PR DESCRIPTION
Reponame is changed from `kubernetes-sigs/scheduling_poseidon ==> kubernet…es-sigs/poseidon` .

cc: https://github.com/kubernetes-sigs/poseidon/pull/17