### PR TITLE
Remove unused log streaming logic

### DIFF
--- a/prow/cmd/deck/jobs_test.go
+++ b/prow/cmd/deck/jobs_test.go
@@ -17,10 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/test-infra/prow/kube"
@@ -45,13 +42,6 @@ type fpkc string
 func (f fpkc) GetLog(pod string) ([]byte, error) {
 	if pod == "wowowow" || pod == "powowow" {
 		return []byte(f), nil
-	}
-	return nil, fmt.Errorf("pod not found: %s", pod)
-}
-
-func (f fpkc) GetLogStream(pod string, options map[string]string) (io.ReadCloser, error) {
-	if pod == "wowowow" {
-		return ioutil.NopCloser(bytes.NewBuffer([]byte("wow"))), nil
 	}
 	return nil, fmt.Errorf("pod not found: %s", pod)
 }

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -108,13 +108,6 @@ func (f flc) GetJobLog(job, id string) ([]byte, error) {
 	return nil, errors.New("muahaha")
 }
 
-func (f flc) GetJobLogStream(job, id string, options map[string]string) (io.ReadCloser, error) {
-	if job == "job" && id == "123" {
-		return ioutil.NopCloser(bytes.NewBuffer([]byte("hello\r\n"))), nil
-	}
-	return nil, errors.New("muahaha")
-}
-
 func TestHandleLog(t *testing.T) {
 	var testcases = []struct {
 		name string
@@ -139,11 +132,6 @@ func TestHandleLog(t *testing.T) {
 		{
 			name: "id and job, found",
 			path: "?job=job&id=123",
-			code: http.StatusOK,
-		},
-		{
-			name: "id and job, found",
-			path: "?job=job&id=123&follow=true",
 			code: http.StatusOK,
 		},
 		{

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -528,14 +528,6 @@ func (c *Client) GetLog(pod string) ([]byte, error) {
 	})
 }
 
-func (c *Client) GetLogStream(pod string, options map[string]string) (io.ReadCloser, error) {
-	c.log("GetLogStream", pod)
-	return c.requestRetryStream(&request{
-		path:  fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.namespace, pod),
-		query: options,
-	})
-}
-
 func (c *Client) CreateConfigMap(content ConfigMap) (ConfigMap, error) {
 	c.log("CreateConfigMap")
 	var retConfigMap ConfigMap


### PR DESCRIPTION
The log streaming endpoint is not functional at the moment and we do not
make use of it anywhere. This patch removes dead code.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @rmmh @BenTheElder @kargakis 
/assign @cjwagner 