### PR TITLE
Add an optional path prefix for GCS uploads

### DIFF
--- a/prow/gcsupload/BUILD.bazel
+++ b/prow/gcsupload/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
+        "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",

--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -55,6 +55,9 @@ func (o Options) Run(extra map[string]gcs.UploadFunc) error {
 
 	var gcsPath string
 	jobBasePath := gcs.PathForSpec(spec, builder)
+	if o.PathPrefix != "" {
+		jobBasePath = path.Join(o.PathPrefix, jobBasePath)
+	}
 	if o.SubDir == "" {
 		gcsPath = jobBasePath
 	} else {

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -106,6 +106,9 @@ const (
 type GCSConfiguration struct {
 	// Bucket is the GCS bucket to upload to
 	Bucket string `json:"bucket,omitempty"`
+	// PathPrefix is an optional path that follows the
+	// bucket name and comes before any structure
+	PathPrefix string `json:"path_prefix,omitempty"`
 	// PathStrategy dictates how the org and repo are used
 	// when calculating the full path to an artifact in GCS
 	PathStrategy string `json:"path_strategy,omitempty"`

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -4,7 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = ["gcs.go"],
     importpath = "k8s.io/test-infra/testgrid/util/gcs",
-    visibility = ["//testgrid:__subpackages__"],
+    visibility = [
+        "//prow/gcsupload:__subpackages__",
+        "//testgrid:__subpackages__",
+    ],
     deps = [
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",


### PR DESCRIPTION
In order to support one GCS bucket holding multiple trees of GCS data,
we need to allow for an optional path prefix to sit between the bucket
name and any GCS path structure.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
fixes https://github.com/kubernetes/test-infra/issues/7566
/cc @cjwagner @BenTheElder 
/assign @fejta 