### PR TITLE
Switch gce-(large|scale)-performance jobs temporarily to etcd 3.2

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
@@ -1,5 +1,8 @@
 # Override GCE defaults.
 
+# Switch back to older etcd temporarily to help debug #62808.
+TEST_ETCD_VERSION=3.1.12
+
 # TODO(shyamjvs): Change the cos version back to default once #62456 is fixed.
 KUBE_GCI_VERSION=cos-stable-63-10032-71-0
 

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -1,5 +1,8 @@
 ### cluster-env
 
+# Switch back to older etcd temporarily to help debug #62808.
+TEST_ETCD_VERSION=3.1.12
+
 # Reduce logs verbosity as the cluster is huge.
 TEST_CLUSTER_LOG_LEVEL=--v=1
 


### PR DESCRIPTION
So that I can save some time checking if the problem is caused by etcd version.
This basically undoes https://github.com/kubernetes/kubernetes/pull/61198/files.

/cc @wojtek-t 