### PR TITLE
more conformance tests, fix 1.8 stable

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11095,6 +11095,51 @@
       "sig-gcp"
     ]
   },
+  "ci-kubernetes-gce-conformance-latest-1-10": {
+    "args": [
+      "--extract=release/latest-1.10",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-gce-conformance-latest-1-8": {
+    "args": [
+      "--extract=release/latest-1.8",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-gce-conformance-latest-1-9": {
+    "args": [
+      "--extract=release/latest-1.9",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=200m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
   "ci-kubernetes-gce-conformance-stable-1-10": {
     "args": [
       "--extract=release/stable-1.10",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13977,6 +13977,43 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 - interval: 6h
   agent: kubernetes
+  name: ci-kubernetes-gce-conformance-latest-1-10
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+- interval: 6h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance-latest-1-8
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+- interval: 6h
+  agent: kubernetes
+  name: ci-kubernetes-gce-conformance-latest-1-9
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=220
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+
+- interval: 6h
+  agent: kubernetes
   name: ci-kubernetes-gce-conformance-stable-1-10
   labels:
     preset-service-account: true
@@ -13999,8 +14036,6 @@ periodics:
       - --timeout=220
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
-
-
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-gce-conformance-stable-1-9

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14035,7 +14035,7 @@ periodics:
     - args:
       - --timeout=220
       - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+      image: gcr.io/k8s-testimages/kubekins-e2e@sha256:773f00d30eca8fc577729f65102aed86febca82a7ce52fbfe6d38ce6a5d63ba0
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-gce-conformance-stable-1-9

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2520,11 +2520,19 @@ test_groups:
 - name: ci-kubernetes-gce-conformance-stable-1-10
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-10
   num_columns_recent: 3
+- name: ci-kubernetes-gce-conformance-latest-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-10
+  num_columns_recent: 3
 - name: ci-kubernetes-gce-conformance-stable-1-9
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-9
   num_columns_recent: 3
+- name: ci-kubernetes-gce-conformance-latest-1-9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-9
+  num_columns_recent: 3
 - name: ci-kubernetes-gce-conformance-stable-1-8
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-8
+- name: ci-kubernetes-gce-conformance-latest-1-8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-8
   num_columns_recent: 3
 - name: ci-kubernetes-dind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-dind-conformance
@@ -2550,75 +2558,108 @@ test_groups:
 
 dashboards:
 - name: conformance-all
-  # entries are named $PROVIDER-$KUBERNETES_RELEASE
+  # entries are named $PROVIDER, $KUBERNETES_RELEASE
   dashboard_tab:
-  - name: "gce, master"
+  - name: "GCE, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master CI build on GCE
     test_group_name: ci-kubernetes-gce-conformance
-  - name: "gce, stable-1.10"
-    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable
+  - name: "GCE, v1.10 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-10
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "gce, stable-1.9"
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+  - name: "GCE, v1.10 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-10
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "GCE, v1.9 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-9
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "gce, stable-1.8"
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+  - name: "GCE, v1.9 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-9
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "GCE, v1.8 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-8
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "dind, master"
+  - name: "GCE, v1.8 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.8 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-8
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "dind, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master with a docker-in-docker cluster
     test_group_name: ci-kubernetes-dind-conformance
-  - name: "local-up-cluster, master"
+  - name: "local-up-cluster, master (dev)"
     description: Runs conformance tests using kubetest with hack/local-up-cluster.sh
     test_group_name: ci-kubernetes-local-e2e
-  - name: "openstack, master"
+  - name: "OpenStack, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-  - name: "openstack, v1.10"
-    description: Runs conformance tests using kubetest against kubernetes v1.10 with cloud-provider-openstack
+  - name: "OpenStack, v1.10 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.10 branch with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
 
 - name: conformance-gce
   dashboard_tab:
-  - name: "gce, master"
+  - name: "GCE, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master CI build on GCE
     test_group_name: ci-kubernetes-gce-conformance
-    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
-    alert_options:
-      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "gce, stable-1.10"
-    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable
+  - name: "GCE, v1.10 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-10
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "gce, stable-1.9"
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+  - name: "GCE, v1.10 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-10
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "GCE, v1.9 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-9
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
-  - name: "gce, stable-1.8"
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable
+  - name: "GCE, v1.9 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-9
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "GCE, v1.8 (release)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
     test_group_name: ci-kubernetes-gce-conformance-stable-1-8
+    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
+  - name: "GCE, v1.8 (dev)"
+    description: Runs conformance tests using kubetest against kubernetes release 1.8 branch on GCE
+    test_group_name: ci-kubernetes-gce-conformance-latest-1-8
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-engprod+alerts@google.com'
 
 - name: conformance-providerless
   dashboard_tab:
-  - name: "dind, master"
+  - name: "dind, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master with a docker-in-docker cluster
     test_group_name: ci-kubernetes-dind-conformance
-  - name: "local-up-cluster, master"
+  - name: "local-up-cluster, master (dev)"
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e
 


### PR DESCRIPTION
- add conformance tests for 1.8 .. 1.10 at latest tags instead of stable releases
- fix the 1.8 stable release job to use an old kubekins image with old gcloud until a new 1.8 release is out with subnet mode cherrypicks
- make dashboard tab names clearer / shinier (still not sure if this is the best naming scheme)