### PR TITLE
Make kettle parse and prefer finished.passed to finished.result.

### DIFF
--- a/docs/tests/node-e2e-ci.md
+++ b/docs/tests/node-e2e-ci.md
@@ -114,7 +114,6 @@ The `TestGrid` then expects the following content of each build:
   ```json
   {
     "node": "ip-172-18-0-237.ec2.internal",
-    "jenkins-node": "ci.openshift",
     "timestamp": 1511906201,
     "repos": {
       "k8s.io/kubernetes": "master"

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -44,8 +44,8 @@
 		<tr><td>Started<td>{{started['timestamp']|timestamp}}
 		{% if finished %}<tr><td>Elapsed<td>{{(finished['timestamp']-started['timestamp'])|duration}}{% endif %}
 		<tr><td>Version<td><a href="https://github.com/{{repo}}/commit/{{commit}}">{{started['version'] or finished['version']}}</a>
-		% if 'jenkins-node' in started
-			<tr><td>Builder<td>{{started['jenkins-node']}}
+		% if 'node' in started
+			<tr><td>Builder<td>{{started['node']}}
 		% endif
 		% if refs
 			<tr><td>Refs<td>

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -174,7 +174,7 @@ class BuildTest(main_test.TestBase):
             {
                 'version': 'v1+56',
                 'timestamp': 1406535800,
-                'jenkins-node': 'agent-light-7',
+                'node': 'agent-light-7',
                 'pull': 'master:1234,35:abcd,72814',
                 'metadata': {
                     'master-version': 'm12'

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -283,7 +283,6 @@ def start(gsutil, paths, stamp, node_name, version, repos):
     """Construct and upload started.json."""
     data = {
         'timestamp': int(stamp),
-        'jenkins-node': node_name,
         'node': node_name,
     }
     if version:

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -124,8 +124,6 @@ def row_for_build(path, started, finished, results):
 
     if started:
         build['started'] = int(started['timestamp'])
-        if 'jenkins-node' in started:
-            build['executor'] = started['jenkins-node']
         if 'node' in started:
             build['executor'] = started['node']
     if finished:

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -130,7 +130,12 @@ def row_for_build(path, started, finished, results):
             build['executor'] = started['node']
     if finished:
         build['finished'] = int(finished['timestamp'])
-        build['result'] = finished['result']
+        if 'result' in finished:
+            build['result'] = finished['result']
+            build['passed'] = build['result'] == 'SUCCESS'
+        elif isinstance(finished.get('passed'), bool):
+            build['passed'] = finished['passed']
+            build['result'] = 'SUCCESS' if build['passed'] else 'FAILURE'
         if 'version' in finished:
             build['version'] = finished['version']
 

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -46,6 +46,8 @@ class MakeJsonTest(unittest.TestCase):
                 'tests_failed': 0,
                 'tests_run': 0,
             }
+            if finish:
+                expected['passed'] = kwargs.get('result') == 'SUCCESS'
             expected.update(kwargs)
             row = make_json.row_for_build(path, start, finish, results)
             self.assertEqual(row, expected)
@@ -60,6 +62,14 @@ class MakeJsonTest(unittest.TestCase):
                job='J', number=123,
                started=10, finished=15, elapsed=5,
                version='v1.2.3', result='SUCCESS', executor='agent-34',
+              )
+        expect(path,
+               {'timestamp': 10},
+               {'timestamp': 15, 'passed': True},
+               [],
+               job='J', number=123,
+               started=10, finished=15, elapsed=5,
+               result='SUCCESS',
               )
         expect(path, None,
                {'timestamp': 15, 'result': 'FAILURE',

--- a/kettle/schema.json
+++ b/kettle/schema.json
@@ -18,7 +18,13 @@
       "name" : "finished"
    },
    {
-      "description" : "\"SUCCESS\" \"FAILED\" \"ABORTED\", etc",
+      "description" : "Whether the build succeeded.",
+      "mode" : "NULLABLE",
+      "type" : "BOOLEAN",
+      "name" : "passed"
+   },
+   {
+      "description" : "(DEPRECATED: use passed) \"SUCCESS\" \"FAILURE\" \"ABORTED\", etc",
       "mode" : "NULLABLE",
       "type" : "STRING",
       "name" : "result"

--- a/kettle/stream_test.py
+++ b/kettle/stream_test.py
@@ -114,6 +114,7 @@ class StreamTest(unittest.TestCase):
               ([[5,
                  now - 5,
                  now,
+                 True,
                  u'SUCCESS',
                  None,
                  u'gs://kubernetes-jenkins/logs/fake/123',


### PR DESCRIPTION
All jobs are currently only returning "SUCCESS" or "FAILURE", so the
freeform text field is simply more cumbersome to query.

Related PR: #6938.

I think after this the only thing left is the testgrid updater.