### PR TITLE
Set up plugins (incl. blunderbuss) and tide for cluster-api

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -92,6 +92,9 @@ branch-protection:
       protect-by-default: true
       require-contexts:
       - cla/linuxfoundation
+      repos:
+        cluster-api:
+          protect-by-default: true
 
 tide:
   queries:
@@ -162,6 +165,7 @@ tide:
     - do-not-merge/work-in-progress
     reviewApprovedRequired: true
   - repos:
+    - kubernetes-sigs/cluster-api
     - kubernetes-sigs/testing_frameworks
     - kubernetes-sigs/poseidon
     labels:
@@ -178,6 +182,7 @@ tide:
     kubernetes/dashboard: squash
     kubernetes/kube-deploy: squash
     kubernetes/website: squash
+    kubernetes-sigs/cluster-api: squash
   target_url: https://prow.k8s.io/tide.html
 
 push_gateway:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -58,6 +58,7 @@ approve:
   implicit_self_approve: true
 - repos:
   - kubernetes-sigs
+  - kubernetes-sigs/cluster-api
   implicit_self_approve: true
 
 blockades:
@@ -345,6 +346,11 @@ plugins:
   - skip
   - wip
   - yuks
+
+  kubernetes-sigs/cluster-api:
+  - approve
+  - blunderbuss
+  - trigger
 
   kubernetes-sigs/testing_frameworks:
   - approve

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -58,7 +58,6 @@ approve:
   implicit_self_approve: true
 - repos:
   - kubernetes-sigs
-  - kubernetes-sigs/cluster-api
   implicit_self_approve: true
 
 blockades:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -346,11 +346,6 @@ plugins:
   - wip
   - yuks
 
-  kubernetes-sigs/cluster-api:
-  - approve
-  - blunderbuss
-  - trigger
-
   kubernetes-sigs/testing_frameworks:
   - approve
   - trigger


### PR DESCRIPTION
Initial automation setup for cluster-api similar to kube-deploy (which is the source repo where most of the cluster-api code is coming from).

cc @krousey @kris-nova @spiffxp @kubernetes/kube-deploy-maintainers 