### PR TITLE
prow: Add more kubeflow repositories

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -104,6 +104,7 @@ tide:
     - kubeflow/tf-operator
     - kubeflow/katib
     - kubeflow/experimental-kvc
+    - kubeflow/experimental-seldon
     labels:
     - lgtm
     - approved
@@ -451,6 +452,22 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-experimental-kvc-presubmit"
     trigger: "(?m)^/test( all| kubeflow-experimental-kvc-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-presubmit
+    context: kubeflow-experimental-seldon-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-experimental-seldon-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-experimental-seldon-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5559,6 +5559,16 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+  kubeflow/website:
+  - name: kubeflow-website-postsubmit
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
   kubeflow/testing:
   - name: kubeflow-testing-postsubmit
     agent: kubernetes
@@ -5593,6 +5603,36 @@ postsubmits:
 
   kubeflow/experimental-kvc:
   - name: kubeflow-experimental-kvc-postsubmit
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-postsubmit
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-postsubmit
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-postsubmit
     agent: kubernetes
     labels:
       preset-service-account: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -107,6 +107,7 @@ tide:
     - kubeflow/experimental-seldon
     - kubeflow/experimental-beagle
     - kubeflow/caffe2-operator
+    - kubeflow/reporting
     labels:
     - lgtm
     - approved

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -103,6 +103,7 @@ tide:
     - kubeflow/testing
     - kubeflow/tf-operator
     - kubeflow/katib
+    - kubeflow/experimental-kvc
     labels:
     - lgtm
     - approved
@@ -434,6 +435,22 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-katib-presubmit"
     trigger: "(?m)^/test( all| kubeflow-katib-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-presubmit
+    context: kubeflow-experimental-kvc-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-experimental-kvc-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-experimental-kvc-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:
@@ -5497,6 +5514,16 @@ postsubmits:
 
   kubeflow/katib:
   - name: kubeflow-katib-postsubmit
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-postsubmit
     agent: kubernetes
     labels:
       preset-service-account: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -106,6 +106,7 @@ tide:
     - kubeflow/experimental-kvc
     - kubeflow/experimental-seldon
     - kubeflow/experimental-beagle
+    - kubeflow/caffe2-operator
     labels:
     - lgtm
     - approved
@@ -485,6 +486,22 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-experimental-beagle-presubmit"
     trigger: "(?m)^/test( all| kubeflow-experimental-beagle-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-presubmit
+    context: kubeflow-caffe2-operator-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-caffe2-operator-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-caffe2-operator-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -108,6 +108,7 @@ tide:
     - kubeflow/experimental-beagle
     - kubeflow/caffe2-operator
     - kubeflow/reporting
+    - kubeflow/website
     labels:
     - lgtm
     - approved
@@ -393,6 +394,22 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-reporting-presubmit"
     trigger: "(?m)^/test( all| kubeflow-reporting-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/website:
+  - name: kubeflow-website-presubmit
+    context: kubeflow-website-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-website-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-website-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -102,7 +102,7 @@ tide:
     - kubeflow/pytorch-operator
     - kubeflow/testing
     - kubeflow/tf-operator
-    - kubeflow/hp-tuning
+    - kubeflow/katib
     labels:
     - lgtm
     - approved
@@ -427,13 +427,13 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
-  kubeflow/hp-tuning:
-  - name: kubeflow-hp-tuning-presubmit
-    context: kubeflow-hp-tuning-presubmit
+  kubeflow/katib:
+  - name: kubeflow-katib-presubmit
+    context: kubeflow-katib-presubmit
     agent: kubernetes
     always_run: true         # Run for every PR, or only when requested.
-    rerun_command: "/test kubeflow-hp-tuning-presubmit"
-    trigger: "(?m)^/test( all| kubeflow-hp-tuning-presubmit),?(\\s+|$)"
+    rerun_command: "/test kubeflow-katib-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-katib-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:
@@ -5495,8 +5495,8 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
-  kubeflow/hp-tuning:
-  - name: kubeflow-hp-tuning-postsubmit
+  kubeflow/katib:
+  - name: kubeflow-katib-postsubmit
     agent: kubernetes
     labels:
       preset-service-account: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -105,6 +105,7 @@ tide:
     - kubeflow/katib
     - kubeflow/experimental-kvc
     - kubeflow/experimental-seldon
+    - kubeflow/experimental-beagle
     labels:
     - lgtm
     - approved
@@ -468,6 +469,22 @@ presubmits:
     always_run: true         # Run for every PR, or only when requested.
     rerun_command: "/test kubeflow-experimental-seldon-presubmit"
     trigger: "(?m)^/test( all| kubeflow-experimental-seldon-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-presubmit
+    context: kubeflow-experimental-beagle-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-experimental-beagle-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-experimental-beagle-presubmit),?(\\s+|$)"
     branches:
     - master
     labels:

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -362,6 +362,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/tf-operator",
 		"kubeflow/katib",
 		"kubeflow/experimental-kvc",
+		"kubeflow/experimental-seldon",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -365,6 +365,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/experimental-seldon",
 		"kubeflow/experimental-beagle",
 		"kubeflow/caffe2-operator",
+		"kubeflow/website",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -364,6 +364,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/experimental-kvc",
 		"kubeflow/experimental-seldon",
 		"kubeflow/experimental-beagle",
+		"kubeflow/caffe2-operator",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -360,7 +360,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/reporting",
 		"kubeflow/testing",
 		"kubeflow/tf-operator",
-		"kubeflow/hp-tuning",
+		"kubeflow/katib",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -361,6 +361,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/testing",
 		"kubeflow/tf-operator",
 		"kubeflow/katib",
+		"kubeflow/experimental-kvc",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -363,6 +363,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/katib",
 		"kubeflow/experimental-kvc",
 		"kubeflow/experimental-seldon",
+		"kubeflow/experimental-beagle",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2018,6 +2018,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-caffe2-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_caffe2-operator/kubeflow-caffe2-operator-postsubmit
+- name: kubeflow-website-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-website-presubmit
+  num_columns_recent: 30
+- name: kubeflow-website-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_website/kubeflow-website-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4282,6 +4287,12 @@ dashboards:
   - name: kubeflow-pytorch-operator-presubmit
     description: Presubmits for kubeflow/pytorch-operator.
     test_group_name: kubeflow-pytorch-operator-presubmit
+  - name: kubeflow-website-postsubmit
+    description: Postsubmit kubeflow/website.
+    test_group_name: kubeflow-website-postsubmit
+  - name: kubeflow-website-presubmit
+    description: Presubmits for kubeflow/website.
+    test_group_name: kubeflow-website-presubmit
   - name: kubeflow-reporting-postsubmit
     description: Postsubmit kubeflow/reporting.
     test_group_name: kubeflow-reporting-postsubmit

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1998,6 +1998,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-katib-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_katib/kubeflow-katib-postsubmit
+- name: kubeflow-experimental-kvc-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-katib-presubmit
+  num_columns_recent: 30
+- name: kubeflow-experimental-kvc-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-kvc/kubeflow-experimental-kvc-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4286,6 +4291,12 @@ dashboards:
   - name: kubeflow-katib-presubmit
     description: Presubmits for kubeflow/katib.
     test_group_name: kubeflow-katib-presubmit
+  - name: kubeflow-experimental-kvc-postsubmit
+    description: Postsubmit kubeflow/experimental-kvc.
+    test_group_name: kubeflow-experimental-kvc-postsubmit
+  - name: kubeflow-experimental-kvc-presubmit
+    description: Presubmits for kubeflow/experimental-kvc.
+    test_group_name: kubeflow-experimental-kvc-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1999,10 +1999,15 @@ test_groups:
 - name: kubeflow-katib-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_katib/kubeflow-katib-postsubmit
 - name: kubeflow-experimental-kvc-presubmit
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-katib-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-experimental-kvc-presubmit
   num_columns_recent: 30
 - name: kubeflow-experimental-kvc-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-kvc/kubeflow-experimental-kvc-postsubmit
+- name: kubeflow-experimental-seldon-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-experimental-seldon-presubmit
+  num_columns_recent: 30
+- name: kubeflow-experimental-seldon-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-seldon/kubeflow-experimental-seldon-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4297,6 +4302,12 @@ dashboards:
   - name: kubeflow-experimental-kvc-presubmit
     description: Presubmits for kubeflow/experimental-kvc.
     test_group_name: kubeflow-experimental-kvc-presubmit
+  - name: kubeflow-experimental-seldon-postsubmit
+    description: Postsubmit kubeflow/experimental-seldon.
+    test_group_name: kubeflow-experimental-seldon-postsubmit
+  - name: kubeflow-experimental-seldon-presubmit
+    description: Presubmits for kubeflow/experimental-seldon.
+    test_group_name: kubeflow-experimental-seldon-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2013,6 +2013,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-experimental-beagle-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-beagle/kubeflow-experimental-beagle-postsubmit
+- name: kubeflow-caffe2-operator-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-caffe2-operator-presubmit
+  num_columns_recent: 30
+- name: kubeflow-caffe2-operator-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_caffe2-operator/kubeflow-caffe2-operator-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4319,6 +4324,12 @@ dashboards:
   - name: kubeflow-experimental-beagle-presubmit
     description: Presubmits for kubeflow/experimental-beagle.
     test_group_name: kubeflow-experimental-beagle-presubmit
+  - name: kubeflow-caffe2-operator-postsubmit
+    description: Postsubmit kubeflow/caffe2-operator.
+    test_group_name: kubeflow-caffe2-operator-postsubmit
+  - name: kubeflow-caffe2-operator-presubmit
+    description: Presubmits for kubeflow/caffe2-operator.
+    test_group_name: kubeflow-caffe2-operator-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2008,6 +2008,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-experimental-seldon-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-seldon/kubeflow-experimental-seldon-postsubmit
+- name: kubeflow-experimental-beagle-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-experimental-beagle-presubmit
+  num_columns_recent: 30
+- name: kubeflow-experimental-beagle-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-beagle/kubeflow-experimental-beagle-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4308,6 +4313,12 @@ dashboards:
   - name: kubeflow-experimental-seldon-presubmit
     description: Presubmits for kubeflow/experimental-seldon.
     test_group_name: kubeflow-experimental-seldon-presubmit
+  - name: kubeflow-experimental-beagle-postsubmit
+    description: Postsubmit kubeflow/experimental-beagle.
+    test_group_name: kubeflow-experimental-beagle-postsubmit
+  - name: kubeflow-experimental-beagle-presubmit
+    description: Presubmits for kubeflow/experimental-beagle.
+    test_group_name: kubeflow-experimental-beagle-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1993,11 +1993,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-tf-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_tf-operator/kubeflow-tf-operator-postsubmit
-- name: kubeflow-hp-tuning-presubmit
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-hp-tuning-presubmit
+- name: kubeflow-katib-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-katib-presubmit
   num_columns_recent: 30
-- name: kubeflow-hp-tuning-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_hp-tuning/kubeflow-hp-tuning-postsubmit
+- name: kubeflow-katib-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_katib/kubeflow-katib-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4280,12 +4280,12 @@ dashboards:
   - name: kubeflow-tf-operator-presubmit
     description: Presubmits for kubeflow/tf-operator.
     test_group_name: kubeflow-tf-operator-presubmit
-  - name: kubeflow-hp-tuning-postsubmit
-    description: Postsubmit kubeflow/hp-tuning.
-    test_group_name: kubeflow-hp-tuning-postsubmit
-  - name: kubeflow-hp-tuning-presubmit
-    description: Presubmits for kubeflow/hp-tuning.
-    test_group_name: kubeflow-hp-tuning-presubmit
+  - name: kubeflow-katib-postsubmit
+    description: Postsubmit kubeflow/katib.
+    test_group_name: kubeflow-katib-postsubmit
+  - name: kubeflow-katib-presubmit
+    description: Presubmits for kubeflow/katib.
+    test_group_name: kubeflow-katib-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke


### PR DESCRIPTION
/cc @jlewi @YujiOshima 

We renamed the repo github.com/kubeflow/hp-tuning to github.com/kubeflow/katib, thus we should change the repo name here.

Signed-off-by: Ce Gao <gaoce@caicloud.io>