### PR TITLE
Bump ci-kubernetes-e2e-kops-gce to use kubekins:v20180323-ba4692a11-master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13718,7 +13718,7 @@ periodics:
     - args:
       - --timeout=140
       - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180323-ba4692a11-master
 
 - interval: 1h
   agent: kubernetes


### PR DESCRIPTION
picks up https://github.com/kubernetes/test-infra/pull/7395

/hold
/assign @BenTheElder @chrislovecnm 