### PR TITLE
split up presubmit-scale to it's own janitor job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11862,6 +11862,15 @@
       "sig-testing"
     ]
   },
+  "maintenance-pull-scale-janitor": {
+    "args": [
+      "--mode=scale"
+    ],
+    "scenario": "kubernetes_janitor",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "metrics-bigquery": {
     "args": [
       "test-infra/metrics/bigquery.py",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14706,6 +14706,25 @@ periodics:
           cpu: 5
           memory: "8Gi"
 
+- interval: 1h
+  agent: kubernetes
+  name: maintenance-pull-scale-janitor
+  labels:
+    preset-service-account: true
+  spec:
+    containers:
+    - args:
+      - --bare
+      - --timeout=30
+      - --service-account=/etc/service-account/service-account.json
+      - --upload=gs://kubernetes-jenkins/logs
+      env:
+      image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      resources:
+        requests:
+          cpu: 5
+          memory: "8Gi"
+
 - name: metrics-bigquery
   interval: 24h
   agent: kubernetes

--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -92,14 +92,16 @@ PR_PROJECTS = {
     'k8s-jkns-pr-node-e2e': 3,
     'k8s-jkns-pr-gce-gpus': 3,
     'k8s-gke-gpu-pr': 3,
+}
+
+SCALE_PROJECT = {
     'k8s-presubmit-scale': 3,
 }
 
-def check_pr_jobs():
-    """Handle PR jobs"""
-    for project, expire in PR_PROJECTS.iteritems():
+def check_predefine_jobs(jobs):
+    """Handle predefined jobs"""
+    for project, expire in jobs.iteritems():
         clean_project(project, hours=expire)
-
 
 def check_ci_jobs():
     """Handle CI jobs"""
@@ -122,7 +124,7 @@ def check_ci_jobs():
             if any(b in project for b in BLACKLIST):
                 print >>sys.stderr, 'Project %r is blacklisted in ci-janitor' % project
                 continue
-            if project in PR_PROJECTS:
+            if project in PR_PROJECTS or project in SCALE_PROJECT:
                 continue # CI janitor skips all PR jobs
             found = project
         if found:
@@ -137,7 +139,9 @@ def check_ci_jobs():
 def main(mode):
     """Run janitor for each project."""
     if mode == 'pr':
-        check_pr_jobs()
+        check_predefine_jobs(PR_PROJECTS)
+    if mode == 'scale':
+        check_predefine_jobs(SCALE_PROJECT)
     else:
         check_ci_jobs()
 
@@ -154,7 +158,7 @@ if __name__ == '__main__':
     FAILED = []
     PARSER = argparse.ArgumentParser()
     PARSER.add_argument(
-        '--mode', default='ci', choices=['ci', 'pr'],
+        '--mode', default='ci', choices=['ci', 'pr', 'scale'],
         help='Which type of projects to clear')
     ARGS = PARSER.parse_args()
     main(ARGS.mode)

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -649,6 +649,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/maintenance-ci-janitor
 - name: maintenance-pull-janitor
   gcs_prefix: kubernetes-jenkins/logs/maintenance-pull-janitor
+- name: maintenance-pull-scale-janitor
+  gcs_prefix: kubernetes-jenkins/logs/maintenance-pull-scale-janitor
 - name: ci-kubernetes-build-debian-unstable
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-debian-unstable
 - name: ci-kubernetes-e2e-gke-large-teardown
@@ -5116,6 +5118,11 @@ dashboards:
   - name: pull-janitor
     description: Deletes old GCP resources from presubmit jobs
     test_group_name: maintenance-pull-janitor
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: pull-scale-janitor
+    description: Deletes old GCP resources from scalability presubmit jobs
+    test_group_name: maintenance-pull-scale-janitor
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: retester


### PR DESCRIPTION
so that it won't affect regular presubmit janitor runs, and has it's own compute resources

/assign @BenTheElder 
cc @shyamjvs  