### PR TITLE
enable k8s-ci-robot for node-problem-detector

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -75,6 +75,7 @@ tide:
     - kubernetes/kube-state-metrics
     - kubernetes/kube-deploy
     - kubernetes/minikube
+    - kubernetes/node-problem-detector
     - kubernetes/repo-infra
     - kubernetes/sig-release
     - kubernetes/steering

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -49,6 +49,7 @@ approve:
   - kubernetes/kubernetes-template-project
   - kubernetes/kube-state-metrics
   - kubernetes/minikube
+  - kubernetes/node-problem-detector
   - kubernetes/repo-infra
   - kubernetes/sig-release
   - kubernetes/steering
@@ -257,6 +258,10 @@ plugins:
 
   kubernetes/minikube:
   - approve
+
+  kubernetes/node-problem-detector:
+  - approve
+  - blunderbuss
 
   kubernetes/repo-infra:
   - approve


### PR DESCRIPTION
Cross fix https://github.com/kubernetes/node-problem-detector/issues/165

This PR will enable k8s-ci-robot for node-problem-detector.

/cc @cblecker @Random-Liu @dchen1107 