### PR TITLE
make deck repo links not tight with github

### DIFF
--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -486,6 +486,8 @@ function redraw(fz) {
 
             if (build.type === "periodic") {
                 r.appendChild(createTextCell(""));
+            } else if (build.repo.startsWith("http://") || build.repo.startsWith("https://") ) {
+                r.appendChild(createLinkCell(build.repo, build.repo, ""));
             } else {
                 r.appendChild(createLinkCell(build.repo, "https://github.com/"
                     + build.repo, ""));


### PR DESCRIPTION
assume repo with `http(s)://` is clickable

/area prow
/assign @BenTheElder 