### PR TITLE
Accumulate five oldest PRs into batch when possible

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -719,19 +719,25 @@ func (c *Controller) pickBatch(sp subpool) ([]PullRequest, error) {
 	if err := r.Checkout(sp.sha); err != nil {
 		return nil, err
 	}
+
+	// we must choose the oldest PRs for the batch
+	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
+
 	var res []PullRequest
-	for i, pr := range sp.prs {
-		// TODO: Make this configurable per subpool.
-		if i == 5 {
-			break
-		}
+	for _, pr := range sp.prs {
 		if !isPassingTests(sp.log, c.ghc, pr) {
 			continue
 		}
 		if ok, err := r.Merge(string(pr.HeadRefOID)); err != nil {
+			// we failed to abort the merge and our git client is
+			// in a bad state; it must be cleaned before we try again
 			return nil, err
 		} else if ok {
 			res = append(res, pr)
+			// TODO: Make this configurable per subpool.
+			if len(res) == 5 {
+				break
+			}
 		}
 	}
 	return res, nil

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -858,32 +858,56 @@ func TestPickBatch(t *testing.T) {
 	testprs := []struct {
 		files   map[string][]byte
 		success bool
+		number  int
 
 		included bool
 	}{
 		{
 			files:    map[string][]byte{"bar": []byte("ok")},
 			success:  true,
+			number:   0,
 			included: true,
 		},
 		{
 			files:    map[string][]byte{"foo": []byte("ok")},
 			success:  true,
+			number:   1,
 			included: true,
 		},
 		{
 			files:    map[string][]byte{"bar": []byte("conflicts with 0")},
 			success:  true,
+			number:   2,
 			included: false,
 		},
 		{
 			files:    map[string][]byte{"qux": []byte("ok")},
 			success:  false,
+			number:   6,
 			included: false,
 		},
 		{
 			files:    map[string][]byte{"bazel": []byte("ok")},
 			success:  true,
+			number:   7,
+			included: false, // batch of 5 smallest excludes this
+		},
+		{
+			files:    map[string][]byte{"other": []byte("ok")},
+			success:  true,
+			number:   5,
+			included: true,
+		},
+		{
+			files:    map[string][]byte{"changes": []byte("ok")},
+			success:  true,
+			number:   4,
+			included: true,
+		},
+		{
+			files:    map[string][]byte{"something": []byte("ok")},
+			success:  true,
+			number:   3,
 			included: true,
 		},
 	}
@@ -894,8 +918,8 @@ func TestPickBatch(t *testing.T) {
 		branch: "master",
 		sha:    "master",
 	}
-	for i, testpr := range testprs {
-		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", i)); err != nil {
+	for _, testpr := range testprs {
+		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", testpr.number)); err != nil {
 			t.Fatalf("Error checking out new branch: %v", err)
 		}
 		if err := lg.AddCommit("o", "r", testpr.files); err != nil {
@@ -904,9 +928,9 @@ func TestPickBatch(t *testing.T) {
 		if err := lg.Checkout("o", "r", "master"); err != nil {
 			t.Fatalf("Error checking out master: %v", err)
 		}
-		oid := githubql.String(fmt.Sprintf("origin/pr-%d", i))
+		oid := githubql.String(fmt.Sprintf("origin/pr-%d", testpr.number))
 		var pr PullRequest
-		pr.Number = githubql.Int(i)
+		pr.Number = githubql.Int(testpr.number)
 		pr.HeadRefOID = oid
 		pr.Commits.Nodes = []struct {
 			Commit Commit
@@ -925,18 +949,18 @@ func TestPickBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error from pickBatch: %v", err)
 	}
-	for i, testpr := range testprs {
+	for _, testpr := range testprs {
 		var found bool
 		for _, pr := range prs {
-			if int(pr.Number) == i {
+			if int(pr.Number) == testpr.number {
 				found = true
 				break
 			}
 		}
 		if found && !testpr.included {
-			t.Errorf("PR %d should not be picked.", i)
+			t.Errorf("PR %d should not be picked.", testpr.number)
 		} else if !found && testpr.included {
-			t.Errorf("PR %d should be picked.", i)
+			t.Errorf("PR %d should be picked.", testpr.number)
 		}
 	}
 }


### PR DESCRIPTION
We must choose the oldest PRs possible for batch testing to ensure that
they do not get denied a chance to merge. Furthermore, we should always
attempt to accumulate a full batch when possible.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @cjwagner
/cc @BenTheElder @rmmh @kargakis 

The earlier behavior seemed wrong? We would only consider the first 5 PRs for batching regardless of how many actually were batchable. Changes here ensure we get up to 5. Is that right?