### PR TITLE
enable trigger for release repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -274,6 +274,9 @@ plugins:
   - approve
   - blunderbuss
 
+  kubernetes/release:
+  - trigger
+
   kubernetes/repo-infra:
   - approve
 


### PR DESCRIPTION
TODO(followup): looks like the release repo also needs OWNERS if we want to add approve / tide in the future