### PR TITLE
use older kubekins image for the other gce 1.8 job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13998,7 +13998,7 @@ periodics:
     - args:
       - --timeout=220
       - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+      image: gcr.io/k8s-testimages/kubekins-e2e@sha256:773f00d30eca8fc577729f65102aed86febca82a7ce52fbfe6d38ce6a5d63ba0
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-gce-conformance-latest-1-9


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/issues/7799