### PR TITLE
Add a branch whitelist to tide queries

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -85,12 +85,13 @@ func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
 
 // TideQuery is turned into a GitHub search query. See the docs for details:
 // https://help.github.com/articles/searching-issues-and-pull-requests/
-// If we choose to add orgs or branches then be sure to update the logic
-// for listing all PRs in the tide package.
+// If we choose to add orgs then be sure to update the logic for listing all
+// PRs in the tide package.
 type TideQuery struct {
 	Repos []string `json:"repos,omitempty"`
 
 	ExcludedBranches []string `json:"excludedBranches,omitempty"`
+	IncludedBranches []string `json:"includedBranches,omitempty"`
 
 	Labels        []string `json:"labels,omitempty"`
 	MissingLabels []string `json:"missingLabels,omitempty"`
@@ -105,6 +106,9 @@ func (tq *TideQuery) Query() string {
 	}
 	for _, b := range tq.ExcludedBranches {
 		toks = append(toks, fmt.Sprintf("-base:\"%s\"", b))
+	}
+	for _, b := range tq.IncludedBranches {
+		toks = append(toks, fmt.Sprintf("base:\"%s\"", b))
 	}
 	for _, l := range tq.Labels {
 		toks = append(toks, fmt.Sprintf("label:\"%s\"", l))

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -224,6 +224,19 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery) (string, int) {
 		}
 	}
 
+	// if no whitelist is configured, the target is OK by default
+	targetBranchWhitelisted := len(q.IncludedBranches) == 0
+	for _, includedBranch := range q.IncludedBranches {
+		if string(pr.BaseRef.Name) == includedBranch {
+			targetBranchWhitelisted = true
+		}
+	}
+
+	if !targetBranchWhitelisted {
+		desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)
+		diff += 1
+	}
+
 	var missingLabels []string
 	for _, l1 := range q.Labels {
 		var found bool


### PR DESCRIPTION
In addition to a blacklist for queries, we should support a whitelist or
a mix of the two for users that need to lock down their tide operations.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area tide
/kind bug
fixes https://github.com/kubernetes/test-infra/issues/7608
/cc @kargakis @BenTheElder 
/assign @cjwagner 