### PR TITLE
Temporarily change number of nodes in gke-large-performance-regional to 3 and run the test hourly.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6731,7 +6731,7 @@
       "--gke-command-group=beta",
       "--gke-environment=test",
       "--gke-node-locations=us-east1-a",
-      "--gke-shape={\"default\":{\"Nodes\":1999,\"MachineType\":\"n1-standard-1\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-8\"}}",
+      "--gke-shape={\"default\":{\"Nodes\":3,\"MachineType\":\"n1-standard-1\"},\"heapster-pool\":{\"Nodes\":1,\"MachineType\":\"n1-standard-8\"}}",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m",
       "--timeout=510m",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11019,7 +11019,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: "0 0 31 2 *" # manual job, set to Feb.31st so it will never be triggered
+- interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-performance-regional
   tags:


### PR DESCRIPTION
The goal is to verify that this test starts correctly.