### PR TITLE
Show build xrefs from github on build list page.

### DIFF
--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -79,7 +79,7 @@
 	% if issues
 		<h4>References</h4>
 		% for issue in issues
-		<a href="https://github.com/{{issue.repo}}/issues/{{issue.number}}">
+		<a href="{{issue.url}}">
 		{% if issue.is_pr %}PR{% else %}Issue{% endif %} #{{issue.number}} {{issue.payload['title']}}</a>
 		<br>
 		% endfor

--- a/gubernator/templates/build_list.html
+++ b/gubernator/templates/build_list.html
@@ -20,16 +20,17 @@
   % if started and 'timestamp' in started
     {{started['timestamp'] | timestamp}}
     % if 'timestamp' in finished
-        took {{(finished['timestamp']-started['timestamp'])|duration}}
-    % endif
+    took {{(finished['timestamp']-started['timestamp'])|duration}}{% endif %}
   % else
-    {{finished['result']}}
-  % endif
-</span>
+    {{finished['result']}}{% endif %}
+</span></a>
 % elif started and 'timestamp' in started
-{{started['timestamp'] | timestamp}}
+{{started['timestamp'] | timestamp}}</a>
 % endif
-</a><br>
+  % for issue in refs[loc]
+    <a href="{{issue.url}}" title="{{issue.title}}">#{{issue.number}}</a>
+  % endfor
+<br>
 % endfor
 % if 'directory' in job_dir or '/pull/' not in job_dir
 <br>

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -337,14 +337,18 @@ def get_build_numbers(job_dir, before, indirect):
 def build_list(job_dir, before):
     """
     Given a job dir, give a (partial) list of recent build
-    finished.jsons.
+    started.json & finished.jsons.
 
     Args:
         job_dir: the GCS path holding the jobs
     Returns:
-        a list of [(build, finished)]. build is a string like "123",
-        finished is either None or a dict of the finished.json.
+        a list of [(build, loc, started, finished)].
+            build is a string like "123",
+            loc is the job directory and build,
+            started/finished are either None or a dict of the finished.json,
+        and a dict of {build: [issues...]} of xrefs.
     """
+    # pylint: disable=too-many-locals
 
     # /directory/ folders have a series of .txt files pointing at the correct location,
     # as a sort of fake symlink.
@@ -376,12 +380,16 @@ def build_list(job_dir, before):
             for build in builds
         ]
 
+    # This is done in parallel with waiting for GCS started/finished.
+    build_refs = models.GHIssueDigest.find_xrefs_multi_async(
+            [b[1] for b in build_futures])
+
     output = []
     for build, loc, started_future, finished_future in build_futures:
         started, finished = normalize_metadata(started_future, finished_future)
         output.append((str(build), loc, started, finished))
 
-    return output
+    return output, build_refs.get_result()
 
 class BuildListHandler(view_base.BaseHandler):
     """Show a list of Builds for a Job."""
@@ -389,12 +397,14 @@ class BuildListHandler(view_base.BaseHandler):
         job_dir = '/%s/%s/' % (prefix, job)
         testgrid_query = testgrid.path_to_query(job_dir)
         before = self.request.get('before')
-        builds = build_list(job_dir, before)
+        builds, refs = build_list(job_dir, before)
         dir_link = re.sub(r'/pull/.*', '/directory/%s' % job, prefix)
+
         self.render('build_list.html',
                     dict(job=job, job_dir=job_dir, dir_link=dir_link,
                          testgrid_query=testgrid_query,
-                         builds=builds, before=before))
+                         builds=builds, refs=refs,
+                         before=before))
 
 
 class JobListHandler(view_base.BaseHandler):

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -111,7 +111,8 @@ class ParseJunitTest(unittest.TestCase):
 class BuildTest(main_test.TestBase):
     # pylint: disable=too-many-public-methods
 
-    BUILD_DIR = '/kubernetes-jenkins/logs/somejob/1234/'
+    JOB_DIR = '/kubernetes-jenkins/logs/somejob/'
+    BUILD_DIR = JOB_DIR + '1234/'
 
     def setUp(self):
         self.init_stubs()
@@ -320,6 +321,16 @@ class BuildTest(main_test.TestBase):
         self.assertIn('an update on testing', response)
         self.assertIn('org/repo/issues/123', response)
 
+    def test_build_list_xref(self):
+        """Test that builds show issues that reference them."""
+        github.models.GHIssueDigest.make(
+            'org/repo', 123, False, True, [],
+            {'xrefs': [self.BUILD_DIR[:-1]], 'title': 'an update on testing'}, None).put()
+        response = app.get('/builds' + self.JOB_DIR)
+        self.assertIn('#123', response)
+        self.assertIn('an update on testing', response)
+        self.assertIn('org/repo/issues/123', response)
+
     def test_cache(self):
         """Test that caching works at some level."""
         response = self.get_build_page()
@@ -348,12 +359,12 @@ class BuildTest(main_test.TestBase):
 
         view_target = job_dir if not indirect else job_dir + 'directory/'
 
-        builds = view_build.build_list(view_target, None)
+        builds, _ = view_build.build_list(view_target, None)
         self.assertEqual(builds,
                          [(str(n), '%s%s' % (job_dir, n), sta_result, fin_result)
                           for n in range(119, 79, -1)])
         # test that ?before works
-        builds = view_build.build_list(view_target, '80')
+        builds, _ = view_build.build_list(view_target, '80')
         self.assertEqual(builds,
                          [(str(n), '%s%s' % (job_dir, n), sta_result, fin_result)
                           for n in range(79, 39, -1)])


### PR DESCRIPTION
Most of the complexity here is for speed-- the DB's built-in IN query
does multiple sequential queries, so instead we use a range query and
do the filtering ourselves.

The datastore query happens in parallel with GCS fetches, so this
doesn't end up affecting page load time.

Fixes #5163.

cc @shyamjvs @porridge