### PR TITLE
Remove HAIRPIN_MODE arg from ci-kubernetes-e2e-gci-gce-ipvs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4825,7 +4825,6 @@
     "args": [
       "--check-leaked-resources",
       "--env=KUBE_PROXY_MODE=ipvs",
-      "--env=HAIRPIN_MODE=hairpin-veth",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",


### PR DESCRIPTION
Now that hairpin-veth is the default, we don't need to explicitly set it here.

/assign @krzyzacy 