### PR TITLE
Instantiate a reference to options structs in utils

### DIFF
--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -25,8 +25,8 @@ import (
 )
 
 func main() {
-	o := clonerefs.Options{}
-	if err := options.Load(&o); err != nil {
+	o := &clonerefs.Options{}
+	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}
 

--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -24,8 +24,8 @@ import (
 )
 
 func main() {
-	o := entrypoint.Options{}
-	if err := options.Load(&o); err != nil {
+	o := &entrypoint.Options{}
+	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}
 

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -28,8 +28,8 @@ import (
 )
 
 func main() {
-	o := gcsupload.Options{}
-	if err := options.Load(&o); err != nil {
+	o := &gcsupload.Options{}
+	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}
 

--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -30,8 +30,8 @@ import (
 )
 
 func main() {
-	o := initupload.Options{}
-	if err := options.Load(&o); err != nil {
+	o := &initupload.Options{}
+	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}
 

--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -24,8 +24,8 @@ import (
 )
 
 func main() {
-	o := sidecar.Options{}
-	if err := options.Load(&o); err != nil {
+	o := &sidecar.Options{}
+	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}
 


### PR DESCRIPTION
For loading to work correctly, the original variable needs to be a
reference instead of taking the reference for the Load call.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @cjwagner 