### PR TITLE
Move ipvs test for ingress-gce into the release blocking sig-network tab

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -774,28 +774,6 @@
       "sig-network"
     ]
   },
-  "ci-ingress-ipvs-gce-e2e": {
-    "args": [
-      "--check-leaked-resources",
-      "--cluster=",
-      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:master",
-      "--env=KUBE_PROXY_MODE=ipvs",
-      "--extract=ci/latest",
-      "--gcp-node-image=ubuntu",
-      "--gcp-project-type=ingress-project",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel=1",
-      "--image-family=ubuntu-gke-1604-lts",
-      "--image-project=ubuntu-os-gke-cloud",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
-      "--timeout=320m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-network"
-    ]
-  },
   "ci-kinflate-periodic-default-gke": {
     "args": [
       "--check-leaked-resources",
@@ -4660,6 +4638,27 @@
       "--gcp-zone=asia-southeast1-a",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]|\\[Feature:NEG\\] --ginkgo.skip=\\[Unreleased\\]",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gce-ingress-ipvs": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=KUBE_PROXY_MODE=ipvs",
+      "--extract=ci/latest",
+      "--gcp-node-image=ubuntu",
+      "--gcp-project-type=ingress-project",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=1",
+      "--image-family=ubuntu-gke-1604-lts",
+      "--image-project=ubuntu-os-gke-cloud",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
       "--timeout=320m"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6752,18 +6752,6 @@ periodics:
       args:
       - "--timeout=340"
       - "--bare"
-- name: ci-ingress-ipvs-gce-e2e
-  agent: kubernetes
-  interval: 60m
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
-      args:
-      - "--timeout=340"
-      - "--bare"
 - interval: 2h
   agent: kubernetes
   name: ci-kinflate-periodic-default-gke
@@ -9909,6 +9897,18 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 
+- name: ci-kubernetes-e2e-gci-gce-ingress-ipvs
+  agent: kubernetes
+  interval: 60m
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+      args:
+      - "--timeout=340"
+      - "--bare"
 - interval: 60m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-ingress-manual-network

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -185,8 +185,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-upgrade-e2e
 - name: ci-ingress-gce-downgrade-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-downgrade-e2e
-- name: ci-ingress-ipvs-gce-e2e
-  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-ipvs-gce-e2e
 - name: ci-kube-deploy-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kube-deploy-build
 - name: ci-kube-deploy-test
@@ -374,6 +372,8 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-manual-network
   alert_stale_results_hours: 24
+- name: ci-kubernetes-e2e-gci-gce-ingress-ipvs
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-ipvs
 - name: ci-kubernetes-e2e-gce-multizone
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-multizone
 - name: ci-kubernetes-e2e-gci-gce-statefulset
@@ -4699,6 +4699,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ingress-ipvs
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-ipvs
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gce-ingress-manual-network
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
     alert_options:
@@ -4886,10 +4890,6 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-gce-e2e-mci-dev
     test_group_name: ci-ingress-gce-e2e-mci-dev
-    alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
-  - name: ingress-ipvs-gce-e2e
-    test_group_name: ci-ingress-ipvs-gce-e2e
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: ingress-gce-e2e-scale


### PR DESCRIPTION
With this change, the test will now run against the latest ingress-gce release, rather than from HEAD. 

Since IPVS will be GA soon, this should start becoming a release-blocking test. Therefore, it should be in the sig-network-gce tab.

/assign @krzyzacy 