### PR TITLE
Make pull-test-infra-verify-labels blocking

### DIFF
--- a/hack/verify-labels.sh
+++ b/hack/verify-labels.sh
@@ -27,6 +27,6 @@ DIFF=$(diff "${TMP_LABELS_DOCS}" "${TESTINFRA_ROOT}/label_sync/labels.md" || tru
 if [ ! -z "$DIFF" ]; then
     echo "${DIFF}"
     echo ""
-    echo "labels.yaml was updated without updating labels.md, please run 'hack/update-labels.sh'"
+    echo "FAILED: labels.yaml was updated without updating labels.md, please run 'hack/update-labels.sh'"
     exit 1
 fi

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -25,10 +25,10 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="close/duplicate" href="#close/duplicate">`close/duplicate`</a> | TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)| humans | |
-| <a id="close/needs-information" href="#close/needs-information">`close/needs-information`</a> | TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)| humans | |
-| <a id="close/not-reproducible" href="#close/not-reproducible">`close/not-reproducible`</a> | TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)| humans | |
-| <a id="close/unresolved" href="#close/unresolved">`close/unresolved`</a> | TODO, see [kubernetes/test-infra#7251](https://github.com/kubernetes/test-infra/issues/7251)| humans | |
+| <a id="triage/duplicate" href="#triage/duplicate">`triage/duplicate`</a> | Indicates an issue is a duplicate of other open issue. The usage should be supported by adding triage findings as an issue comment. <br><br> This was previously `close/duplicate`, | humans | |
+| <a id="triage/needs-information" href="#triage/needs-information">`triage/needs-information`</a> | Indicates an issue needs more information in order to work on it. The usage should be supported by adding triage findings as an issue comment. <br><br> This was previously `close/needs-information`, | humans | |
+| <a id="triage/not-reproducible" href="#triage/not-reproducible">`triage/not-reproducible`</a> | Indicates an issue can not be reproduced as described. The usage should be supported by adding triage findings as an issue comment. <br><br> This was previously `close/not-reproducible`, | humans | |
+| <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not be resolved. The usage should be supported by adding triage findings as an issue comment. <br><br> This was previously `close/unresolved`, | humans | |
 | <a id="committee/conduct" href="#committee/conduct">`committee/conduct`</a> | Denotes an issue or PR intended to be handled by the (as of yet non-existent) code of conduct committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="committee/steering" href="#committee/steering">`committee/steering`</a> | Denotes an issue or PR intended to be handled by the kubernetes steering committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | Categorizes issue or PR as related to a bug.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5306,8 +5306,6 @@ presubmits:
     rerun_command: "/test pull-test-infra-verify-labels"
     trigger: "/test pull-test-infra-verify-labels"
     run_if_changed: '^label_sync'
-    always_run: false # introduce job as non-blocking
-    skip_report: true # introduce job as non-blocking
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true


### PR DESCRIPTION
Looks like #7554 didn't update label docs

I believe using a non-empty `run_if_changed` makes `always_run: false` redundant

Also
- run hack/update-labels.sh to fix the existing error
- add some fail for gubernator to highlight