### PR TITLE
Fix containerd ingress test.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -310,14 +310,15 @@
   "ci-cri-containerd-e2e-gci-gce-ingress": {
     "args": [
       "--check-leaked-resources",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-ingress.env",
       "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
       "--extract=ci/latest",
       "--gcp-node-image=gci",
       "--gcp-project-type=ingress-project",
-      "--gcp-zone=us-central1-f",
+      "--gcp-zone=asia-southeast1-a",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --ginkgo.skip=\\[Unreleased\\] --minStartupPods=8",
-      "--timeout=90m"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|\\[Feature:NEG\\] --ginkgo.skip=\\[Unreleased\\]",
+      "--timeout=320m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -661,8 +662,7 @@
       "--check-leaked-resources",
       "--cluster=",
       "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:master",
-      "--env=GCE_ALPHA_FEATURES=NetworkEndpointGroup",
-      "--env=KUBE_GCE_ENABLE_IP_ALIASES=true",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-ingress.env",
       "--extract=ci/latest",
       "--gcp-project-type=ingress-project",
       "--gcp-zone=asia-southeast1-a",
@@ -4652,8 +4652,7 @@
   "ci-kubernetes-e2e-gci-gce-ingress": {
     "args": [
       "--check-leaked-resources",
-      "--env=GCE_ALPHA_FEATURES=NetworkEndpointGroup",
-      "--env=KUBE_GCE_ENABLE_IP_ALIASES=true",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-ingress.env",
       "--extract=ci/latest",
       "--gcp-node-image=gci",
       "--gcp-project-type=ingress-project",

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-ingress.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-ingress.env
@@ -1,0 +1,3 @@
+### job-env
+GCE_ALPHA_FEATURES=NetworkEndpointGroup
+KUBE_GCE_ENABLE_IP_ALIASES=true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6354,7 +6354,7 @@ periodics:
     containers:
     - args:
       - "--repo=github.com/containerd/cri=master"
-      - "--timeout=110"
+      - "--timeout=340"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 
 - interval: 2h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4790,6 +4790,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: containerd-e2e-gci-gce-ingress
+    test_group_name: ci-cri-containerd-e2e-gci-gce-ingress
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
 
 - name: sig-network-gke
   dashboard_tab:


### PR DESCRIPTION
Fix containerd ingress test and add it to the sig-network-ingress-gce-e2e dashboard.
The config was 3 months old without updating, but it was passing until last week.

It is still signode's responsibility to make sure the test green, but when update ingress test config, please also update the containerd ingress job. @kubernetes/sig-network-misc 

@jingax10 We may miss some test coverage for p2p because of this, let's wait and see the new test result.

Signed-off-by: Lantao Liu <lantaol@google.com>