### PR TITLE
Remove deprecated InitialResources admission plugin

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env
@@ -5,6 +5,6 @@ MAX_INSTANCES_PER_MIG=2
 KUBE_AUTOSCALER_MIN_NODES=1
 KUBE_AUTOSCALER_MAX_NODES=6
 KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-KUBE_ADMISSION_CONTROL=NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
+KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
 ENABLE_POD_PRIORITY=true
 

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-autoscaling.env
@@ -5,5 +5,5 @@ KUBE_ENABLE_CLUSTER_AUTOSCALER=true
 KUBE_AUTOSCALER_MIN_NODES=3
 KUBE_AUTOSCALER_MAX_NODES=6
 KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-KUBE_ADMISSION_CONTROL=NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
+KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,Priority
 ENABLE_POD_PRIORITY=true


### PR DESCRIPTION
kubernetes/kubernetes#58784 removed this plugin. Since then, API server fails in autoscaling tests on GCE with: 

```
I0418 11:09:02.668891       1 server.go:750] Initializing cache sizes based on 180MB limit
Error: admission-control plugin "InitialResources" is unknown
```
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling/6463/artifacts/ca-master/kube-apiserver.log
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling/6463