### PR TITLE
bump timeout for soak tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11716,7 +11716,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",
@@ -11738,7 +11738,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-beta",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",
@@ -11760,7 +11760,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-stable1",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",
@@ -11781,7 +11781,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-stable2",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",
@@ -11802,7 +11802,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-stable3",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",
@@ -11825,7 +11825,7 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci",
       "--soak",
       "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=800m",
       "--up=false"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15391,7 +15391,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 
@@ -15404,7 +15404,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 
@@ -15417,7 +15417,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 
@@ -15430,7 +15430,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 
@@ -15443,7 +15443,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 
@@ -15456,7 +15456,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180316-92e6ccade-master
 


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/61485

also bumped old releases... 1.9 soak job took 9h51m to finish, next time it might hit timeout as well

/assign @BenTheElder 