### PR TITLE
Proxy GCS requests through Gubernator on auth errors.

### DIFF
--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -112,4 +112,5 @@ app = webapp2.WSGIApplication([
     (r'/pr/(.*/build-log.txt)', view_pr.PRBuildLogHandler),
     (r'/github_auth(.*)', github_auth.Endpoint),
     (r'/config', ConfigHandler),
+    (r'/gcsproxy', view_build.GcsProxyHandler)
 ], debug=True, config=config)

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -137,7 +137,7 @@
 		<h2 id="log">Error lines from build-log.txt</h2>
 		<ul class="log">
 			<li class="log"><button onclick="javascript:expand_all(this.parentElement)">Expand Skipped Lines</button></li>
-			<li class="log"><a href="{{build_log_src or "https://storage.googleapis.com%s/build-log.txt" % build_dir}}">Raw build-log.txt</a></li>
+			<li class="log"><a id="rawloglink" href="{{build_log_src or "https://storage.googleapis.com%s/build-log.txt" % build_dir}}">Raw build-log.txt</a></li>
 		</ul>
 		<pre data-src="{{build_log_src or "%s/build-log.txt" % build_dir}}">{{build_log | safe}}</pre>
 	</div>

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -404,3 +404,21 @@ class JobListHandler(view_base.BaseHandler):
         fstats = view_base.gcs_ls(jobs_dir)
         fstats.sort()
         self.render('job_list.html', dict(jobs_dir=jobs_dir, fstats=fstats))
+
+
+class GcsProxyHandler(view_base.BaseHandler):
+    """Proxy results from GCS.
+
+    Useful for buckets that don't have public read permissions."""
+    def get(self):
+        # let's lock this down to build logs for now.
+        path = self.request.get('path')
+        if not re.match(r'^[-\w/.]+$', path):
+            self.abort(403)
+        if not path.endswith('/build-log.txt'):
+            self.abort(403)
+        content = gcs_async.read(path).get_result()
+        # lazy XSS prevention.
+        # doesn't work on terrible browsers that do content sniffing (ancient IE).
+        self.response.headers['Content-Type'] = 'text/plain'
+        self.response.write(content)


### PR DESCRIPTION
This makes build logs in private buckets expandable.

Fixed #7063.