### PR TITLE
Adding logic for the new sigs.k8s.io redirect

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -205,6 +205,8 @@ def repository(repo, ssh):
     """Return the url associated with the repo."""
     if repo.startswith('k8s.io/'):
         repo = 'github.com/kubernetes/%s' % (repo[len('k8s.io/'):])
+    elif repo.startswith('sigs.k8.io/'):
+        repo = 'github.com/kubernetes-sigs/%s' % (repo[len('sigs.k8s.io/'):])
     elif repo.startswith('istio.io/'):
         repo = 'github.com/istio/%s' % (repo[len('istio.io/'):])
     if ssh:


### PR DESCRIPTION
Specifically to fix https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cluster-api-build/15

```console
I0417 13:18:59.097] Call:  git fetch --quiet --tags https://sigs.k8s.io/cluster-api master
W0417 13:18:59.500] remote: Please upgrade your git client.
W0417 13:18:59.501] remote: GitHub.com no longer supports git over dumb-http: https://github.com/blog/809-git-dumb-http-transport-to-be-turned-off-in-90-days
W0417 13:18:59.501] fatal: unable to access 'https://sigs.k8s.io/cluster-api/': The requested URL returned error: 403
E0417 13:18:59.505] Command failed
```