### PR TITLE
[do not merge] Test GCE scalability with CoreDNS

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12602,6 +12602,27 @@
       "sig-scalability"
     ]
   },
+  "pull-kubernetes-e2e-gce-100-performance-coredns": {
+    "args": [
+      "--build=bazel",
+      "--cluster=",
+      "--env=CLUSTER_DNS_CORE_DNS=true",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability-tiny.env",
+      "--extract=local",
+      "--gcp-project=k8s-presubmit-scale",
+      "--gcp-zone=us-east1-b",
+      "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-100-performance-coredns",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=1 --node-schedulable-timeout=10m --minStartupPods=8 --gather-resource-usage=true --gather-metrics-at-teardown=true",
+      "--timeout=100m",
+      "--use-logexporter"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-scalability"
+    ]
+  },
   "pull-kubernetes-e2e-gce-big-performance": {
     "args": [
       "--build=bazel",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -532,6 +532,7 @@ class JobTest(unittest.TestCase):
             'pull-kubernetes-kubemark-e2e-gce-big': 'ci-kubernetes-scale-*',
             'pull-kubernetes-kubemark-e2e-gce-scale': 'ci-kubernetes-scale-*',
             'pull-kubernetes-e2e-gce-100-performance': 'ci-kubernetes-scale-*',
+            'pull-kubernetes-e2e-gce-100-performance-coredns': 'ci-kubernetes-scale-*',
             'pull-kubernetes-e2e-gce-big-performance': 'ci-kubernetes-scale-*',
             'pull-kubernetes-e2e-gce-large-performance': 'ci-kubernetes-scale-*',
             'ci-kubernetes-e2e-gce-large-manual-up': 'ci-kubernetes-scale-*',

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-scalability-tiny.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-scalability-tiny.env
@@ -1,0 +1,21 @@
+### job-env
+
+# Create a project k8s-jenkins-scalability-head and move this test there
+
+# Override GCE defaults.
+NODE_SIZE=n1-standard-1
+NODE_DISK_SIZE=50GB
+NUM_NODES=5
+ALLOWED_NOTREADY_NODES=1
+REGISTER_MASTER=true
+KUBE_GCE_ENABLE_IP_ALIASES=true
+
+# Switch off image puller to workaround #44701
+PREPULL_E2E_IMAGES=false
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1795,6 +1795,34 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+  - name: pull-kubernetes-e2e-gce-100-performance-coredns
+    agent: kubernetes
+    context: pull-kubernetes-e2e-gce-100-performance
+    rerun_command: "/test pull-kubernetes-e2e-gce-100-performance-coredns"
+    trigger: "(?m)^/test (all|pull-kubernetes-e2e-gce-100-performance-coredns),?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+      preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=120
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180402-7b54c4ba6-master
+        resources:
+          requests:
+            memory: "6Gi"
   - name: pull-kubernetes-e2e-gce-big-performance
     agent: kubernetes
     context: pull-kubernetes-e2e-gce-big-performance
@@ -3960,6 +3988,48 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce-100-performance),?(\s+|$)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce-100-performance
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-security-kubernetes-e2e-gce-100-performance-coredns
+    rerun_command: /test pull-security-kubernetes-e2e-gce-100-performance-coredns
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=120
+        - --
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-100-performance-coredns
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180402-7b54c4ba6-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test (all|pull-security-kubernetes-e2e-gce-100-performance-coredns),?(\s+|$)
   - agent: kubernetes
     always_run: false
     branches:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2076,6 +2076,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-100-performance
   days_of_results: 60
   num_columns_recent: 20
+- name: pull-kubernetes-e2e-gce-100-performance-coredns
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-100-performance
+  days_of_results: 60
+  num_columns_recent: 20
 - name: pull-kubernetes-e2e-gce-big-performance
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-big-performance
   days_of_results: 60
@@ -5554,6 +5558,9 @@ dashboards:
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance
+    test_group_name: pull-kubernetes-e2e-gce-100-performance
+    base_options: 'width=10'
+  - name: pull-kubernetes-e2e-gce-100-performance-coredns
     test_group_name: pull-kubernetes-e2e-gce-100-performance
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-big-performance


### PR DESCRIPTION
### Please do not merge

CoreDNS is currently deployed with k8s as a BETA feature.
It is expected to replace kube-dns when GA.

This PR is to validate that a scalability tests of k8s with CoreDNS as DNS service is still on track.
Target is to use to run the test within this PR.

/test pull-kubernetes-e2e-gce-100-performance-coredns 