### PR TITLE
Update testing framework package name

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5080,7 +5080,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
         args:
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
 


### PR DESCRIPTION
Now that we have a working sigs.k8s.io URL for the testing_frameworks, our tests are failing: see https://github.com/kubernetes-sigs/testing_frameworks/pull/51

This change tells prow to check the code out into the right place in the GOPATH.