### PR TITLE
More restructuring of sig-network test grid

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4436,6 +4436,30 @@ dashboards:
     base_options: 'include-filter-by-regex=\[sig-network\]'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gce-ingress-manual-network
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.7
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.8
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.9
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-release-1.10
+    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
     base_options: 'include-filter-by-regex=\[sig-network\]'
@@ -4534,60 +4558,6 @@ dashboards:
     description: 'network gci-gke alpha features e2e tests for master branch'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-      
-- name: sig-network-gce-ingress
-  dashboard_tab:
-  - name: gci-gce-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gce-ingress-manual-network
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-e2e
-    test_group_name: ci-ingress-gce-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-ipvs-gce-e2e
-    test_group_name: ci-ingress-ipvs-gce-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-e2e-scale
-    test_group_name: ci-ingress-gce-e2e-scale
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-image-push
-    test_group_name: ci-ingress-gce-image-push
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-upgrade-e2e
-    test_group_name: ci-ingress-gce-upgrade-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-gce-downgrade-e2e
-    test_group_name: ci-ingress-gce-downgrade-e2e
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.7
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.8
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.9
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: gci-gce-ingress-release-1.10
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  
-- name: sig-network-gke-ingress
-  dashboard_tab:
   - name: gci-gke-ingress
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress
     alert_options:
@@ -4640,7 +4610,34 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-ubuntu2-k8sstable3-ingress
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-
+      
+- name: sig-network-ingress-gce-e2e
+  dashboard_tab:
+  - name: ingress-gce-e2e
+    test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-ipvs-gce-e2e
+    test_group_name: ci-ingress-ipvs-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-scale
+    test_group_name: ci-ingress-gce-e2e-scale
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-image-push
+    test_group_name: ci-ingress-gce-image-push
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-upgrade-e2e
+    test_group_name: ci-ingress-gce-upgrade-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-downgrade-e2e
+    test_group_name: ci-ingress-gce-downgrade-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+      
 - name: sig-node-cri-o
   dashboard_tab:
   - name: crio-e2e-fedora
@@ -5757,8 +5754,7 @@ dashboard_groups:
   dashboard_names:
   - sig-network-gce
   - sig-network-gke
-  - sig-network-gce-ingress
-  - sig-network-gke-ingress
+  - sig-network-ingress-gce-e2e
 
 - name: sig-node
   dashboard_names:


### PR DESCRIPTION
After some discussion with @nicksardo, we decided that it would be best to only have 3 tabs under sig-network. All the ingress-related tests that are Kubernetes release blocking will stay under sig-network-gce and sig-network-gke. All ingress-related tests that are important for k/ingress-gce will go under sig-network-ingress-gce-e2e. 

/assign @krzyzacy 
/assign @nicksardo 