### PR TITLE
Disable calico for containerd test.

### DIFF
--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -7,7 +7,7 @@ KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd
 KUBE_LOAD_IMAGE_COMMAND=/home/containerd/usr/local/bin/ctr cri load
-NETWORK_POLICY_PROVIDER=calico
+NETWORK_PROVIDER=
 NON_MASQUERADE_CIDR=0.0.0.0/0
 KUBELET_TEST_ARGS=--runtime-cgroups=/system.slice/containerd.service
 # TODO(random-liu): Enable this after kubernetes/kubernetes#55141 is fixed.


### PR DESCRIPTION
The `cri` version in containerd has been updated https://github.com/containerd/containerd/pull/2290, we can disable calico now.

Signed-off-by: Lantao Liu <lantaol@google.com>