### PR TITLE
Fix PR path parsing for kubernetes-sigs/testing_frameworks.

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -16,6 +16,10 @@ external_services:
     gcs_bucket: kubernetes-jenkins/
     gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
     prow_url: prow.k8s.io
+  kubernetes-sigs:
+    gcs_bucket: kubernetes-jenkins/
+    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
+    prow_url: prow.k8s.io
   tensorflow:
     gcs_bucket: kubernetes-jenkins/
     gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -207,8 +207,8 @@ def parse_pr_path(gcs_path, default_org, default_repo):
         pr_path = parsed_repo + '/'
         repo = '%s/%s' % (default_org, parsed_repo)
     else:
-        pr_path = parsed_repo.replace('_', '/') + '/'
-        repo = parsed_repo.replace('_', '/')
+        pr_path = parsed_repo.replace('_', '/', 1) + '/'
+        repo = parsed_repo.replace('_', '/', 1)
     return pull_number, pr_path, repo
 
 

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -278,6 +278,9 @@ class BuildTest(main_test.TestBase):
         check(
             'kubernetes-jenkins/pr-logs/pull/google_cadvisor/296',
             ('296', 'google/cadvisor/', 'google/cadvisor'))
+        check(
+            'kj/pr-logs/pull/kubernetes-sigs_testing_frameworks/49',
+            ('49', 'kubernetes-sigs/testing_frameworks/', 'kubernetes-sigs/testing_frameworks'))
 
     def test_github_commit_links(self):
         def check(build_dir, result):


### PR DESCRIPTION
To support orgs with underscores in the name, we'll need something
smarter-- preferably a repo field in started/finished.json.

Fixes #7389.