### PR TITLE
CoreDNS - Add 2 e2e jobs running kube-dns for comparisons

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4724,6 +4724,23 @@
       "sig-network"
     ]
   },
+  "ci-kubernetes-e2e-gci-gce-kube-dns": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--env=CLUSTER_DNS_CORE_DNS=false",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds": {
     "args": [
       "--check-leaked-resources",
@@ -4895,6 +4912,24 @@
     "args": [
       "--check-leaked-resources",
       "--env=NODE_LOCAL_SSDS_EXT=1,scsi,fs",
+      "--extract=ci/latest",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gce-serial-kube-dns": {
+    "args": [
+      "--check-leaked-resources",
+      "--env=NODE_LOCAL_SSDS_EXT=1,scsi,fs",
+      "--env=CLUSTER_DNS_CORE_DNS=false",
       "--extract=ci/latest",
       "--gcp-master-image=gci",
       "--gcp-node-image=gci",

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4940,7 +4940,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-gcp"
+      "sig-network"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-sig-cli": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9831,19 +9831,6 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 
-- interval: 4h
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gci-gce-kube-dns
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - args:
-      - --timeout=170
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
-
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-es-logging
@@ -9951,6 +9938,19 @@ periodics:
 - interval: 60m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-ipvs
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+
+- interval: 4h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-kube-dns
   labels:
     preset-service-account: true
     preset-k8s-ssh: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9831,6 +9831,19 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
 
+- interval: 4h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-kube-dns
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-es-logging
@@ -10080,6 +10093,19 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-serial
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=520
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+
+- interval: 4h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
   labels:
     preset-service-account: true
     preset-k8s-ssh: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -352,9 +352,13 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ipvs
 - name: ci-kubernetes-e2e-gci-gce-coredns
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-coredns
+- name: ci-kubernetes-e2e-gci-gce-kube-dns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-kube-dns
 - name: ci-kubernetes-e2e-gce-alpha-api
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
+- name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
 - name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
@@ -4736,6 +4740,12 @@ dashboards:
     description: 'network gci-gce tests with CoreDNS'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-kube-dns
+    test_group_name: ci-kubernetes-e2e-gci-gce-kube-dns
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gce tests with kube-dns'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gce-alpha-api
     test_group_name: ci-kubernetes-e2e-gce-alpha-api
     alert_options:
@@ -4756,6 +4766,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-serial
     base_options: 'include-filter-by-regex=\[sig-network\]'
     description: 'network gci-gce serial e2e tests for master branch'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-serial-kube-dns
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
+    base_options: 'include-filter-by-regex=\[sig-network\]'
+    description: 'network gci-gce with kube-dns serial e2e tests for master branch'
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-alpha-features

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -359,7 +359,7 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
 - name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-kube-dns
 - name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
 - name: ci-kubernetes-e2e-gke-gci-serial-sig-cli


### PR DESCRIPTION
## Ability to verify tests results of CoreDNS against kube-dns

CoreDNS is expected to replace kube-dns. See KEP : https://github.com/kubernetes/community/pull/1956

One of the graduation criteria is to be able to:

> Validate all e2e conformance and DNS related tests (xxx-kubernetes-e2e-gce, ci-kubernetes-e2e-gce-gci-ci-master and filtered by --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]) for CoreDNS. None of the tests successful with Kube-DNS should be failing with CoreDNS.

I propose here these 2 extra tests that will run always with kube-dns, whatever the default DNS service defined for K8s:
- the test for graduation criteria
- another test to validate the [Serial], [Slow] (but not Flaky). These tests includes some other DNS specifics (like updating the DNS configuration by configMap).


NOTE: we may remove these tests after the graduation.


