### PR TITLE
AWS: enable more AZs

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -33,51 +33,56 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # The zones below are the zones available in the CNCF account (in theory, zones vary by account)
-# We comment out zones below because we want to stay proportional to the limits
-# We do one zone for every 10 t2.medium instances allowed
+# We aim for 3 zones per region to try to maintain even spreading.
+# We also remove a few zones where our preferred instance type is not available,
+# though really this needs a better fix (likely in kops)
 DEFAULT_AWS_ZONES = [
-    #'ap-northeast-1a', # insufficient quota
-    #'ap-northeast-1c', # insufficient quota
-    #'ap-northeast-2a', # insufficient quota
-    #'ap-northeast-2b', # insufficient quota
+    'ap-northeast-1a',
+    'ap-northeast-1c',
+    'ap-northeast-1d',
+    'ap-northeast-2a',
+    #'ap-northeast-2a' - AZ does not exist, so we're breaking the 3 AZs per region target here
+    'ap-northeast-2c',
     #'ap-south-1a', # no c4.large instances available
     #'ap-south-1b', # no c4.large instances available
-    #'ap-southeast-1a', # insufficient quota
-    #'ap-southeast-1b', # insufficient quota
-    #'ap-southeast-1c', # insufficient quota
-    #'ap-southeast-2a', # insufficient quota
-    #'ap-southeast-2b', # insufficient quota
-    #'ap-southeast-2c', # insufficient quota
-    #'ca-central-1a', # insufficient quota
-    #'ca-central-1b', # insufficient quota
-    #'eu-central-1a', # insufficient quota
-    #'eu-central-1b', # insufficient quota
-    #'eu-central-1c', # insufficient quota
-    #'eu-west-1a', # insufficient quota
-    #'eu-west-1b', # insufficient quota
-    #'eu-west-1c', # insufficient quota
-    #'eu-west-2a', # insufficient quota
-    #'eu-west-2b', # insufficient quota
-    #'eu-west-2c', # insufficient quota
-    #'eu-west-3a', # insufficient quota
-    #'eu-west-3b', # insufficient quota
-    #'eu-west-3c', # insufficient quota
-    #'sa-east-1a', # insufficient quota
-    #'sa-east-1c' # insufficient quota
+    'ap-southeast-1a',
+    'ap-southeast-1b',
+    'ap-southeast-1c',
+    'ap-southeast-2a',
+    'ap-southeast-2b',
+    'ap-southeast-2c',
+    'ca-central-1a',
+    'ca-central-1b',
+    'eu-central-1a',
+    'eu-central-1b',
+    'eu-central-1c',
+    'eu-west-1a',
+    'eu-west-1b',
+    'eu-west-1c',
+    'eu-west-2a',
+    'eu-west-2b',
+    'eu-west-2c',
+    'eu-west-3a',
+    'eu-west-3b',
+    'eu-west-3c',
+    'sa-east-1a',
+    'sa-east-1b',
+    'sa-east-1c',
     'us-east-1a',
     'us-east-1b',
-    #'us-east-1c', # limiting to 2 zones to not overallocate
-    #'us-east-1d', # limiting to 2 zones to not overallocate
-    #'us-east-1e', # limiting to 2 zones to not overallocate
-    #'us-east-1f', # limiting to 2 zones to not overallocate
+    'us-east-1c',
+    #'us-east-1d', # limiting to 3 zones to not overallocate
+    #'us-east-1e', # limiting to 3 zones to not overallocate
+    #'us-east-1f', # limiting to 3 zones to not overallocate
     #'us-east-2a', # no c4.large instances available
     #'us-east-2b', # no c4.large instances available
     #'us-east-2c', # no c4.large instances available
     'us-west-1a',
-    #'us-west-1b', # overall limit is 10 instances
+    'us-west-1b',
+    'us-west-1c',
     'us-west-2a',
     'us-west-2b',
-    #'us-west-2c' # limiting to 2 zones to not overallocate
+    'us-west-2c'
 ]
 
 def test_infra(*paths):


### PR DESCRIPTION
We now have quota in more AZs, so we can run tests in more regions.

This should alleviate the pressure on us-east-1, which was hitting VPC
limits.