### PR TITLE
Autogo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//autogo:all-srcs",
         "//boskos:all-srcs",
         "//def:all-srcs",
         "//dind/cmd/cluster-up:all-srcs",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -443,3 +443,14 @@ pip_import(
 load("@kettle_deps//:requirements.bzl", "pip_install")
 
 pip_install()
+
+load("//autogo:deps.bzl", "autogo_dependencies")
+
+autogo_dependencies()
+
+load("//autogo:def.bzl", "autogo_generate")
+
+autogo_generate(
+    name = "autogo",
+    prefix = "k8s.io/test-infra",
+)

--- a/autogo/BUILD.bazel
+++ b/autogo/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["shadow.go"],
+    importpath = "k8s.io/test-infra/autogo",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "autogo",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["shadow_test.go"],
+    embed = [":go_default_library"],
+)

--- a/autogo/README.md
+++ b/autogo/README.md
@@ -1,0 +1,55 @@
+# Automatically generate bazel rules for go packages
+
+This uses [gazelle] to generate and update [bazel] rules for golang packages without
+adding new `BUILD.bazel` files to the repository.
+
+## Usage
+
+See options for [installing bazel].
+
+```
+# Install bazel
+brew install bazel # See https://docs.bazel.build/versions/master/install.html
+
+# Create a bazel WORKSPACE file in your repo root
+echo >WORKSPACE <<END
+git_repository(
+  name = "fejta_autogo",
+  remote = "https://github.com/fejta/test-infra.git",
+  commit = "f478925cc6179f1abf6245698aaf514d873cfcc9",
+)
+load("@fejta_autogo//autogo:deps.bzl", "autogo_dependencies")
+autogo_dependencies()
+load("@fejta_autogo//autogo:def.bzl", "autogo_generate")
+autogo_generate(
+    name = "autogo",
+    prefix = "github.com/golang/dep", # change to your go get path
+)
+END
+
+# Create an empty BUILD.bazel file (needed by bazel)
+touch BUILD.bazel
+
+# Use bazel with an @autogo prefix to access the auto-generated repo
+bazel query @autogo//...
+bazel run @autogo//path/to/my/cmd/binary
+```
+
+
+## Demo
+
+Add bazel support to [dep]:
+
+```
+git clone https://github.com/fejta/dep  # golang/dep + a WORKSPACE file
+cd dep && ls WORKSPACE
+bazel run @autogo//cmd/dep -- help
+```
+
+See the [concrete] `WORKSPACE` that enables this.
+
+[bazel]: https://bazel.build
+[concrete]: https://github.com/fejta/dep/blob/master/WORKSPACE
+[dep]: http://github.com/golang/dep
+[gazelle]: https://github.com/bazelbuild/bazel-gazelle
+[installing bazel]: https://docs.bazel.build/versions/master/install.html

--- a/autogo/def.bzl
+++ b/autogo/def.bzl
@@ -1,0 +1,89 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_context")
+
+def _impl(repo_ctx):
+  print("Generating @%s//... rules for %s..." % (repo_ctx.name, repo_ctx.attr.prefix))
+  # tell gazelle which package it is generating
+  prefix = repo_ctx.attr.prefix
+  # find the gazelle binary for the host env
+  gazelle = repo_ctx.path(repo_ctx.attr._gazelle)
+  # get the path to the root workspace
+  root_workspace = repo_ctx.path(repo_ctx.attr._workspace).dirname
+
+  go = repo_ctx.path(repo_ctx.attr._go)
+  shadow = repo_ctx.path(repo_ctx.attr._shadow)
+
+
+  # Create a shadow copy of root_workspace in the repo workspace
+
+  # First, delete anything we created last time
+  # TODO(fejta): massively unoptimized, but expedient way to ensure correctness
+  _exec(repo_ctx, ["rm", "-rf", repo_ctx.path(".")])
+  _exec(repo_ctx, ["touch", repo_ctx.path("BUILD.bazel")]) # required by bazel
+  # Update the timestamp of the autogo binary, invalidating the autogo result cache.
+  # Critically, this ensures that we reevaluate the root workspace for any changes.
+  # Otherwise, if a file/package is added/deleted/moved we will not notice and not rerun gazelle.
+  _exec(repo_ctx, ["touch", shadow])
+  # Create a shadow copy of root workspace (clone the dir tree, symlinks in relevant files)
+  _exec(repo_ctx, [go, "run", shadow, root_workspace, repo_ctx.path(".")])
+  # Run gazelle to auto-create rules
+  _exec(repo_ctx, [gazelle, "--repo_root", repo_ctx.path(""), "--go_prefix", repo_ctx.attr.prefix])
+
+_autogo_generate = repository_rule(
+    implementation=_impl,
+    local=True,
+    attrs={
+        "prefix": attr.string(mandatory=True),
+        "_go": attr.label(
+            allow_single_file=True,
+            default="@go_sdk//:bin/go"),
+        "_workspace": attr.label(
+            allow_single_file=True,
+            default="@//:WORKSPACE"),
+        "_shadow": attr.label(
+            allow_single_file=True,
+            default="//autogo:shadow.go"),
+        "_gazelle": attr.label(
+            default="@io_bazel_rules_go_repository_tools//:bin/gazelle",
+            allow_single_file=True),
+        },
+)
+
+def autogo_generate(name="autogo", **kw):
+  """Generates automatic rules for go packages at @name (usually @autogo).
+
+  Usage:
+    autogo_generate(name="autogo", prefix="github.com/my/go/get/path")
+  """
+  if "go_sdk" not in native.existing_rules():
+      go_rules_dependencies()
+      go_register_toolchains()
+  for need in ["go_sdk", "io_bazel_rules_go_repository_tools"]:
+      if need not in native.existing_rules():
+          fail("expected go_rules_dependencies() to load %s" % need)
+  _autogo_generate(name=name, **kw)
+
+def _exec(repo_ctx, cmd, quiet=True, **kw):
+  """Run a command and fail if it returns non-zero."""
+  # set quiet=False to help debugging
+  ret = repo_ctx.execute(cmd, quiet=quiet, **kw)
+  if ret.return_code:
+    if not quiet:
+      print(cmd, "returned", ret.return_code)
+      print("out:", ret.stdout)
+      print("err:", ret.stderr)
+    fail(cmd)
+  return ret

--- a/autogo/deps.bzl
+++ b/autogo/deps.bzl
@@ -1,0 +1,22 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def autogo_dependencies():
+  """Ensure we load all the rules autogo depends on (mainly go/gazelle)."""
+  if "io_bazel_rules_go" not in native.existing_rules():
+    print("Creating @io_bazel_rules_go...")
+    native.git_repository(
+        name = "io_bazel_rules_go",
+        tag = "0.11.0",
+        remote = "https://github.com/bazelbuild/rules_go.git")

--- a/autogo/shadow.go
+++ b/autogo/shadow.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// autogo creates a shadow copy of the go packages at origin in a destination.
+//
+// In other words this program will walk the directory tree at origin
+// and for each:
+// * directory - create a directory with the same name in destination
+// * go-related-file - link the file into the matching destination directory
+//
+// The effect is similar to:
+//   rsync -zarv --include="*/" --include="*.sh" --exclude="*" "$from" "$to"
+// TODO(fejta): investigate just using rsync?
+//
+// The intended use case of this program is with the autogo_generate in //autogo:def.bzl. This rule will clone your primary workspace into an autogo workspace, and then run gazelle to generate rules for go packages.
+//
+// Usage:
+//   autogo -- <ORIGIN_DIR> <DEST_DIR>
+//
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// main calls shadowClone and exits non-zero on failure
+func main() {
+	if n := len(os.Args); n != 3 {
+		log.Printf("Expected 2 args, not %d", n)
+		log.Fatalf("Usage: %s <ORIGIN> <DEST>", filepath.Base(os.Args[0]))
+	}
+	if err := shadowClone(os.Args[1], os.Args[2]); err != nil {
+		log.Fatalf("Failed to clone %s to %s: %v", os.Args[1], os.Args[2], err)
+	}
+}
+
+// shadowClone walks origin to clone the directory structure and link files at the destination.
+func shadowClone(origin, dest string) error {
+	v := visitor{
+		origin: origin,
+		dest:   dest,
+	}
+	return filepath.Walk(v.origin, v.visit)
+}
+
+// action does something with the current file (mkdir or link)
+type action func(origin string, info os.FileInfo, dest string) error
+
+// visitor stores the origin we're cloning from and destination we clone to.
+type visitor struct {
+	// origin is the path we read to determine what to clone
+	origin string
+	// dest is where we clone
+	dest string
+}
+
+// visit chooses and then performs the right action for the current path
+func (v visitor) visit(path string, info os.FileInfo, verr error) error {
+	act, dest, err := v.choose(path, info, verr)
+	if err != nil {
+		return err
+	}
+	if act == nil {
+		return nil
+	}
+	return act(path, info, dest)
+}
+
+// choose looks at the current path and returns the appropriate action:
+// - testdata directory => skip it and everything under it
+// - directory => create the directory
+// - go file (.go, .s) => create it at dest
+// - other files => do nothing
+// TODO(fejta): consider including .proto in the mix
+func (v visitor) choose(path string, info os.FileInfo, verr error) (action, string, error) {
+	if verr != nil {
+		return nil, "", fmt.Errorf("failed to walk to %s: %v", path, verr)
+	}
+
+	// If origin is /foo/bar and we receive /foo/bar/something/special
+	// Change this to something/special
+	r, err := filepath.Rel(v.origin, path)
+	// First ensure the path is a child of origin
+	if err != nil {
+		return nil, "", fmt.Errorf("%q is not relative to %q: %v", path, v.origin, err)
+	}
+	if r == ".." || strings.HasPrefix(r, "../") {
+		return nil, "", fmt.Errorf("%q is not a child of %q", path, v.origin)
+	}
+
+	// TODO(fejta): handle symlink loops better
+	// Many repos (dep is one) have testdata folders which are
+	// either symlink loops back to some other part of the repo
+	// or else intentionally do not compile.
+	//
+	// The gazelle tool is not robust to packages containing files that fail to compile.
+	//
+	// For now just ignore these testdata folders (usually in vendored packages). This makes bazel build work at the cost of breaking bazel test
+	if info.IsDir() && strings.HasSuffix(path, "/testdata") {
+		log.Printf("Skipping %s...", path)
+		return nil, "", filepath.SkipDir
+	}
+
+	d := filepath.Join(v.dest, r)
+	// Create dirs
+	if info.IsDir() {
+		return mkdir, d, nil
+	}
+
+	if strings.Contains(path, "/testdata/") {
+		return nil, "", fmt.Errorf("%s is within a testdata dir, which should not happen", path)
+	}
+
+	// Ignore files irrelevant to go
+	if !strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, ".s") {
+		// Assume .go and .s are the only relevant files to a build
+		// TODO(fejta): consider adding BUILD and BUILD.bazel files, or at least the go rules within them
+		return nil, "", nil
+	}
+
+	// Link in golang files
+	return link, d, nil
+}
+
+// mkdir creates directories for dest
+func mkdir(_ string, info os.FileInfo, dest string) error {
+	if err := os.MkdirAll(dest, info.Mode()); err != nil {
+		return fmt.Errorf("failed to create %q: %v", dest, err)
+	}
+	return nil
+}
+
+// link clones source at dest
+func link(source string, _ os.FileInfo, dest string) error {
+	// First try a hard link
+	if err := os.Link(source, dest); err == nil {
+		return nil
+	}
+
+	// If that fails require a symlink
+	return os.Symlink(source, dest)
+}

--- a/autogo/shadow_test.go
+++ b/autogo/shadow_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+type fakeInfo struct {
+	dir bool
+}
+
+func (i fakeInfo) Name() string {
+	return "fake"
+}
+
+func (i fakeInfo) Size() int64 {
+	return 0
+}
+func (i fakeInfo) Mode() os.FileMode {
+	return 0
+}
+
+func (i fakeInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (i fakeInfo) IsDir() bool {
+	return i.dir
+}
+func (i fakeInfo) Sys() interface{} {
+	return nil
+}
+
+func TestChoose(t *testing.T) {
+	cases := []struct {
+		name     string
+		origin   string
+		dest     string
+		path     string
+		dir      bool
+		verr     bool
+		skip     bool
+		err      bool
+		action   bool
+		destpath string
+	}{
+		{
+			name:     "mkdir",
+			origin:   "something",
+			dest:     "hello",
+			path:     "something/foo",
+			dir:      true,
+			action:   true,
+			destpath: "hello/foo",
+		},
+		{
+			name:     "link .go",
+			origin:   "foo",
+			dest:     "bar",
+			path:     "foo/hello/world.go",
+			action:   true,
+			destpath: "bar/hello/world.go",
+		},
+		{
+			name:     "link .s",
+			origin:   "foo",
+			dest:     "bar",
+			path:     "foo/something.s",
+			action:   true,
+			destpath: "bar/something.s",
+		},
+		{
+			name:   "skip random file",
+			origin: "foo",
+			path:   "foo/something.random",
+		},
+		{
+			name:   "skip testdata dir",
+			origin: "foo",
+			path:   "foo/good/testdata",
+			dir:    true,
+			skip:   true,
+		},
+		{
+			name:   "error file in testdata",
+			origin: "foo",
+			path:   "foo/testdata/unexpected.go",
+			err:    true,
+		},
+		{
+			name:   "error on verr",
+			origin: "foo",
+			path:   "foo/error.go",
+			verr:   true,
+			err:    true,
+		},
+		{
+			name:   "error on foreign path",
+			origin: "foo",
+			path:   "not-relative-to-foo",
+			err:    true,
+		},
+		{
+			name:   "error on non-child path",
+			origin: "foo",
+			path:   "foo/../bar",
+			err:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := visitor{
+				origin: tc.origin,
+				dest:   tc.dest,
+			}
+			i := fakeInfo{
+				dir: tc.dir,
+			}
+			var verr error
+			if tc.verr {
+				verr = errors.New("verr")
+			}
+			act, dest, err := v.choose(tc.path, i, verr)
+			switch {
+			case tc.skip:
+				if err != filepath.SkipDir {
+					t.Errorf("error %v is not SkipDir", err)
+				}
+			case err != nil && !tc.err:
+				t.Errorf("unexpected error: %v", err)
+			case err == nil && tc.err:
+				t.Errorf("failed to raise an error")
+			case act == nil && tc.action:
+				t.Errorf("failed to receive an action")
+			case act != nil && !tc.action:
+				t.Errorf("unexpected action: %v", act)
+			case dest != tc.destpath:
+				t.Errorf("wrong destionation %s != expected %s", dest, tc.dest)
+			}
+		})
+	}
+}
+
+func TestShadowClone(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin []string
+		dest   []string
+	}{
+		{
+			name: "basic",
+			origin: []string{
+				"foo/hello.go",
+				"foo/yes.s",
+				"foo/skip.random",
+				"bar/something/nice.go",
+				"totally/ignore/this.txt",
+				"skip/testdata/woops.go",
+			},
+			dest: []string{
+				"foo/hello.go",
+				"foo/yes.s",
+				"bar/something/nice.go",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o, err := ioutil.TempDir("", "shadow-origin")
+			if err != nil {
+				t.Fatalf("failed to create shadow-origin: %v", err)
+			}
+			defer os.RemoveAll(o)
+			for _, op := range tc.origin {
+				p := filepath.Join(o, op)
+				d := filepath.Dir(p)
+				if err := os.MkdirAll(d, 0700); err != nil {
+					t.Fatalf("failed to create %s: %v", d, err)
+				}
+				if err := ioutil.WriteFile(p, []byte(op), 0600); err != nil {
+					t.Fatalf("failed to create %s: %v", p, err)
+				}
+			}
+			d, err := ioutil.TempDir("", "shadow-dest")
+			if err != nil {
+				t.Fatalf("failed to create shadow-dest: %v", err)
+			}
+			defer os.RemoveAll(d)
+			if err = shadowClone(o, d); err != nil {
+				t.Fatalf("shadowClone() failed: %v", err)
+			}
+			found := []string{}
+			err = filepath.Walk(d, func(path string, info os.FileInfo, verr error) error {
+				if verr != nil {
+					return verr
+				}
+				if info.IsDir() {
+					return nil
+				}
+				rel, err := filepath.Rel(d, path)
+				if err != nil {
+					return err
+				}
+				found = append(found, rel)
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("failed to walk %s: %v", d, err)
+			}
+			sort.Strings(tc.dest)
+			sort.Strings(found)
+			if !reflect.DeepEqual(found, tc.dest) {
+				t.Errorf("actual %s != expected %s", found, tc.dest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/assign @ixdy @rmmh @BenTheElder 

Automatically generates rules for go packages without checking `BUILD` files by using an `@autogo` prefix, for example:

`bazel build -- @autogo//... -@autogo//vendor/... # build all go packages`
or
`bazel build -- @autogo//prow/cmd/branchprotector`

Successfully builds [istio](https://github.com/istio/test-infra/pull/806), [dep](https://github.com/fejta/dep/commit/293b2d7ba9ce9c4a114d8a24d66e4077568b5f59) and other repos.