### PR TITLE
Fallback to approvers as reviewers

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -131,7 +131,6 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 			return err
 		}
 		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
 			if !excludeApprovers {
 				// Attempt to use approvers as additional reviewers. This must use
 				// reviewerCount instead of missing because owners can be both reviewers
@@ -144,15 +143,18 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 				}
 				combinedReviewers := sets.NewString(reviewers...)
 				combinedReviewers.Insert(approvers...)
-				log.Warnf("Added %d approvers as reviewers. %d/%d reviewers found.", combinedReviewers.Len()-len(reviewers), combinedReviewers.Len(), *reviewerCount)
+				log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", combinedReviewers.Len()-len(reviewers), combinedReviewers.Len(), *reviewerCount)
 				reviewers = combinedReviewers.List()
 			}
+		}
+		if missing := *reviewerCount - len(reviewers); missing > 0 {
+			log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
 		}
 	}
 
 	if len(reviewers) > 0 {
 		if maxReviewers > 0 && len(reviewers) > maxReviewers {
-			log.Warnf("Limiting request of %d reviewers to %d maxReviewers.", len(reviewers), maxReviewers)
+			log.Infof("Limiting request of %d reviewers to %d maxReviewers.", len(reviewers), maxReviewers)
 			reviewers = reviewers[:maxReviewers]
 		}
 		log.Infof("Requesting reviews from users %s.", reviewers)

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -60,10 +60,33 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-type ownersClient interface {
+type reviewersClient interface {
 	FindReviewersOwnersForFile(path string) string
 	Reviewers(path string) sets.String
 	LeafReviewers(path string) sets.String
+}
+
+type ownersClient interface {
+	reviewersClient
+	FindApproverOwnersForFile(path string) string
+	Approvers(path string) sets.String
+	LeafApprovers(path string) sets.String
+}
+
+type fallbackReviewersClient struct {
+	ownersClient
+}
+
+func (foc fallbackReviewersClient) FindReviewersOwnersForFile(path string) string {
+	return foc.ownersClient.FindApproverOwnersForFile(path)
+}
+
+func (foc fallbackReviewersClient) Reviewers(path string) sets.String {
+	return foc.ownersClient.Approvers(path)
+}
+
+func (foc fallbackReviewersClient) LeafReviewers(path string) sets.String {
+	return foc.ownersClient.LeafApprovers(path)
 }
 
 type githubClient interface {
@@ -87,11 +110,12 @@ func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) err
 		pc.PluginConfig.Blunderbuss.ReviewerCount,
 		pc.PluginConfig.Blunderbuss.FileWeightCount,
 		pc.PluginConfig.Blunderbuss.MaxReviewerCount,
+		pc.PluginConfig.Blunderbuss.ExcludeApprovers,
 		&pre,
 	)
 }
 
-func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount, oldReviewCount *int, maxReviewers int, pre *github.PullRequestEvent) error {
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount, oldReviewCount *int, maxReviewers int, excludeApprovers bool, pre *github.PullRequestEvent) error {
 	changes, err := ghc.GetPullRequestChanges(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
 	if err != nil {
 		return fmt.Errorf("error getting PR changes: %v", err)
@@ -107,12 +131,28 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 			return err
 		}
 		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), reviewerCount)
+			log.Warnf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
+			if !excludeApprovers {
+				// Attempt to use approvers as additional reviewers. This must use
+				// reviewerCount instead of missing because owners can be both reviewers
+				// and approvers and the search might stop too early if it finds
+				// duplicates.
+				frc := fallbackReviewersClient{ownersClient: oc}
+				approvers, err := getReviewers(frc, pre.PullRequest.User.Login, changes, *reviewerCount)
+				if err != nil {
+					return err
+				}
+				combinedReviewers := sets.NewString(reviewers...)
+				combinedReviewers.Insert(approvers...)
+				log.Warnf("Added %d approvers as reviewers. %d/%d reviewers found.", combinedReviewers.Len()-len(reviewers), combinedReviewers.Len(), *reviewerCount)
+				reviewers = combinedReviewers.List()
+			}
 		}
 	}
 
 	if len(reviewers) > 0 {
 		if maxReviewers > 0 && len(reviewers) > maxReviewers {
+			log.Warnf("Limiting request of %d reviewers to %d maxReviewers.", len(reviewers), maxReviewers)
 			reviewers = reviewers[:maxReviewers]
 		}
 		log.Infof("Requesting reviews from users %s.", reviewers)
@@ -121,20 +161,20 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 	return nil
 }
 
-func getReviewers(owners ownersClient, author string, files []github.PullRequestChange, minReviewers int) ([]string, error) {
+func getReviewers(rc reviewersClient, author string, files []github.PullRequestChange, minReviewers int) ([]string, error) {
 	authorSet := sets.NewString(author)
 	reviewers := sets.NewString()
 	leafReviewers := sets.NewString()
 	ownersSeen := sets.NewString()
 	// first build 'reviewers' by taking a unique reviewer from each OWNERS file.
 	for _, file := range files {
-		ownersFile := owners.FindReviewersOwnersForFile(file.Filename)
+		ownersFile := rc.FindReviewersOwnersForFile(file.Filename)
 		if ownersSeen.Has(ownersFile) {
 			continue
 		}
 		ownersSeen.Insert(ownersFile)
 
-		fileUnusedLeafs := owners.LeafReviewers(file.Filename).Difference(reviewers).Difference(authorSet)
+		fileUnusedLeafs := rc.LeafReviewers(file.Filename).Difference(reviewers).Difference(authorSet)
 		if fileUnusedLeafs.Len() == 0 {
 			continue
 		}
@@ -150,7 +190,7 @@ func getReviewers(owners ownersClient, author string, files []github.PullRequest
 		if reviewers.Len() >= minReviewers {
 			break
 		}
-		fileReviewers := owners.Reviewers(file.Filename).Difference(authorSet)
+		fileReviewers := rc.Reviewers(file.Filename).Difference(authorSet)
 		for reviewers.Len() < minReviewers && fileReviewers.Len() > 0 {
 			reviewers.Insert(popRandom(fileReviewers))
 		}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -199,6 +199,11 @@ type Blunderbuss struct {
 	// reviews from. Selects reviewers based on file weighting.
 	// This and request_count are mutually exclusive options.
 	FileWeightCount *int `json:"file_weight_count,omitempty"`
+	// ExcludeApprovers controls whether approvers are considered to be
+	// reviewers. By default, approvers are considered as reviewers if
+	// insufficient reviewers are available. If ExcludeApprovers is true,
+	// approvers will never be considered as reviewers.
+	ExcludeApprovers bool `json:"exclude_approvers,omitempty"`
 }
 
 // Owners contains configuration related to handling OWNERS files.


### PR DESCRIPTION
If the newly added blunderbuss option `ApproverFallback` is true, the reviewer selection method will attempt to add approvers to the list if there aren't enough qualifying reviewers to satisfy the requested reviewer count.

While the implementation works and is tested with mixed approver and reviewer lists, this feature is most useful for projects that don't have a reviewer role and thus have OWNERS files containing only approver lists. Those projects should now enable the `ApproverFallback` option to have Blunderbuss select reviewers from approver lists.

/kind feature
/area prow

/assign @cjwagner
/cc @rsdcastro @fejta

Fixes #7691