### PR TITLE
Fix pull-poseidon-verify job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4987,6 +4987,7 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
+        - "--timeout=45"
 
   kubernetes/release:
   - name: pull-release-cluster-up


### PR DESCRIPTION
This is to fix the failing https://k8s-testgrid.appspot.com/presubmits-misc#poseidon

the image used does not contain golint, so used the one which is used by pull-kubernetes-verify job, which obviosly has golint binary and should fix the current issue.

/cc @dhilipkumars @shivramsrivastava @deepak-vij @m1093782566 