### PR TITLE
Filter out stale and rotten PRs in merge conflict analysis

### DIFF
--- a/experiment/find-merge-conflicts.sh
+++ b/experiment/find-merge-conflicts.sh
@@ -53,7 +53,9 @@ conflicting_prs=()
 page=0
 while true; do
   page=$((page + 1))
-  open_prs=$("${GHCURL[@]}" "https://api.github.com/repos/${ORG}/${REPO}/pulls?base=master&per_page=100&page=${page}" | jq -r '.[].number')
+  # Select only PRs that have not been tagged as stale or rotten.
+  open_prs=$("${GHCURL[@]}" "https://api.github.com/repos/${ORG}/${REPO}/pulls?base=master&per_page=100&page=${page}" |\
+    jq -r '.[] | select(.labels | map(.name != "lifecycle/stale" and .name != "lifecycle/rotten") | all) | .number')
   [[ -z "${open_prs}" ]] && break
   for pr in ${open_prs}; do
     mergeable=$("${GHCURL[@]}" -sfSL "https://api.github.com/repos/${ORG}/${REPO}/pulls/${pr}" | jq -r '.mergeable')


### PR DESCRIPTION
We can make the analysis a little more meaningful by ignoring PRs which are abandoned (and thus likely to have more merge conflicts, and also conflicts on files that may no longer exist).

Two interesting results from this:

There are plenty of conflicts on non-generated files
```console
$ grep -v '^*' ~/k-k-conflicts.txt | sort | uniq -c | sort -rn | head -n 20
     11 pkg/kubelet/kubelet.go
      9 staging/src/k8s.io/api/core/v1/generated.pb.go
      9 pkg/kubectl/cmd/create.go
      7 pkg/kubectl/cmd/BUILD
      6 pkg/proxy/ipvs/proxier.go
      5 pkg/proxy/iptables/proxier.go
      5 pkg/controller/route/route_controller.go
      5 cmd/kubelet/app/server.go
      4 vendor/BUILD
      4 pkg/registry/core/service/rest.go
      4 pkg/kubelet/rkt/rkt.go
      4 pkg/features/kube_features.go
      4 hack/local-up-cluster.sh
      4 hack/.golint_failures
      4 cmd/kubelet/app/options/options.go
      4 cmd/kube-controller-manager/app/options/options.go
      3 staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/BUILD
      3 pkg/registry/core/service/rest_test.go
      3 pkg/proxy/iptables/proxier_test.go
      3 pkg/printers/internalversion/describe.go
```

When we group by "kind", then generated files are the top 5.
```console
$ grep -v '^*' ~/k-k-conflicts.txt | sed 's|^.*/\([^/]*\)$|\1|' | sort | uniq -c | sort -rn | head -n 20
     89 BUILD
     87 zz_generated.deepcopy.go
     37 zz_generated.conversion.go
     34 zz_generated.defaults.go
     25 types.go
     16 README.md
     13 proxier.go
     13 clientset.go
     11 kubelet.go
     11 generated.pb.go
     10 server.go
     10 create.go
      9 options.go
      8 util.go
      8 admission_test.go
      7 storage.go
      7 Makefile
      6 rest.go
      6 kube_features.go
      5 types_swagger_doc_generated.go
```

/assign @fejta 