### PR TITLE
Enable prow jobs on all branches for kubeflow/kubeflow & kubeflow/tf-operator

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -284,8 +284,6 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-presubmit"
     trigger: "(?m)^/test( all| kubeflow-presubmit),?(\\s+|$)"
-    branches:
-    - master
     labels:
       preset-service-account: true
     spec:
@@ -348,8 +346,6 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-tf-operator-presubmit"
     trigger: "(?m)^/test( all| kubeflow-tf-operator-presubmit),?(\\s+|$)"
-    branches:
-    - master
     labels:
       preset-service-account: true
     spec:
@@ -6322,8 +6318,6 @@ postsubmits:
   kubeflow/kubeflow:
   - name: kubeflow-postsubmit
     agent: kubernetes
-    branches:
-    - master
     labels:
       preset-service-account: true
     spec:
@@ -6370,8 +6364,6 @@ postsubmits:
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-postsubmit
     agent: kubernetes
-    branches:
-    - master
     labels:
       preset-service-account: true
     spec:


### PR DESCRIPTION
Enable prow jobs on all branches for kubeflow/kubeflow & kubeflow/tf-operator

* Kubeflow will use branches for releases and we want to run prow jobs
  on them.

Related to
Fix kubeflow/kubeflow#507 continuous testing for Kubeflow release branches
Related to kubeflow/kubeflow #215 release process for Kubeflow