### PR TITLE
Updating multicluster ingress test job to use kubekins-e2e image

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -596,7 +596,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-test:1.11-v20180402-74c08e269
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180405-7df977424-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -14772,7 +14772,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-test:1.11-v20180402-74c08e269
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180405-7df977424-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src


### PR DESCRIPTION
As per discussion in https://github.com/kubernetes/test-infra/pull/7604#issuecomment-379418028

cc @G-Harmon @BenTheElder @krzyzacy 