### PR TITLE
Do not use calico for cri-containerd test.

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -7,7 +7,7 @@ KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd
 KUBE_LOAD_IMAGE_COMMAND=/home/containerd/usr/local/bin/ctr cri load
-NETWORK_POLICY_PROVIDER=calico
+NETWORK_PROVIDER=
 NON_MASQUERADE_CIDR=0.0.0.0/0
 KUBELET_TEST_ARGS=--runtime-cgroups=/runtime
 # TODO(random-liu): Enable this after kubernetes/kubernetes#55141 is fixed.


### PR DESCRIPTION
Depends on https://github.com/containerd/cri/pull/724.

Use containerd naive cni instead of calico.

/hold
Signed-off-by: Lantao Liu <lantaol@google.com>