### PR TITLE
map gke-staging tests to last three branches

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7783,12 +7783,13 @@
       "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gke-staging-latest-parallel": {
+  "ci-kubernetes-e2e-gke-staging-stable1-parallel": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--cluster=",
       "--deployment=gke",
-      "--extract=gke-latest",
+      "--extract=gke-latest-1.9",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
@@ -7803,12 +7804,95 @@
       "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gke-staging-latest-serial": {
+  "ci-kubernetes-e2e-gke-staging-stable1-serial": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--cluster=",
       "--deployment=gke",
-      "--extract=gke-latest",
+      "--extract=gke-latest-1.9",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=staging",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-staging-stable2-parallel": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=gke-latest-1.8",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel",
+      "--gke-environment=staging",
+      "--provider=gke",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-staging-stable2-serial": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=gke-latest-1.8",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=staging",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-staging-stable3-parallel": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=gke-latest-1.7",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel",
+      "--gke-environment=staging",
+      "--provider=gke",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-staging-stable3-serial": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=gke-latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11846,7 +11846,7 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-staging-latest-parallel
+  name: ci-kubernetes-e2e-gke-staging-stable1-parallel
   labels:
     preset-service-account: true
     preset-k8s-ssh: true
@@ -11859,7 +11859,59 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
-  name: ci-kubernetes-e2e-gke-staging-latest-serial
+  name: ci-kubernetes-e2e-gke-staging-stable1-serial
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=620
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-staging-stable2-parallel
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=100
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-staging-stable2-serial
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=620
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-staging-stable3-parallel
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=100
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180322-179eac85b-master
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-staging-stable3-serial
   labels:
     preset-service-account: true
     preset-k8s-ssh: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -476,14 +476,22 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ha-master
 - name: ci-kubernetes-e2e-gci-gke-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-sig-cli
-- name: ci-kubernetes-e2e-gke-staging-latest-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-serial
-- name: ci-kubernetes-e2e-gke-staging-default-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-default-serial
-- name: ci-kubernetes-e2e-gke-staging-latest-parallel
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-parallel
 - name: ci-kubernetes-e2e-gke-staging-default-parallel
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-default-parallel
+- name: ci-kubernetes-e2e-gke-staging-default-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-default-serial
+- name: ci-kubernetes-e2e-gke-staging-stable1-parallel
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable1-parallel
+- name: ci-kubernetes-e2e-gke-staging-stable1-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable1-serial
+- name: ci-kubernetes-e2e-gke-staging-stable2-parallel
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable2-parallel
+- name: ci-kubernetes-e2e-gke-staging-stable2-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable2-serial
+- name: ci-kubernetes-e2e-gke-staging-stable3-parallel
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable3-parallel
+- name: ci-kubernetes-e2e-gke-staging-stable3-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-stable3-serial
 - name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   alert_stale_results_hours: 24
@@ -3067,14 +3075,22 @@ dashboards:
 
 - name: google-gke-staging
   dashboard_tab:
-  - name: gke-staging-latest-serial
-    test_group_name: ci-kubernetes-e2e-gke-staging-latest-serial
-  - name: gke-staging-default-serial
-    test_group_name: ci-kubernetes-e2e-gke-staging-default-serial
-  - name: gke-staging-latest-parallel
-    test_group_name: ci-kubernetes-e2e-gke-staging-latest-parallel
   - name: gke-staging-default-parallel
     test_group_name: ci-kubernetes-e2e-gke-staging-default-parallel
+  - name: gke-staging-default-serial
+    test_group_name: ci-kubernetes-e2e-gke-staging-default-serial
+  - name: gke-staging-1.9-parallel
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable1-parallel
+  - name: gke-staging-1.9-serial
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable1-serial
+  - name: gke-staging-1.8-parallel
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable2-parallel
+  - name: gke-staging-1.8-serial
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable2-serial
+  - name: gke-staging-1.7-parallel
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable3-parallel
+  - name: gke-staging-1.7-serial
+    test_group_name: ci-kubernetes-e2e-gke-staging-stable3-serial
   - name: gke-staging-latest-device-plugin-gpu
     test_group_name: ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   - name: gke-staging-latest-device-plugin-gpu-v100


### PR DESCRIPTION
previously we only test against gke-latest, now given we can already do --extract=gke-latest-$VERSION, let's expand staging tests to last three k8s branches.

/assign @caesarxuchao @mml 