### PR TITLE
let bootstrap takes in optional refs (for gerrit)

### DIFF
--- a/prow/clonerefs/parse_test.go
+++ b/prow/clonerefs/parse_test.go
@@ -110,6 +110,18 @@ func TestParseRefs(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:  "base branch and pr with refs",
+			value: "org,repo=branch:sha,1:pull-1-sha:pull-1-ref",
+			expected: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				BaseSHA: "sha",
+				Pulls:   []kube.Pull{{Number: 1, SHA: "pull-1-sha", Ref: "pull-1-ref"}},
+			},
+			expectErr: false,
+		},
+		{
 			name:      "no org or repo",
 			value:     "branch:sha",
 			expectErr: true,
@@ -131,7 +143,7 @@ func TestParseRefs(t *testing.T) {
 		},
 		{
 			name:      "malformed pull ref",
-			value:     "org,repo=branch:sha,1:what:ever",
+			value:     "org,repo=branch:sha,1:what:so:ever",
 			expectErr: true,
 		},
 		{

--- a/prow/gerrit/gerrit.go
+++ b/prow/gerrit/gerrit.go
@@ -283,6 +283,7 @@ func (c *Controller) ProcessChange(change gerrit.ChangeInfo) error {
 					Number: change.Number,
 					Author: rev.Commit.Author.Name,
 					SHA:    change.CurrentRevision,
+					Ref:    rev.Ref,
 				},
 			},
 		}

--- a/prow/gerrit/gerrit_test.go
+++ b/prow/gerrit/gerrit_test.go
@@ -367,11 +367,13 @@ func TestProcessChange(t *testing.T) {
 				CurrentRevision: "1",
 				Project:         "test-infra",
 				Revisions: map[string]gerrit.RevisionInfo{
-					"1": {},
+					"1": {
+						Ref: "refs/changes/00/1/1",
+					},
 				},
 			},
 			numPJ: 1,
-			pjRef: "1",
+			pjRef: "refs/changes/00/1/1",
 		},
 		{
 			name: "multiple revisions",
@@ -379,12 +381,16 @@ func TestProcessChange(t *testing.T) {
 				CurrentRevision: "2",
 				Project:         "test-infra",
 				Revisions: map[string]gerrit.RevisionInfo{
-					"1": {},
-					"2": {},
+					"1": {
+						Ref: "refs/changes/00/2/1",
+					},
+					"2": {
+						Ref: "refs/changes/00/2/2",
+					},
 				},
 			},
 			numPJ: 1,
-			pjRef: "2",
+			pjRef: "refs/changes/00/2/2",
 		},
 	}
 
@@ -425,8 +431,8 @@ func TestProcessChange(t *testing.T) {
 		}
 
 		if len(fkc.prowjobs) > 0 {
-			if fkc.prowjobs[0].Spec.Refs.Pulls[0].SHA != tc.pjRef {
-				t.Errorf("tc %s - ref should be %s, got %s", tc.name, tc.pjRef, fkc.prowjobs[0].Spec.Refs.BaseRef)
+			if fkc.prowjobs[0].Spec.Refs.Pulls[0].Ref != tc.pjRef {
+				t.Errorf("tc %s - ref should be %s, got %s", tc.name, tc.pjRef, fkc.prowjobs[0].Spec.Refs.Pulls[0].Ref)
 			}
 		}
 	}

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -164,7 +164,12 @@ type Pull struct {
 	Number int    `json:"number,omitempty"`
 	Author string `json:"author,omitempty"`
 	SHA    string `json:"sha,omitempty"`
-	Ref    string `json:"ref,omitempty"`
+
+	// Ref is git ref can be checked out for a change
+	// for example,
+	// github: pull/123/head
+	// gerrit: refs/changes/00/123/1
+	Ref string `json:"ref,omitempty"`
 }
 
 type Refs struct {

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -164,6 +164,7 @@ type Pull struct {
 	Number int    `json:"number,omitempty"`
 	Author string `json:"author,omitempty"`
 	SHA    string `json:"sha,omitempty"`
+	Ref    string `json:"ref,omitempty"`
 }
 
 type Refs struct {
@@ -185,7 +186,13 @@ type Refs struct {
 func (r Refs) String() string {
 	rs := []string{fmt.Sprintf("%s:%s", r.BaseRef, r.BaseSHA)}
 	for _, pull := range r.Pulls {
-		rs = append(rs, fmt.Sprintf("%d:%s", pull.Number, pull.SHA))
+		ref := fmt.Sprintf("%d:%s", pull.Number, pull.SHA)
+
+		if pull.Ref != "" {
+			ref = fmt.Sprintf("%s:%s", ref, pull.Ref)
+		}
+
+		rs = append(rs, ref)
 	}
 	return strings.Join(rs, ",")
 }

--- a/prow/kube/prowjob_test.go
+++ b/prow/kube/prowjob_test.go
@@ -62,6 +62,25 @@ func TestRefs(t *testing.T) {
 			},
 			expected: "foo:123,1:qwe,2:asd",
 		},
+		{
+			ref: Refs{
+				BaseRef: "foo",
+				BaseSHA: "123",
+				Pulls: []Pull{
+					{
+						Number: 1,
+						SHA:    "qwe",
+						Ref:    "refs/changes/00/1/1",
+					},
+					{
+						Number: 2,
+						SHA:    "asd",
+						Ref:    "refs/changes/00/1/2",
+					},
+				},
+			},
+			expected: "foo:123,1:qwe:refs/changes/00/1/1,2:asd:refs/changes/00/1/2",
+		},
 	}
 	for _, tc := range testcases {
 		actual := tc.ref.String()

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -68,7 +68,11 @@ func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail string) Record {
 	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", refs.BaseRef))
 
 	for _, prRef := range refs.Pulls {
-		commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, fmt.Sprintf("pull/%d/head", prRef.Number)))
+		ref := fmt.Sprintf("pull/%d/head", prRef.Number)
+		if prRef.Ref != "" {
+			ref = prRef.Ref
+		}
+		commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, ref))
 		var prCheckout string
 		if prRef.SHA != "" {
 			prCheckout = prRef.SHA


### PR DESCRIPTION
/hold
for discussion

So basically I'm trying to resolve https://github.com/kubernetes/test-infra/issues/7426, this works but not super great - because currently bootstrap assumes github pull refs and generates that from the PR number.

How we should handle this better, in podutils? I'm also thinking of add a `Ref` field in `kube.Refs`, and we can construct `$PULL_REFS` accordingly.

/assign @BenTheElder @cjwagner @stevekuznetsov 