### PR TITLE
Fix panics in kubernetes prowjob client

### DIFF
--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -440,6 +440,11 @@ func (c *Client) getHiddenRepos() sets.String {
 }
 
 func shouldHide(pj *ProwJob, hiddenRepos sets.String, showHiddenOnly bool) bool {
+	if pj.Spec.Refs == nil {
+		// periodic jobs do not have refs and therefore cannot be
+		// hidden by the org/repo mechanism
+		return false
+	}
 	shouldHide := hiddenRepos.HasAny(fmt.Sprintf("%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo), pj.Spec.Refs.Org)
 	if showHiddenOnly {
 		return !shouldHide


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @kargakis 
/cc @cjwagner @BenTheElder 


Fixes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa70397]
goroutine 1 [running]:
k8s.io/test-infra/prow/kube.shouldHide(0xc4202dccc0, 0xc42141e450, 0x700, 0x700)
	/go/src/k8s.io/test-infra/prow/kube/client.go:443 +0x57
k8s.io/test-infra/prow/kube.(*Client).ListProwJobs(0xc4206220e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/test-infra/prow/kube/client.go:480 +0x403
main.(*JobAgent).update(0xc4206221c0, 0x0, 0x0)
	/go/src/k8s.io/test-infra/prow/cmd/deck/jobs.go:195 +0xaf
main.(*JobAgent).tryUpdate(0xc4206221c0)
	/go/src/k8s.io/test-infra/prow/cmd/deck/jobs.go:183 +0x2f
main.(*JobAgent).Start(0xc4206221c0)
	/go/src/k8s.io/test-infra/prow/cmd/deck/jobs.go:95 +0x2b
main.prodOnlyMain(0xd1b10f, 0x12, 0x0, 0x0, 0x7ffc19d2a85e, 0xc, 0x7ffc19d2a876, 0x1c, 0x7ffc19d2a89f, 0xd, ...)
	/go/src/k8s.io/test-infra/prow/cmd/deck/main.go:163 +0x485
main.main()
	/go/src/k8s.io/test-infra/prow/cmd/deck/main.go:123 +0x3ee
```