### PR TITLE
Small fix to make sig-network-*-ingress fall under the sig-network tab

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5812,6 +5812,8 @@ dashboard_groups:
   dashboard_names:
   - sig-network-gce
   - sig-network-gke
+  - sig-network-gce-ingress
+  - sig-network-gke-ingress
 
 - name: sig-node
   dashboard_names:


### PR DESCRIPTION
/assign @krzyzacy 