### PR TITLE
Split out gke | non-gke janitor deployments

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 5  # 5 distributed janitor instances
+  replicas: 3  # 3 distributed janitor instances for gke
   template:
     metadata:
       labels:
@@ -18,7 +18,7 @@ spec:
         image: gcr.io/k8s-testimages/janitor:v20180402-43203f868
         args:
         - --service-account=/etc/service-account/service-account.json
-        - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project,ingress-project
+        - --resource-type=gke-project
         - --pool-size=20
         volumeMounts:
         - mountPath: /etc/service-account
@@ -28,3 +28,35 @@ spec:
       - name: service
         secret:
           secretName: service-account
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: boskos-janitor-nongke
+  labels:
+    app: boskos-janitor-nongke
+  namespace: test-pods
+spec:
+  replicas: 4  # 4 distributed janitor instances
+  template:
+    metadata:
+      labels:
+        app: boskos-janitor-nongke
+    spec:
+      terminationGracePeriodSeconds: 300
+      containers:
+      - name: boskos-janitor-nongke
+        image: gcr.io/k8s-testimages/janitor:v20180402-43203f868
+        args:
+        - --service-account=/etc/service-account/service-account.json
+        - --resource-type=gce-project,gci-qa-project,gpu-project,ingress-project
+        - --pool-size=20
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+


### PR DESCRIPTION
temporarily, due to gke down failures

```
running ['gcloud', 'container', '-q', 'clusters', 'delete', u'bootstrap-e2e', '--project=k8s-jkns-gci-gke-serial-1-3', u'--zone=us-central1-c']
Deleting cluster bootstrap-e2e...done.                                         
ERROR: (gcloud.container.clusters.delete) Some requests did not succeed:
 - args: [u"Operation [<Operation\n endTime: u'2018-04-23T17:27:11.690210463Z'\n name: u'operation-1524504403036-394a1375'\n operationType: OperationTypeValueValuesEnum(DELETE_CLUSTER, 2)\n selfLink: u'https://test-container.sandbox.googleapis.com/v1/projects/211964288403/zones/us-central1-c/operations/operation-1524504403036-394a1375'\n startTime: u'2018-04-23T17:26:43.036373611Z'\n status: StatusValueValuesEnum(DONE, 3)\n statusMessage: u'Failed to delete cluster'\n targetLink: u'https://test-container.sandbox.googleapis.com/v1/projects/211964288403/zones/us-central1-c/clusters/bootstrap-e2e'\n zone: u'us-central1-c'>] finished with error: Failed to delete cluster"]
   exit_code: 1
   message: Operation [<Operation
 endTime: u'2018-04-23T17:27:11.690210463Z'
 name: u'operation-1524504403036-394a1375'
 operationType: OperationTypeValueValuesEnum(DELETE_CLUSTER, 2)
 selfLink: u'https://test-container.sandbox.googleapis.com/v1/projects/211964288403/zones/us-central1-c/operations/operation-1524504403036-394a1375'
 startTime: u'2018-04-23T17:26:43.036373611Z'
 status: StatusValueValuesEnum(DONE, 3)
 statusMessage: u'Failed to delete cluster'
 targetLink: u'https://test-container.sandbox.googleapis.com/v1/projects/211964288403/zones/us-central1-c/clusters/bootstrap-e2e'
 zone: u'us-central1-c'>] finished with error: Failed to delete cluster

Error try to delete cluster bootstrap-e2e: CalledProcessError()
```

deployed already
/assign @BenTheElder 