### PR TITLE
create kubekins-test 1.11 image with go 1.10.1

### DIFF
--- a/images/kubekins-test/Dockerfile-1.11
+++ b/images/kubekins-test/Dockerfile-1.11
@@ -1,0 +1,48 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM golang:1.10.1
+LABEL maintainer="Sen Lu <senlu@google.com>"
+
+# Setup workspace and symlink to gopath
+WORKDIR /workspace
+RUN mkdir -p /go/src/k8s.io/kubernetes /workspace \
+    && ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# Install linux packages
+# bc is needed by shell2junit
+# dnsutils is needed by federation cluster scripts.
+# file is used when uploading test artifacts to GCS.
+# jq is used by hack/verify-godep-licenses.sh
+# python-pip is needed to install the AWS cli.
+# netcat is used by integration test scripts.
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+	bc \
+	dnsutils \
+	file \
+	jq \
+	python-pip \
+	netcat-openbsd \
+	rsync \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install any go packages
+RUN go get \
+    github.com/golang/lint/golint

--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -27,7 +27,7 @@ import sys
 
 
 BRANCH_VERSION = {
-    'master': '1.10',
+    'master': '1.11',
 }
 
 VERSION_TAG = {
@@ -35,6 +35,7 @@ VERSION_TAG = {
     '1.8': '1.8-v20170906-3a1c5ae5',
     '1.9': '1.9-v20171018-6ddbad97',
     '1.10': '1.10-v20180221-3655e24ae',
+    '1.11': '1.11-v20180402-bfc4f266c',
 }
 
 


### PR DESCRIPTION
we need this since kubernetes master has diverged from release 1.10 on go version

/area images
/area scenarios