### PR TITLE
add a presubmit for the release repo

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -13086,6 +13086,25 @@
       "sig-scheduling"
     ]
   },
+  "pull-release-null-e2e": {
+    "args": [
+      "--build=bazel",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/pull-kubernetes-e2e.env",
+      "--extract=local",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-release-null-e2e",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\]",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
   "pull-test-infra-bazel": {
     "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
     "args": [],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5601,6 +5601,34 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
 
+  kubernetes/release:
+  - name: pull-release-null-e2e
+    agent: kubernetes
+    context: pull-release-null-e2e
+    rerun_command: "/test pull-release-null-e2e"
+    trigger: "(?m)^/test (all|pull-release-null-e2e),?(\\s+|$)"
+    always_run: true
+    labels:
+      preset-service-account: true
+      preset-k8s-ssh: true
+      preset-bazel-scratch-dir: true
+      preset-bazel-remote-cache-enabled: true
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes
+        - --repo=k8s.io/release=$(PULL_REFS)
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180410-27f5a5388-master
+        resources:
+          requests:
+            memory: "6Gi"
+
   kubernetes/test-infra:
   - name: pull-test-infra-bazel
     agent: kubernetes


### PR DESCRIPTION
this job should:
- build a quick release (well, with bazel)
- stage the cluster using the release scripts in the PR
- up a cluster
- e2e "test" with zero matching tests
- down the cluster

That should be enough to verify that we can correctly stage a build from the scripts in that PR

/area jobs
