### PR TITLE
Remove broken vendor/k8s.io/client-go/util/cert/BUILD from the repo

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -26,6 +26,9 @@ TMP_GOPATH=$(mktemp -d)
 # exists; there is a specific set-gen rule that breaks importing
 # ref: https://github.com/kubernetes/kubernetes/blob/4e2f5e2212b05a305435ef96f4b49dc0932e1264/staging/src/k8s.io/apimachinery/pkg/util/sets/BUILD#L23-L49
 rm -f ${TESTINFRA_ROOT}/vendor/k8s.io/apimachinery/pkg/util/sets/{BUILD,BUILD.bazel}
+# manually remove BUILD file for k8s.io/client-go/util/cert/BUILD if it exists;
+# there is a testdata rule there that depends on testdata not imported.
+rm -f ${TESTINFRA_ROOT}/vendor/k8s.io/client-go/util/cert/{BUILD,BUILD.bazel}
 
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/kubernetes/repo-infra/kazel \

--- a/vendor/k8s.io/client-go/util/cert/BUILD.bazel
+++ b/vendor/k8s.io/client-go/util/cert/BUILD.bazel
@@ -1,9 +1,4 @@
-package(default_visibility = ["//visibility:public"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -14,6 +9,7 @@ go_library(
         "pem.go",
     ],
     importpath = "k8s.io/client-go/util/cert",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -27,4 +23,5 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The upstream `k8s.io/client-go/util/cert/BUILD` file has dependencies on`testdata/`, but that directory is pruned by dep.

I'm not sure how this dependency was even successfully vendored in the first place, but running `hack/update-deps.sh` brings in the broken rule, which then breaks bazel build and test.

This PR explicitly removes the upstream `BUILD` file, leaving gazelle to generate a working one instead.

The test rule was fixed upstream (https://github.com/kubernetes/kubernetes/pull/60901), and the publisher robot also removes upstream BUILD files, but there hasn't been a new client-go release yet, so we can't use those improvements.