### PR TITLE
Add check-cla comment to force rechecking of cncf cla.

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -28,6 +28,8 @@ See also: [Life of a Prow Job](./architecture.md)
 
 New features added to each components:
 
+ - *April 10, 2018* `cla` plugin now supports `/check-cla` command 
+   to force rechecking of the CLA status.
  - *February 1, 2018* `updateconfig` will now update any configmap on merge
  - *November 14, 2017* `jenkins-operator:0.58` exposes prometheus metrics.
  - *November 8, 2017* `horologium:0.14` prow periodic job now support cron

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -170,3 +170,219 @@ func TestCLALabels(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckCLA(t *testing.T) {
+	var testcases = []struct {
+		name         string
+		context      string
+		state        string
+		issueState   string
+		SHA          string
+		action       string
+		body         string
+		pullRequests []github.PullRequest
+		hasCLAYes    bool
+		hasCLANo     bool
+
+		addedLabel   string
+		removedLabel string
+	}{
+		{
+			name:       "ignore non cla/linuxfoundation context",
+			context:    "random/context",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+		},
+		{
+			name:       "ignore non open PRs",
+			context:    "cla/linuxfoundation",
+			state:      "success",
+			issueState: "closed",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+		},
+		{
+			name:       "ignore non /check-cla comments",
+			context:    "cla/linuxfoundation",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/shrug",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+		},
+		{
+			name:       "do nothing on when status state is \"pending\"",
+			context:    "cla/linuxfoundation",
+			state:      "pending",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/shrug",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+		},
+		{
+			name:       "cla/linuxfoundation status adds the cla-yes label when its state is \"success\"",
+			context:    "cla/linuxfoundation",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+
+			addedLabel: fmt.Sprintf("/#3:%s", claYesLabel),
+		},
+		{
+			name:       "cla/linuxfoundation status adds the cla-yes label and removes cla-no label when its state is \"success\"",
+			context:    "cla/linuxfoundation",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLANo: true,
+
+			addedLabel:   fmt.Sprintf("/#3:%s", claYesLabel),
+			removedLabel: fmt.Sprintf("/#3:%s", claNoLabel),
+		},
+		{
+			name:       "cla/linuxfoundation status adds the cla-no label when its state is \"failure\"",
+			context:    "cla/linuxfoundation",
+			state:      "failure",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+
+			addedLabel: fmt.Sprintf("/#3:%s", claNoLabel),
+		},
+		{
+			name:       "cla/linuxfoundation status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "cla/linuxfoundation",
+			state:      "failure",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLAYes: true,
+
+			addedLabel:   fmt.Sprintf("/#3:%s", claNoLabel),
+			removedLabel: fmt.Sprintf("/#3:%s", claYesLabel),
+		},
+		{
+			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			context:    "cla/linuxfoundation",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLANo:  true,
+			hasCLAYes: true,
+
+			removedLabel: fmt.Sprintf("/#3:%s", claNoLabel),
+		},
+		{
+			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "cla/linuxfoundation",
+			state:      "failure",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLANo:  true,
+			hasCLAYes: true,
+
+			removedLabel: fmt.Sprintf("/#3:%s", claYesLabel),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pullRequests := make(map[int]*github.PullRequest)
+			for _, pr := range tc.pullRequests {
+				pullRequests[pr.Number] = &pr
+			}
+			fc := &fakegithub.FakeClient{
+				CreatedStatuses: make(map[string][]github.Status),
+				PullRequests:    pullRequests,
+			}
+			e := &github.GenericCommentEvent{
+				Action:     github.GenericCommentEventAction(tc.action),
+				Body:       tc.body,
+				Number:     3,
+				IssueState: tc.issueState,
+			}
+			fc.CreatedStatuses["sha"] = []github.Status{
+				{
+					State:   tc.state,
+					Context: tc.context,
+				},
+			}
+			if tc.hasCLAYes {
+				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", claYesLabel))
+			}
+			if tc.hasCLANo {
+				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", claNoLabel))
+			}
+			if err := handleComment(fc, logrus.WithField("plugin", pluginName), e); err != nil {
+				t.Errorf("For case %s, didn't expect error from cla plugin: %v", tc.name, err)
+			}
+			ok := tc.addedLabel == ""
+			if !ok {
+				for _, label := range fc.LabelsAdded {
+					if reflect.DeepEqual(tc.addedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.LabelsAdded, tc.name)
+			}
+			ok = tc.removedLabel == ""
+			if !ok {
+				for _, label := range fc.LabelsRemoved {
+					if reflect.DeepEqual(tc.removedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.LabelsRemoved, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Commenting "/check-cla" will check for commit statuses and add the necessary label derived from "cla/linuxfoundation" status events.

Fixes [#6939](https://github.com/kubernetes/test-infra/issues/6939)