### PR TITLE
Enable tide+prow for kubernetes-sigs/federation-v2

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -163,6 +163,7 @@ tide:
     - do-not-merge/work-in-progress
     reviewApprovedRequired: true
   - repos:
+    - kubernetes-sigs/federation-v2
     - kubernetes-sigs/testing_frameworks
     - kubernetes-sigs/poseidon
     labels:
@@ -15554,4 +15555,3 @@ periodics:
       - "--repo=github.com/tensorflow/minigo=master"
       - "--service-account=/etc/service-account/service-account.json"
       - "--upload=gs://kubernetes-jenkins/logs"
-

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -347,6 +347,10 @@ plugins:
   - wip
   - yuks
 
+  kubernetes-sigs/federation-v2:
+  - approve
+  - trigger
+
   kubernetes-sigs/testing_frameworks:
   - approve
   - trigger


### PR DESCRIPTION
Currently ci is via travis, can that remain for now?