### PR TITLE
Revert "Move 100-node scalability tests to increased verbosity of V4"

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
@@ -11,6 +11,8 @@ REGISTER_MASTER=true
 
 # Switch off image puller to workaround #44701
 PREPULL_E2E_IMAGES=false
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
 # Increase resync period to simulate production
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase delete collection parallelism


### PR DESCRIPTION
Reverts kubernetes/test-infra#7356

As this is causing some failures due to crossing mem-usage threshold in controller-manager. E.g:

- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/11844
- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/11846
- https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/11847

fyi - @wojtek-t 