### PR TITLE
add rpmbuild to kubekins

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -30,10 +30,13 @@ ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p /go/src/k8s.io/kubernetes \
     && ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 
-# preinstall graphviz package for graphing profiles
-# also install bc for shell to junit
+# preinstall:
+# - graphviz package for graphing profiles
+# - bc for shell to junit
+# - rpmbuild for building RPMs with Bazel
 RUN apt-get install -y bc \
-    graphviz
+    graphviz \
+    rpmbuild
 # preinstall this for kops tests xref kubetest prepareAws(...)
 # TODO(bentheelder,krzyzacy,justisb,chrislovecnm): remove this
 RUN pip install awscli


### PR DESCRIPTION
see: https://github.com/kubernetes/kubernetes/pull/61633#issuecomment-379934306

/area images
/shrug

we'll need to follow up with:
- making the bazel caching config version tooling based on rpmbuild version
- bumping bootstrap
- bumping kubekins on top of bootstrap