### PR TITLE
whitelist lavalamp for feature branch management

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -120,6 +120,7 @@ slack:
     - jpbetz # 1.8 patch release manager
     - mbohlool # 1.9 patch release manager
     - calebamiles # 1.10 branch manager
+    - lavalamp # feature-serverside-apply "branch manager"
   - repos:
     - kubernetes/test-infra
     channels:


### PR DESCRIPTION
lavalamp and team are working on [a feature branch](https://github.com/kubernetes/kubernetes/tree/feature-serverside-apply) for server side apply, which currently requires some manual merges / rebase and force push. If merged this PR would whitelist lavalamp's merges to the mergewarnings slack integration.

Holding for discussion.
/hold
