### PR TITLE
Stop using the cherrypick-auto-approve munger for k/k

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -3,7 +3,7 @@ app: misc-mungers
 http-cache-dir: /cache/httpcache
 organization: kubernetes
 project: kubernetes
-pr-mungers: cherrypick-auto-approve,label-unapproved-picks,path-label,stale-green-ci,comment-deleter,milestone-maintainer
+pr-mungers: label-unapproved-picks,path-label,stale-green-ci,comment-deleter,milestone-maintainer
 state: open
 token-file: /etc/secret-volume/token
 period: 60s


### PR DESCRIPTION
Based on talking to folks on slack and mailing lists, I think we'd be better off if the `cherrypick-auto-approve` munger was disabled.  Many don't even know that it exists, those that do find it confusing or insufficient.  We're all pretty much used to `cherrypick-approved` being a label that the branch/patch manager manually applies to PR's.

I anticipate we can come up with something more intuitive down the line with prow's /cherrypick command, but for now how about we disable the confusing thing.

@liggitt
since you raised concerns over how cherry picking works today

@kubernetes/sig-release-pr-reviews @kubernetes/sig-contributor-experience-pr-reviews
this affects cherry picking

/cc @wojtek-t @jpbetz @mbohlool @MaciekPytel
patch release managers

/cc @calebamiles @krzyzacy
v1.11 branch managers

/hold
for comment from the above