### PR TITLE
Pass cookies to the tracer backend from the frontend

### DIFF
--- a/experiment/tracer/static/script.js
+++ b/experiment/tracer/static/script.js
@@ -26,7 +26,7 @@ var logger = {
   // the actual fetch
   request: function(endpoint) {
     generateView.toggleElement(generateView.loader, true);
-    fetch(endpoint).then(
+    fetch(endpoint, {credentials: 'same-origin'}).then(
         function(response) {
 
           if (response.status !== 200) {


### PR DESCRIPTION
When the tracer service is sitting behind an OAuth proxy to limit access
to the service, we need to pass the OAuth cookie to persist state and
not re-trigger the flow on each request from the front-end to the
back-end.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @BenTheElder 
/assign @kargakis 