### PR TITLE
Port fix 7160 to kubeadm ipvs and kubeadm coredns jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10278,7 +10278,7 @@
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubeadm-feature-gates=CoreDNS=true",
       "--kubernetes-anywhere-kubelet-ci-version=latest-bazel",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-bazel",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"
@@ -10297,7 +10297,7 @@
       "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubelet-ci-version=latest-bazel",
-      "--kubernetes-anywhere-kubernetes-version=ci/latest-bazel",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--kubernetes-anywhere-proxy-mode=ipvs",
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",


### PR DESCRIPTION
The following jobs are failing consistently:
    ci-kubernetes-e2e-kubeadm-gce-dns-coredns
    ci-kubernetes-e2e-kubeadm-gce-ipvs
The failure signature looks similar to the problem that was fixed for other test jobs with PR #7160.
I'm thinking that the fix for 7160 needs to be ported to the remaining 2 kubeadm jobs listed above.

xref: [kubernetes/kubernetes#59762 (comment)](https://github.com/kubernetes/kubernetes/issues/59762#issuecomment-370954435)

/area jobs
/cc @BenTheElder @caseydavenport 
