### PR TITLE
Remove '+' tokens from query string in PR overview

### DIFF
--- a/prow/cmd/deck/static/pr-script.js
+++ b/prow/cmd/deck/static/pr-script.js
@@ -42,7 +42,7 @@ function createXMLHTTPRequest(fulfillFn, errorHandler) {
  * @return {string}
  */
 function getPRQuery(q) {
-    const tokens = q.split(" ");
+    const tokens = q.replace(/\+/g, " ").split(" ");
     // Firstly, drop all pr/issue search tokens
     let result = tokens.filter(tkn => {
         tkn = tkn.trim();


### PR DESCRIPTION
These are valid in the query but should be replaced with spaces for
nicer rendering.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @BenTheElder 
/assign @qhuynh96 