### PR TITLE
Only show "needs approval" PRs in "Needs Attention" when they have LGTM.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -176,6 +176,9 @@ def do_render_status(payload, user):
                 # Don't show overall status as pending when Submit
                 # won't continue without LGTM.
                 continue
+        if ctx == 'tide' and state == 'pending':
+            # Ignore pending tide statuses for now.
+            continue
         if ctx == 'code-review/reviewable' and state == 'pending':
             # Reviewable isn't a CI, so we don't care if it's pending.
             # Its dashboard might replace all of this eventually.

--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -159,11 +159,18 @@ def do_classify_size(payload):
     return size
 
 
+def has_lgtm_without_missing_approval(payload, user):
+    labels = payload.get('labels', []) or []
+    return 'lgtm' in labels and not (
+        user in payload.get('approvers', [])
+        and 'approved' not in labels)
+
+
 def do_render_status(payload, user):
     states = set()
 
     text = 'Pending'
-    if 'lgtm' in payload.get('labels', []):
+    if has_lgtm_without_missing_approval(payload, user):
         text = 'LGTM'
     elif user in payload.get('attn', {}):
         text = payload['attn'][user].title()

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -133,6 +133,11 @@ class HelperTest(unittest.TestCase):
         expect({'attn': {'foo': 'Needs Rebase'}}, 'Needs Rebase', user='foo')
         expect({'attn': {'foo': 'Needs Rebase'}, 'labels': {'lgtm'}}, 'LGTM', user='foo')
 
+        expect({'author': 'u', 'labels': ['lgtm']}, 'LGTM', 'u')
+        expect({'author': 'b', 'labels': ['lgtm'], 'approvers': ['u'],
+                'attn': {'u': 'needs approval'}},
+               'Needs Approval', 'u')
+
     def test_tg_url(self):
         self.assertEqual(
             filters.do_tg_url('a#b'),

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -126,6 +126,8 @@ class HelperTest(unittest.TestCase):
         expect({'status': {'ci': ['success', '', ''],
             'Submit Queue': ['pending', '', 'does not have LGTM']}}, 'success check Pending')
         expect({'status': {'ci': ['success', '', ''],
+            'tide': ['pending', '', '']}}, 'success check Pending')
+        expect({'status': {'ci': ['success', '', ''],
             'code-review/reviewable': ['pending', '', '10 files left']}}, 'success check Pending')
         expect({'status': {'ci': ['success', '', '']}, 'labels': ['lgtm']}, 'success check LGTM')
         expect({'attn': {'foo': 'Needs Rebase'}}, 'Needs Rebase', user='foo')

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -183,19 +183,30 @@ class PRDashboard(view_base.BaseHandler):
                     keys = ['repo', 'number'] + list(obj._values)
                     return {k: getattr(obj, k) for k in keys}
                 raise TypeError
-            self.response.write(json.dumps(prs, sort_keys=True, default=serial))
+            self.response.write(json.dumps(prs, sort_keys=True, default=serial, indent=True))
         elif fmt == 'html':
             if user:
                 user = InsensitiveString(user)
                 def acked(p):
-                    if 'lgtm' in p.payload.get('labels', {}):
-                        return True  # LGTM is an implicit Ack
+                    if filters.has_lgtm_without_missing_approval(p, user):
+                        # LGTM is an implicit Ack (suppress from incoming)...
+                        # if it doesn't also need approval
+                        return True
                     if acks is None:
                         return False
                     return filters.do_get_latest(p.payload, user) <= acks.get(p.key.id(), 0)
+                def needs_attention(p):
+                    labels = p.payload.get('labels', {})
+                    for u, reason in p.payload['attn'].iteritems():
+                        if user == u:  # case insensitive compare
+                            if acked(p):
+                                continue  # hide acked PRs
+                            if reason == 'needs approval' and 'lgtm' not in labels:
+                                continue  # hide PRs that need approval but haven't been LGTMed yet
+                            return True
+                    return False
                 cats = [
-                    ('Needs Attention', lambda p: any(user == u for u in p.payload['attn'])
-                                                  and not acked(p), ''),
+                    ('Needs Attention', needs_attention, ''),
                     ('Approvable', lambda p: user in p.payload.get('approvers', []),
                      'is:open is:pr ("additional approvers: {0}" ' +
                      'OR "additional approver: {0}")'.format(user)),


### PR DESCRIPTION
Also, don't count the pending Tide status as a pending test.