### PR TITLE
Release presubmit improvements

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -13086,7 +13086,7 @@
       "sig-scheduling"
     ]
   },
-  "pull-release-null-e2e": {
+  "pull-release-cluster-up": {
     "args": [
       "--build=bazel",
       "--cluster=",
@@ -13096,7 +13096,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--stage=gs://kubernetes-release-pull/ci/pull-release-null-e2e",
+      "--stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\]",
       "--timeout=65m"
     ],

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -13097,7 +13097,7 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\]",
+      "--test_args=--ginkgo.focus=definitely-not-a-real-focus",
       "--timeout=65m"
     ],
     "scenario": "kubernetes_e2e",

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -13090,6 +13090,7 @@
     "args": [
       "--build=bazel",
       "--cluster=",
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
       "--extract=local",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5615,11 +5615,11 @@ presubmits:
         - "--clean"
 
   kubernetes/release:
-  - name: pull-release-null-e2e
+  - name: pull-release-cluster-up
     agent: kubernetes
-    context: pull-release-null-e2e
-    rerun_command: "/test pull-release-null-e2e"
-    trigger: "(?m)^/test (all|pull-release-null-e2e),?(\\s+|$)"
+    context: pull-release-cluster-up
+    rerun_command: "/test pull-release-cluster-up"
+    trigger: "(?m)^/test (all|pull-release-cluster-up),?(\\s+|$)"
     always_run: true
     labels:
       preset-service-account: true


### PR DESCRIPTION
- `pull-release-cluster-up` instead of `pull-release-null-e2e`
- don't actually run e2e tests
- skip cluster down