### PR TITLE
Optionally link to the PR Dashboard in tide status context

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -55,6 +55,11 @@ type Tide struct {
 	// allowing it to be a template.
 	TargetURL string `json:"target_url,omitempty"`
 
+	// PRStatusBaseUrl is the base URL for the PR status page.
+	// This is used to link to a merge requirements overview
+	// in the tide status context.
+	PRStatusBaseUrl string `json:"pr_status_base_url,omitempty"`
+
 	// MaxGoroutines is the maximum number of goroutines spawned inside the
 	// controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
 	// positive number.


### PR DESCRIPTION
If configured, we should be able to link to the PR dashboard for a given
pull request in the tide status context link in GitHub as that gives a
much cleaner and more straightforward overview of what is going on for a
specific PR than the administrator-level tide overview page that is
currently linked.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind feature
/area prow
/cc @fejta @kargakis 
/assign @cjwagner @BenTheElder 

Suggestions on how to ensure the query is unique without having to provide the head ref name (and increase query complexity) would be cool.

/woof