### PR TITLE
Update list of jobs used to compute PR consistency

### DIFF
--- a/metrics/configs/pr-consistency-config.yaml
+++ b/metrics/configs/pr-consistency-config.yaml
@@ -41,14 +41,12 @@ query: |
           and job in ( /* only consider merge-blocking jobs */
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
-            'pr:pull-kubernetes-e2e-gce', /* 2017-10-17, replaced pull-kubernetes-e2e-gce-etcd3 */
-            'pr:pull-kubernetes-e2e-gce-etcd3',
+            'pr:pull-kubernetes-e2e-gce',
             'pr:pull-kubernetes-e2e-kops-aws',
-            'pr:pull-kubernetes-integration', /* 2018-02-28, renamed from pull-kubernetes-unit */
+            'pr:pull-kubernetes-integration',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
-            'pr:pull-kubernetes-unit',
-            'pr:pull-kubernetes-typecheck', /* 2018-03-14, marked as required */
+            'pr:pull-kubernetes-typecheck',
             'pr:pull-kubernetes-verify',
           )
       )

--- a/metrics/configs/pr-consistency-config.yaml
+++ b/metrics/configs/pr-consistency-config.yaml
@@ -41,11 +41,14 @@ query: |
           and job in ( /* only consider merge-blocking jobs */
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
+            'pr:pull-kubernetes-e2e-gce', /* 2017-10-17, replaced pull-kubernetes-e2e-gce-etcd3 */
             'pr:pull-kubernetes-e2e-gce-etcd3',
             'pr:pull-kubernetes-e2e-kops-aws',
+            'pr:pull-kubernetes-integration', /* 2018-02-28, renamed from pull-kubernetes-unit */
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
             'pr:pull-kubernetes-unit',
+            'pr:pull-kubernetes-typecheck', /* 2018-03-14, marked as required */
             'pr:pull-kubernetes-verify',
           )
       )

--- a/metrics/configs/weekly-consistency-config.yaml
+++ b/metrics/configs/weekly-consistency-config.yaml
@@ -38,14 +38,12 @@ query: |
           and job in ( /* only consider merge-blocking jobs */
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
-            'pr:pull-kubernetes-e2e-gce', /* 2017-10-17, replaced pull-kubernetes-e2e-gce-etcd3 */
-            'pr:pull-kubernetes-e2e-gce-etcd3',
+            'pr:pull-kubernetes-e2e-gce',
             'pr:pull-kubernetes-e2e-kops-aws',
-            'pr:pull-kubernetes-integration', /* 2018-02-28, renamed from pull-kubernetes-unit */
+            'pr:pull-kubernetes-integration',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
-            'pr:pull-kubernetes-unit',
-            'pr:pull-kubernetes-typecheck', /* 2018-03-14, marked as required */
+            'pr:pull-kubernetes-typecheck',
             'pr:pull-kubernetes-verify',
           )
         having kind=='pull'

--- a/metrics/configs/weekly-consistency-config.yaml
+++ b/metrics/configs/weekly-consistency-config.yaml
@@ -38,11 +38,14 @@ query: |
           and job in ( /* only consider merge-blocking jobs */
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
+            'pr:pull-kubernetes-e2e-gce', /* 2017-10-17, replaced pull-kubernetes-e2e-gce-etcd3 */
             'pr:pull-kubernetes-e2e-gce-etcd3',
             'pr:pull-kubernetes-e2e-kops-aws',
+            'pr:pull-kubernetes-integration', /* 2018-02-28, renamed from pull-kubernetes-unit */
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
             'pr:pull-kubernetes-unit',
+            'pr:pull-kubernetes-typecheck', /* 2018-03-14, marked as required */
             'pr:pull-kubernetes-verify',
           )
         having kind=='pull'


### PR DESCRIPTION
Noticed we've added/replaced some jobs while gathering 
data for my Kubecon EU talk. I found it useful to keep
the old jobs in the query for historical purposes but
I could see removing them too. Longer term it'd be useful
to have blocking status as part of job output, or date
ranges for when jobs are considered blocking.