### PR TITLE
Support --image-family for node e2e tests

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -689,8 +689,12 @@ func prepareGcp(o *options) error {
 			if len(latestImage) == 0 {
 				return fmt.Errorf("failed to get latest image from family %q in project %q", o.gcpImageFamily, o.gcpImageProject)
 			}
-			os.Setenv("KUBE_GCE_NODE_IMAGE", latestImage)
-			os.Setenv("KUBE_GCE_NODE_PROJECT", o.gcpImageProject)
+			if o.deployment == "node" {
+				o.nodeArgs += fmt.Sprintf(" --images=%s --image-project=%s", latestImage, o.gcpImageProject)
+			} else {
+				os.Setenv("KUBE_GCE_NODE_IMAGE", latestImage)
+				os.Setenv("KUBE_GCE_NODE_PROJECT", o.gcpImageProject)
+			}
 		}
 	} else if o.provider == "gke" {
 		if o.deployment == "" {


### PR DESCRIPTION
I expect to use `--image-family` and `--image-project` to replace
https://github.com/kubernetes/test-infra/blob/ff03f24f3dfce505dc0c231727240774f0e6e5bf/experiment/test_config.yaml#L1158-L1175
Once this change is released.