### PR TITLE
Refactor testgrid/cmd/config, include service mode

### DIFF
--- a/testgrid/BUILD.bazel
+++ b/testgrid/BUILD.bazel
@@ -24,18 +24,6 @@ go_proto_library(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "gen-config",
-    srcs = [
-        "config.yaml",
-    ],
-    outs = ["testgrid-config"],
-    cmd = "$(location //testgrid/cmd/config) --yaml=$< --output=$@",
-    tools = [
-        "//testgrid/cmd/config",
-    ],
-)
-
 filegroup(
     name = "config-yaml",
     srcs = ["config.yaml"],
@@ -57,6 +45,7 @@ filegroup(
         "//testgrid/cmd/config:all-srcs",
         "//testgrid/cmd/updater:all-srcs",
         "//testgrid/images:all-srcs",
+        "//testgrid/util/gcs:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/testgrid/README.md
+++ b/testgrid/README.md
@@ -336,14 +336,16 @@ All PRs updating the configuration must pass prior to merging
 Updates to the testgrid configuration are automatically pushed immediately when
 merging a change.
 
-It may take some time (around an hour) after merging a change for test results
-to first appear.
-
-If for some reason you want to run this manually then do the following:
+Manually convert the yaml file to the config proto with:
 ```
-go build ./yaml2proto  # Build the yaml2proto library
-go install .  # Install the config converter
-config --yaml=config.yaml --output=config.pb.txt  # Run the conversion
+bazel run //testgrid/cmd/config -- \
+  --yaml=testgrid/config.yaml \
+  --print-text \
+  --oneshot \
+  --output=/tmp/config.pb \
+  # Or push to gcs
+  # --output=gs://my-bucket/config
+  # --gcp-service-account=/path/to/foo.json
 ```
 
 [`config.proto`]: ./config.proto

--- a/testgrid/cmd/config/BUILD.bazel
+++ b/testgrid/cmd/config/BUILD.bazel
@@ -35,6 +35,8 @@ go_library(
     importpath = "k8s.io/test-infra/testgrid/cmd/config",
     deps = [
         "//testgrid:config",
+        "//testgrid/util/gcs:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
     ],

--- a/testgrid/cmd/config/main.go
+++ b/testgrid/cmd/config/main.go
@@ -17,60 +17,196 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"net/url"
 	"os"
 	"strings"
+	"time"
+
+	"k8s.io/test-infra/testgrid/util/gcs"
+
+	"cloud.google.com/go/storage"
 )
 
-var (
-	yamlPaths  = flag.String("yaml", "", "comma-separated list of input YAML files")
-	printText  = flag.Bool("print-text", false, "print generated proto in text format to stdout")
-	outputPath = flag.String("output", "", "output path to save generated protobuf data")
-)
+type multiString []string
 
-func errExit(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, a...)
-	os.Exit(1)
+func (m multiString) String() string {
+	return strings.Join(m, ",")
+}
+
+func (m *multiString) Set(v string) error {
+	*m = strings.Split(v, ",")
+	return nil
+}
+
+type options struct {
+	creds     string
+	inputs    multiString
+	oneshot   bool
+	output    string
+	printText bool
+}
+
+func gatherOptions() options {
+	o := options{}
+	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty")
+	flag.BoolVar(&o.oneshot, "oneshot", false, "Write proto once and exit instead of monitoring --yaml files for changes")
+	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
+	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")
+	flag.Var(&o.inputs, "yaml", "comma-separated list of input YAML files")
+	flag.Parse()
+	return o
+}
+
+func (o *options) validate() error {
+	if len(o.inputs) == 0 || o.inputs[0] == "" {
+		return errors.New("--yaml must include at least one file")
+	}
+
+	if !o.printText && o.output == "" {
+		return errors.New("--print-text or --output=gs://path required")
+	}
+	return nil
+}
+
+// announceChanges watches for changes to files and writes one of them to the channel
+func announceChanges(ctx context.Context, paths []string, channel chan []string) {
+	defer close(channel)
+	modified := map[string]time.Time{}
+	for _, p := range paths {
+		modified[p] = time.Time{} // Never seen
+	}
+
+	// TODO(fejta): consider waiting for a notification rather than polling
+	// but performance isn't that big a deal here.
+	for {
+		var changed []string
+		for p, last := range modified {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			switch info, err := os.Stat(p); {
+			case os.IsNotExist(err) && !last.IsZero():
+				// File deleted
+				modified[p] = time.Time{}
+				changed = append(changed, p)
+			case err != nil:
+				log.Printf("Error reading %s: %v", p, err)
+			default:
+				if t := info.ModTime(); t.After(last) {
+					changed = append(changed, p)
+					modified[p] = t
+				}
+			}
+		}
+		if len(changed) > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case channel <- changed:
+			}
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+func readConfig(paths []string) (*Config, error) {
+	var c Config
+	for _, file := range paths {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %v", file, err)
+		}
+		if err = c.Update(b); err != nil {
+			return nil, fmt.Errorf("failed to merge %s into config: %v", file, err)
+		}
+	}
+	return &c, nil
+}
+
+func write(client *storage.Client, ctx context.Context, path string, bytes []byte) error {
+	u, err := url.Parse(path)
+	if err != nil {
+		return fmt.Errorf("invalid url %s: %v", path, err)
+	}
+	if u.Scheme != "gs" {
+		return ioutil.WriteFile(path, bytes, 0644)
+	}
+	var p gcs.Path
+	if err = p.SetURL(u); err != nil {
+		return err
+	}
+	return gcs.Upload(client, ctx, p, bytes)
+}
+
+func doOneshot(client *storage.Client, ctx context.Context, opt options) error {
+	// Ignore what changed for now and just recompute everything
+	c, err := readConfig(opt.inputs)
+	if err != nil {
+		return fmt.Errorf("could not read config: %v", err)
+	}
+
+	// Print proto if requested
+	if opt.printText {
+		if err := c.MarshalText(os.Stdout); err != nil {
+			return fmt.Errorf("could not print config: %v", err)
+		}
+	}
+
+	// Write proto if requested
+	if opt.output != "" {
+		b, err := c.MarshalBytes()
+		if err == nil {
+			err = write(client, ctx, opt.output, b)
+		}
+		if err != nil {
+			return fmt.Errorf("could not write config: %v", err)
+		}
+	}
+	return nil
 }
 
 func main() {
-	flag.Parse()
-
-	yamlFiles := strings.Split(*yamlPaths, ",")
-	if len(yamlFiles) == 0 || yamlFiles[0] == "" {
-		errExit("Must specify one or more YAML files with --yaml\n")
-	}
-	if !*printText && *outputPath == "" {
-		errExit("Must set --print-text or --output\n")
-	}
-	if *printText && *outputPath != "" {
-		errExit("Cannot set both --print-text and --output\n")
+	// Parse flags
+	opt := gatherOptions()
+	if err := opt.validate(); err != nil {
+		log.Fatalf("Bad flags: %v", err)
 	}
 
-	var c Config
-	for _, file := range yamlFiles {
-		b, err := ioutil.ReadFile(file)
-		if err != nil {
-			errExit("IO Error : Cannot Read File %s : %v\n", file, err)
-		}
-		if err = c.Update(b); err != nil {
-			errExit("Error parsing file %s : %v\n", file, err)
-		}
+	// Setup stuff
+	ctx := context.Background()
+	client, err := gcs.ClientWithCreds(ctx, opt.creds)
+	if err != nil {
+		log.Fatalf("Failed to create storage client: %v", err)
 	}
 
-	if *printText {
-		if err := c.MarshalText(os.Stdout); err != nil {
-			errExit("err printing proto: %v", err)
+	// Oneshot mode, write config and exit
+	if opt.oneshot {
+		if err := doOneshot(client, ctx, opt); err != nil {
+			log.Fatalf("FAIL: %v", err)
 		}
-	} else {
-		b, err := c.MarshalBytes()
-		if err != nil {
-			errExit("err encoding proto: %v", err)
+		return
+	}
+
+	// Service mode, monitor input files for changes
+	channel := make(chan []string)
+	// Monitor files for changes
+	go announceChanges(ctx, opt.inputs, channel)
+
+	// Wait for changed files
+	for range channel {
+		if err := doOneshot(client, ctx, opt); err != nil {
+			log.Printf("FAIL: %v", err)
+			continue
 		}
-		if err = ioutil.WriteFile(*outputPath, b, 0644); err != nil {
-			errExit("IO Error : Cannot Write File %v\n", outputPath)
-		}
+		log.Printf("Wrote config to %s", opt.output)
 	}
 }

--- a/testgrid/cmd/updater/BUILD.bazel
+++ b/testgrid/cmd/updater/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -9,10 +8,10 @@ go_library(
     deps = [
         "//testgrid:config",
         "//testgrid:state",
+        "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/google.golang.org/api/iterator:go_default_library",
-        "//vendor/google.golang.org/api/option:go_default_library",
         "//vendor/vbom.ml/util/sortorder:go_default_library",
     ],
 )
@@ -43,5 +42,8 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    deps = ["//testgrid:state"],
+    deps = [
+        "//testgrid:state",
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
+    ],
 )

--- a/testgrid/cmd/updater/main.go
+++ b/testgrid/cmd/updater/main.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"io/ioutil"
 	"log"
@@ -40,18 +39,18 @@ import (
 
 	"k8s.io/test-infra/testgrid/config"
 	"k8s.io/test-infra/testgrid/state"
+	"k8s.io/test-infra/testgrid/util/gcs"
 
 	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 
 	"vbom.ml/util/sortorder"
 )
 
 // options configures the updater
 type options struct {
-	config           gcsPath // gs://path/to/config/proto
+	config           gcs.Path // gs://path/to/config/proto
 	creds            string
 	confirm          bool
 	group            string
@@ -64,7 +63,7 @@ func (o *options) validate() error {
 	if o.config.String() == "" {
 		return errors.New("empty --config")
 	}
-	if o.config.bucket() == "k8s-testgrid" { // TODO(fejta): remove
+	if o.config.Bucket() == "k8s-testgrid" { // TODO(fejta): remove
 		return fmt.Errorf("--config=%s cannot start with gs://k8s-testgrid", o.config)
 	}
 	if o.groupConcurrency == 0 {
@@ -90,57 +89,17 @@ func gatherOptions() options {
 	return o
 }
 
-// gcsPath parses gs://bucket/obj urls
-type gcsPath struct {
-	url url.URL
-}
-
-// String() returns the gs://bucket/obj url
-func (g gcsPath) String() string {
-	return g.url.String()
-}
-
-// Set() updates value from a gs://bucket/obj string, validating errors.
-func (g *gcsPath) Set(v string) error {
-	u, err := url.Parse(v)
-	switch {
-	case err != nil:
-		return fmt.Errorf("invalid gs:// url %s: %v", v, err)
-	case u.Scheme != "gs":
-		return fmt.Errorf("must use a gs:// url: %s", v)
-	case strings.Contains(u.Host, ":"):
-		return fmt.Errorf("gs://bucket may not contain a port: %s", v)
-	case u.Opaque != "":
-		return fmt.Errorf("url must start with gs://: %s", v)
-	case u.User != nil:
-		return fmt.Errorf("gs://bucket may not contain an user@ prefix: %s", v)
-	case u.RawQuery != "":
-		return fmt.Errorf("gs:// url may not contain a ?query suffix: %s", v)
-	case u.Fragment != "":
-		return fmt.Errorf("gs:// url may not contain a #fragment suffix: %s", v)
+// testGroupPath() returns the path to a test_group proto given this proto
+func testGroupPath(g gcs.Path, name string) (*gcs.Path, error) {
+	u, err := url.Parse(name)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url %s: %v", name, err)
 	}
-	g.url = *u
-	return nil
-}
-
-// bucket() returns bucket in gs://bucket/obj
-func (g gcsPath) bucket() string {
-	return g.url.Host
-}
-
-// object() returns path/to/something in gs://bucket/path/to/something
-func (g gcsPath) object() string {
-	if g.url.Path == "" {
-		return g.url.Path
+	np, err := g.ResolveReference(u)
+	if err == nil && np.Bucket() != g.Bucket() {
+		return nil, fmt.Errorf("testGroup %s should not change bucket", name)
 	}
-	return g.url.Path[1:]
-}
-
-// testGroup() returns the path to a test_group proto given this proto
-func (g gcsPath) testGroup(name string) gcsPath {
-	newG := g
-	newG.url.Path = path.Join(path.Dir(g.url.Path), name)
-	return newG
+	return np, nil
 }
 
 type Build struct {
@@ -859,13 +818,13 @@ func (b Builds) Less(i, j int) bool {
 }
 
 // listBuilds lists and sorts builds under path, sending them to the builds channel.
-func listBuilds(client *storage.Client, ctx context.Context, path gcsPath) (Builds, error) {
+func listBuilds(client *storage.Client, ctx context.Context, path gcs.Path) (Builds, error) {
 	log.Printf("LIST: %s", path)
-	p := path.object()
+	p := path.Object()
 	if p[len(p)-1] != '/' {
 		p += "/"
 	}
-	bkt := client.Bucket(path.bucket())
+	bkt := client.Bucket(path.Bucket())
 	it := bkt.Objects(ctx, &storage.Query{
 		Delimiter: "/",
 		Prefix:    p,
@@ -1068,16 +1027,12 @@ func main() {
 	}
 
 	ctx := context.Background()
-	var options []option.ClientOption
-	if opt.creds != "" {
-		options = append(options, option.WithCredentialsFile(opt.creds))
-	}
-	client, err := storage.NewClient(ctx, options...)
+	client, err := gcs.ClientWithCreds(ctx, opt.creds)
 	if err != nil {
 		log.Fatalf("Failed to create storage client: %v", err)
 	}
 
-	cfg, err := ReadConfig(client.Bucket(opt.config.bucket()).Object(opt.config.object()), ctx)
+	cfg, err := ReadConfig(client.Bucket(opt.config.Bucket()).Object(opt.config.Object()), ctx)
 	if err != nil {
 		log.Fatalf("Failed to read %s: %v", opt.config, err)
 	}
@@ -1090,7 +1045,11 @@ func main() {
 		wg.Add(1)
 		go func() {
 			for tg := range groups {
-				if err := updateGroup(client, ctx, tg, opt.config.testGroup(tg.Name), opt.buildConcurrency, opt.confirm); err != nil {
+				tgp, err := testGroupPath(opt.config, tg.Name)
+				if err == nil {
+					err = updateGroup(client, ctx, tg, *tgp, opt.buildConcurrency, opt.confirm)
+				}
+				if err != nil {
 					log.Printf("FAIL: %v", err)
 				}
 			}
@@ -1118,10 +1077,10 @@ func main() {
 	wg.Wait()
 }
 
-func updateGroup(client *storage.Client, ctx context.Context, tg config.TestGroup, gridPath gcsPath, concurrency int, write bool) error {
+func updateGroup(client *storage.Client, ctx context.Context, tg config.TestGroup, gridPath gcs.Path, concurrency int, write bool) error {
 	o := tg.Name
 
-	var tgPath gcsPath
+	var tgPath gcs.Path
 	if err := tgPath.Set("gs://" + tg.GcsPrefix); err != nil {
 		return fmt.Errorf("group %s has an invalid gcs_prefix %s: %v", o, tg.GcsPrefix, err)
 	}
@@ -1145,7 +1104,7 @@ func updateGroup(client *storage.Client, ctx context.Context, tg config.TestGrou
 		log.Printf("  Not writing %s (%d bytes) to %s", o, len(buf), tgp)
 	} else {
 		log.Printf("  Writing %s (%d bytes) to %s", o, len(buf), tgp)
-		if err := uploadBytes(client, ctx, tgp, buf); err != nil {
+		if err := gcs.Upload(client, ctx, tgp, buf); err != nil {
 			return fmt.Errorf("upload %s to %s failed: %v", o, tgp, err)
 		}
 	}
@@ -1153,7 +1112,7 @@ func updateGroup(client *storage.Client, ctx context.Context, tg config.TestGrou
 	return nil
 }
 
-// marhshalGrid serializes a state proto into zlib-compressed bytes and its crc32 checksum.
+// marhshalGrid serializes a state proto into zlib-compressed bytes.
 func marshalGrid(grid state.Grid) ([]byte, error) {
 	buf, err := proto.Marshal(&grid)
 	if err != nil {
@@ -1168,31 +1127,4 @@ func marshalGrid(grid state.Grid) ([]byte, error) {
 		return nil, fmt.Errorf("zlib closing failed: %v", err)
 	}
 	return zbuf.Bytes(), nil
-}
-
-func calcCRC(buf []byte) uint32 {
-	return crc32.Checksum(buf, crc32.MakeTable(crc32.Castagnoli))
-}
-
-// uploadBytes writes bytes to the specified gcsPath
-func uploadBytes(client *storage.Client, ctx context.Context, path gcsPath, buf []byte) error {
-	crc := calcCRC(buf)
-	w := client.Bucket(path.bucket()).Object(path.object()).NewWriter(ctx)
-	w.SendCRC32C = true
-	// Send our CRC32 to ensure google received the same data we sent.
-	// See checksum example at:
-	// https://godoc.org/cloud.google.com/go/storage#Writer.Write
-	w.ObjectAttrs.CRC32C = crc
-	w.ProgressFunc = func(bytes int64) {
-		log.Printf("Uploading %s: %d/%d...", path, bytes, len(buf))
-	}
-	if n, err := w.Write(buf); err != nil {
-		return fmt.Errorf("writing %s failed: %v", path, err)
-	} else if n != len(buf) {
-		return fmt.Errorf("partial write of %s: %d < %d", path, n, len(buf))
-	}
-	if err := w.Close(); err != nil {
-		return fmt.Errorf("closing %s failed: %v", path, err)
-	}
-	return nil
 }

--- a/testgrid/cmd/updater/main_test.go
+++ b/testgrid/cmd/updater/main_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"k8s.io/test-infra/testgrid/state"
 )
 
@@ -380,24 +382,18 @@ func Test_MarshalGrid(t *testing.T) {
 
 	b1, e1 := marshalGrid(g1)
 	b2, e2 := marshalGrid(g2)
-	b1a, e1a := marshalGrid(g1)
+	uncompressed, e1a := proto.Marshal(&g1)
 
 	switch {
-	case e1 != nil, e2 != nil, e1a != nil:
+	case e1 != nil, e2 != nil:
 		t.Errorf("unexpected error %v %v %v", e1, e2, e1a)
 	}
 
-	c1 := calcCRC(b1)
-	c2 := calcCRC(b2)
-	c1a := calcCRC(b1a)
-
-	switch {
-	case c1 == c2:
-		t.Errorf("g1 crc %d should not equal g2 crc %d", c1, c2)
-	case len(b1) == 0, len(b2) == 0:
-		t.Errorf("empty b1 b2 %s %s", b1, b2)
-	case len(b1) != len(b1a), c1 != c1a:
-		t.Errorf("different results: %s %d != %s %d", b1, c1, b1a, c1a)
+	if reflect.DeepEqual(b1, b2) {
+		t.Errorf("unexpected equality %v == %v", b1, b2)
 	}
 
+	if reflect.DeepEqual(b1, uncompressed) {
+		t.Errorf("should be compressed but is not: %v", b1)
+	}
 }

--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -18,7 +18,11 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-bazel clean --expunge
-bazel build //testgrid:testgrid-config
-gsutil cp bazel-genfiles/testgrid/testgrid-config gs://k8s-testgrid/config
-gsutil cp bazel-genfiles/testgrid/testgrid-config gs://k8s-testgrid-canary/config
+
+for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
+  bazel run //testgrid/cmd/config -- \
+    --yaml="$(dirname "${BASH_SOURCE}")"/config.yaml \
+    --output="${output}" \
+    --print-text \
+    --oneshot
+done

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gcs.go"],
+    importpath = "k8s.io/test-infra/testgrid/util/gcs",
+    visibility = ["//testgrid:__subpackages__"],
+    deps = [
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gcs_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/testgrid/util/gcs/gcs.go
+++ b/testgrid/util/gcs/gcs.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"log"
+	"net/url"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+// ClientWithCreds returns a storage client, optionally authenticated with the specified .json creds
+func ClientWithCreds(ctx context.Context, creds ...string) (*storage.Client, error) {
+	var options []option.ClientOption
+	switch l := len(creds); l {
+	case 0: // Do nothing
+	case 1:
+		options = append(options, option.WithCredentialsFile(creds[0]))
+	default:
+		return nil, fmt.Errorf("%d creds files unsupported (at most 1).", l)
+	}
+	return storage.NewClient(ctx, options...)
+}
+
+// Path parses gs://bucket/obj urls
+type Path struct {
+	url url.URL
+}
+
+// String() returns the gs://bucket/obj url
+func (g Path) String() string {
+	return g.url.String()
+}
+
+// Set() updates value from a gs://bucket/obj string, validating errors.
+func (g *Path) Set(v string) error {
+	u, err := url.Parse(v)
+	if err != nil {
+		return fmt.Errorf("invalid gs:// url %s: %v", v, err)
+	}
+	return g.SetURL(u)
+}
+
+func (g *Path) SetURL(u *url.URL) error {
+	switch {
+	case u == nil:
+		return errors.New("nil url")
+	case u.Scheme != "gs":
+		return fmt.Errorf("must use a gs:// url: %s", u)
+	case strings.Contains(u.Host, ":"):
+		return fmt.Errorf("gs://bucket may not contain a port: %s", u)
+	case u.Opaque != "":
+		return fmt.Errorf("url must start with gs://: %s", u)
+	case u.User != nil:
+		return fmt.Errorf("gs://bucket may not contain an user@ prefix: %s", u)
+	case u.RawQuery != "":
+		return fmt.Errorf("gs:// url may not contain a ?query suffix: %s", u)
+	case u.Fragment != "":
+		return fmt.Errorf("gs:// url may not contain a #fragment suffix: %s", u)
+	}
+	g.url = *u
+	return nil
+}
+
+// Resolve returns the path relative to the current path
+func (p Path) ResolveReference(ref *url.URL) (*Path, error) {
+	var newP Path
+	if err := newP.SetURL(p.url.ResolveReference(ref)); err != nil {
+		return nil, err
+	}
+	return &newP, nil
+}
+
+// Bucket() returns bucket in gs://bucket/obj
+func (g Path) Bucket() string {
+	return g.url.Host
+}
+
+// Object() returns path/to/something in gs://bucket/path/to/something
+func (g Path) Object() string {
+	if g.url.Path == "" {
+		return g.url.Path
+	}
+	return g.url.Path[1:]
+}
+
+func calcCRC(buf []byte) uint32 {
+	return crc32.Checksum(buf, crc32.MakeTable(crc32.Castagnoli))
+}
+
+// Upload writes bytes to the specified Path
+func Upload(client *storage.Client, ctx context.Context, path Path, buf []byte) error {
+	crc := calcCRC(buf)
+	w := client.Bucket(path.Bucket()).Object(path.Object()).NewWriter(ctx)
+	w.SendCRC32C = true
+	// Send our CRC32 to ensure google received the same data we sent.
+	// See checksum example at:
+	// https://godoc.org/cloud.google.com/go/storage#Writer.Write
+	w.ObjectAttrs.CRC32C = crc
+	w.ProgressFunc = func(bytes int64) {
+		log.Printf("Uploading %s: %d/%d...", path, bytes, len(buf))
+	}
+	if n, err := w.Write(buf); err != nil {
+		return fmt.Errorf("writing %s failed: %v", path, err)
+	} else if n != len(buf) {
+		return fmt.Errorf("partial write of %s: %d < %d", path, n, len(buf))
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("closing %s failed: %v", path, err)
+	}
+	return nil
+}

--- a/testgrid/util/gcs/gcs_test.go
+++ b/testgrid/util/gcs/gcs_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"net/url"
+	"testing"
+)
+
+func Test_SetURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		url    string
+		err    bool
+		bucket string
+		object string
+	}{
+		{
+			name:   "only bucket",
+			url:    "gs://thisbucket",
+			bucket: "thisbucket",
+		},
+		{
+			name:   "bucket and object",
+			url:    "gs://first/second",
+			bucket: "first",
+			object: "second",
+		},
+		{
+			name: "reject files",
+			url:  "/path/to/my/bucket",
+			err:  true,
+		},
+		{
+			name: "reject websites",
+			url:  "http://example.com/object",
+			err:  true,
+		},
+		{
+			name: "reject ports",
+			url:  "gs://first:123/second",
+			err:  true,
+		},
+		{
+			name: "reject username",
+			url:  "gs://erick@first/second",
+			err:  true,
+		},
+		{
+			name: "reject queries",
+			url:  "gs://first/second?query=true",
+			err:  true,
+		},
+		{
+			name: "reject fragments",
+			url:  "gs://first/second#fragment",
+			err:  true,
+		},
+	}
+	for _, tc := range cases {
+		var p Path
+		err := p.Set(tc.url)
+		switch {
+		case err != nil && !tc.err:
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		case err == nil && tc.err:
+			t.Errorf("%s: failed to raise an error", tc.name)
+		default:
+			if p.Bucket() != tc.bucket {
+				t.Errorf("%s: bad bucket %s != %s", tc.name, p.Bucket(), tc.bucket)
+			}
+			if p.Object() != tc.object {
+				t.Errorf("%s: bad object %s != %s", tc.name, p.Object(), tc.object)
+			}
+		}
+	}
+}
+
+func Test_ResolveReference(t *testing.T) {
+	var p Path
+	err := p.Set("gs://bucket/path/to/config")
+	if err != nil {
+		t.Fatalf("bad path: %v", err)
+	}
+	u, err := url.Parse("testgroup")
+	if err != nil {
+		t.Fatalf("bad url: %v", err)
+	}
+	q, err := p.ResolveReference(u)
+	if q.Object() != "path/to/testgroup" {
+		t.Errorf("bad object: %s", q)
+	}
+	if q.Bucket() != "bucket" {
+		t.Errorf("bad bucket: %s", q)
+	}
+}
+
+// Ensure that a == b => calcCRC(a) == calcCRC(b)
+func Test_calcCRC(t *testing.T) {
+	b1 := []byte("hello")
+	b2 := []byte("world")
+	b1a := []byte("h")
+	b1a = append(b1a, []byte("ello")...)
+	c1 := calcCRC(b1)
+	c2 := calcCRC(b2)
+	c1a := calcCRC(b1a)
+
+	switch {
+	case c1 == c2:
+		t.Errorf("g1 crc %d should not equal g2 crc %d", c1, c2)
+	case len(b1) == 0, len(b2) == 0:
+		t.Errorf("empty b1 b2 %s %s", b1, b2)
+	case len(b1) != len(b1a), c1 != c1a:
+		t.Errorf("different results: %s %d != %s %d", b1, c1, b1a, c1a)
+	}
+
+}


### PR DESCRIPTION
/assign @michelle192837 @krzyzacy @rmmh 
/cc @BenTheElder 

* Put gcs logic into `testgrid/util/gcs` package.
* Allow config to write proto to GCS
* Default config to monitoring yaml files for changes, writing the new proto each time
* Update `config-upload.sh` to use new `--output` and `--oneshot` flags.

After this I plan to:
* Create a config image and deployment
* Eventually replace the config postsubmit job with updateconfig plugin usage that deploys the config.yaml file to a cluster whenever it changes (that the config image then reads and converts to a proto)