### PR TITLE
create testgrid conformance dashboard, populate with gci-gce job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11320,6 +11320,23 @@
       "sig-multicluster"
     ]
   },
+  "ci-kubernetes-gce-conformance": {
+    "args": [
+      "--env=KUBERNETES_CONFORMANCE_TEST=y",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
   "ci-kubernetes-integration-beta": {
     "args": [
       "--branch=release-1.10",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14393,6 +14393,18 @@ periodics:
     - name: docker-graph
       emptyDir: {}
 
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180405-7df977424-master
 - interval: 2h
   name: ci-kubernetes-integration-beta
   agent: kubernetes

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -45,6 +45,7 @@ var (
 		"redhat",
 	}
 	orgs = []string{
+		"conformance",
 		"presubmits",
 		"sig",
 		"wg",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2497,6 +2497,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-poseidon-verify
   num_columns_recent: 20
 
+
+# conformance tests
+- name: ci-kubernetes-gce-conformance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance
+
 # Add New Testgroups Here
 
 #
@@ -2504,6 +2509,16 @@ test_groups:
 #
 
 dashboards:
+- name: conformance-all
+  dashboard_tab:
+  - name: gci-gce
+    test_group_name: ci-kubernetes-gce-conformance
+
+- name: conformance-gce
+  dashboard_tab:
+  - name: gci-gce
+    test_group_name: ci-kubernetes-gce-conformance
+
 - name: canonical-ubuntu1-k8sbeta
   dashboard_tab:
   - name: e2enode-ubuntu1-k8sbeta-gkespec
@@ -5809,3 +5824,8 @@ dashboard_groups:
     - sig-autoscaling-cluster-autoscaler
     - sig-autoscaling-hpa
     - sig-autoscaling-vpa
+
+- name: conformance
+  dashboard_names:
+  - conformance-all
+  - conformance-gce


### PR DESCRIPTION
we'll add more jobs here in the future to cover more environments, I just want to get something up covering the conformance suite specifically and start a dashboard. in the future a job like this should probably be master-blocking...