### PR TITLE
create and document testgrid conformance uploader

### DIFF
--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -1,0 +1,40 @@
+# Display Conformance Tests with Testgrid
+
+This directory contains tooling for displaying [kubernetes conformance test](https://github.com/cncf/k8s-conformance) results on [testgrid](../README.md).
+
+
+## Using
+
+1. First you will need to set up a publicly readable GCS bucket per [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results).
+
+2. Make a PR to test-infra adding your bucket to the testgrid config (again see [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results)).
+
+3. Run the conformance tests, you can do this by:
+
+ - [following the official guide](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#running)
+
+ - or using [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest):
+   - cd to a Kubernetes source tree for the release you wish to test
+   - run `make quick-release` to build the test binaries
+   - make sure `kubectl` / `$KUBECONFIG` is authed to your cluster
+   - run kubetest with:
+    ```sh
+    kubetest --provider=skeleton \
+             --test --test_args="--ginkgo.focus=\[Conformance\]" \ 
+             --dump=./_artifacts | tee ./e2e.log
+    ```
+
+ - or using [Heptio Scanner](https://scanner.heptio.com/)
+
+4. Obtain the log file and JUnit xml output.
+
+ - With the above kubetest command you can find the log file and JUnit at `./e2e.log` and `./_artifacts/junit_01.xml` respectively.
+
+ - For [Sonobuouy](https://github.com/heptio/sonobuoy) run locally you can obtain a "snapshot" with the official instructions [when run locally](https://github.com/heptio/sonobuoy#download-and-run). You can then get the e2e log and junit from the snapshot (see the [plugins section](https://github.com/heptio/sonobuoy/blob/master/docs/snapshot.md#plugins) of the snapshot documentation)
+
+ - For Sonobuoy run via Heptio Scanner you can click "download test report" and extract the log and junit files.
+
+5. Authenticate [the gcloud sdk](https://cloud.google.com/sdk/downloads) / [gsutil](https://cloud.google.com/storage/docs/gsutil) to your GCS bucket
+
+6. run `upload_e2e.py --junit=<path to junit_01.xml> --log=<path to log file> --bucket=gs://your-bucket` (optionally supplying `--year=YYYY`, otherwise the current year on the host is assumed when parsing timestamps)
+

--- a/testgrid/conformance/upload_e2e.py
+++ b/testgrid/conformance/upload_e2e.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script parses conformance test output to produce testgrid entries
+#
+# Assumptions:
+# - there is one log file and one JUnit file (true for current conformance tests..)
+# - the log file contains ginkgo's output (true for kubetest and sonobuoy..)
+# - the ginkgo output will give us start / end time, and overall success
+#
+# - the start timestamp is suitable as a testgrid ID (unique, monotonic)
+#
+# - the test ran in the current year unless --year is provided
+# - the timestamps are parsed on a machine with the same local time (zone)
+#   settings as the machine that produced the logs
+#
+# The log file is the source of truth for metadata, the JUnit will be consumed
+# by testgrid / gubernator for individual test case results
+#
+# Usage: see README.md
+
+
+import re
+import sys
+import time
+import datetime
+import argparse
+import json
+import subprocess
+from os import path
+
+# NOTE e2e logs use go's time.StampMilli ("Jan _2 15:04:05.000")
+# Example log line with a timestamp:
+# Jan 26 06:38:46.284: INFO: Running AfterSuite actions on all node
+# the third ':' separates the date from the rest
+E2E_LOG_TIMESTAMP_RE = re.compile(r'(... .\d \d\d:\d\d:\d\d\.\d\d\d):.*')
+
+# Ginkgo gives a line like the following at the end of successful runs:
+# SUCCESS! -- 123 Passed | 0 Failed | 0 Pending | 587 Skipped PASS
+# we match this to detect overall success
+E2E_LOG_SUCCESS_RE = re.compile(r'SUCCESS! -- .* PASS')
+
+def parse_e2e_log_line_timestamp(line, year):
+    """parses a ginkgo e2e log line for the leading timestamp
+
+    Args:
+        line (str) - the log line
+        year (str) - 'YYYY'
+
+    Returns:
+        timestamp (datetime.datetime) or None
+    """
+    match = E2E_LOG_TIMESTAMP_RE.match(line)
+    if match is None:
+        return None
+    # note we add year to the timestamp because the actual timestamp doesn't
+    # contain one and we want a datetime object...
+    timestamp = year+' '+match.group(1)
+    return datetime.datetime.strptime(timestamp, '%Y %b %d %H:%M:%S.%f')
+
+def parse_e2e_logfile(file_handle, year):
+    """parse e2e logfile at path, assuming the log is from year
+
+    Args:
+        file_handle (file): the log file, iterated for lines
+        year (str): YYYY year logfile is from
+
+    Returns:
+        started (datetime.datetime), finished (datetime.datetime), passed (boolean)
+    """
+    started = finished = None
+    passed = False
+    for line in file_handle:
+        # try to get a timestamp from each line, keep the first one as
+        # start time, and the last one as finish time
+        timestamp = parse_e2e_log_line_timestamp(line, year)
+        if started:
+            finished = timestamp
+        else:
+            started = timestamp
+        # if we found the ginkgo success line then the run passed
+        is_success = E2E_LOG_SUCCESS_RE.match(line)
+        if is_success:
+            passed = True
+    return started, finished, passed
+
+def datetime_to_unix(datetime_obj):
+    """convert datetime.datetime to unix timestamp"""
+    return int(time.mktime(datetime_obj.timetuple()))
+
+def testgrid_started_json_contents(start_time):
+    """returns the string contents of a testgrid started.json file
+
+    Args:
+        start_time (datetime.datetime)
+
+    Returns:
+        contents (str)
+    """
+    started = datetime_to_unix(start_time)
+    return json.dumps({
+        'timestamp': started
+    })
+
+def testgrid_finished_json_contents(finish_time, passed):
+    """returns the string contents of a testgrid finished.json file
+
+    Args:
+        finish_time (datetime.datetime)
+        passed (bool)
+
+    Returns:
+        contents (str)
+    """
+    finished = datetime_to_unix(finish_time)
+    result = 'SUCCESS' if passed else 'FAILURE'
+    return json.dumps({
+        'timestamp': finished,
+        'result': result
+    })
+
+def upload_string(gcs_path, text):
+    """Uploads text to gcs_path"""
+    cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
+    print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    proc.communicate(input=text)
+    if proc.returncode != 0:
+        raise RuntimeError("Failed to upload with exit code: %d" % proc.returncode)
+
+def upload_file(gcs_path, file_path):
+    """Uploads file at file_path to gcs_path"""
+    cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', file_path, gcs_path]
+    print >>sys.stderr, 'Run:', cmd
+    proc = subprocess.Popen(cmd)
+    proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError('Failed to upload with exit code: %d' % proc.returncode)
+
+def parse_args(cli_args=None):
+    if cli_args is None:
+        cli_args = sys.argv[1:]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--bucket',
+        help=('GCS bucket to upload the results to,'
+              ' of the form \'gs://foo/bar\''),
+        required=True,
+    )
+    parser.add_argument(
+        '--year',
+        help=('the year in which the log is from, defaults to the current year.'
+              ' format: YYYY'),
+        default=str(datetime.datetime.now().year),
+    )
+    parser.add_argument(
+        '--junit',
+        help='path to the junit xml results file',
+        required=True,
+    )
+    parser.add_argument(
+        '--log',
+        help='path to the test log file, should contain the ginkgo output',
+        required=True,
+    )
+    return parser.parse_args(args=cli_args)
+
+def main(cli_args):
+    args = parse_args(cli_args)
+    log, junit, year, bucket = args.log, args.junit, args.year, args.bucket
+
+    # parse the e2e.log for start time, finish time, and success
+    with open(log) as file_handle:
+        started, finished, passed = parse_e2e_logfile(file_handle, year)
+
+    # convert parsed results to testgrid json metadata blobs
+    started_json = testgrid_started_json_contents(started)
+    finished_json = testgrid_finished_json_contents(finished, passed)
+
+    # use timestamp as build ID
+    gcs_dir = bucket + '/' + str(datetime_to_unix(started))
+
+    # upload metadata, log, junit to testgrid
+    print 'Uploading entry to: %s' % gcs_dir
+    upload_string(gcs_dir+'/started.json', started_json)
+    upload_string(gcs_dir+'/finished.json', finished_json)
+    upload_file(gcs_dir+'/build-log.txt', log)
+    upload_file(gcs_dir+'/artifacts/'+path.basename(junit), junit)
+
+    print 'Done.'
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
This version is a bit more minimal than the original design, it does not support obtaining the outputs magically and requires the user to manage GCS credentials and obtaining the log file and junit output, I have however documented how to do this.

/area testgrid
