### PR TITLE
Refactor clonerefs to take args using JSON

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -51,6 +51,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//prow/clonerefs:all-srcs",
         "//prow/cluster:all-srcs",
         "//prow/cmd/branchprotector:all-srcs",
         "//prow/cmd/clonerefs:all-srcs",

--- a/prow/README.md
+++ b/prow/README.md
@@ -17,6 +17,9 @@ not make any attempt to preserve backwards compatibility.
 * `cmd/tot` vends incrementing build numbers.
 * `cmd/horologium` starts periodic jobs when necessary.
 * `cmd/mkpj` creates `ProwJobs`.
+* `cmd/clonerefs`, `cmd/initupload`, `cmd/gcsupload`, `cmd/entrypoint`, and
+  `cmd/sidecar` are small utilities used in `ProwJob`s created by `plank` as
+  `Pod`s. See [their README](./pod-utilities.md) for more information
 
 See also: [Life of a Prow Job](./architecture.md)
 

--- a/prow/clonerefs/BUILD.bazel
+++ b/prow/clonerefs/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "options.go",
+        "parse.go",
+        "run.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/clonerefs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "//prow/pod-utils/clone:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "options_test.go",
+        "parse_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/clonerefs/OWNERS
+++ b/prow/clonerefs/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- stevekuznetsov

--- a/prow/clonerefs/doc.go
+++ b/prow/clonerefs/doc.go
@@ -14,25 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clone
-
-import (
-	"k8s.io/test-infra/prow/kube"
-)
-
-// Record is a trace of what the desired
-// git state was, what steps we took to get there,
-// and whether or not we were successful.
-type Record struct {
-	Refs     *kube.Refs `json:"refs"`
-	Commands []Command  `json:"commands"`
-	Failed   bool       `json:"failed"`
-}
-
-// Command is a trace of a command executed
-// while achieving the desired git state.
-type Command struct {
-	Command string `json:"command"`
-	Output  string `json:"output,omitempty"`
-	Error   string `json:"error,omitempty"`
-}
+// Package clonerefs is a library for cloning references
+package clonerefs

--- a/prow/clonerefs/options.go
+++ b/prow/clonerefs/options.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clonerefs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/kube"
+)
+
+// Options configures the clonerefs tool
+// completely and may be provided using JSON
+// or user-specified flags, but not both.
+type Options struct {
+	// SrcRoot is the root directory under which
+	// all source code is cloned
+	SrcRoot string `json:"src_root"`
+	// Log is the log file to which clone records are written
+	Log string `json:"log"`
+
+	// GitUserName is an optional field that is used with
+	// `git config user.name`
+	GitUserName string `json:"git_user_name,omitempty"`
+	// GitUserEmail is an optional field that is used with
+	// `git config user.email`
+	GitUserEmail string `json:"git_user_email,omitempty"`
+
+	// GitRefs are the refs to clone
+	GitRefs []*kube.Refs `json:"refs"`
+}
+
+// Validate ensures that the configuration options are valid
+func (o *Options) Validate() error {
+	if o.SrcRoot == "" {
+		return errors.New("no source root specified")
+	}
+
+	if o.Log == "" {
+		return errors.New("no log file specified")
+	}
+
+	if len(o.GitRefs) == 0 {
+		return errors.New("no refs specified to clone")
+	}
+
+	seen := map[string]sets.String{}
+	for _, ref := range o.GitRefs {
+		if _, seenOrg := seen[ref.Org]; seenOrg {
+			if seen[ref.Org].Has(ref.Repo) {
+				return errors.New("sync config for %s/%s provided more than once")
+			}
+			seen[ref.Org].Insert(ref.Repo)
+		} else {
+			seen[ref.Org] = sets.NewString(ref.Repo)
+		}
+	}
+
+	return nil
+}
+
+const (
+	// JSONConfigEnvVar is the environment variable that
+	// clonerefs expects to find a full JSON configuration
+	// in when run.
+	JSONConfigEnvVar = "CLONEREFS_OPTIONS"
+	// DefaultGitUserName is the default name used in git config
+	DefaultGitUserName = "ci-robot"
+	// DefaultGitUserEmail is the default email used in git config
+	DefaultGitUserEmail = "ci-robot@k8s.io"
+)
+
+// ResolveOptions will resolve the set of options, preferring
+// to use the full JSON configuration variable but falling
+// back to user-provided flags if the variable is not
+// provided.
+func ResolveOptions() (*Options, error) {
+	options := &Options{}
+	if jsonConfig, provided := os.LookupEnv(JSONConfigEnvVar); provided {
+		if err := json.Unmarshal([]byte(jsonConfig), &options); err != nil {
+			return options, fmt.Errorf("could not resolve config from env: %v", err)
+		}
+		return options, nil
+	}
+
+	flag.StringVar(&options.SrcRoot, "src-root", "", "Where to root source checkouts")
+	flag.StringVar(&options.Log, "log", "", "Where to write logs")
+	flag.StringVar(&options.GitUserName, "git-user-name", DefaultGitUserName, "Username to set in git config")
+	flag.StringVar(&options.GitUserEmail, "git-user-email", DefaultGitUserEmail, "Email to set in git config")
+
+	refs := gitRefs{}
+	aliases := pathAliases{}
+	flag.Var(&refs, "repo", "Mapping of Git URI to refs to check out, can be provided more than once")
+	flag.Var(&aliases, "clone-alias", "Mapping of org and repo to path to clone to, can be provided more than once")
+	flag.Parse()
+
+	options.GitRefs = refs.gitRefs
+
+	for _, pathAlias := range aliases.aliases {
+		for _, ref := range options.GitRefs {
+			if pathAlias.Org == ref.Org && pathAlias.Repo == ref.Repo {
+				ref.PathAlias = pathAlias.Path
+			}
+		}
+	}
+	return options, nil
+}
+
+type gitRefs struct {
+	gitRefs []*kube.Refs
+}
+
+func (r *gitRefs) String() string {
+	representation := bytes.Buffer{}
+	for _, ref := range r.gitRefs {
+		fmt.Fprintf(&representation, "%s,%s=%s", ref.Org, ref.Repo, ref.String())
+	}
+	return representation.String()
+}
+
+// Set parses out a kube.Refs from the user string.
+// The following example shows all possible fields:
+//   org,repo=base-ref:base-sha[,pull-number:pull-sha]...
+// For the base ref and every pull number, the SHAs
+// are optional and any number of them may be set or
+// unset.
+func (r *gitRefs) Set(value string) error {
+	gitRef, err := ParseRefs(value)
+	if err != nil {
+		return err
+	}
+	r.gitRefs = append(r.gitRefs, gitRef)
+	return nil
+}
+
+type pathAliases struct {
+	aliases []ClonePathAlias
+}
+
+func (a *pathAliases) String() string {
+	representation := bytes.Buffer{}
+	for _, resolver := range a.aliases {
+		fmt.Fprint(&representation, resolver.String())
+	}
+	return representation.String()
+}
+
+// Set parses out path aliases from user input
+func (a *pathAliases) Set(value string) error {
+	resolver, err := ParseAliases(value)
+	if err != nil {
+		return err
+	}
+	a.aliases = append(a.aliases, resolver)
+	return nil
+}
+
+// Encode will encode the set of options in the format that
+// is expected for the configuration environment variable
+func Encode(options Options) (string, error) {
+	encoded, err := json.Marshal(options)
+	return string(encoded), err
+}

--- a/prow/clonerefs/options_test.go
+++ b/prow/clonerefs/options_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package clonerefs
 
 import (
 	"testing"
@@ -25,37 +25,63 @@ import (
 func TestOptions_Validate(t *testing.T) {
 	var testCases = []struct {
 		name        string
-		input       options
+		input       Options
 		expectedErr bool
 	}{
 		{
 			name: "all ok",
-			input: options{
-				srcRoot: "test",
-				log:     "thing",
+			input: Options{
+				SrcRoot: "test",
+				Log:     "thing",
+				GitRefs: []*kube.Refs{
+					{
+						Repo: "repo1",
+						Org:  "org1",
+					},
+				},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "missing src root",
-			input: options{
-				log: "thing",
+			input: Options{
+				Log: "thing",
+				GitRefs: []*kube.Refs{
+					{
+						Repo: "repo1",
+						Org:  "org1",
+					},
+				},
 			},
 			expectedErr: true,
 		},
 		{
-			name: "missing log location",
-			input: options{
-				srcRoot: "test",
+			name: "missing Log location",
+			input: Options{
+				SrcRoot: "test",
+				GitRefs: []*kube.Refs{
+					{
+						Repo: "repo1",
+						Org:  "org1",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "missing refs",
+			input: Options{
+				SrcRoot: "test",
+				Log:     "thing",
 			},
 			expectedErr: true,
 		},
 		{
 			name: "separate repos",
-			input: options{
-				srcRoot: "test",
-				log:     "thing",
-				refs: gitRefs{gitRefs: []kube.Refs{
+			input: Options{
+				SrcRoot: "test",
+				Log:     "thing",
+				GitRefs: []*kube.Refs{
 					{
 						Repo: "repo1",
 						Org:  "org1",
@@ -64,16 +90,16 @@ func TestOptions_Validate(t *testing.T) {
 						Repo: "repo2",
 						Org:  "org2",
 					},
-				}},
+				},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "duplicate repos",
-			input: options{
-				srcRoot: "test",
-				log:     "thing",
-				refs: gitRefs{gitRefs: []kube.Refs{
+			input: Options{
+				SrcRoot: "test",
+				Log:     "thing",
+				GitRefs: []*kube.Refs{
 					{
 						Repo: "repo",
 						Org:  "org",
@@ -82,7 +108,7 @@ func TestOptions_Validate(t *testing.T) {
 						Repo: "repo",
 						Org:  "org",
 					},
-				}},
+				},
 			},
 			expectedErr: true,
 		},

--- a/prow/clonerefs/parse.go
+++ b/prow/clonerefs/parse.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clone
+package clonerefs
 
 import (
 	"fmt"
@@ -37,8 +37,8 @@ import (
 //   kubernetes,test-infra=master:abcde12,34:fghij56
 //   kubernetes,test-infra=master,34:fghij56
 //   kubernetes,test-infra=master:abcde12,34:fghij56,78
-func ParseRefs(value string) (kube.Refs, error) {
-	gitRef := kube.Refs{}
+func ParseRefs(value string) (*kube.Refs, error) {
+	gitRef := &kube.Refs{}
 	values := strings.SplitN(value, "=", 2)
 	if len(values) != 2 {
 		return gitRef, fmt.Errorf("refspec %s invalid: does not contain '='", value)
@@ -86,31 +86,20 @@ func ParseRefs(value string) (kube.Refs, error) {
 	return gitRef, nil
 }
 
-// PathResolver provides path overrides for a given set
-// of repos
-type PathResolver struct {
-	org  string
-	repo string
+// ClonePathAlias provides path overrides for a given repo
+type ClonePathAlias struct {
+	Org  string
+	Repo string
 
-	path string
+	Path string
 }
 
-// Resolve returns an override clone path if the org and
-// repo match the settings in in the resolver
-func (r *PathResolver) Resolve(org, repo string) string {
-	if r.org == org && r.repo == repo {
-		return r.path
-	}
-
-	return ""
-}
-
-func (r *PathResolver) String() string {
-	return fmt.Sprintf("%s,%s=%s", r.org, r.repo, r.path)
+func (r *ClonePathAlias) String() string {
+	return fmt.Sprintf("%s,%s=%s", r.Org, r.Repo, r.Path)
 }
 
 // ParseAliases parses a human-provided string into a
-// PathResolver that resolves the path under the
+// ClonePathAlias that resolves the path under the
 // $GOPATH/src directory where the repository should
 // be cloned. The format for the human-provided string
 // is:
@@ -118,20 +107,20 @@ func (r *PathResolver) String() string {
 // Examples:
 //   kubernetes,test-infra=k8s.io/test-infra
 //   myorg,non-go-project=somewhere/else
-func ParseAliases(value string) (PathResolver, error) {
-	var resolver PathResolver
+func ParseAliases(value string) (ClonePathAlias, error) {
+	var resolver ClonePathAlias
 	values := strings.SplitN(value, "=", 2)
 	if len(values) != 2 {
 		return resolver, fmt.Errorf("path override %s invalid: does not contain '='", value)
 	}
 	info := values[0]
-	resolver.path = values[1]
+	resolver.Path = values[1]
 
 	infoValues := strings.SplitN(info, ",", 2)
 	switch len(infoValues) {
 	case 2:
-		resolver.org = infoValues[0]
-		resolver.repo = infoValues[1]
+		resolver.Org = infoValues[0]
+		resolver.Repo = infoValues[1]
 		return resolver, nil
 	default:
 		return resolver, fmt.Errorf("path override %s invalid: does not contain 'org,repo' as prefix", value)

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clonerefs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sync"
+
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pod-utils/clone"
+)
+
+// Run clones the configured refs
+func (o Options) Run() error {
+	wg := &sync.WaitGroup{}
+	wg.Add(len(o.GitRefs))
+
+	output := make(chan clone.Record, len(o.GitRefs))
+	for _, gitRef := range o.GitRefs {
+		go func(ref *kube.Refs) {
+			defer wg.Done()
+			output <- clone.Run(ref, o.SrcRoot, o.GitUserName, o.GitUserEmail)
+		}(gitRef)
+	}
+
+	wg.Wait()
+	close(output)
+
+	var results []clone.Record
+	for record := range output {
+		results = append(results, record)
+	}
+
+	logData, err := json.Marshal(results)
+	if err != nil {
+		return fmt.Errorf("failed to marshal clone records: %v", err)
+	}
+
+	if err := ioutil.WriteFile(o.Log, logData, 0755); err != nil {
+		return fmt.Errorf("failed to write clone records: %v", err)
+	}
+
+	return nil
+}

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -7,12 +7,9 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/clonerefs",
     visibility = ["//visibility:private"],
     deps = [
-        "//prow/kube:go_default_library",
+        "//prow/clonerefs:go_default_library",
         "//prow/logrusutil:go_default_library",
-        "//prow/pod-utils/clone:go_default_library",
-        "//prow/pod-utils/downwardapi:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -41,11 +38,4 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["main_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/cmd/clonerefs/README.md
+++ b/prow/cmd/clonerefs/README.md
@@ -1,0 +1,66 @@
+# `clonerefs`
+
+`clonerefs` clones code under test at the specified locations. Regardless of the success or failure
+of clone operations, this utility will have an exit code of `0` and will record the clone operation
+status to the specified log file. Clone records have the form:
+
+```json
+[
+    {
+        "failed": false,
+        "refs": {
+            "org": "kubernetes",
+            "repo": "kubernetes",
+            "base_ref": "master",
+            "base_sha": "a36820b10cde020818b8dd437e285d0e2e7d5e98",
+            "pulls": [
+                {
+                    "number": 123,
+                    "author": "smarterclayton",
+                    "sha": "2b58234a8aee0d55918b158a3b38c292d6a95ef7"
+                }
+            ]
+        },
+        "commands": [
+            {
+                "command": "git init",
+                "output": "Reinitialized existing Git repository in /go/src/k8s.io/kubernetes/.git/"
+                "error": ""
+            }
+        ]
+    }
+]
+```
+
+Note: the utility _will_ exit with a non-zero status if a fatal error is detected and no clone
+operations can even begin to run.
+
+This utility is intended to be used with [`initupload`](./../initupload/README.md), which will
+decode the JSON output by `clonerefs` and can format it for human consumption.
+
+`clonerefs` can be configured by either passing in flags or by specifying a full set of options
+as JSON in the `$CLONEREFS_OPTIONS` environment variable, which has the form:
+
+```json
+{
+    "src_root": "/go",
+    "log": "/logs/clone-log.txt",
+    "git_user_name": "ci-robot",
+    "git_user_email": "ci-robot@k8s.io",
+    "refs": [
+        {
+            "org": "kubernetes",
+            "repo": "kubernetes",
+            "base_ref": "master",
+            "base_sha": "a36820b10cde020818b8dd437e285d0e2e7d5e98",
+            "pulls": [
+                {
+                    "number": 123,
+                    "author": "smarterclayton",
+                    "sha": "2b58234a8aee0d55918b158a3b38c292d6a95ef7"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -17,122 +17,18 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"sync"
-
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/logrusutil"
 
-	"k8s.io/test-infra/prow/kube"
-	"k8s.io/test-infra/prow/pod-utils/clone"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	"k8s.io/test-infra/prow/clonerefs"
+	"k8s.io/test-infra/prow/logrusutil"
 )
 
-type options struct {
-	srcRoot string
-	log     string
-
-	gitUserName  string
-	gitUserEmail string
-
-	refs    gitRefs
-	aliases pathAliases
-}
-
-func (o *options) Validate() error {
-	if o.srcRoot == "" {
-		return errors.New("no source root specified")
-	}
-
-	if o.log == "" {
-		return errors.New("no log file specified")
-	}
-
-	seen := map[string]sets.String{}
-	for _, ref := range o.refs.gitRefs {
-		if _, seenOrg := seen[ref.Org]; seenOrg {
-			if seen[ref.Org].Has(ref.Repo) {
-				return errors.New("sync config for %s/%s provided more than once")
-			}
-
-			seen[ref.Org].Insert(ref.Repo)
-		} else {
-			seen[ref.Org] = sets.NewString(ref.Repo)
-		}
-	}
-
-	return nil
-}
-
-func gatherOptions() options {
-	o := options{}
-	flag.StringVar(&o.srcRoot, "src-root", "", "Where to root source checkouts")
-	flag.StringVar(&o.log, "log", "", "Where to write logs")
-	flag.StringVar(&o.gitUserName, "git-user-name", "ci-robot", "Username to set in git config")
-	flag.StringVar(&o.gitUserEmail, "git-user-email", "ci-robot@k8s.io", "Email to set in git config")
-	flag.Var(&o.refs, "repo", "Mapping of Git URI to refs to check out, can be provided more than once")
-	flag.Var(&o.aliases, "clone-alias", "Mapping of org and repo to path to clone to, can be provided more than once")
-	flag.Parse()
-	return o
-}
-
-type gitRefs struct {
-	gitRefs []kube.Refs
-}
-
-func (r *gitRefs) String() string {
-	representation := bytes.Buffer{}
-	for _, ref := range r.gitRefs {
-		fmt.Fprintf(&representation, "%s,%s=%s", ref.Org, ref.Repo, ref.String())
-	}
-	return representation.String()
-}
-
-// Set parses out a kube.Refs from the user string.
-// The following example shows all possible fields:
-//   org,repo=base-ref:base-sha[,pull-number:pull-sha]...
-// For the base ref and every pull number, the SHAs
-// are optional and any number of them may be set or
-// unset.
-func (r *gitRefs) Set(value string) error {
-	gitRef, err := clone.ParseRefs(value)
-	if err != nil {
-		return err
-	}
-	r.gitRefs = append(r.gitRefs, gitRef)
-	return nil
-}
-
-type pathAliases struct {
-	aliases []clone.PathResolver
-}
-
-func (a *pathAliases) String() string {
-	representation := bytes.Buffer{}
-	for _, resolver := range a.aliases {
-		fmt.Fprint(&representation, resolver.String())
-	}
-	return representation.String()
-}
-
-// Set parses out path aliases from user input
-func (a *pathAliases) Set(value string) error {
-	resolver, err := clone.ParseAliases(value)
-	if err != nil {
-		return err
-	}
-	a.aliases = append(a.aliases, resolver)
-	return nil
-}
-
 func main() {
-	o := gatherOptions()
+	o, err := clonerefs.ResolveOptions()
+	if err != nil {
+		logrus.Fatalf("Could not resolve options: %v", err)
+	}
+
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
@@ -141,52 +37,8 @@ func main() {
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "clonerefs"}),
 	)
 
-	wg := &sync.WaitGroup{}
-	output := make(chan clone.Record, len(o.refs.gitRefs)+1)
-
-	jobRefs, err := downwardapi.ResolveSpecFromEnv()
-	if err != nil {
-		logrus.WithError(err).Warn("Could not determine Prow job refs from environment")
-	} else {
-		if jobRefs.Type != kube.PeriodicJob {
-			// periodic jobs do not configure a set
-			// of refs to clone, so we ignore them
-			for _, gitRef := range o.refs.gitRefs {
-				if gitRef.Org == jobRefs.Refs.Org && gitRef.Repo == jobRefs.Refs.Repo {
-					logrus.Fatalf("Clone specification for %s/%s found both in Prow variables and user-provided flags", jobRefs.Refs.Org, jobRefs.Refs.Repo)
-				}
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				output <- clone.Run(jobRefs.Refs, o.srcRoot, o.gitUserName, o.gitUserEmail, o.aliases.aliases)
-			}()
-		}
-	}
-
-	wg.Add(len(o.refs.gitRefs))
-	for _, gitRef := range o.refs.gitRefs {
-		go func(ref kube.Refs) {
-			defer wg.Done()
-			output <- clone.Run(ref, o.srcRoot, o.gitUserName, o.gitUserEmail, o.aliases.aliases)
-		}(gitRef)
-	}
-
-	wg.Wait()
-	close(output)
-
-	var results []clone.Record
-	for record := range output {
-		results = append(results, record)
-	}
-
-	logData, err := json.Marshal(results)
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to marshal clone records")
-	} else {
-		if err := ioutil.WriteFile(o.log, logData, 0755); err != nil {
-			logrus.WithError(err).Fatal("Failed to write clone records")
-		}
+	if err := o.Run(); err != nil {
+		logrus.WithError(err).Fatal("Failed to clone refs")
 	}
 
 	logrus.Info("Finished cloning refs")

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -152,6 +152,12 @@ type Refs struct {
 	BaseSHA string `json:"base_sha,omitempty"`
 
 	Pulls []Pull `json:"pulls,omitempty"`
+
+	// PathAlias is the location under <root-dir>/src
+	// where this repository is cloned. If this is not
+	// set, <root-dir>/src/github.com/org/repo will be
+	// used as the default.
+	PathAlias string `json:"path_alias,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -1,0 +1,19 @@
+# Pod Utilities
+
+Pod utilities are small, focused Go programs used by `plank` to decorate user-provided `PodSpec`s
+in order to increase the ease of integration for new jobs into the entire CI infrastructure. The
+utilities today wrap the execution of the test code to ensure that the tests run against correct
+versions of the source code, that test commands run in the appropriate environment and that output
+from the test (in the form of status, logs and artifacts) is correctly uploaded to the cloud.
+
+These utilities are integrated into a test run by adding `InitContainer`s and sidecar `Container`s
+to the user-provided `PodSpec`, as well as by overwriting the `Container` entrypoint for the test
+`Container` provided by the user. The following utilities exist today:
+
+ - [`clonerefs`](./cmd/clonerefs/README.md): clones source code under test
+ - [`initupload`](./cmd/initupload/README.md): records the beginning of a test in cloud storage
+   and reports the status of the clone operations
+ - [`entrypoint`](./cmd/entrypoint/README.md): is injected into the test `Container`, wraps the
+   test code to capture logs and exit status
+ - [`sidecar`](./cmd/sidecar/README.md): runs alongside the test `Container`, uploads status, logs
+   and test artifacts to cloud storage once the test is finished

--- a/prow/pod-utils/clone/BUILD.bazel
+++ b/prow/pod-utils/clone/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = [
         "clone.go",
         "format.go",
-        "parse.go",
         "types.go",
     ],
     importpath = "k8s.io/test-infra/prow/pod-utils/clone",
@@ -32,7 +31,7 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["parse_test.go"],
+    srcs = ["clone_test.go"],
     embed = [":go_default_library"],
     deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -17,22 +17,37 @@ limitations under the License.
 package clone
 
 import (
+	"testing"
+
 	"k8s.io/test-infra/prow/kube"
 )
 
-// Record is a trace of what the desired
-// git state was, what steps we took to get there,
-// and whether or not we were successful.
-type Record struct {
-	Refs     *kube.Refs `json:"refs"`
-	Commands []Command  `json:"commands"`
-	Failed   bool       `json:"failed"`
-}
+func TestPathForRefs(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		refs     *kube.Refs
+		expected string
+	}{
+		{
+			name: "literal override",
+			refs: &kube.Refs{
+				PathAlias: "alias",
+			},
+			expected: "base/src/alias",
+		},
+		{
+			name: "default generated",
+			refs: &kube.Refs{
+				Org:  "org",
+				Repo: "repo",
+			},
+			expected: "base/src/github.com/org/repo",
+		},
+	}
 
-// Command is a trace of a command executed
-// while achieving the desired git state.
-type Command struct {
-	Command string `json:"command"`
-	Output  string `json:"output,omitempty"`
-	Error   string `json:"error,omitempty"`
+	for _, testCase := range testCases {
+		if actual, expected := PathForRefs("base", testCase.refs), testCase.expected; actual != expected {
+			t.Errorf("%s: expected path %q, got %q", testCase.name, expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
When the `clonerefs` tool is being launched by a program like Prow, it
does not make sense to take rich, structured data and flatten it into
simple strings to pass arguments between the two programs. We can use a
JSON configuration file to pass the minimal set of configuration options
necessary for the tool to function. This option can coexist with the
current set of flags, which were written to be backwards compatible with
those on `bootstrap.py` and will be useful if a human is to use the
tool.

This patch also introduces a new field, `PathAlias`, into the `Refs`
structure. This is necessary to ensure that Prow is declarative in how
it instructs jobs to clone their refs. This field is currently only set
by the `clonerefs` tooling when a user passes the correct flags but we
will ask users to pass this information in through Prow job
configuration in the future.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind feature
/cc @kargakis @cjwagner 
/assign @fejta @BenTheElder 

This is the first in a number of pulls where I apply this pattern to all of the utilities. These changes make it straightforward and minimal to decorate the `PodSpec` with all the auxiliary containers in the future.