### PR TITLE
Use explicit JSON fields for embedded options in sidecar

### DIFF
--- a/prow/cmd/sidecar/README.md
+++ b/prow/cmd/sidecar/README.md
@@ -9,24 +9,28 @@ This utility is intended to be used with [`entrypoint`](./../sidecar/README.md),
 write the files watched by this utility.
 
 `sidecar` can be configured by either passing in flags or by specifying a full set of options
-as JSON in the `$SIDECAR_OPTIONS` environment variable, which the same form as that for
+as JSON in the `$SIDECAR_OPTIONS` environment variable, which has the same form as that for
 `gcsupload`, plus the `"process_log"` and `"marker_file"` fields. See
 [that documentation](./../gcsupload/README.md) for an explanation.
 
 ```json
 {
-    "process_log": "/logs/process-log.txt",
-    "marker_file": "/logs/marker-file.txt",
-    "bucket": "kubernetes-jenkins",
-    "sub_dir": "",
-    "items": [
-        "/logs/artifacts/"
-    ],
-    "path_strategy": "legacy",
-    "default_org": "kubernetes",
-    "default_repo": "kubernetes",
-    "gcs_credentials_file": "/secrets/gcs/service-account.json",
-    "dry_run": "false"
+    "wrapper_options": {
+        "process_log": "/logs/process-log.txt",
+        "marker_file": "/logs/marker-file.txt"
+    },
+    "gcs_options": {
+        "bucket": "kubernetes-jenkins",
+        "sub_dir": "",
+        "items": [
+            "/logs/artifacts/"
+        ],
+        "path_strategy": "legacy",
+        "default_org": "kubernetes",
+        "default_repo": "kubernetes",
+        "gcs_credentials_file": "/secrets/gcs/service-account.json",
+        "dry_run": "false"
+    }
 }
 ```
 

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -19,8 +19,6 @@ package sidecar
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
-	"os"
 
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
@@ -30,8 +28,8 @@ import (
 // for defining the process being watched and
 // where in GCS an upload will land.
 type Options struct {
-	GcsOptions     *gcsupload.Options `json:"-"`
-	WrapperOptions *wrapper.Options   `json:"-"`
+	GcsOptions     *gcsupload.Options `json:"gcs_options"`
+	WrapperOptions *wrapper.Options   `json:"wrapper_options"`
 }
 
 // Validate ensures that the set of options are
@@ -71,28 +69,6 @@ func (o *Options) BindOptions(flags *flag.FlagSet) {
 // Complete internalizes command line arguments
 func (o *Options) Complete(args []string) {
 	o.GcsOptions.Complete(args)
-}
-
-// ResolveOptions will resolve the set of options, preferring
-// to use the full JSON configuration variable but falling
-// back to user-provided flags if the variable is not
-// provided.
-func ResolveOptions() (*Options, error) {
-	options := &Options{}
-	if jsonConfig, provided := os.LookupEnv(JSONConfigEnvVar); provided {
-		if err := json.Unmarshal([]byte(jsonConfig), &options); err != nil {
-			return options, fmt.Errorf("could not resolve config from env: %v", err)
-		}
-		return options, nil
-	}
-
-	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	gcsupload.BindOptions(options.GcsOptions, fs)
-	wrapper.BindOptions(options.WrapperOptions, fs)
-	fs.Parse(os.Args[1:])
-	options.GcsOptions.Complete(fs.Args())
-
-	return options, nil
 }
 
 // Encode will encode the set of options in the format that


### PR DESCRIPTION
There is no way to get Go to serialize two different embedded structs
with the same name both into inline fields in JSON. Instead of
defaulting to the camel-case field names, we should use snake-case to be
consistent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @kargakis 
/assign @cjwagner 

Unfortunately could not get side-by-side inline serialization to work and a custom JSON serialization is not worth it.