### PR TITLE
Increase timeout on ci-kubernetes-e2e-gci-gce-ingress

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4777,7 +4777,7 @@
       "--gcp-zone=us-east2-a",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|\\[Feature:NEG\\]",
-      "--timeout=90m"
+      "--timeout=320m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10594,7 +10594,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=110
+      - --timeout=340
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
 


### PR DESCRIPTION
Test is timing out most likely because we recently added NEG tests. Increased timeout to 320 min

/assign @krzyzacy 