### PR TITLE
upgrade rules go and go to 0.10.3 / 1.10.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,10 +8,10 @@ load("@bazel_skylib//:lib.bzl", "versions")
 
 versions.check(minimum_bazel_version = "0.10.0")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "6b39964af66c98580be4c5ac6cf1d243332f78e4",
-    remote = "https://github.com/bazelbuild/rules_go.git",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
+    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.9.3",
+    go_version = "1.10.1",
 )
 
 git_repository(


### PR DESCRIPTION
we have a lot of tens right now 🙃 
rules_go upgrade is required to avoid a bug parsing the go version:
```
$ bazel build //...
......................
ERROR: /Users/bentheelder/go/src/k8s.io/test-infra/WORKSPACE:21:1: Traceback (most recent call last):
        File "/Users/bentheelder/go/src/k8s.io/test-infra/WORKSPACE", line 21
                go_register_toolchains(go_version = "1.10.1")
        File "/private/var/tmp/_bazel_bentheelder/4c072a8c986e7dd2b494f380f92d80d4/external/io_bazel_rules_go/go/toolchain/toolchains.bzl", line 222, in go_register_toolchains
                fail("Unknown go version {}".format(g...))
Unknown go version 1.10.1
```

/area bazel