### PR TITLE
Add "default_external_services" to the Gubernator config to fix 500s.

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -1,29 +1,16 @@
 ---
+default_external_services:
+  gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
+  prow_url: prow.k8s.io
 default_org: kubernetes
 default_repo: kubernetes
 external_services:
-  GoogleCloudPlatform:
-    gcs_bucket: kubernetes-jenkins/
-    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
-    prow_url: prow.k8s.io
   istio:
     gcs_pull_prefix: istio-prow/pull
     prow_url: prow.istio.io
   istio-releases:
     gcs_pull_prefix: istio-prow/pull
     prow_url: prow.istio.io
-  kubernetes:
-    gcs_bucket: kubernetes-jenkins/
-    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
-    prow_url: prow.k8s.io
-  kubernetes-sigs:
-    gcs_bucket: kubernetes-jenkins/
-    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
-    prow_url: prow.k8s.io
-  tensorflow:
-    gcs_bucket: kubernetes-jenkins/
-    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
-    prow_url: prow.k8s.io
 jobs:
   kubernetes-jenkins/logs/:
   - ci-kubernetes-build

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -284,8 +284,8 @@ def get_build_config(prefix, config):
     for item in config['external_services'].values():
         if prefix.startswith(item['gcs_pull_prefix']):
             return item
-        if 'gcs_bucket' in item and prefix.startswith(item['gcs_bucket']):
-            return item
+    if prefix.startswith(config['default_external_services']['gcs_pull_prefix']):
+        return config['default_external_services']
 
 def get_pr_info(prefix, config):
     if config is not None:

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -78,6 +78,12 @@ def org_repo(path, default_org, default_repo):
     return org, repo
 
 
+def get_pull_prefix(config, org):
+    if org in config['external_services']:
+        return config['external_services'][org]['gcs_pull_prefix']
+    return config['default_external_services']['gcs_pull_prefix']
+
+
 class PRHandler(view_base.BaseHandler):
     """Show a list of test runs for a PR."""
     def get(self, path, pr):
@@ -87,7 +93,7 @@ class PRHandler(view_base.BaseHandler):
             default_repo=self.app.config['default_repo'],
         )
         path = pr_path(org=org, repo=repo, pr=pr,
-            pull_prefix=self.app.config['external_services'][org]['gcs_pull_prefix'],
+            pull_prefix=get_pull_prefix(self.app.config, org),
             default_org=self.app.config['default_org'],
             default_repo=self.app.config['default_repo'],
         )
@@ -246,5 +252,5 @@ class PRBuildLogHandler(view_base.BaseHandler):
             default_repo=self.app.config['default_repo'],
         )
         self.redirect('https://storage.googleapis.com/%s/%s' % (
-            self.app.config['external_services'][org]['gcs_pull_prefix'], path
+            get_pull_prefix(self.app.config, org), path
         ))

--- a/gubernator/view_pr_test.py
+++ b/gubernator/view_pr_test.py
@@ -96,7 +96,7 @@ class PRTest(main_test.TestBase):
         builds = view_pr.pr_builds(view_pr.pr_path(org, repo, '123',
             app.app.config['default_repo'],
             app.app.config['default_repo'],
-            app.app.config['external_services'][org]['gcs_pull_prefix'],
+            app.app.config['default_external_services']['gcs_pull_prefix'],
         ))
         self.assertEqual(builds, self.BUILDS)
 


### PR DESCRIPTION
This lets a primary prow instance & GCS bucket service many different
org repos without another entry in external_services for each.

Some URLs fail without this, like:
    https://k8s-gubernator.appspot.com/pr/google/cadvisor/1881