### PR TITLE
Make testgrid-config-upload need two failures in a row to alert.

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -635,7 +635,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/maintenance-boskos-config-upload
 - name: maintenance-ci-testgrid-config-upload
   gcs_prefix: kubernetes-jenkins/logs/maintenance-ci-testgrid-config-upload
-  num_failures_to_alert: 1
+  num_failures_to_alert: 2
 - name: maintenance-ci-aws-janitor
   gcs_prefix: kubernetes-jenkins/logs/maintenance-ci-aws-janitor
 - name: maintenance-ci-janitor


### PR DESCRIPTION
A daily failure email from a non-actionable flake trains people to
ignore alerts.