### PR TITLE
remove hostPort from all jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1076,6 +1076,7 @@ presubmits:
     - release-1.9
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
@@ -1088,9 +1089,6 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1271,9 +1269,6 @@ presubmits:
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1306,9 +1301,6 @@ presubmits:
         - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -2151,9 +2143,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -6057,6 +6046,7 @@ postsubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
@@ -6065,9 +6055,6 @@ postsubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         resources:
           requests:
             memory: "1Gi"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7166,7 +7166,6 @@ periodics:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7178,24 +7177,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
           memory: "8Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 30m
   name: ci-kubernetes-build-beta
@@ -7207,7 +7197,6 @@ periodics:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes=release-1.10
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7219,24 +7208,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
           memory: "8Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 2h
   name: ci-kubernetes-build-debian-unstable
@@ -7290,24 +7270,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
           memory: "8Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 1h
   name: ci-kubernetes-build-stable2
@@ -7319,7 +7290,6 @@ periodics:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes=release-1.8
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7331,24 +7301,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
           memory: "8Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 2h
   name: ci-kubernetes-build-stable3
@@ -7360,7 +7321,6 @@ periodics:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
       - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes=release-1.7
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7372,24 +7332,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
           memory: "8Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 1h
   agent: kubernetes
@@ -7414,8 +7365,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7427,24 +7376,15 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - name: cache-ssd
-        mountPath: /root/.cache
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 7
           memory: "41Gi"
     volumes:
-    - name: cache-ssd
-      hostPath:
-        path: /mnt/disks/ssd0
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - name: ci-kubernetes-e2e-autoscaling-vpa-actuation
   interval: 2h
@@ -15063,16 +15003,12 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
     volumes:
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 1h
   name: ci-kubernetes-verify-master
@@ -15095,16 +15031,12 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
     volumes:
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 2h
   name: ci-kubernetes-verify-stable1
@@ -15127,16 +15059,12 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
     volumes:
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 6h
   name: ci-kubernetes-verify-stable2
@@ -15159,16 +15087,12 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
     volumes:
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - interval: 24h
   name: ci-kubernetes-verify-stable3
@@ -15191,16 +15115,12 @@ periodics:
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
       resources:
         requests:
           cpu: 4
     volumes:
     - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
+      emptyDir: {}
 
 - name: ci-perf-tests-e2e-gce-clusterloader
   interval: 2h
@@ -15243,7 +15163,6 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
       args:
       - "--clean"
-      - "--git-cache=/root/.cache/git"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"
       - "--service-account=/etc/service-account/service-account.json"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1054,7 +1054,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1066,20 +1065,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        # TODO(bentheelder): eliminate the "git caching" junk
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
     run_after_success:
     - name: pull-kubernetes-e2e-kubeadm-gce
       agent: kubernetes
@@ -1103,22 +1091,11 @@ presubmits:
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
           - "--timeout=75"
           - "--clean"
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
-          volumeMounts:
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
   - name: pull-kubernetes-bazel-build
     agent: kubernetes
     context: pull-kubernetes-bazel-build
@@ -1134,7 +1111,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1149,19 +1125,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
     run_after_success:
     - name: pull-kubernetes-e2e-kubeadm-gce
       agent: kubernetes
@@ -1182,22 +1148,11 @@ presubmits:
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
           - "--timeout=75"
           - "--clean"
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
-          volumeMounts:
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
   - name: pull-kubernetes-bazel-build
     agent: kubernetes
     context: pull-kubernetes-bazel-build
@@ -1209,12 +1164,12 @@ presubmits:
     - release-1.8
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1223,25 +1178,12 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/..."
         - "--release=//build/release-tars"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
     run_after_success:
     - name: pull-kubernetes-e2e-kubeadm-gce
       agent: kubernetes
@@ -1269,16 +1211,6 @@ presubmits:
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
-          volumeMounts:
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-bazel-build-canary
     agent: kubernetes
@@ -1332,7 +1264,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1348,20 +1279,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        # TODO(bentheelder): eliminate the "git caching" junk
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -1372,12 +1292,12 @@ presubmits:
     - release-1.9
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1395,19 +1315,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -1419,12 +1329,12 @@ presubmits:
     - release-1.8
     labels:
       preset-service-account: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1441,19 +1351,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-bazel-test-canary
     agent: kubernetes
@@ -1471,7 +1371,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1536,7 +1435,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1549,24 +1447,15 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 7
             memory: "41Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
 
   - name: pull-kubernetes-cross
     agent: kubernetes
@@ -1586,7 +1475,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1599,24 +1487,15 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 7
             memory: "41Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
 
   - name: pull-kubernetes-cross-prow
     agent: kubernetes
@@ -1632,7 +1511,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1645,24 +1523,15 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 7
             memory: "41Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-dind-e2e
     agent: kubernetes
     context: pull-kubernetes-dind-e2e
@@ -1777,26 +1646,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-kubernetes-e2e-gce
     agent: kubernetes
     context: pull-kubernetes-e2e-gce
@@ -1810,6 +1668,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -1817,31 +1676,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.9
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-kubernetes-e2e-gce
     agent: kubernetes
     context: pull-kubernetes-e2e-gce
@@ -1853,6 +1696,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -1860,31 +1704,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-kubernetes-e2e-gce
     agent: kubernetes
     context: pull-kubernetes-e2e-gce
@@ -1896,6 +1724,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -1903,31 +1732,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
 
   - name: pull-kubernetes-e2e-gce-100-performance
     agent: kubernetes
@@ -2012,7 +1825,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2022,19 +1834,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-gce-device-plugin-gpu
     agent: kubernetes
     branches:
@@ -2048,38 +1850,25 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.9
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-gce-device-plugin-gpu
     agent: kubernetes
     branches:
@@ -2093,38 +1882,25 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-gce-large-performance
     agent: kubernetes
     context: pull-kubernetes-e2e-gce-large-performance
@@ -2137,6 +1913,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -2144,31 +1921,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=570
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
 
   - name: pull-kubernetes-e2e-gke
     agent: kubernetes
@@ -2186,6 +1947,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -2193,31 +1955,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-kubernetes-e2e-gke
     agent: kubernetes
     context: pull-kubernetes-e2e-gke
@@ -2230,6 +1976,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -2237,31 +1984,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-kubernetes-e2e-gke
     agent: kubernetes
     context: pull-kubernetes-e2e-gke
@@ -2274,6 +2005,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - args:
@@ -2281,31 +2013,15 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
-        volumeMounts:
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
 
   - name: pull-kubernetes-e2e-gke-device-plugin-gpu
     agent: kubernetes
@@ -2322,38 +2038,25 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-gke-device-plugin-gpu
     agent: kubernetes
     branches:
@@ -2367,38 +2070,25 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
@@ -2417,13 +2107,13 @@ presubmits:
       preset-aws-ssh: true
       preset-aws-credential: true
       preset-bazel-remote-cache-enabled: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2433,19 +2123,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     branches:
@@ -2459,38 +2139,25 @@ presubmits:
       preset-service-account: true
       preset-aws-ssh: true
       preset-aws-credential: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.9
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     branches:
@@ -2504,6 +2171,7 @@ presubmits:
       preset-service-account: true
       preset-aws-ssh: true
       preset-aws-credential: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
@@ -2517,25 +2185,12 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=75"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     branches:
@@ -2549,6 +2204,7 @@ presubmits:
       preset-service-account: true
       preset-aws-ssh: true
       preset-aws-credential: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
@@ -2568,19 +2224,9 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-integration
     agent: kubernetes
     always_run: true
@@ -2608,16 +2254,12 @@ presubmits:
         volumeMounts:
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 4
       volumes:
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-integration-prow
     agent: kubernetes
     always_run: false
@@ -2632,7 +2274,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2645,23 +2286,14 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 4
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
@@ -2676,13 +2308,13 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2695,29 +2327,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
@@ -2730,13 +2351,13 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2749,29 +2370,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
@@ -2784,13 +2394,13 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2803,29 +2413,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
 
   - name: pull-kubernetes-kubemark-e2e-gce-big
     agent: kubernetes
@@ -2973,6 +2572,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -2980,7 +2580,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2993,29 +2592,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-kubemark-e2e-gce-canary
     agent: kubernetes
     always_run: false
@@ -3028,6 +2616,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.8
@@ -3035,7 +2624,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -3048,29 +2636,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   - name: pull-kubernetes-kubemark-e2e-gce-canary
     agent: kubernetes
     always_run: false
@@ -3083,6 +2660,7 @@ presubmits:
     labels:
       preset-service-account: true
       preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.7
@@ -3090,7 +2668,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -3103,29 +2680,18 @@ presubmits:
         # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
       volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
 
   - name: pull-kubernetes-kubemark-e2e-gce-scale
     agent: kubernetes
@@ -3228,7 +2794,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -3236,19 +2801,10 @@ presubmits:
         - "--timeout=90"
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
         ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-node-e2e
     agent: kubernetes
     branches:
@@ -3267,7 +2823,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -3275,19 +2830,9 @@ presubmits:
         - "--timeout=90"
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-kubernetes-node-e2e
     agent: kubernetes
     branches:
@@ -3306,7 +2851,6 @@ presubmits:
         args:
         - --root=/go/src
         - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -3314,19 +2858,9 @@ presubmits:
         - "--timeout=90"
         - "--" # end bootstrap args, scenario args below
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml"
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-node-e2e-containerd
     agent: kubernetes
@@ -3406,16 +2940,13 @@ presubmits:
         volumeMounts:
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 4
       volumes:
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
+
   - name: pull-kubernetes-verify-prow
     agent: kubernetes
     always_run: false
@@ -3444,16 +2975,12 @@ presubmits:
         volumeMounts:
         - name: docker-graph
           mountPath: /docker-graph
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
         resources:
           requests:
             cpu: 4
       volumes:
       - name: docker-graph
-        hostPath:
-          path: /mnt/disks/ssd0/docker-graph
+        emptyDir: {}
   kubernetes-security/kubernetes:
   - agent: kubernetes
     always_run: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2980,6 +2980,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-bazel-build
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 0
     name: pull-security-kubernetes-bazel-build
@@ -3063,6 +3064,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-bazel-build
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 0
     name: pull-security-kubernetes-bazel-build
@@ -3239,6 +3241,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-bazel-test
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 0
     name: pull-security-kubernetes-bazel-test
@@ -3284,6 +3287,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-bazel-test
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 0
     name: pull-security-kubernetes-bazel-test
@@ -3712,6 +3716,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -3753,6 +3758,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -3794,6 +3800,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -3966,6 +3973,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -4009,6 +4017,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -4052,6 +4061,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gce-large-performance
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 1
@@ -4091,6 +4101,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gke
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -4136,6 +4147,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gke
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -4177,6 +4189,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gke
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 0
@@ -4216,6 +4229,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 1
@@ -4263,6 +4277,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 1
@@ -4306,6 +4321,7 @@ presubmits:
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-kops-aws
@@ -4355,6 +4371,7 @@ presubmits:
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-kops-aws
@@ -4399,6 +4416,7 @@ presubmits:
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-kops-aws
@@ -4443,6 +4461,7 @@ presubmits:
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
+      preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-kops-aws
@@ -4570,6 +4589,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -4624,6 +4644,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -4674,6 +4695,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -4877,6 +4899,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-canary
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 5
@@ -4931,6 +4954,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-canary
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 5
@@ -4982,6 +5006,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-kubemark-e2e-gce-canary
     labels:
+      preset-bazel-scratch-dir: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 5

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -258,7 +258,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
-        - "--clean"
         - "--"
         - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml --test-suite=cadvisor"
 
@@ -371,7 +370,6 @@ presubmits:
         - "--repo=k8s.io/charts=$(PULL_REFS)"
         - "--root=/go/src/"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
@@ -403,7 +401,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-cloud-provider-openstack-test
     agent: kubernetes
@@ -422,7 +419,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/community:
   - name: pull-community-verify
@@ -442,7 +438,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/dns:
   - name: pull-kubernetes-dns-test
@@ -462,7 +457,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/ingress-gce:
   - name: pull-ingress-gce-test
@@ -483,7 +477,6 @@ presubmits:
         - "--repo=k8s.io/ingress-gce=$(PULL_REFS)"
         - "--root=/go/src/"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
@@ -515,7 +508,6 @@ presubmits:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         volumeMounts:
         - name: coveralls
           mountPath: /etc/coveralls-token
@@ -539,8 +531,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -575,7 +565,6 @@ presubmits:
         - "--repo=k8s.io/release"
         - "--root=/go/src/"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         - "--timeout=110"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -604,7 +593,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/heapster:
   - name: pull-heapster-e2e
@@ -623,7 +611,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
@@ -652,7 +639,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
   - name: pull-kube-deploy-test
     agent: kubernetes
     always_run: true
@@ -668,7 +654,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
   kubernetes/kops:
   - name: pull-kops-bazel-build
     agent: kubernetes
@@ -687,7 +672,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -720,7 +704,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -751,7 +734,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -790,7 +772,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-kops-verify-boilerplate
     agent: kubernetes
@@ -809,7 +790,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-kops-verify-gofmt
     agent: kubernetes
@@ -828,7 +808,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-kops-verify-govet
     agent: kubernetes
@@ -847,7 +826,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-kops-verify-packages
     agent: kubernetes
@@ -866,7 +844,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/cluster-registry:
   - name: pull-cluster-registry-bazel
@@ -883,7 +860,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -906,7 +882,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -931,7 +906,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -955,7 +929,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -1005,7 +978,6 @@ presubmits:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
           args:
           - --root=/go/src
-          - "--clean"
           - "--job=$(JOB_NAME)"
           - "--repo=k8s.io/kubernetes"
           - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
@@ -1053,7 +1025,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1092,7 +1063,6 @@ presubmits:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=75"
-          - "--clean"
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
@@ -1110,7 +1080,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1149,7 +1118,6 @@ presubmits:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=75"
-          - "--clean"
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
@@ -1169,7 +1137,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1205,9 +1172,7 @@ presubmits:
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
-          - "--git-cache=/root/.cache/git"
           - "--timeout=75"
-          - "--clean"
           env:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: true
@@ -1227,7 +1192,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1263,7 +1227,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1297,7 +1260,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1334,7 +1296,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1370,7 +1331,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1402,7 +1362,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1434,7 +1393,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1474,7 +1432,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1510,7 +1467,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -1549,7 +1505,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
         - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
@@ -1616,7 +1571,6 @@ presubmits:
         - --repo=k8s.io/release
         - --repo=github.com/containerd/cri
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1646,7 +1600,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1676,7 +1629,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1704,7 +1656,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1732,7 +1683,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1762,7 +1712,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=120
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1791,7 +1740,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=270
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1824,7 +1772,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -1856,7 +1803,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.9
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -1888,7 +1834,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -1921,7 +1866,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=570
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1955,7 +1899,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -1984,7 +1927,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -2013,7 +1955,6 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --clean
         - --timeout=90
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -2044,7 +1985,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2076,7 +2016,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2113,7 +2052,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2145,7 +2083,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.9
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2177,8 +2114,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2210,8 +2145,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
         args:
         - --root=/go/src
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2239,7 +2172,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2273,7 +2205,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2314,7 +2245,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2357,7 +2287,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2400,7 +2329,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2446,7 +2374,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2489,7 +2416,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2533,7 +2459,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2579,7 +2504,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2623,7 +2547,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2667,7 +2590,6 @@ presubmits:
         imagePullPolicy: Always
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2711,7 +2633,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=k8s.io/release"
@@ -2755,7 +2676,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2793,7 +2713,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2822,7 +2741,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.8
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2850,7 +2768,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.7
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2879,7 +2796,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
         - --root=/go/src
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--repo=github.com/containerd/cri"
@@ -2905,7 +2821,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -2925,7 +2840,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -2960,7 +2874,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:latest
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -3017,7 +2930,6 @@ presubmits:
           - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
           - --upload=gs://kubernetes-security-prow/pr-logs
           - --timeout=75
-          - --clean
           - --
           - --gcs-shared=gs://kubernetes-security-prow/bazel
           env:
@@ -3046,7 +2958,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3106,7 +3017,6 @@ presubmits:
           - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
           - --upload=gs://kubernetes-security-prow/pr-logs
           - --timeout=75
-          - --clean
           - --
           - --gcs-shared=gs://kubernetes-security-prow/bazel
           env:
@@ -3130,7 +3040,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3192,7 +3101,6 @@ presubmits:
           - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
           - --upload=gs://kubernetes-security-prow/pr-logs
           - --timeout=75
-          - --clean
           - --
           - --gcs-shared=gs://kubernetes-security-prow/bazel
           env:
@@ -3216,7 +3124,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3259,7 +3166,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3309,7 +3215,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3355,7 +3260,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3401,7 +3305,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3444,7 +3347,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3487,7 +3389,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3532,7 +3433,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3581,7 +3481,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3626,7 +3525,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -3677,7 +3575,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --root=/go/src
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
@@ -3757,7 +3654,6 @@ presubmits:
         - --repo=k8s.io/release
         - --repo=github.com/containerd/cri
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-containerd-gce
@@ -3801,7 +3697,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
@@ -3843,7 +3738,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
@@ -3885,7 +3779,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
@@ -3927,7 +3820,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
@@ -3970,7 +3862,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=120
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-100-performance
@@ -4013,7 +3904,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=270
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-big-performance
@@ -4056,7 +3946,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4100,7 +3989,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4144,7 +4032,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4191,7 +4078,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=570
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-large-performance
@@ -4235,7 +4121,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gke
@@ -4277,7 +4162,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gke
@@ -4319,7 +4203,6 @@ presubmits:
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --clean
         - --timeout=90
         - --
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gke
@@ -4360,7 +4243,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4404,7 +4286,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4452,7 +4333,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4497,7 +4377,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4542,7 +4421,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4587,7 +4465,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4627,7 +4504,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -4671,7 +4547,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -4722,7 +4597,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4773,7 +4647,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4824,7 +4697,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4878,7 +4750,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4930,7 +4801,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -4982,7 +4852,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -5034,7 +4903,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -5086,7 +4954,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -5138,7 +5005,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -5191,7 +5057,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
@@ -5242,7 +5107,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5290,7 +5154,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5331,7 +5194,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5372,7 +5234,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5413,7 +5274,6 @@ presubmits:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --repo=github.com/containerd/cri
@@ -5452,7 +5312,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --root=/go/src
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
@@ -5486,7 +5345,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5530,7 +5388,6 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - --clean
         - --job=$(JOB_NAME)
         - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
         - --service-account=/etc/service-account/service-account.json
@@ -5579,7 +5436,6 @@ presubmits:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   kubernetes/test-infra:
   - name: pull-test-infra-bazel
@@ -5598,7 +5454,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5628,7 +5483,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5678,7 +5532,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5713,7 +5566,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-test-infra-verify-config
     agent: kubernetes
@@ -5733,7 +5585,6 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         - --service-account=/etc/service-account/service-account.json
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -5760,7 +5611,6 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
         - --service-account=/etc/service-account/service-account.json
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
@@ -5786,7 +5636,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
   - name: pull-test-infra-verify-govet
     agent: kubernetes
@@ -5805,7 +5654,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
 
 
   tensorflow/minigo:
@@ -5824,7 +5672,6 @@ presubmits:
       - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/tensorflow/minigo=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5913,7 +5760,6 @@ postsubmits:
         args:
         - "--repo=k8s.io/ingress-gce=master"
         - "--root=/go/src/"
-        - "--clean"
         - "--timeout=320"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -5941,7 +5787,6 @@ postsubmits:
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
-        - "--clean"
         - "--timeout=90"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
@@ -5966,7 +5811,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -5991,7 +5835,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6020,7 +5863,6 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
           args:
-          - "--clean"
           - "--job=$(JOB_NAME)"
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--service-account=/etc/service-account/service-account.json"
@@ -6050,7 +5892,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6080,7 +5921,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6110,7 +5950,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6140,7 +5979,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6171,7 +6009,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6198,8 +6035,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
         args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6226,8 +6061,6 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
         args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6252,7 +6085,6 @@ postsubmits:
       - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
         imagePullPolicy: Always
         args:
-        - "--clean"
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/tensorflow/minigo=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -6289,7 +6121,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=github.com/google/cadvisor
       - --root=/go/src
       - --timeout=30
@@ -6713,7 +6544,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/federation=master
       - --repo=k8s.io/release
       - --root=/go/src
@@ -6853,7 +6683,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
       - "--repo=k8s.io/kubectl"
@@ -6871,7 +6700,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - --clean
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
       - --root=/go/src
@@ -6901,7 +6729,6 @@ periodics:
       - "--repo=k8s.io/kube-deploy"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
-      - "--clean"
 - name: ci-kube-deploy-test
   interval: 1h
   agent: kubernetes
@@ -6914,7 +6741,6 @@ periodics:
       - "--repo=k8s.io/kube-deploy"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
-      - "--clean"
 
 - interval: 60m
   agent: kubernetes
@@ -6942,7 +6768,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=master"
       - "--service-account=/etc/service-account/service-account.json"
@@ -6979,7 +6804,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.10"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7008,7 +6832,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7034,7 +6857,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7060,7 +6882,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.9"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7089,7 +6910,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - --clean
       - --repo=k8s.io/kubernetes
       - --root=/go/src
       - "--service-account=/etc/service-account/service-account.json"
@@ -7124,7 +6944,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7145,7 +6964,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--service-account=/etc/service-account/service-account.json"
@@ -7165,7 +6983,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7196,7 +7013,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes=release-1.10
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7227,7 +7043,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/release
       - --root=/go/src
       - --timeout=50
@@ -7257,8 +7072,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
-      - --git-cache=/root/.cache/git
       - --repo=k8s.io/kubernetes=release-1.9
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7289,7 +7102,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes=release-1.8
       - --repo=k8s.io/release
       - --root=/go/src
@@ -7320,7 +7132,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes=release-1.7
       - --repo=k8s.io/release
       - --root=/go/src
@@ -13318,7 +13129,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13333,7 +13143,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.10"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13349,7 +13158,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.7"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13381,7 +13189,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.8"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13396,7 +13203,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.9"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13411,7 +13217,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.9"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13426,7 +13231,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.10"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13441,7 +13245,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
@@ -13455,7 +13258,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
@@ -13469,7 +13271,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13484,7 +13285,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
@@ -13498,7 +13298,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
@@ -13512,7 +13311,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
@@ -13526,7 +13324,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.7"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13541,7 +13338,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.9"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13556,7 +13352,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=release-1.10"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
@@ -13571,7 +13366,6 @@ periodics:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180322-703c85f84
       args:
       - "--repo=k8s.io/kubernetes=master"
-      - "--clean"
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 - name: ci-kubernetes-e2e-node-canary
@@ -14264,7 +14058,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes=release-1.7
       - --repo=k8s.io/release
       - --root=/go/src
@@ -14295,7 +14088,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - --clean
       - --repo=k8s.io/kubernetes=release-1.8
       - --repo=k8s.io/release
       - --root=/go/src
@@ -14326,7 +14118,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.10"
       - "--timeout=100"
       env:
@@ -14354,7 +14145,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes"
       - "--timeout=100"
       env:
@@ -14382,7 +14172,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.9"
       - "--timeout=100"
       env:
@@ -14410,7 +14199,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--timeout=100"
       env:
@@ -14438,7 +14226,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--timeout=100"
       env:
@@ -14991,7 +14778,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.10"
       - "--timeout=75"
       env:
@@ -15019,7 +14805,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes"
       - "--timeout=75"
       env:
@@ -15047,7 +14832,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.9"
       - "--timeout=75"
       env:
@@ -15075,7 +14859,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--timeout=75"
       env:
@@ -15103,7 +14886,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
       args:
-      - "--clean"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--timeout=75"
       env:
@@ -15162,7 +14944,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-experimental
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15208,7 +14989,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/cluster-registry=master"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15255,7 +15035,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - "--clean"
       - "--repo=github.com/istio/istio=master"
       - "--timeout=90"
 
@@ -15362,7 +15141,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.10"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15393,7 +15171,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15415,7 +15192,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15437,7 +15213,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.9"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15462,7 +15237,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-1.10
       args:
-      - "--clean"
       - --root=/go/src
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.10"
@@ -15497,7 +15271,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15518,7 +15291,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.6.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.8"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15539,7 +15311,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes=release-1.9"
       - "--service-account=/etc/service-account/service-account.json"
@@ -15722,7 +15493,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
       - "--upload=gs://kubernetes-jenkins/logs/"
@@ -15753,7 +15523,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
       - "--upload=gs://kubernetes-jenkins/logs/"
@@ -15785,7 +15554,6 @@ periodics:
     - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
       imagePullPolicy: Always
       args:
-      - "--clean"
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/tensorflow/minigo=master"
       - "--service-account=/etc/service-account/service-account.json"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -546,7 +546,6 @@ func checkBazelbuildSpec(t *testing.T, name string, spec *v1.PodSpec, periodic b
 			"--service-account",
 			"--upload",
 			"--job",
-			"--clean",
 		} {
 			if _, ok := found[f]; !ok {
 				t.Errorf("%s: missing %s flag", name, f)


### PR DESCRIPTION
Discussed this offline with krzyzacy, we think the benefits outweigh the downsides at this point. `pull-kubernetes-typecheck` has run without any local caching flawlessly for a few weeks now.

cleaning up associated caching flags (many of which were useless copy paste or left behind...) also helped net us ~ -800 lines of prow config

also updated a presubmit to reflect that we no longer need `--clean` on jobs

/area jobs
xref #6865 