### PR TITLE
Log the exit code of wrapped process in entrypoint

### DIFF
--- a/prow/entrypoint/run.go
+++ b/prow/entrypoint/run.go
@@ -90,7 +90,7 @@ func (o Options) Run() error {
 		return fmt.Errorf("could not write return code to marker file: %v", err)
 	}
 	if commandErr != nil {
-		return fmt.Errorf("wrapped process failed: %v", err)
+		return fmt.Errorf("wrapped process failed with code %s: %v", returnCode, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/assign @fejta 
fixes https://github.com/kubernetes/test-infra/issues/7507