### PR TITLE
jobs/e2e_node: use --image-family for CoreOS images

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -150,21 +150,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   coreosalpha-resource1:
-    image: coreos-alpha-1478-0-0-v20170719
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   coreosalpha-resource2:
-    image: coreos-alpha-1478-0-0-v20170719
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   coreosalpha-resource3:
-    image: coreos-alpha-1478-0-0-v20170719
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
@@ -172,21 +172,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   coreosstable-resource1:
-    image: coreos-stable-1409-7-0-v20170719
+    image-family: coreos-stable
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   coreosstable-resource2:
-    image: coreos-stable-1409-7-0-v20170719
+    image-family: coreos-stable
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   coreosstable-resource3:
-    image: coreos-stable-1409-7-0-v20170719
+    image-family: coreos-stable
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1

--- a/jobs/e2e_node/image-config-1-10.yaml
+++ b/jobs/e2e_node/image-config-1-10.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-7.yaml
+++ b/jobs/e2e_node/image-config-1-7.yaml
@@ -7,7 +7,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:

--- a/jobs/e2e_node/image-config-1-8.yaml
+++ b/jobs/e2e_node/image-config-1-8.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-9.yaml
+++ b/jobs/e2e_node/image-config-1-9.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable2:

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image-family: coreos-alpha
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:


### PR DESCRIPTION
This PR replaces pinned down coreOS images in the node e2e tests with `--image-family`.
This would eliminate the need to update the coreOS image tag every time an old image gets deprecated.