### PR TITLE
Update config updated to take in a namespace

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -41,6 +41,17 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 2, 2018* `updateconfig` format has been changed from
+   ```yaml
+   path/to/some/other/thing: configName
+   ```
+   to
+   ```yaml
+   path/to/some/other/thing:
+     Name: configName
+     # If unspecified, Namespace default to the value of ProwJobNamespace.
+     Namespace: myNamespace
+   ```
  - *March 15, 2018* `jenkins_operator` is removed from the config in favor of
    `jenkins_operators`.
  - *March 1, 2018* `MilestoneStatus` has been removed from the plugins Configuration

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -542,10 +542,14 @@ func (c *Client) CreateConfigMap(content ConfigMap) (ConfigMap, error) {
 
 func (c *Client) ReplaceConfigMap(name string, config ConfigMap) (ConfigMap, error) {
 	c.log("ReplaceConfigMap", name)
+	namespace := c.namespace
+	if config.Namespace != "" {
+		namespace = config.Namespace
+	}
 	var retConfigMap ConfigMap
 	err := c.request(&request{
 		method:      http.MethodPut,
-		path:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/%s", c.namespace, name),
+		path:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/%s", namespace, name),
 		requestBody: &config,
 	}, &retConfigMap)
 

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -135,9 +135,12 @@ milestone:
 
 config_updater:
   maps:
-    label_sync/labels.yaml: label-config
-    prow/config.yaml: config
-    prow/plugins.yaml: plugins
+    label_sync/labels.yaml:
+      name: label-config
+    prow/config.yaml:
+      name: config
+    prow/plugins.yaml:
+      name: plugins
 
 plugins:
   google/cadvisor:

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -158,26 +158,26 @@ func TestSetDefault_Maps(t *testing.T) {
 	cases := []struct {
 		name     string
 		config   ConfigUpdater
-		expected map[string]string
+		expected map[string]ConfigMapSpec
 	}{
 		{
 			name: "nothing",
-			expected: map[string]string{
-				"prow/config.yaml":  "config",
-				"prow/plugins.yaml": "plugins",
+			expected: map[string]ConfigMapSpec{
+				"prow/config.yaml":  {Name: "config"},
+				"prow/plugins.yaml": {Name: "plugins"},
 			},
 		},
 		{
 			name: "basic",
 			config: ConfigUpdater{
-				Maps: map[string]string{
-					"hello.yaml": "my-cm",
-					"world.yaml": "you-cm",
+				Maps: map[string]ConfigMapSpec{
+					"hello.yaml": {Name: "my-cm"},
+					"world.yaml": {Name: "you-cm"},
 				},
 			},
-			expected: map[string]string{
-				"hello.yaml": "my-cm",
-				"world.yaml": "you-cm",
+			expected: map[string]ConfigMapSpec{
+				"hello.yaml": {Name: "my-cm"},
+				"world.yaml": {Name: "you-cm"},
 			},
 		},
 		{
@@ -185,9 +185,9 @@ func TestSetDefault_Maps(t *testing.T) {
 			config: ConfigUpdater{
 				ConfigFile: "foo.yaml",
 			},
-			expected: map[string]string{
-				"foo.yaml":          "config",
-				"prow/plugins.yaml": "plugins",
+			expected: map[string]ConfigMapSpec{
+				"foo.yaml":          {Name: "config"},
+				"prow/plugins.yaml": {Name: "plugins"},
 			},
 		},
 		{
@@ -195,9 +195,9 @@ func TestSetDefault_Maps(t *testing.T) {
 			config: ConfigUpdater{
 				PluginFile: "bar.yaml",
 			},
-			expected: map[string]string{
-				"bar.yaml":         "plugins",
-				"prow/config.yaml": "config",
+			expected: map[string]ConfigMapSpec{
+				"bar.yaml":         {Name: "plugins"},
+				"prow/config.yaml": {Name: "config"},
 			},
 		},
 		{
@@ -206,26 +206,26 @@ func TestSetDefault_Maps(t *testing.T) {
 				ConfigFile: "foo.yaml",
 				PluginFile: "bar.yaml",
 			},
-			expected: map[string]string{
-				"foo.yaml": "config",
-				"bar.yaml": "plugins",
+			expected: map[string]ConfigMapSpec{
+				"foo.yaml": {Name: "config"},
+				"bar.yaml": {Name: "plugins"},
 			},
 		},
 		{
 			name: "both current and deprecated",
 			config: ConfigUpdater{
-				Maps: map[string]string{
-					"config.yaml":        "overwrite-config",
-					"plugins.yaml":       "overwrite-plugins",
-					"unconflicting.yaml": "ignored",
+				Maps: map[string]ConfigMapSpec{
+					"config.yaml":        {Name: "overwrite-config"},
+					"plugins.yaml":       {Name: "overwrite-plugins"},
+					"unconflicting.yaml": {Name: "ignored"},
 				},
 				ConfigFile: "config.yaml",
 				PluginFile: "plugins.yaml",
 			},
-			expected: map[string]string{
-				"config.yaml":        "overwrite-config",
-				"plugins.yaml":       "overwrite-plugins",
-				"unconflicting.yaml": "ignored",
+			expected: map[string]ConfigMapSpec{
+				"config.yaml":        {Name: "overwrite-config"},
+				"plugins.yaml":       {Name: "overwrite-plugins"},
+				"unconflicting.yaml": {Name: "ignored"},
 			},
 		},
 	}

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/updateconfig/README.md
+++ b/prow/plugins/updateconfig/README.md
@@ -13,9 +13,16 @@ plugins:
 config_updater:
   maps:
     # Update the whatever configmap whenever thing changes
-    path/to/some/other/thing: whatever
+    path/to/some/other/thing:
+      name: thing-config
+      # Using ProwJobNamespace by default.
+    path/to/some/other/thing2:
+      name: thing2-config
+      namespace: otherNamespace
     # Update the config configmap whenever config.yaml changes
-    prow/config.yaml: config
+    prow/config.yaml:
+      name: config
     # Update the plugin configmap whenever plugins.yaml changes
-    prow/plugins.yaml: plugin
+    prow/plugins.yaml:
+      name: plugin
 ```


### PR DESCRIPTION
I would like Prow to push my configuration changes for config that are not in the default namespace. Boskos config is an example.

MERGING this will break the current config, as we need to build a new version of the binary that holds the plugins and I don't have access to push this binary. Help form a maintainer would be appreciated.