### PR TITLE
Remove 1.7->1.8 upgrade GKE Regional Clusters

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7539,28 +7539,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-regional-cluster": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--deployment=gke",
-      "--extract=gke-latest-1.8",
-      "--extract=gke-latest-1.7",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
-      "--gcp-node-image=gci",
-      "--gcp-region=us-central1",
-      "--gke-command-group=beta",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--test_args=--gce-multizone=true --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--timeout=900m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.8 --upgrade-image=gci"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-cluster": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12318,19 +12318,6 @@ periodics:
 
 - interval: 2h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-regional-cluster
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - args:
-      - --timeout=920
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
-
-- interval: 2h
-  agent: kubernetes
   name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-cluster
   labels:
     preset-service-account: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2471,8 +2471,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster
 - name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster-new
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster-new
-- name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-regional-cluster
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-regional-cluster
 - name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-master
 - name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-cluster
@@ -3071,8 +3069,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster
   - name: gke-staging-1-7-1-8-upgrade-cluster-new
     test_group_name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-cluster-new
-  - name: gke-staging-1-7-1-8-upgrade-regional-cluster
-    test_group_name: ci-kubernetes-e2e-gke-staging-1-7-1-8-upgrade-regional-cluster
   - name: gke-staging-1-8-1-9-upgrade-master
     test_group_name: ci-kubernetes-e2e-gke-staging-1-8-1-9-upgrade-master
   - name: gke-staging-1-8-1-9-upgrade-cluster


### PR DESCRIPTION
Those are no longer needed. 1.8->1.9 tests are still there.