### PR TITLE
Rename issue triage labels

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -41,22 +41,22 @@ labels:
     addedBy: googlebot
   - color: d455d0
     description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
-    name: close/duplicate
+    name: triage/duplicate
     target: both
     addedBy: humans
   - color: d455d0
     description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
-    name: close/needs-information
+    name: triage/needs-information
     target: both
     addedBy: humans
   - color: d455d0
     description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
-    name: close/not-reproducible
+    name: triage/not-reproducible
     target: both
     addedBy: humans
   - color: d455d0
     description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
-    name: close/unresolved
+    name: triage/unresolved
     target: both
     addedBy: humans
   - color: c0ff4a

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -40,23 +40,31 @@ labels:
     target: prs
     addedBy: googlebot
   - color: d455d0
-    description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
+    description: Indicates an issue is a duplicate of other open issue. The usage should be supported by adding triage findings as an issue comment.
     name: triage/duplicate
     target: both
+    previously:
+      - name: close/duplicate
     addedBy: humans
   - color: d455d0
-    description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
+    description: Indicates an issue needs more information in order to work on it. The usage should be supported by adding triage findings as an issue comment.
     name: triage/needs-information
+    previously:
+      - name: close/needs-information
     target: both
     addedBy: humans
   - color: d455d0
-    description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
+    description: Indicates an issue can not be reproduced as described. The usage should be supported by adding triage findings as an issue comment.
     name: triage/not-reproducible
+    previously:
+      - name: close/not-reproducible
     target: both
     addedBy: humans
   - color: d455d0
-    description: "TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)"
+    description: Indicates an issue that can not be resolved. The usage should be supported by adding triage findings as an issue comment.
     name: triage/unresolved
+    previously:
+      - name: close/unresolved
     target: both
     addedBy: humans
   - color: c0ff4a


### PR DESCRIPTION
Per broader discussion in the contribX SIG meeting today April 4th, we
have decided to rename close/* labels to triage/*.

Related disussion is also under, https://github.com/kubernetes/test-infra/issues/7251