### PR TITLE
kops-ssh-user: expose in bootstrap, map to KUBE_SSH_USER

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9667,7 +9667,6 @@
     "args": [
       "--cluster=e2e-kops-aws-canary.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-etcd-version=3.1.10",
@@ -9687,7 +9686,6 @@
     "args": [
       "--cluster=e2e-kops-aws-channelalpha.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--channel=alpha",
@@ -9705,7 +9703,6 @@
     "args": [
       "--cluster=e2e-kops-aws-ena-nvme.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha",
@@ -9742,10 +9739,10 @@
     "args": [
       "--cluster=e2e-kops-aws-imagecentos7.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=centos",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--image=ami-4bf3d731",
+      "--kops-ssh-user=centos",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
       "--kops-zones=us-east-1c",
       "--provider=aws",
@@ -9761,10 +9758,10 @@
     "args": [
       "--cluster=e2e-kops-aws-imageubuntu1604.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=ubuntu",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180122",
+      "--kops-ssh-user=ubuntu",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
@@ -9779,7 +9776,6 @@
     "args": [
       "--cluster=e2e-kops-aws-kopeio-vxlan.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=kopeio-vxlan",
@@ -9797,7 +9793,6 @@
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -50,7 +50,7 @@ var (
 	kopsPath         = flag.String("kops", "", "(kops only) Path to the kops binary. kops will be downloaded from kops-base-url if not set.")
 	kopsCluster      = flag.String("kops-cluster", "", "(kops only) Deprecated. Cluster name for kops; if not set defaults to --cluster.")
 	kopsState        = flag.String("kops-state", "", "(kops only) s3:// path to kops state store. Must be set.")
-	kopsSSHUser      = flag.String("kops-ssh-user", os.Getenv("USER"), "(kops only) Username for SSH connections to nodes.)")
+	kopsSSHUser      = flag.String("kops-ssh-user", os.Getenv("USER"), "(kops only) Username for SSH connections to nodes.")
 	kopsSSHKey       = flag.String("kops-ssh-key", "", "(kops only) Path to ssh key-pair for each node (defaults '~/.ssh/kube_aws_rsa' if unset.)")
 	kopsKubeVersion  = flag.String("kops-kubernetes-version", "", "(kops only) If set, the version of Kubernetes to deploy (can be a URL to a GCS path where the release is stored) (Defaults to kops default, latest stable release.).")
 	kopsZones        = flag.String("kops-zones", "", "(kops only) zones for kops deployment, comma delimited.")
@@ -525,6 +525,13 @@ func (k kops) TestSetup() error {
 	}
 	if info.Size() == 0 {
 		return fmt.Errorf("exported kubeconfig file %s was empty", k.kubecfg)
+	}
+
+	// Set KUBE_SSH_USER if it isn't set and we know what it should be
+	if os.Getenv("KUBE_SSH_USER") == "" && k.sshUser != "" {
+		if err := os.Setenv("KUBE_SSH_USER", k.sshUser); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -349,7 +349,7 @@ def set_up_kops_aws(workspace, args, mode, cluster, runner_args):
         '--kops-state=%s' % args.kops_state,
         '--kops-nodes=%s' % args.kops_nodes,
         '--kops-ssh-key=%s' % aws_ssh,
-        "--kops-ssh-user=admin",
+        '--kops-ssh-user=%s' % args.kops_ssh_user,
     ])
 
 
@@ -383,7 +383,7 @@ def set_up_aws(workspace, args, mode, cluster, runner_args):
         '--kops-state=%s' % args.kops_state,
         '--kops-nodes=%s' % args.kops_nodes,
         '--kops-ssh-key=%s' % aws_ssh,
-        "--kops-ssh-user=admin",
+        '--kops-ssh-user=%s' % args.kops_ssh_user,
     ])
     # TODO(krzyzacy):Remove after retire kops-e2e-runner.sh
     mode.add_aws_runner()
@@ -665,6 +665,10 @@ def create_parser():
     parser.add_argument(
         '--kops-state-gce', default='gs://k8s-kops-gce/',
         help='Name of the kops state storage for GCE')
+    parser.add_argument(
+        '--kops-ssh-user',
+        default='admin',
+        help='(kops only) Username for SSH connections to nodes.')
     parser.add_argument(
         '--kops-zones', help='Comma-separated list of zones else random choice')
     parser.add_argument(


### PR DESCRIPTION
* expose the kops-ssh-user in the python bootstrap

* pass it through to kubetest (which should fix collection of logs on
OSes with other SSH usernames)

* switch the jobs bound to the latest kubetest to use the new flag (or
drop the env var where it was admin).