### PR TITLE
Add support for triage/ labels to label plugin

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -31,8 +31,8 @@ import (
 const pluginName = "label"
 
 var (
-	labelRegex              = regexp.MustCompile(`(?m)^/(area|committee|kind|priority|sig)\s*(.*)$`)
-	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|committee|kind|priority|sig)\s*(.*)$`)
+	labelRegex              = regexp.MustCompile(`(?m)^/(area|committee|kind|priority|sig|triage)\s*(.*)$`)
+	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|committee|kind|priority|sig|triage)\s*(.*)$`)
 	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
 )
 
@@ -43,10 +43,10 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'priority/*' and 'sig/*'.",
+		Description: "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'priority/*', 'sig/*', and 'triage/*'.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/[remove-](area|committee|kind|priority|sig) <target>",
+		Usage:       "/[remove-](area|committee|kind|priority|sig|triage) <target>",
 		Description: "Applies or removes a label from one of the recognized types of labels.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can trigger this command on a PR.",

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -109,6 +109,15 @@ func TestLabel(t *testing.T) {
 			commenter:             orgMember,
 		},
 		{
+			name:                  "Add Single Triage Label",
+			body:                  "/triage needs-information",
+			repoLabels:            []string{"area/infra", "triage/needs-information"},
+			issueLabels:           []string{"area/infra"},
+			expectedNewLabels:     formatLabels("triage/needs-information"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+		},
+		{
 			name:                  "Adding Labels is Case Insensitive",
 			body:                  "/kind BuG",
 			repoLabels:            []string{"area/infra", "priority/critical", "kind/bug"},
@@ -295,6 +304,15 @@ func TestLabel(t *testing.T) {
 			issueLabels:           []string{"area/infra", "sig/testing"},
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("sig/testing"),
+			commenter:             orgMember,
+		},
+		{
+			name:                  "Remove Triage Label",
+			body:                  "/remove-triage needs-information",
+			repoLabels:            []string{"area/infra", "triage/needs-information"},
+			issueLabels:           []string{"area/infra", "triage/needs-information"},
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: formatLabels("triage/needs-information"),
 			commenter:             orgMember,
 		},
 		{


### PR DESCRIPTION
fixes #7251.

This adds support for the triage class of labels to the label plugin that any user can use.