### PR TITLE
Set executor metadata to the VM name, not the pod name.

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -72,12 +72,15 @@ class FakeSubprocess(object):
     def __init__(self):
         self.calls = []
         self.file_data = []
+        self.output = {}
 
     def __call__(self, cmd, *a, **kw):
         self.calls.append((cmd, a, kw))
         for arg in cmd:
             if arg.startswith('/') and os.path.exists(arg):
                 self.file_data.append(open(arg).read())
+        if kw.get('output') and self.output.get(cmd[0]):
+            return self.output[cmd[0]].pop(0)
 
 
 # pylint: disable=invalid-name
@@ -573,6 +576,34 @@ class GubernatorUriTest(unittest.TestCase):
             bootstrap.GUBERNATOR + '/blah/blah',
             bootstrap.gubernator_uri(self.create_path(uri)))
 
+
+class UploadPodspecTest(unittest.TestCase):
+    """ Tests for maybe_upload_podspec() """
+
+    def test_missing_env(self):
+        """ Missing env vars return without doing anything. """
+        # pylint: disable=no-self-use
+        bootstrap.maybe_upload_podspec(None, '', None, {}.get)
+        bootstrap.maybe_upload_podspec(None, '', None, {bootstrap.K8S_ENV: 'foo'}.get)
+        bootstrap.maybe_upload_podspec(None, '', None, {'HOSTNAME': 'blah'}.get)
+
+    def test_upload(self):
+        gsutil = FakeGSUtil()
+        call = FakeSubprocess()
+
+        output = 'type: gamma/example\n'
+        call.output['kubectl'] = [output]
+        artifacts = 'gs://bucket/logs/123/artifacts'
+        bootstrap.maybe_upload_podspec(
+            call, artifacts, gsutil,
+            {bootstrap.K8S_ENV: 'exists', 'HOSTNAME': 'abcd'}.get)
+
+        self.assertEqual(
+            call.calls,
+            [(['kubectl', 'get', '-oyaml', 'pods/abcd'], (), {'output': True})])
+        self.assertEqual(
+            gsutil.texts,
+            [(('%s/prow_podspec.yaml' % artifacts, output), {})])
 
 
 class AppendResultTest(unittest.TestCase):


### PR DESCRIPTION
This makes it useful for debugging evictions, and more interesting for
bigquery metrics (measuring throughput per node? finding slow ones?).

We still log the pod name in the build log, just in case.

Fixes #5494