### PR TITLE
Update bot merge whitelist for k/k

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -112,7 +112,9 @@ slack:
     channels:
     - kubernetes-dev
     whitelist:
-    - k8s-merge-robot
+    - k8s-ci-robot # future home of tide
+    - k8s-merge-robot # submit queue
+    - k8s-release-robot # anago
     - wojtek-t # 1.7 patch release manager
     - jpbetz # 1.8 patch release manager
     - mbohlool # 1.9 patch release manager


### PR DESCRIPTION
This adds the @k8s-ci-robot account for when we move to tide, as well as the @k8s-release-robot account that is used the the release tooling.