### PR TITLE
Increase Tide status search overlap time.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -452,7 +452,7 @@ func (sc *statusController) waitSync() {
 func (sc *statusController) sync(pool []PullRequest) {
 	sc.lastSyncStart = time.Now()
 
-	sinceTime := sc.lastSuccessfulQueryStart.Add(-time.Second)
+	sinceTime := sc.lastSuccessfulQueryStart.Add(-10 * time.Second)
 	query := sc.ca.Config().Tide.Queries.AllPRsSince(sinceTime)
 	queryStartTime := time.Now()
 	allPRs, err := search(sc.ghc, sc.logger, context.Background(), query)


### PR DESCRIPTION
This will hopefully prevent PRs from missing Tide statuses.
See this slack thread: https://kubernetes.slack.com/archives/C7J9RP96G/p1523553551000728

/area prow
/kind bug
/cc @stevekuznetsov 