### PR TITLE
Choose oldest PRs for batches

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -720,11 +720,12 @@ func (c *Controller) pickBatch(sp subpool) ([]PullRequest, error) {
 		return nil, err
 	}
 	var res []PullRequest
-	for i, pr := range sp.prs {
+	for i := range sp.prs {
 		// TODO: Make this configurable per subpool.
 		if i == 5 {
 			break
 		}
+		pr := sp.prs[len(sp.prs)-i-1]
 		if !isPassingTests(sp.log, c.ghc, pr) {
 			continue
 		}


### PR DESCRIPTION
PRs are sorted in descending order of PR number, so if we grab PRs for a
batch from the end of the list we will grab the oldest ones.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @cjwagner
/cc @rmmh
fixes https://github.com/kubernetes/test-infra/issues/7561

The "dumb but simple" approach if we don't want to incur sorting costs every time...