### PR TITLE
Change merge method for kube-deploy repo to squash commits

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -176,6 +176,7 @@ tide:
     kubeflow: squash
     kubernetes/charts: squash
     kubernetes/dashboard: squash
+    kubernetes/kube-deploy: squash
     kubernetes/website: squash
   target_url: https://prow.k8s.io/tide.html
 


### PR DESCRIPTION
This changes merge method for kube-deploy repo so PRs have commits squashed.

@kubernetes/kube-deploy-maintainers 