### PR TITLE
Using latest gclb image in kubemci e2e tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -754,6 +754,7 @@
   "ci-kubemci-ingress-conformance": {
     "args": [
       "--check-leaked-resources",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:latest",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/latest",
       "--gcp-node-image=gci",


### PR DESCRIPTION
Updating kubemci ingress conformance e2e test to use the latest gclb image from HEAD.

This makes this job similar to [ci-ingress-gce-e2e](https://github.com/nikhiljindal/test-infra/blob/d168ce2ba6b2624bee2ce859a5f77f94de2172da/jobs/config.json#L505) which also uses the same image.

cc @nicksardo @MrHohn @G-Harmon @csbell 