### PR TITLE
Use 1.8 and 1.9 branch heads for GCI testing and retire old jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2828,23 +2828,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "ci-kubernetes-e2e-gce-gci-qa-m63": {
-    "args": [
-      "--check-leaked-resources",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-63",
-      "--gcp-project-type=gci-qa-project",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel=25",
-      "--provider=gce",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=50m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
   "ci-kubernetes-e2e-gce-gci-qa-m64": {
     "args": [
       "--check-leaked-resources",
@@ -2866,7 +2849,7 @@
     "args": [
       "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-65",
+      "--extract=gci/gci-65/latest-1.8",
       "--gcp-project-type=gci-qa-project",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=25",
@@ -2883,7 +2866,7 @@
     "args": [
       "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-66",
+      "--extract=gci/gci-66/latest-1.9",
       "--gcp-project-type=gci-qa-project",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=25",
@@ -2913,22 +2896,6 @@
       "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gce-gci-qa-serial-m63": {
-    "args": [
-      "--check-leaked-resources",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-63",
-      "--gcp-project-type=gci-qa-project",
-      "--gcp-zone=us-central1-f",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m64": {
     "args": [
       "--check-leaked-resources",
@@ -2949,7 +2916,7 @@
     "args": [
       "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-65",
+      "--extract=gci/gci-65/latest-1.8",
       "--gcp-project-type=gci-qa-project",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
@@ -2965,7 +2932,7 @@
     "args": [
       "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-66",
+      "--extract=gci/gci-66/latest-1.8",
       "--gcp-project-type=gci-qa-project",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
@@ -2987,23 +2954,6 @@
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=300m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
-  "ci-kubernetes-e2e-gce-gci-qa-slow-m63": {
-    "args": [
-      "--check-leaked-resources",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-63",
-      "--gcp-project-type=gci-qa-project",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel=25",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8243,19 +8243,6 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gci-qa-m63
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180413-ff6991978-master
-
-- interval: 30m
-  agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-m64
   labels:
     preset-service-account: true
@@ -8308,19 +8295,6 @@ periodics:
 
 - interval: 1h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gci-qa-serial-m63
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - args:
-      - --timeout=320
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180413-ff6991978-master
-
-- interval: 1h
-  agent: kubernetes
   name: ci-kubernetes-e2e-gce-gci-qa-serial-m64
   labels:
     preset-service-account: true
@@ -8368,19 +8342,6 @@ periodics:
     containers:
     - args:
       - --timeout=320
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180413-ff6991978-master
-
-- interval: 2h
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gci-qa-slow-m63
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - args:
-      - --timeout=170
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180413-ff6991978-master
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -299,8 +299,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-ci-serial-master
 - name: ci-kubernetes-e2e-gce-gci-ci-slow-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-ci-slow-master
-- name: ci-kubernetes-e2e-gce-gci-qa-m63
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-m63
 - name: ci-kubernetes-e2e-gce-gci-qa-m64
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-m64
 - name: ci-kubernetes-e2e-gce-gci-qa-m65
@@ -309,8 +307,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-m66
 - name: ci-kubernetes-e2e-gce-gci-qa-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-master
-- name: ci-kubernetes-e2e-gce-gci-qa-serial-m63
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-serial-m63
 - name: ci-kubernetes-e2e-gce-gci-qa-serial-m64
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-serial-m64
 - name: ci-kubernetes-e2e-gce-gci-qa-serial-m65
@@ -319,8 +315,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-serial-m66
 - name: ci-kubernetes-e2e-gce-gci-qa-serial-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-serial-master
-- name: ci-kubernetes-e2e-gce-gci-qa-slow-m63
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-slow-m63
 - name: ci-kubernetes-e2e-gce-gci-qa-slow-m64
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-slow-m64
 - name: ci-kubernetes-e2e-gce-gci-qa-slow-m65
@@ -2925,8 +2919,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-gci-ci-serial-master
   - name: ci-slow-master
     test_group_name: ci-kubernetes-e2e-gce-gci-ci-slow-master
-  - name: qa-m63
-    test_group_name: ci-kubernetes-e2e-gce-gci-qa-m63
   - name: qa-m64
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-m64
   - name: qa-m65
@@ -2935,8 +2927,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-m66
   - name: qa-master
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-master
-  - name: qa-serial-m63
-    test_group_name: ci-kubernetes-e2e-gce-gci-qa-serial-m63
   - name: qa-serial-m64
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-serial-m64
   - name: qa-serial-m65
@@ -2945,8 +2935,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-serial-m66
   - name: qa-serial-master
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-serial-master
-  - name: qa-slow-m63
-    test_group_name: ci-kubernetes-e2e-gce-gci-qa-slow-m63
   - name: qa-slow-m64
     test_group_name: ci-kubernetes-e2e-gce-gci-qa-slow-m64
   - name: qa-slow-m65


### PR DESCRIPTION
This is a variant of https://github.com/kubernetes/test-infra/issues/7646.
The GCI test jobs always pin to the built-in version of k8s, which are
broken by the newer gcloud cli used by the infra to launch jobs. Both
1.8 and 1.9 have been patched, but no release has been made so far. This
change uses the `gciCi` extract strategy to pick up the latest CI
version on the older branches so the tests will pass again.

Also, remove jobs for GCI m63 which is deprecated now.

@krzyzacy @rmmh @adityakali @kubernetes/goog-image 