### PR TITLE
Adding a ci job to run kubemci unit tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11477,6 +11477,23 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-multicluster-ingress-test": {
+    "args": [
+      "make",
+      "--",
+      "-j",
+      "5",
+      "test",
+      "coveralls",
+      "vet",
+      "fmt",
+      "lint"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-multicluster"
+    ]
+  },
   "ci-kubernetes-node-kubelet": {
     "args": [
       "--deployment=node",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14752,6 +14752,29 @@ periodics:
     - name: docker-graph
       emptyDir: {}
 
+- interval: 6h
+  name: ci-kubernetes-multicluster-ingress-test
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      args:
+      - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
+      - --root=/go/src
+      - --timeout=50
+      - --service-account=/etc/service-account/service-account.json
+      - --upload=gs://kubernetes-jenkins/logs
+      volumeMounts:
+      - name: coveralls
+        mountPath: /etc/coveralls-token
+        readOnly: true
+    volumes:
+    - name: coveralls
+      secret:
+        secretName: k8s-multicluster-ingress-coveralls-token
+
 - name: ci-kubernetes-node-kubelet
   interval: 1h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1970,6 +1970,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
 - name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
+- name: ci-kubernetes-multicluster-ingress-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-multicluster-ingress-test
 - name: kubeflow-periodic
   gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic
 - name: kubeflow-presubmit
@@ -4402,6 +4404,8 @@ dashboards:
     test_group_name: ci-kubemci-image-push
   - name: kubemci-ingress-conformance
     test_group_name: ci-kubemci-ingress-conformance
+  - name: ci-kubemci-unit-tests
+    test_group_name: ci-kubernetes-multicluster-ingress-test
 
 - name: sig-instrumentation
   dashboard_tab:


### PR DESCRIPTION
Adding a `ci-kubernetes-multicluster-ingress-test` which is the ci version of existing `pull-kubernetes-multicluster-ingress-test`. The pull-* job runs as presubmit on every PR.

ci-* job will run once every 24 hour.
The ci job can catch breakages (for ex: due to go version changes or flaky tests) when there are no PRs.

cc @G-Harmon @krzyzacy @BenTheElder @AishSundar 