### PR TITLE
Remove reference to non-existent script

### DIFF
--- a/dind/build-cluster.sh
+++ b/dind/build-cluster.sh
@@ -56,8 +56,6 @@ cp ${TOOL_ROOT}/start.sh ${CLUSTER_DIR}
 # Get the test execution script.
 cp ${TOOL_ROOT}/dind-test.sh ${CLUSTER_DIR}
 
-cp ${TOOL_ROOT}/../bazel-bin/dind/cluster-up/linux_amd64_stripped/cluster-up ${CLUSTER_DIR}
-
 cp ${TOOL_ROOT}/cluster/Dockerfile ${CLUSTER_DIR}/Dockerfile
 cp ${TOOL_ROOT}/cluster/Makefile ${CLUSTER_DIR}/Makefile
 


### PR DESCRIPTION
Whoops, forgot to remove reference to something that doesn't exist in the checked-in branch.