### PR TITLE
entrypoint: send SIGTERM after timeout, SIGKILL after grace period

### DIFF
--- a/prow/cmd/entrypoint/README.md
+++ b/prow/cmd/entrypoint/README.md
@@ -16,8 +16,11 @@ as JSON in the `$ENTRYPOINT_OPTIONS` environment variable, which has the form:
         "/bin/ls",
         "-la"
     ],
-    "timeout_minutes": 10,
+    "timeout": 7200000000000,
+    "grace_period": 15000000000,
     "process_log": "/logs/process-log.txt",
     "marker_file": "/logs/marker-file.txt",
 }
 ```
+
+Note: the `"timeout"` and `"grace_period"` fields hold the duration in nanoseconds.

--- a/prow/entrypoint/options.go
+++ b/prow/entrypoint/options.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"time"
 
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
 )
@@ -28,8 +29,15 @@ import (
 // for defining the process being watched and
 // where in GCS an upload will land.
 type Options struct {
-	Args           []string `json:"args"`
-	TimeoutMinutes int      `json:"timeout_minutes"`
+	// Args is the process and args to run
+	Args []string `json:"args"`
+	// Timeout determines how long to wait before the
+	// entrypoint sends SIGINT to the process
+	Timeout time.Duration `json:"timeout"`
+	// GracePeriod determines how long to wait after
+	// sending SIGINT before the entrypoint sends
+	// SIGKILL.
+	GracePeriod time.Duration `json:"grace_period"`
 
 	*wrapper.Options
 }
@@ -64,7 +72,8 @@ func (o *Options) LoadConfig(config string) error {
 
 // BindOptions binds flags to options
 func (o *Options) BindOptions(flags *flag.FlagSet) {
-	flags.IntVar(&o.TimeoutMinutes, "timeout", DefaultTimeoutMinutes, "Timeout for the test command.")
+	flags.DurationVar(&o.Timeout, "timeout", DefaultTimeout, "Timeout for the test command.")
+	flags.DurationVar(&o.GracePeriod, "grace-period", DefaultGracePeriod, "Grace period after timeout for the test command.")
 	wrapper.BindOptions(o.Options, flags)
 }
 

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,10 +99,14 @@ type ProwJobSpec struct {
 	// need to be cloned, determined from config
 	ExtraRefs []*Refs `json:"extra_refs,omitempty"`
 
-	// TimeoutMinutes is the number of minutes that
-	// the pod utilities will wait before aborting
+	// Timeout is how long the pod utilities will wait
+	// before aborting a job with SIGINT. Only applicable
+	// if decorating the PodSpec.
+	Timeout time.Duration `json:"timeout,omitempty"`
+	// GracePeriod is how long the pod utilities will wait
+	// after sending SIGINT to send SIGKILL when aborting
 	// a job. Only applicable if decorating the PodSpec.
-	TimeoutMinutes int `json:"timeout_minutes,omitempty"`
+	GracePeriod time.Duration `json:"grace_period,omitempty"`
 	// Report determines if the result of this job should
 	// be posted as a status on GitHub
 	Report bool `json:"report,omitempty"`


### PR DESCRIPTION
Test processes may have clean-up or artifact collection trapped on
SIGTERM, so we should allow them time to execute these steps before
sending SIGKILL.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
fixes https://github.com/kubernetes/test-infra/issues/7506
/assign @fejta 

Going to work on a test for this routine in general for https://github.com/kubernetes/test-infra/issues/7508