### PR TITLE
Bump timeout of manual-network test && fix image ref

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -670,7 +670,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--env=GCE_GLBC_IMAGE=k8s.gcr.io/ingress-gce-glbc-amd64:1.1.0",
+      "--env=GCE_GLBC_IMAGE=k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.0",
       "--extract=ci/latest",
       "--gcp-project-type=ingress-project",
       "--gcp-zone=us-central1-f",
@@ -4714,7 +4714,7 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --ginkgo.skip=\\[Unreleased\\] --minStartupPods=8",
-      "--timeout=90m"
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9479,7 +9479,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=110
+      - --timeout=200
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180410-27f5a5388-master
 
@@ -10469,7 +10469,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180410-27f5a5388-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
-  # interval: 12h #expensive test, 
+  # interval: 12h #expensive test,
   cron: "0 0 31 2 *" # inactive, set to Feb.31st so it will never be triggered
   agent: kubernetes
   labels:


### PR DESCRIPTION
- Bump timeout of manual-network test
  - New tests were added and one of them takes awhile due to frequent ingress changes. The test has been timing out ever since the addition.
  - https://k8s-testgrid.appspot.com/sig-network-gce#gce-ingress-manual-network
- Fix GLBC image tag
  - https://k8s-testgrid.appspot.com/sig-network-ingress-gce-e2e#ingress-gce-upgrade-e2e