### PR TITLE
fix pull-test-infra-verify-labels

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5787,12 +5787,12 @@ presubmits:
       preset-bazel-scratch-dir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180402-7b54c4ba6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--clean"
+        - --service-account=/etc/service-account/service-account.json
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true


### PR DESCRIPTION
ran into this while testing via #7533

```
I0403 19:35:25.332] Call:  /workspace/./test-infra/jenkins/../scenarios/execute.py ./hack/verify-labels.sh
W0403 19:35:25.360] Run: ('./hack/verify-labels.sh',)
W0403 19:35:25.388] /go/src/k8s.io/test-infra/hack/update-labels.sh: line 25: bazel: command not found
```