### PR TITLE
Use realpath, since bazel mucks with PWD

### DIFF
--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -18,11 +18,9 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-
 for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
   bazel run //testgrid/cmd/config -- \
-    --yaml="$(dirname "${BASH_SOURCE}")"/config.yaml \
+    --yaml="$(realpath "$(dirname "${BASH_SOURCE}")"/config.yaml)" \
     --output="${output}" \
-    --print-text \
     --oneshot
 done


### PR DESCRIPTION
/assign @rmmh @michelle192837 

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/maintenance-ci-testgrid-config-upload/55446