### PR TITLE
Revert "Increase frequency of ci-kubernetes-e2e-gci-gce-scalability-beta"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9579,7 +9579,7 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180410-27f5a5388-master
 
-- interval: 1h
+- cron: "0 */6 * * *" # every six hours
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-scalability-beta
   tags:


### PR DESCRIPTION
Reverts kubernetes/test-infra#7666

Since we no longer seem to need it.

/cc @wojtek-t 
fyi - @MaciekPytel 