### PR TITLE
Properly escape dind regex

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1639,7 +1639,7 @@ presubmits:
         - "--"
         - "--build=dind"
         - "--deployment=dind"
-        - "--ginkgo-focus=[Conformance]"
+        - "--ginkgo-focus=\\[Conformance\\]"
         - "--ginkgo-skip=(DNS)|(NodeSelector)"
         - "--up"
         - "--test"
@@ -3479,7 +3479,7 @@ presubmits:
         - --
         - --build=dind
         - --deployment=dind
-        - --ginkgo-focus=[Conformance]
+        - --ginkgo-focus=\[Conformance\]
         - --ginkgo-skip=(DNS)|(NodeSelector)
         - --up
         - --test
@@ -7078,7 +7078,7 @@ periodics:
       - "--deployment=dind"
       - "--up"
       - "--test"
-      - "--ginkgo-focus=[Conformance]"
+      - "--ginkgo-focus=\\[Conformance\\]"
       - "--down"
       env:
       - name: DOCKER_IN_DOCKER_ENABLED


### PR DESCRIPTION
The regex needs special characters escape. Currently anything with one of the letters in "Conformance" is matching the focus regex.