### PR TITLE
Prow: Set up a proxy cache for Github interactions.

### DIFF
--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -7,6 +7,7 @@ release(
     "production",
     component("branchprotector", "cronjob"),
     component("deck", "service", "deployment"),
+    component("github-cache", "service", "deployment"),
     component("hook", "service", "deployment"),
     component("horologium", "deployment"),
     component("lego", "deployment"),

--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -7,6 +7,7 @@ release(
     "production",
     component("branchprotector", "cronjob"),
     component("deck", "service", "deployment"),
+    component("gce-ssd-retain", "storageclass"),
     component("github-cache", "service", "deployment"),
     component("hook", "service", "deployment"),
     component("horologium", "deployment"),

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -19,6 +19,7 @@ spec:
             - --config-path=/etc/config/config
             - --github-token-path=/etc/github/oauth
             - --confirm
+            - --github-endpoint=http://github-cache
             volumeMounts:
             - name: oauth
               mountPath: /etc/github

--- a/prow/cluster/gce-ssd-retain_storageclass.yaml
+++ b/prow/cluster/gce-ssd-retain_storageclass.yaml
@@ -1,0 +1,24 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The 'gce-ssd-retain' storage class provisions a pd-ssd from GCE and
+# specifies the 'Retain' reclaim policy.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gce-ssd-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain

--- a/prow/cluster/github-cache_deployment.yaml
+++ b/prow/cluster/github-cache_deployment.yaml
@@ -1,0 +1,71 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app: github-cache
+  name: github-cache
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: github-cache
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: github-cache
+  name: github-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: github-cache
+spec:
+  replicas: 1 
+  template:
+    metadata:
+      labels:
+        app: github-cache
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.13.11
+        ports:
+        - containerPort: 80 
+        volumeMounts:
+        - name: conf
+          mountPath: /etc/nginx
+        - name: cache
+          mountPath: /cache
+      volumes:
+      - name: conf
+        configMap:
+          name: github-cache
+      - name: cache
+        persistentVolumeClaim:
+          claimName: github-cache

--- a/prow/cluster/github-cache_deployment.yaml
+++ b/prow/cluster/github-cache_deployment.yaml
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    app: github-cache
-  name: github-cache
-spec:
-  capacity:
-    storage: 100Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  gcePersistentDisk:
-    pdName: github-cache
-    fsType: ext4
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -40,6 +24,14 @@ spec:
   resources:
     requests:
       storage: 100Gi
+  # gce-ssd-retain is specified in prow/cluster/gce-ssd-retain_storageclass.yaml
+  #
+  # If you are setting up your own Prow instance you can do any of the following:
+  # 1) Delete this to use the default storage class for your cluster.
+  # 2) Specify your own storage class.
+  # 3) If you are using GKE you can use the gce-ssd-retain storage class. It can be
+  #    created with: `kubectl create -f prow/cluster/gce-ssd-retain_storageclass.yaml
+  storageClassName: gce-ssd-retain
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/prow/cluster/github-cache_service.yaml
+++ b/prow/cluster/github-cache_service.yaml
@@ -1,0 +1,28 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: github-cache
+  name: github-cache
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: github-cache
+  type: NodePort

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         args:
         - --dry-run=false
         - --slack-token-file=/etc/slack/token
+        - --github-endpoint=http://github-cache
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -32,6 +32,7 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --github-endpoint=http://github-cache
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false
+        - --github-endpoint=http://github-cache
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         image: gcr.io/k8s-prow/tide:v20180411-68d5d28e8
         args:
         - --dry-run=false
+        - --github-endpoint=http://github-cache
         ports:
           - name: http
             containerPort: 8888

--- a/prow/github-cache/nginx.conf
+++ b/prow/github-cache/nginx.conf
@@ -1,0 +1,24 @@
+events {
+  worker_connections  1024;
+}
+
+http {
+  # use 2 directory levels for cache storage.
+  # 100mb of cache-key memory
+  # no 'max_size' value => use all available disk space for caching.
+  # delete cache entries after 48h
+  # write cache files directly to their cache location instead of moving them
+  proxy_cache_path /cache levels=1:2 keys_zone=my_cache:100m inactive=48h use_temp_path=off;
+  server {
+    proxy_cache my_cache; # enables the cache
+    listen 80;
+    location / {
+        if ($http_user_agent ~ (GoogleHC) ) {
+          return 200;
+        }
+        proxy_cache_revalidate on; # use Last-Modified headers
+        proxy_cache_lock on; # serialize requests for uncached items so that only first request costs a token.
+        proxy_pass https://api.github.com;
+    }
+  }
+}

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -141,6 +141,8 @@ config_updater:
       name: config
     prow/plugins.yaml:
       name: plugins
+    prow/github-cache/nginx.conf:
+      name: github-cache
 
 plugins:
   google/cadvisor:


### PR DESCRIPTION
The plan is to try this out and see if we have any problems with it before we are actually depend on it. If we encounter problems we can easily bypass the nginx server by deleting the `--github-endpoint` args from the deployment specs.

I've tried this out in a test cluster and it seems to be caching and passing authentication properly. Requests for unchanged resources don't cost any API tokens!

I'm also looking into a read token pool.

/cc @BenTheElder @stevekuznetsov 
/area prow