### PR TITLE
Move all ingress tests to a separate tab under sig-network

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4489,54 +4489,6 @@ dashboards:
     base_options: 'include-filter-by-regex=\[sig-network\]'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gce-ingress-manual-network
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-e2e
-    test_group_name: ci-ingress-gce-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-ipvs-gce-e2e
-    test_group_name: ci-ingress-ipvs-gce-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-e2e-scale
-    test_group_name: ci-ingress-gce-e2e-scale
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-image-push
-    test_group_name: ci-ingress-gce-image-push
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-upgrade-e2e
-    test_group_name: ci-ingress-gce-upgrade-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-downgrade-e2e
-    test_group_name: ci-ingress-gce-downgrade-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.7
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.8
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.9
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.10
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
     base_options: 'include-filter-by-regex=\[sig-network\]'
@@ -4611,6 +4563,84 @@ dashboards:
 
 - name: sig-network-gke
   dashboard_tab:
+  - name: gci-gke
+    test_group_name: ci-kubernetes-e2e-gci-gke
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gke e2e tests for master branch'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gke-slow
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gke slow e2e tests for master branch'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gke-serial
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gke serial e2e tests for master branch'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gke-alpha-features
+    test_group_name: ci-kubernetes-e2e-gci-gke-alpha-features
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gke alpha features e2e tests for master branch'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+      
+- name: sig-network-gce-ingress
+  dashboard_tab:
+  - name: gci-gce-ingress
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gce-ingress-manual-network
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e
+    test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-ipvs-gce-e2e
+    test_group_name: ci-ingress-ipvs-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-scale
+    test_group_name: ci-ingress-gce-e2e-scale
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-image-push
+    test_group_name: ci-ingress-gce-image-push
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-upgrade-e2e
+    test_group_name: ci-ingress-gce-upgrade-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-downgrade-e2e
+    test_group_name: ci-ingress-gce-downgrade-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.7
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.8
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.9
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.10
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  
+- name: sig-network-gke-ingress
+  dashboard_tab:
   - name: gci-gke-ingress
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress
     alert_options:
@@ -4661,30 +4691,6 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gke-ubuntu2-k8sstable3-ingress
     test_group_name: ci-kubernetes-e2e-gke-ubuntu2-k8sstable3-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gke
-    test_group_name: ci-kubernetes-e2e-gci-gke
-    base_options: 'include-filter-by-regex=\[sig-network\]'
-    description: 'network gci-gke e2e tests for master branch'
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gke-slow
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow
-    base_options: 'include-filter-by-regex=\[sig-network\]'
-    description: 'network gci-gke slow e2e tests for master branch'
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gke-serial
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial
-    base_options: 'include-filter-by-regex=\[sig-network\]'
-    description: 'network gci-gke serial e2e tests for master branch'
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gke-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gke-alpha-features
-    base_options: 'include-filter-by-regex=\[sig-network\]'
-    description: 'network gci-gke alpha features e2e tests for master branch'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
 


### PR DESCRIPTION
This will result in going from two tabs to four with the two additional tabs being named "sig-network-gce-ingress" and "sig-network-gke-ingress". The motivation behind this change is to get the tests for sig-network a little more organized. 

/assign @krzyzacy 
/assign @nicksardo 
/cc @MrHohn 