### PR TITLE
Refactor branchprotection config.

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -275,9 +275,9 @@ func (p *Protector) UpdateBranch(orgName, repo string, branchName string, branch
 		Org:      orgName,
 		Repo:     repo,
 		Branch:   branchName,
-		Protect:  *bp.Get().Protect,
-		Contexts: bp.Get().Contexts,
-		Pushers:  bp.Get().Pushers,
+		Protect:  *bp.Protect,
+		Contexts: bp.Contexts,
+		Pushers:  bp.Pushers,
 	}
 
 	return nil

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -275,9 +275,9 @@ func (p *Protector) UpdateBranch(orgName, repo string, branchName string, branch
 		Org:      orgName,
 		Repo:     repo,
 		Branch:   branchName,
-		Protect:  *bp.Protect,
-		Contexts: bp.Contexts,
-		Pushers:  bp.Pushers,
+		Protect:  *bp.Get().Protect,
+		Contexts: bp.Get().Contexts,
+		Pushers:  bp.Get().Pushers,
 	}
 
 	return nil

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -22,102 +22,123 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type BranchProtection struct {
-	ProtectTested bool           `json:"protect-tested-repos,omitempty"`
-	Protect       *bool          `json:"protect-by-default,omitempty"`
-	Contexts      []string       `json:"require-contexts,omitempty"`
-	Pushers       []string       `json:"allow-push,omitempty"`
-	Orgs          map[string]Org `json:"orgs,omitempty"`
-}
-
-type Org struct {
-	Protect  *bool           `json:"protect-by-default,omitempty"`
-	Contexts []string        `json:"require-contexts,omitempty"`
-	Pushers  []string        `json:"allow-push,omitempty"`
-	Repos    map[string]Repo `json:"repos,omitempty"`
-}
-
-type Repo struct {
-	Protect  *bool             `json:"protect-by-default,omitempty"`
-	Contexts []string          `json:"require-contexts,omitempty"`
-	Pushers  []string          `json:"allow-push,omitempty"`
-	Branches map[string]Branch `json:"branches,omitempty"`
-}
-
-type Branch struct {
-	Protect  *bool    `json:"protect-by-default,omitempty"`
+type PolicyStruct struct {
+	Protect *bool `json:"protect-by-default,omitempty"`
+	// TODO(fejta): add all protection options
 	Contexts []string `json:"require-contexts,omitempty"`
 	Pushers  []string `json:"allow-push,omitempty"`
 }
 
-func (bp BranchProtection) isSet() bool {
-	switch {
-	case bp.ProtectTested:
-		return true
-	case bp.Protect != nil:
-		return true
-	case len(bp.Orgs) > 0:
-		return true
-	case len(bp.Pushers) > 0:
-		return true
-	default:
-		return false
+// selectBool returns the child argument if set, otherwise the parent
+func selectBool(parent, child *bool) *bool {
+	if child != nil {
+		return child
+	}
+	return parent
+}
+
+// unionStrings merges the parent and child items together
+func unionStrings(parent, child []string) []string {
+	if child == nil {
+		return parent
+	}
+	if parent == nil {
+		return child
+	}
+	s := sets.NewString(parent...)
+	s.Insert(child...)
+	return s.List()
+}
+
+// apply returns a policy that merges the child into the parent
+func (parent PolicyStruct) Apply(child Policy) Policy {
+	p := parent.Get()
+	c := child.Get()
+	return PolicyStruct{
+		Protect:  selectBool(p.Protect, c.Protect),
+		Contexts: unionStrings(p.Contexts, c.Contexts),
+		Pushers:  unionStrings(p.Pushers, c.Pushers),
 	}
 }
 
-func (c *Config) GetBranchProtection(org, repo, branch string) (*Branch, error) {
-	if !c.BranchProtection.isSet() {
+func (p PolicyStruct) Get() PolicyStruct {
+	return p
+}
+
+type Policy interface {
+	Apply(parent Policy) Policy
+	Get() PolicyStruct
+}
+
+// BranchProtection specifies the global branch protection policy
+type BranchProtection struct {
+	PolicyStruct
+	ProtectTested bool           `json:"protect-tested-repos,omitempty"`
+	Orgs          map[string]Org `json:"orgs,omitempty"`
+}
+
+type Org struct {
+	PolicyStruct
+	Repos map[string]Repo `json:"repos,omitempty"`
+}
+
+type Repo struct {
+	PolicyStruct
+	Branches map[string]Branch `json:"branches,omitempty"`
+}
+
+type Branch struct {
+	PolicyStruct
+}
+
+func (c *Config) GetBranchProtection(org, repo, branch string) (Policy, error) {
+	var policy Policy
+	policy = c.BranchProtection
+
+	if o, ok := c.BranchProtection.Orgs[org]; ok {
+		policy = policy.Apply(o)
+		if r, ok := o.Repos[repo]; ok {
+			policy = policy.Apply(r)
+			if b, ok := r.Branches[branch]; ok {
+				policy = policy.Apply(b)
+				if policy.Get().Protect == nil {
+					return nil, fmt.Errorf("protect should not be nil")
+				}
+			}
+		}
+	} else {
 		return nil, nil
 	}
 
-	var protect *bool
-	pushers := sets.NewString()
-	contexts := sets.NewString()
-
-	update := func(b *bool, c, p []string) {
-		if b != nil {
-			protect = b
-
+	// Automatically require any required prow jobs
+	if prowContexts := branchRequirements(org, repo, branch, c.Presubmits); len(prowContexts) > 0 {
+		// Error if protection is disabled
+		if policy.Get().Protect != nil && !*policy.Get().Protect {
+			return nil, fmt.Errorf("required prow jobs require branch protection")
 		}
-		pushers.Insert(p...)
-		contexts.Insert(c...)
-	}
-
-	if c.BranchProtection.ProtectTested {
-		// Adding ProwJobs
-		prowContexts := branchRequirements(org, repo, branch, c.Presubmits)
-		if len(prowContexts) > 0 {
+		ps := PolicyStruct{
+			Contexts: prowContexts,
+			Protect:  nil,
+		}
+		// Require protection by default if ProtectTested is true
+		if c.BranchProtection.ProtectTested {
 			yes := true
-			update(&yes, prowContexts, nil)
+			ps.Protect = &yes
+		}
+		policy = policy.Apply(ps)
+	}
+
+	got := policy.Get()
+	if got.Protect != nil && !*got.Protect {
+		if len(got.Contexts) > 0 {
+			return nil, fmt.Errorf("required contexts requires branch protection")
+		}
+		if len(got.Pushers) > 0 {
+			return nil, fmt.Errorf("push restrictions requires branch protection")
 		}
 	}
 
-	update(c.BranchProtection.Protect, c.BranchProtection.Contexts, c.BranchProtection.Pushers)
-	if orgP, exists := c.BranchProtection.Orgs[org]; exists {
-		update(orgP.Protect, orgP.Contexts, orgP.Pushers)
-		if repoP, exists := orgP.Repos[repo]; exists {
-			update(repoP.Protect, repoP.Contexts, repoP.Pushers)
-			if branchP, exists := repoP.Branches[branch]; exists {
-				update(branchP.Protect, branchP.Contexts, branchP.Pushers)
-			}
-		}
-	}
-
-	if protect == nil {
-		return nil, fmt.Errorf("protect should not be nil")
-	}
-
-	if contexts.Len() > 0 || pushers.Len() > 0 {
-		if !*protect {
-			return nil, fmt.Errorf("setting pushers or contexts requires protection")
-		}
-	}
-
-	return &Branch{
-		Protect:  protect,
-		Contexts: contexts.List(),
-		Pushers:  pushers.List(),
-	}, nil
+	return policy, nil
 }
 
 func jobRequirements(jobs []Presubmit, branch string, after bool) []string {


### PR DESCRIPTION
Take advantage of embedded types.
Prepare to deprecate protection dialect in favor of github's naming.

This should make https://github.com/kubernetes/test-infra/pull/7613 easier to review

/assign @stevekuznetsov @cjwagner 