### PR TITLE
Properly migrate dind base to stretch

### DIFF
--- a/dind/base/Dockerfile
+++ b/dind/base/Dockerfile
@@ -19,34 +19,34 @@ ENV container docker
 ARG DEBIAN_FRONTEND=noninteractive
 RUN clean-install apt-utils \
     apt-transport-https \
+    bash \
     ca-certificates \
     curl \
+    ethtool \
     gnupg2 \
-    software-properties-common \
-    curl \
-    lxc \
     iptables \
     iproute2 \
-    socat \
-    util-linux \
-    mount ebtables \
-    ethtool \
-    vim \
-    bash \
-    procps \
-    less \
+    jq \
     kmod \
+    lsb-core \
+    less \
+    lxc \
+    mount ebtables \
+    procps \
+    socat \
+    software-properties-common \
+    util-linux \
+    vim \
     systemd \
-    systemd-sysv \
-    jq
+    systemd-sysv
 
 
 # Install docker.
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && apt-key fingerprint 0EBFCD88 && add-apt-repository \
     "deb [arch=amd64] https://download.docker.com/linux/debian \
-    jessie \
+    $(lsb_release -cs) \
     stable"
-RUN clean-install docker-ce=17.03.2~ce-0~debian-jessie
+RUN clean-install docker-ce=17.03.2~ce-0~debian-stretch
 
 # Install our startup configuration for docker.
 COPY daemon.json /etc/docker/daemon.json

--- a/dind/base/Makefile
+++ b/dind/base/Makefile
@@ -18,7 +18,7 @@
 PREFIX = gcr.io/k8s-testimages
 NAME = dind-test-base
 ARCH = amd64
-TAG = 0.1
+TAG = 0.2
 
 IMAGE_NO_TAG = ${PREFIX}/${NAME}-${ARCH}
 IMAGE = ${IMAGE_NO_TAG}:$(TAG)

--- a/dind/cluster/Dockerfile
+++ b/dind/cluster/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.1
+FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.2
 
 # Get our short startup scripts first, because they're least likely to change.
 COPY init-wrapper.sh /init-wrapper.sh

--- a/dind/node/Dockerfile
+++ b/dind/node/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.1
+FROM gcr.io/k8s-testimages/dind-test-base-amd64:0.2
 
 # Get our short startup scripts first, because they're least likely to change.
 COPY init-wrapper.sh /init-wrapper.sh


### PR DESCRIPTION
The base image was hard-coded to jessie. I've changed it to consume lsb-core, so it always gets the appropriate package versions.

At the suggestion of @ixdy, I've also alphabetized the installs.