### PR TITLE
Allow branches to be excluded in tide queries

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -85,6 +85,8 @@ func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
 type TideQuery struct {
 	Repos []string `json:"repos,omitempty"`
 
+	ExcludedBranches []string `json:"excludedBranches,omitempty"`
+
 	Labels        []string `json:"labels,omitempty"`
 	MissingLabels []string `json:"missingLabels,omitempty"`
 
@@ -95,6 +97,9 @@ func (tq *TideQuery) Query() string {
 	toks := []string{"is:pr", "state:open"}
 	for _, r := range tq.Repos {
 		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
+	}
+	for _, b := range tq.ExcludedBranches {
+		toks = append(toks, fmt.Sprintf("-base:\"%s\"", b))
 	}
 	for _, l := range tq.Labels {
 		toks = append(toks, fmt.Sprintf("label:\"%s\"", l))


### PR DESCRIPTION
In order to support code freeze on a branch, the queries used to gather
pull requests for the tide pool need too allow negative base ref
searches. The status posted by `tide` also expose this behavior on PRs
against those branches that are otherwise good to merge.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/kubernetes/test-infra/issues/7450
/area prow
/kind feature
/cc @kargakis @fejta 
/assign @cjwagner @BenTheElder 