### PR TITLE
Start docker with systemd. Allow dind as well as dindind.

### DIFF
--- a/dind/base/Dockerfile
+++ b/dind/base/Dockerfile
@@ -40,12 +40,17 @@ RUN clean-install apt-utils \
     systemd-sysv \
     jq
 
+
 # Install docker.
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && apt-key fingerprint 0EBFCD88 && add-apt-repository \
     "deb [arch=amd64] https://download.docker.com/linux/debian \
     jessie \
     stable"
-RUN clean-install docker-ce
+RUN clean-install docker-ce=17.03.2~ce-0~debian-jessie
+
+# Install our startup configuration for docker.
+COPY daemon.json /etc/docker/daemon.json
+COPY docker.service /lib/systemd/system/docker.service
 
 # Install the magic wrapper.
 COPY dind /bin/dind
@@ -60,11 +65,6 @@ RUN for i in /lib/systemd/system/sysinit.target.wants/*; do [ "${i##*/}" = "syst
   rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
   rm -f /lib/systemd/system/basic.target.wants/*;\
   rm -f /lib/systemd/system/anaconda.target.wants/*;
-
-# We don't want systemd to start docker for us.
-RUN find / -name docker.conf -exec rm {} \;
-RUN find / -name docker.service -exec rm {} \;
-RUN find / -name docker.socket -exec rm {} \;
 
 # TODO(Q-Lee): SIGRTMIN+3 is the shutdown signal for systemd. Investigate why "STOPSIGNAL SIGRTMIN+3" breaks.
 

--- a/dind/base/daemon.json
+++ b/dind/base/daemon.json
@@ -1,0 +1,3 @@
+{
+  "log-level": "debug"
+}

--- a/dind/base/docker.service
+++ b/dind/base/docker.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target docker.socket firewalld.service
+Wants=network-online.target
+Requires=docker.socket
+
+[Service]
+Environment=container=docker
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/bin/dockerd-entrypoint.sh
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+#TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/dind/build-cluster.sh
+++ b/dind/build-cluster.sh
@@ -49,12 +49,14 @@ cp ${KUBE_ROOT}/bazel-bin/test/e2e/e2e.test ${CLUSTER_DIR}
 cat ${KUBE_ROOT}/bazel-out/stable-status.txt | grep STABLE_BUILD_SCM_REVISION | awk '{print $2}' > ${CLUSTER_DIR}/source_version
 cat ${KUBE_ROOT}/bazel-out/stable-status.txt | grep STABLE_DOCKER_TAG | awk '{print $2}' > ${CLUSTER_DIR}/docker_version
 
-# Get systemd wrapper (needed until we put cluster-up into a systemd target).
+# Get systemd wrapper (needed until we have systemd run start.sh at startup).
 cp ${TOOL_ROOT}/init-wrapper.sh ${CLUSTER_DIR}
 # Get the cluster-up script.
 cp ${TOOL_ROOT}/start.sh ${CLUSTER_DIR}
 # Get the test execution script.
 cp ${TOOL_ROOT}/dind-test.sh ${CLUSTER_DIR}
+
+cp ${TOOL_ROOT}/../bazel-bin/dind/cluster-up/linux_amd64_stripped/cluster-up ${CLUSTER_DIR}
 
 cp ${TOOL_ROOT}/cluster/Dockerfile ${CLUSTER_DIR}/Dockerfile
 cp ${TOOL_ROOT}/cluster/Makefile ${CLUSTER_DIR}/Makefile
@@ -64,3 +66,5 @@ cd ${CLUSTER_DIR}
 docker save gcr.io/google-containers/dind-node-amd64:$(cat docker_version) -o dind-node-bundle.tar
 make build K8S_VERSION=$(cat docker_version)
 cd -
+
+rm -rf ${CLUSTER_DIR}

--- a/dind/build-node.sh
+++ b/dind/build-node.sh
@@ -72,3 +72,5 @@ cp ${TOOL_ROOT}/node/Makefile ${NODE_DIR}/Makefile
 cd ${NODE_DIR}
 make build K8S_VERSION=$(cat docker_version)
 cd -
+
+rm -rf ${NODE_DIR}

--- a/dind/dind-up.sh
+++ b/dind/dind-up.sh
@@ -17,6 +17,7 @@
 KUBE_ROOT=${KUBE_ROOT:-"../../kubernetes"}
 K8S_VERSION=$(cat ${KUBE_ROOT}/bazel-out/stable-status.txt | grep STABLE_DOCKER_TAG | awk '{print $2}')
 
+TMPDIR=$(mktemp -d -p /tmp)
 CONTAINER=$(docker run -d --privileged=true --security-opt seccomp:unconfined --cap-add=SYS_ADMIN \
   -v /lib/modules:/lib/modules -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
   gcr.io/google-containers/dind-cluster-amd64:${K8S_VERSION})

--- a/third_party/moby/dockerd-entrypoint.sh
+++ b/third_party/moby/dockerd-entrypoint.sh
@@ -9,7 +9,6 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
     --host=unix:///var/run/docker.sock \
     --host=tcp://0.0.0.0:2375 \
     --storage-driver=overlay \
-    --bip=10.0.0.1/8 \
     "$@"
 fi
 


### PR DESCRIPTION
We need to start docker with systemd to let journalctl grab the logs.