### PR TITLE
expand conformance testing, clarify tab names

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11095,6 +11095,51 @@
       "sig-gcp"
     ]
   },
+  "ci-kubernetes-gce-conformance-stable-1-10": {
+    "args": [
+      "--extract=release/stable-1.10",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-gce-conformance-stable-1-8": {
+    "args": [
+      "--extract=release/stable-1.8",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-gce-conformance-stable-1-9": {
+    "args": [
+      "--extract=release/stable-1.9",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
   "ci-kubernetes-integration-beta": {
     "args": [
       "--branch=release-1.11",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13976,7 +13976,44 @@ periodics:
       - --timeout=220
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+- interval: 6h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance-stable-1-10
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+- interval: 6h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance-stable-1-8
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 
+
+- interval: 6h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance-stable-1-9
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 - interval: 2h
   name: ci-kubernetes-integration-beta
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2517,6 +2517,15 @@ test_groups:
 - name: ci-kubernetes-gce-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance
   num_columns_recent: 3
+- name: ci-kubernetes-gce-conformance-stable-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-10
+  num_columns_recent: 3
+- name: ci-kubernetes-gce-conformance-stable-1-9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-9
+  num_columns_recent: 3
+- name: ci-kubernetes-gce-conformance-stable-1-8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-8
+  num_columns_recent: 3
 - name: ci-kubernetes-dind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-dind-conformance
   num_columns_recent: 3
@@ -2541,32 +2550,75 @@ test_groups:
 
 dashboards:
 - name: conformance-all
+  # entries are named $PROVIDER-$KUBERNETES_RELEASE
   dashboard_tab:
-  - name: gce
+  - name: "gce, master"
     description: Runs conformance tests using kubetest against latest kubernetes master CI build on GCE
     test_group_name: ci-kubernetes-gce-conformance
-  - name: dind
+  - name: "gce, stable-1.10"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-10
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "gce, stable-1.9"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-9
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "gce, stable-1.8"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-8
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "dind, master"
     description: Runs conformance tests using kubetest against latest kubernetes master with a docker-in-docker cluster
     test_group_name: ci-kubernetes-dind-conformance
-  - name: local-e2e
-    description: Runs conformance tests using kubetest with local-up-cluster
+  - name: "local-up-cluster, master"
+    description: Runs conformance tests using kubetest with hack/local-up-cluster.sh
     test_group_name: ci-kubernetes-local-e2e
+  - name: "openstack, master"
+    description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
+    test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
+  - name: "openstack, v1.10"
+    description: Runs conformance tests using kubetest against kubernetes v1.10 with cloud-provider-openstack
+    test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
 
 - name: conformance-gce
   dashboard_tab:
-  - name: gce
+  - name: "gce, master"
     description: Runs conformance tests using kubetest against latest kubernetes master CI build on GCE
     test_group_name: ci-kubernetes-gce-conformance
-    # TODO(bentheelder): there's might be a more appropriate alias to alert this to
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "gce, stable-1.10"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-10
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "gce, stable-1.9"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-9
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "gce, stable-1.8"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+    test_group_name: ci-kubernetes-gce-conformance-stable-1-8
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
 
 - name: conformance-providerless
   dashboard_tab:
-  - name: dind
+  - name: "dind, master"
     description: Runs conformance tests using kubetest against latest kubernetes master with a docker-in-docker cluster
     test_group_name: ci-kubernetes-dind-conformance
-  - name: local-e2e
+  - name: "local-up-cluster, master"
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e
 


### PR DESCRIPTION
- add GCE jobs for release/stable-1.8 .. 1.10
- clarify job names to `$PROVIDER, $KUBERNETES_VERSION`

TODO: 
- if the clarified tab names work correctly (spaces, commas and all...), follow up with openstack to clarify their entries in the same fashion.
- add more jobs for latest versions instead of stable releases.