### PR TITLE
Stop including sample data in the Deck image.

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -17,7 +17,14 @@ container_image(
     # Add files under into the root directory.
     directory = "/",
     # Everything under static/
-    files = glob(["static/**/*"]),
+    files = glob(
+        ["static/**/*"],
+        exclude = [
+            "static/tide.js",
+            "static/data.js",
+            "static/plugin-help.js",
+        ],
+    ),
 )
 
 go_image(


### PR DESCRIPTION
This unnecessarily increases the image size and can result in the sample data being displayed in some cases.

/area prow
/kind bug
/cc @krzyzacy 