### PR TITLE
Run make init before e2e istio test

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11980,7 +11980,7 @@
       "--gke-environment=test",
       "--provider=gke",
       "--test=false",
-      "--test-cmd=../tests/e2e_istio_preinstalled.sh",
+      "--test-cmd=make init; ../tests/e2e_istio_preinstalled.sh",
       "--test-cmd-args=simple",
       "--test-cmd-name=istio-addon",
       "--timeout=60m"


### PR DESCRIPTION
make e2e does not initialize istioctl which causes it to fail.