### PR TITLE
Add test jobs for ingress release branches

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -619,7 +619,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:latest",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:master",
       "--env=GCE_ALPHA_FEATURES=NetworkEndpointGroup",
       "--env=KUBE_GCE_ENABLE_IP_ALIASES=true",
       "--extract=ci/latest",
@@ -628,6 +628,57 @@
       "--ginkgo-parallel=1",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|\\[Feature:NEG\\]",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-ingress-gce-e2e-mci-dev": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:mci-dev",
+      "--extract=ci/latest",
+      "--gcp-project-type=ingress-project",
+      "--ginkgo-parallel=1",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-ingress-gce-e2e-release-1-0": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:1.0",
+      "--extract=ci/latest",
+      "--gcp-project-type=ingress-project",
+      "--ginkgo-parallel=1",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-ingress-gce-e2e-release-1-1": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:1.1",
+      "--extract=ci/latest",
+      "--gcp-project-type=ingress-project",
+      "--ginkgo-parallel=1",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|",
       "--timeout=320m"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6383,6 +6383,42 @@ periodics:
       args:
       - "--timeout=340"
       - "--bare"
+- name: ci-ingress-gce-e2e-mci-dev
+  agent: kubernetes
+  interval: 60m
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180417-006059177-master
+      args:
+      - "--timeout=340"
+      - "--bare"
+- name: ci-ingress-gce-e2e-release-1-0
+  agent: kubernetes
+  interval: 480m
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180417-006059177-master
+      args:
+      - "--timeout=340"
+      - "--bare"
+- name: ci-ingress-gce-e2e-release-1-1
+  agent: kubernetes
+  interval: 240m
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180417-006059177-master
+      args:
+      - "--timeout=340"
+      - "--bare"
 - name: ci-ingress-gce-e2e-scale
   agent: kubernetes
   interval: 6h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -171,6 +171,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-image-push
 - name: ci-ingress-gce-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e
+- name: ci-ingress-gce-e2e-release-1-0
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-0
+- name: ci-ingress-gce-e2e-release-1-1
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-1
+- name: ci-ingress-gce-e2e-mci-dev
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-mci-dev
 - name: ci-ingress-gce-e2e-scale
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-scale
 - name: ci-ingress-gce-upgrade-e2e
@@ -4654,6 +4660,18 @@ dashboards:
   dashboard_tab:
   - name: ingress-gce-e2e
     test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-release-1.0
+    test_group_name: ci-ingress-gce-e2e-release-1-0
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-release-1.1
+    test_group_name: ci-ingress-gce-e2e-release-1-1
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e-mci-dev
+    test_group_name: ci-ingress-gce-e2e-mci-dev
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-ipvs-gce-e2e


### PR DESCRIPTION
This adds config for three new jobs, each targeting a branch on k/ingress-gce.

For now, I would like to manage all this manually. Later, I am going to try to figure out how to reuse the test generation stuff to make this a little easier.

/assign @krzyzacy 
/cc @MrHohn  