### PR TITLE
Enable trigger plugin for testing_frameworks repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -326,6 +326,7 @@ plugins:
 
   kubernetes-sigs/testing_frameworks:
   - approve
+  - trigger
 
   kubernetes-sigs/poseidon:
   - approve


### PR DESCRIPTION
The trigger plugin vanished when the repo was renamed. 