### PR TITLE
kops HA test on AWS, running in us-west-2

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9720,6 +9720,24 @@
       "sig-aws"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-ha-uswest2": {
+    "args": [
+      "--cluster=e2e-kops-aws-ha-uswest2.k8s.local",
+      "--deployment=kops",
+      "--extract=ci/latest",
+      "--ginkgo-parallel=30",
+      "--kops-args=--master-count=3",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
+      "--kops-zones=us-west-2a,us-west-2b,us-west-2c",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-imagecentos7": {
     "args": [
       "--cluster=e2e-kops-aws-imagecentos7.test-cncf-aws.k8s.io",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13625,6 +13625,21 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-ha-uswest2
+  labels:
+    preset-service-account: true
+    preset-aws-ssh: true
+    preset-aws-credential: true
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
 - interval: 4h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-imagecentos7

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1496,6 +1496,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-channelalpha
 - name: ci-kubernetes-e2e-kops-aws-ena-nvme
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ena-nvme
+- name: ci-kubernetes-e2e-kops-aws-ha-uswest2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ha-uswest2
 - name: ci-kubernetes-e2e-kops-aws-imagecentos7
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-imagecentos7
 - name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
@@ -2824,6 +2826,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-channelalpha
   - name: kops-aws-ena-nvme
     test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
+  - name: kops-aws-ha-uswest2
+    test_group_name: ci-kubernetes-e2e-kops-aws-ha-uswest2
   - name: kops-aws-newrunner
     test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
   - name: kops-aws-imagecentos7


### PR DESCRIPTION
We lock to us-west-2 because we don't (currently) seem to have any
infrastructure availability issues there.