### PR TITLE
fix kubetest command in conformance docs

### DIFF
--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -19,6 +19,7 @@ This directory contains tooling for displaying [kubernetes conformance test](htt
    - make sure `kubectl` / `$KUBECONFIG` is authed to your cluster
    - run kubetest with:
     ```sh
+    export KUBERNETES_CONFORMANCE_TEST=y
     kubetest --provider=skeleton \
              --test --test_args="--ginkgo.focus=\[Conformance\]" \ 
              --dump=./_artifacts | tee ./e2e.log


### PR DESCRIPTION
[you should `export KUBECONFIG=$HOME/.kube/config`](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#conformance-tests), which is indeed how I ran it before.