### PR TITLE
Disable checking leaked resource for prometheus job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3359,7 +3359,6 @@
   },
   "ci-kubernetes-e2e-gce-prometheus": {
     "args": [
-      "--check-leaked-resources",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-prometheus.env",
       "--extract=ci/latest",
       "--gcp-zone=us-central1-f",


### PR DESCRIPTION
Prometheus addon creates dynamic persistent PVC.
It's impossible to clean it during test suite and not safe enough to delete dynamically named Volume during kube-down. 
This PR disables checking of leaked resources so tests can succeed. We will depend on janitor cleaning created volumes.

/cc @shyamjvs 