### PR TITLE
Protect unprotected k/* repos that use tide

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -23,7 +23,37 @@ branch-protection:
       require-contexts:
       - cla/linuxfoundation
       repos:
+        cloud-provider-aws:
+          protect-by-default: true
+        cloud-provider-azure:
+          protect-by-default: true
+        cloud-provider-gcp:
+          protect-by-default: true
+        cloud-provider-openstack:
+          protect-by-default: true
+        cluster-registry:
+          protect-by-default: true
         community:
+          protect-by-default: true
+        features:
+          protect-by-default: true
+        federation:
+          protect-by-default: true
+        gengo:
+          protect-by-default: true
+        heapster:
+          protect-by-default: true
+        ingress-nginx:
+          protect-by-default: true
+        kubernetes-template-project:
+          protect-by-default: true
+        kube-state-metrics:
+          protect-by-default: true
+        kube-deploy:
+          protect-by-default: true
+        node-problem-detector:
+          protect-by-default: true
+        steering:
           protect-by-default: true
         test-infra:
           protect-by-default: true


### PR DESCRIPTION
Automated branch protection is currently enabled on the following repos:
* `kubernetes/community`
* `kubernetes/test-infra`

This PR extends branch protection to repos that meet all the following conditions:
* Use tide to merge PRs
* Have not manually configured branch protection

This matches the following repos:
* `kubernetes/cloud-provider-aws`
* `kubernetes/cloud-provider-azure`
* `kubernetes/cloud-provider-gcp`
* `kubernetes/cloud-provider-openstack`
* `kubernetes/cluster-registry`
* `kubernetes/features`
* `kubernetes/federation`
* `kubernetes/gengo`
* `kubernetes/heapster`
* `kubernetes/ingress-nginx`
* `kubernetes/kubernetes-template-project`
* `kubernetes/kube-state-metrics`
* `kubernetes/kube-deploy`
* `kubernetes/node-problem-detector`
* `kubernetes/steering`

Some repos that use tide manually configured branch protection (leave alone for now):
* charts, contrib, dashboard, kops, kubectl, minikube, repo-infra, sig-release, website

Documentation for the branch protector configuration: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector

/hold
allowing time for feedback from https://groups.google.com/d/msg/kubernetes-wg-contribex/TX6E6vGZjSs/yKMx9xDFCAAJ