### PR TITLE
Enable pure go for branchprotector image

### DIFF
--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -10,7 +10,7 @@ k8s_object(
     name = "oneshot",
     cluster = "{STABLE_PROW_CLUSTER}",
     image_chroot = "{STABLE_DOCKER_REPO}",
-    images = prow_tags("branchprotector"),
+    images = {"gcr.io/k8s-testimages/branchprotector:latest": ":image"},
     kind = "Job",
     template = ":oneshot-job.yaml",
 )
@@ -65,5 +65,6 @@ filegroup(
 go_binary(
     name = "branchprotector",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
/assign @ixdy @BenTheElder 

`prow_tags()` macro seems to break `k8s_object` here (may have never worked).

Enable pure go binary for this image.