### PR TITLE
Update containerd test based on new bootstrapping logic.

### DIFF
--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -1,8 +1,8 @@
 ### job-env
 # Envs for containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=/workspace/github.com/containerd/cri/test/containerd/pkg-prefix,deploy-path=/workspace/github.com/containerd/cri/test/containerd/deploy-path
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,pkg-prefix=/workspace/github.com/containerd/cri/test/containerd/pkg-prefix,deploy-path=/workspace/github.com/containerd/cri/test/containerd/deploy-path
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/containerd/env
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/containerd/env
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -1,8 +1,8 @@
 ### job-env
 # Envs for containerd.
 LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
-KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh
-KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/env
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/test/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/env
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/run/containerd/containerd.sock
 KUBE_CONTAINER_RUNTIME_NAME=containerd


### PR DESCRIPTION
Depends on https://github.com/containerd/cri/pull/740.

/hold
Signed-off-by: Lantao Liu <lantaol@google.com>