### PR TITLE
Prow: Use git credentials where needed.

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -164,6 +164,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting git client.")
 	}
+	defer gitClient.Clean()
 	// Get the bot's name in order to set credentials for the git client.
 	botName, err := githubClient.BotName()
 	if err != nil {

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -111,6 +111,12 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting git client.")
 	}
 	defer gc.Clean()
+	// Get the bot's name in order to set credentials for the git client.
+	botName, err := ghcSync.BotName()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot name.")
+	}
+	gc.SetCredentials(botName, oauthSecret)
 
 	c := tide.NewController(ghcSync, ghcStatus, kc, configAgent, gc, nil)
 	defer c.Shutdown()

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -134,10 +134,10 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 	c.lockRepo(repo)
 	defer c.unlockRepo(repo)
 
-	remote := c.base + "/" + repo
+	base := c.base
 	user, pass := c.getCredentials()
 	if user != "" && pass != "" {
-		remote = fmt.Sprintf("https://%s:%s@%s/%s", user, pass, github, repo)
+		base = fmt.Sprintf("https://%s:%s@%s", user, pass, github)
 	}
 	cache := filepath.Join(c.dir, repo) + ".git"
 	if _, err := os.Stat(cache); os.IsNotExist(err) {
@@ -146,6 +146,7 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 		if err := os.Mkdir(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
+		remote := fmt.Sprintf("%s/%s", base, repo)
 		if b, err := retryCmd(c.logger, "", c.git, "clone", "--mirror", remote, cache); err != nil {
 			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
 		}
@@ -169,7 +170,7 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 		Dir:    t,
 		logger: c.logger,
 		git:    c.git,
-		base:   c.base,
+		base:   base,
 		repo:   repo,
 		user:   user,
 		pass:   pass,


### PR DESCRIPTION
This PR:
1. Makes Prow's git client use credentials when checking out PRs.
1. Makes Tide use an authenticated git client.

fixes: https://github.com/openshift/release/issues/762
This should also make plugins that checkout PRs (like `golint` and `buildifier`) work in private repos.

/cc @stevekuznetsov @kargakis @adrcunha @mattmoor 