### PR TITLE
Show a tooltip for PR statuses on the dashboard.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -185,18 +185,22 @@ def do_render_status(payload, user):
         states.add(state)
 
     icon = ''
+    title = ''
     if 'failure' in states:
         icon = 'x'
         state = 'failure'
+        title = 'failing tests'
     elif 'pending' in states:
         icon = 'primitive-dot'
         state = 'pending'
+        title = 'pending tests'
     elif 'success' in states:
         icon = 'check'
         state = 'success'
+        title = 'tests passing'
     if icon:
-        icon = '<span class="text-%s octicon octicon-%s"></span>' % (
-            state, icon)
+        icon = '<span class="text-%s octicon octicon-%s" title="%s"></span>' % (
+            state, icon, title)
     return jinja2.Markup('%s%s' % (icon, text))
 
 

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -102,7 +102,7 @@ class HelperTest(unittest.TestCase):
     def test_render_status_basic(self):
         payload = {'status': {'ci': ['pending', '', '']}}
         self.assertEqual(str(filters.do_render_status(payload, '')),
-            '<span class="text-pending octicon octicon-primitive-dot">'
+            '<span class="text-pending octicon octicon-primitive-dot" title="pending tests">'
             '</span>Pending')
 
     def test_render_status_complex(self):
@@ -110,7 +110,8 @@ class HelperTest(unittest.TestCase):
             # strip the excess html from the result down to the text class,
             # the opticon class, and the rendered text
             result = str(filters.do_render_status(payload, user))
-            result = re.sub(r'<span class="text-|octicon octicon-|</span>', '', result)
+            result = re.sub(r'<span class="text-|octicon octicon-| title="[^"]*"|</span>',
+                            '', result)
             result = result.replace('">', ' ')
             self.assertEqual(result, expected)
 


### PR DESCRIPTION
These generally match the Github icons, but the tooltip helps explain it.

Fixes #1731.