### PR TITLE
Github API reverse proxy HTTP cache

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,7 @@ filegroup(
         "//gcsweb/cmd/gcsweb:all-srcs",
         "//gcsweb/pkg/version:all-srcs",
         "//ghclient:all-srcs",
+        "//ghproxy:all-srcs",
         "//greenhouse:all-srcs",
         "//hack:all-srcs",
         "//images/bootstrap/barnacle:all-srcs",

--- a/ghproxy/.gitignore
+++ b/ghproxy/.gitignore
@@ -1,0 +1,1 @@
+ghproxy

--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -22,7 +22,7 @@ docker_push(
 
 go_image(
     name = "image",
-    base = "@distroless-base//image",
+    base = "@alpine-base//image",
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -1,0 +1,66 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+docker_bundle(
+    name = "bundle",
+    images = {
+        "{STABLE_DOCKER_REPO}/ghproxy:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/ghproxy:latest": ":image",
+        "{STABLE_DOCKER_REPO}/ghproxy:latest-{BUILD_USER}": ":image",
+    },
+    stamp = True,
+)
+
+docker_push(
+    name = "push",
+    bundle = ":bundle",
+)
+
+go_image(
+    name = "image",
+    base = "@distroless-base//image",
+    embed = [":go_default_library"],
+    pure = "on",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ghproxy.go"],
+    importpath = "k8s.io/test-infra/ghproxy",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//ghproxy/ghcache:go_default_library",
+        "//greenhouse/diskutil:go_default_library",
+        "//prow/logrusutil:go_default_library",
+        "//prow/metrics:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "ghproxy",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//ghproxy/ghcache:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/ghproxy/OWNERS
+++ b/ghproxy/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- cjwagner

--- a/ghproxy/README.md
+++ b/ghproxy/README.md
@@ -1,0 +1,6 @@
+# ghProxy
+
+ghProxy is a reverse proxy HTTP cache optimized for use with the GitHub API (https://api.github.com).
+It is essentially just a reverse proxy wrapper around [ghCache](/ghproxy/ghcache) with some additional prometheus instrumentation logic to monitor disk usage and push metrics to a prometheus push gateway.
+
+ghProxy is designed to reduce API token usage by allowing many components to share a single ghCache. Note that components must use the same API token to benefit from the cache and avoid clobbering existing cache entries for other tokens.

--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "coalesce.go",
+        "ghcache.go",
+    ],
+    importpath = "k8s.io/test-infra/ghproxy/ghcache",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/gregjones/httpcache:go_default_library",
+        "//vendor/github.com/gregjones/httpcache/diskcache:go_default_library",
+        "//vendor/github.com/peterbourgon/diskv:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["coalesce_test.go"],
+    embed = [":go_default_library"],
+)

--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//vendor/github.com/gregjones/httpcache/diskcache:go_default_library",
         "//vendor/github.com/peterbourgon/diskv:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 

--- a/ghproxy/ghcache/README.md
+++ b/ghproxy/ghcache/README.md
@@ -1,0 +1,17 @@
+# ghCache
+
+## What?
+
+ghCache is an HTTP cache optimized for caching responses from the GitHub API (https://api.github.com). Specifically, it has the following non-standard caching behavior:
+- Every cache hit is revalidated with a conditional HTTP request to GitHub regardless of cache entry freshness (TTL). The 'Cache-Control' header is ignored and overwritten to achieve this.
+- Concurrent requests for the same resource are coalesced and share a single request/response from GitHub instead of each request resulting in a corresponding upstream request and response.
+
+ghCache also provides prometheus instrumentation to expose cache activity and API token usage/savings.
+
+## Why?
+
+The most important behavior of ghCache is the mandatory cache entry revalidation.
+While this property would cause most API caches to use tokens excessively, in the case of GitHub, we can actually save API tokens. This is because because conditional requests for unchanged resources don't cost any API tokens!!! See: https://developer.github.com/v3/#conditional-requests
+Free revalidation allows us to ensure that every request is satisfied with the most up to date resource without actually spending an API token unless the resource has been updated since we last checked it.
+
+Request coalescing is beneficial for use cases in which the same resource is requested multiple times in rapid succession. Normally these requests would each result in an upstream request to GitHub, potentially costing API tokens, but with request coalescing at most one token is used.

--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghcache
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+)
+
+// requestCoalescer allows concurrent requests for the same URI to share a
+// single upstream request and response.
+type requestCoalescer struct {
+	sync.Mutex
+	keys map[string]*responseWaiter
+
+	delegate http.RoundTripper
+}
+
+type responseWaiter struct {
+	*sync.Cond
+
+	waiting bool
+	resp    []byte
+	err     error
+}
+
+// RoundTrip coalesces concurrent GET requests for the same URI by blocking
+// the later requests until the first request returns and then sharing the
+// response between all requests.
+//
+// Notes: Deadlock shouldn't be possible because the map lock is always
+// acquired before responseWaiter lock if both locks are to be held and we
+// never hold multiple responseWaiter locks.
+func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only coalesce GET requests
+	if req.Method != http.MethodGet {
+		return r.delegate.RoundTrip(req)
+	}
+
+	var cacheMode = ModeError
+	defer func() {
+		cacheCounter.WithLabelValues(cacheMode).Inc()
+	}()
+
+	key := req.URL.String()
+	r.Lock()
+	waiter, ok := r.keys[key]
+	if ok {
+		// Earlier request in flight. Wait for it's response.
+		defer req.Body.Close() // Since we won't pass the request we must close it.
+		waiter.L.Lock()
+		r.Unlock()
+		waiter.waiting = true
+		// The documentation for Wait() says:
+		// "Because c.L is not locked when Wait first resumes, the caller typically
+		// cannot assume that the condition is true when Wait returns. Instead, the
+		// caller should Wait in a loop."
+		// This does not apply to this use of Wait() because the condition we are
+		// waiting for remains true once it becomes true. This lets us avoid the
+		// normal check to see if the condition has switched back to false between
+		// the signal being sent and this thread acquiring the lock.
+		waiter.Wait()
+		waiter.L.Unlock()
+		// Earlier request completed.
+
+		if waiter.err != nil {
+			return nil, waiter.err
+		}
+		resp, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(waiter.resp)), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		cacheMode = ModeCoalesced
+		return resp, nil
+	}
+	// No earlier request in flight (common case).
+	// Register a new responseWaiter and make the request ourself.
+	waiter = &responseWaiter{Cond: sync.NewCond(&sync.Mutex{})}
+	r.keys[key] = waiter
+	r.Unlock()
+
+	resp, err := r.delegate.RoundTrip(req)
+	// Real response received. Remove this responseWaiter from the map THEN
+	// wake any requesters that were waiting on this response.
+	r.Lock()
+	delete(r.keys, key)
+	r.Unlock()
+
+	waiter.L.Lock()
+	if waiter.waiting {
+		if err != nil {
+			waiter.resp, waiter.err = nil, err
+		} else {
+			// Copy the response before releasing to waiter(s).
+			waiter.resp, waiter.err = httputil.DumpResponse(resp, true)
+		}
+		waiter.Broadcast()
+	}
+	waiter.L.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	cacheMode = cacheResponseMode(resp.Header)
+	return resp, nil
+}

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -39,8 +39,6 @@ type testDelegate struct {
 }
 
 func (t *testDelegate) RoundTrip(req *http.Request) (*http.Response, error) {
-	defer req.Body.Close()
-
 	t.hitsLock.Lock()
 	t.hits[req.URL.Path] += 1
 	t.hitsLock.Unlock()
@@ -101,7 +99,7 @@ func runRequest(t *testing.T, rt http.RoundTripper, uri string, immediate bool) 
 		if err != nil {
 			res <- err
 		}
-		req, err := http.NewRequest(http.MethodGet, u.String(), bytes.NewBufferString(""))
+		req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
 			res <- err
 		}

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghcache
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// testDelegate is a fake upstream transport delegate that logs hits by URI and
+// will wait to respond to requests until signaled unless the request has
+// a header specifying it should be responded to immediately.
+type testDelegate struct {
+	beginResponding *sync.Cond
+
+	hitsLock sync.Mutex
+	hits     map[string]int
+}
+
+func (t *testDelegate) RoundTrip(req *http.Request) (*http.Response, error) {
+	defer req.Body.Close()
+
+	t.hitsLock.Lock()
+	t.hits[req.URL.Path] += 1
+	t.hitsLock.Unlock()
+
+	if req.Header.Get("test-immediate-response") == "" {
+		t.beginResponding.L.Lock()
+		t.beginResponding.Wait()
+		t.beginResponding.L.Unlock()
+	}
+	return &http.Response{
+			Body: ioutil.NopCloser(bytes.NewBufferString("Response")),
+		},
+		nil
+}
+
+func TestRoundTrip(t *testing.T) {
+	// Check that only 1 request goes to upstream if there are concurrent requests.
+	delegate := &testDelegate{
+		hits:            make(map[string]int),
+		beginResponding: sync.NewCond(&sync.Mutex{}),
+	}
+	coalesce := &requestCoalescer{
+		keys:     make(map[string]*responseWaiter),
+		delegate: delegate,
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			runRequest(t, coalesce, "/resource1", false)
+			wg.Done()
+		}()
+	}
+	// There is a race here. We need to wait for all requests to be made to the
+	// coalescer before letting upstream respond, but we don't have a way of
+	// knowing when all requests have actually started waiting on the
+	// responseWaiter...
+	time.Sleep(time.Second * 5)
+
+	// Check that requests for different resources are not blocked.
+	runRequest(t, coalesce, "/resource2", true) // Doesn't return until timeout or success.
+	delegate.beginResponding.Broadcast()
+
+	// Check that non concurrent requests all hit upstream.
+	runRequest(t, coalesce, "/resource2", true)
+
+	wg.Wait()
+	expectedHits := map[string]int{"/resource1": 1, "/resource2": 2}
+	if !reflect.DeepEqual(delegate.hits, expectedHits) {
+		t.Errorf("Unexpected hit count(s). Expected %v, but got %v.", expectedHits, delegate.hits)
+	}
+}
+
+func runRequest(t *testing.T, rt http.RoundTripper, uri string, immediate bool) {
+	res := make(chan error)
+	run := func() {
+		u, err := url.Parse("http://foo.com" + uri)
+		if err != nil {
+			res <- err
+		}
+		req, err := http.NewRequest(http.MethodGet, u.String(), bytes.NewBufferString(""))
+		if err != nil {
+			res <- err
+		}
+		if immediate {
+			req.Header.Set("test-immediate-response", "true")
+		}
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			res <- err
+		} else if b, err := ioutil.ReadAll(resp.Body); err != nil {
+			res <- err
+		} else if string(b) != "Response" {
+			res <- errors.New("unexpected response value")
+		}
+		res <- nil
+	}
+	go run()
+	select {
+	case <-time.After(time.Second * 10):
+		t.Errorf("Request for %q timed out.", uri)
+	case err := <-res:
+		if err != nil {
+			t.Errorf("Request error: %v.", err)
+		}
+	}
+}

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ghcache implements an HTTP cache optimized for caching responses
+// from the GitHub API (https://api.github.com).
+//
+// Specifically, it enforces a cache policy that revalidates every cache hit
+// with a conditional request to upstream regardless of cache entry freshness
+// because conditional requests for unchanged resources don't cost any API
+// tokens!!! See: https://developer.github.com/v3/#conditional-requests
+//
+// It also provides request coalescing and prometheus instrumentation.
+package ghcache
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/gregjones/httpcache"
+	"github.com/gregjones/httpcache/diskcache"
+	"github.com/peterbourgon/diskv"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Cache response modes describe how ghcache fulfilled a request.
+const (
+	ModeError   = "ERROR"    // internal error handling request
+	ModeNoStore = "NO-STORE" // response not cacheable
+	ModeMiss    = "MISS"     // not in cache, request proxied and response cached.
+	ModeChanged = "CHANGED"  // cache value invalid: resource changed, cache updated
+	// The modes below are the happy cases in which the request is fulfilled for
+	// free (no API tokens used).
+	ModeCoalesced   = "COALESCED"   // coalesced request, this is a copied response
+	ModeRevalidated = "REVALIDATED" // cached value revalidated and returned
+)
+
+// cacheCounter provides the 'ghcache_responses' counter vec that is indexed
+// by the cache response mode.
+var cacheCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "ghcache_responses",
+		Help: "How many cache responses of each cache response mode there are.",
+	},
+	[]string{"mode"},
+)
+
+func init() {
+	prometheus.MustRegister(cacheCounter)
+}
+
+func cacheResponseMode(headers http.Header) string {
+	if strings.Contains(headers.Get("Cache-Control"), "no-store") {
+		return ModeNoStore
+	}
+	if strings.Contains(headers.Get("Status"), "304 Not Modified") {
+		return ModeRevalidated
+	}
+	if headers.Get("X-Conditional-Request") != "" {
+		return ModeChanged
+	}
+	return ModeMiss
+}
+
+// upstreamTransport changes response headers from upstream before they
+// reach the cache layer in order to force the caching policy we require.
+//
+// By default github responds to PR requests with:
+//    Cache-Control: private, max-age=60, s-maxage=60
+// Which means the httpcache would not consider anything stale for 60 seconds.
+// However, we want to always revalidate cache entries using ETags and last
+// modified times so this RoundTripper overrides response headers to:
+//    Cache-Control: no-cache
+// This instructs the cache to store the response, but always consider it stale.
+type upstreamTransport struct {
+	delegate http.RoundTripper
+}
+
+func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	etag := req.Header.Get("if-none-match")
+	// Don't modify request, just pass to delegate.
+	resp, err := u.delegate.RoundTrip(req)
+	if err == nil {
+		if resp.StatusCode >= 400 {
+			// Don't store errors. They can't be revalidated to save API tokens.
+			resp.Header.Set("Cache-Control", "no-store")
+		} else {
+			resp.Header.Set("Cache-Control", "no-cache")
+		}
+		if etag != "" {
+			resp.Header.Set("X-Conditional-Request", etag)
+		}
+	}
+	return resp, err
+}
+
+// NewDiskCache creates a GitHub cache RoundTripper that is backed by a disk
+// cache.
+func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB int) http.RoundTripper {
+	return NewFromCache(delegate, diskcache.NewWithDiskv(
+		diskv.New(diskv.Options{
+			BasePath:     path.Join(cacheDir, "data"),
+			TempDir:      path.Join(cacheDir, "temp"),
+			CacheSizeMax: uint64(cacheSizeGB) * uint64(1000000000), // convert G to B
+		}),
+	))
+}
+
+// NewMemCache creates a GitHub cache RoundTripper that is backed by a memory
+// cache.
+func NewMemCache(delegate http.RoundTripper) http.RoundTripper {
+	return NewFromCache(delegate, httpcache.NewMemoryCache())
+}
+
+// NewFromCache creates a GitHub cache RoundTripper that is backed by the
+// specified httpcache.Cache implementation.
+func NewFromCache(delegate http.RoundTripper, cache httpcache.Cache) http.RoundTripper {
+	cacheTransport := httpcache.NewTransport(cache)
+	cacheTransport.Transport = upstreamTransport{delegate: delegate}
+	return &requestCoalescer{
+		keys:     make(map[string]*responseWaiter),
+		delegate: cacheTransport,
+	}
+}

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/ghproxy/ghcache"
+	"k8s.io/test-infra/greenhouse/diskutil"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/metrics"
+)
+
+var (
+	diskFree = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ghcache_disk_free",
+		Help: "Free gb on github-cache disk",
+	})
+	diskUsed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ghcache_disk_used",
+		Help: "Used gb on github-cache disk",
+	})
+	diskTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ghcache_disk_total",
+		Help: "Total gb on github-cache disk",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(diskFree)
+	prometheus.MustRegister(diskUsed)
+	prometheus.MustRegister(diskTotal)
+}
+
+// GitHub reverse proxy HTTP cache RoundTripper stack:
+//  v -   <Client(s)>
+//  v ^ reverse proxy
+//  v ^ ghcache: downstreamTransport (coalescing, instrumentation)
+//  v ^ ghcache: httpcache layer
+//  v ^ ghcache: upstreamTransport (cache-control, instrumentation)
+//  v ^ http.DefaultTransport
+//  > ^   <Upstream>
+
+type options struct {
+	dir    string
+	sizeGB int
+
+	port           int
+	upstream       string
+	upstreamParsed *url.URL
+
+	// pushGateway fields are used to configure pushing prometheus metrics.
+	pushGateway         string
+	pushGatewayInterval time.Duration
+}
+
+func (o *options) validate() error {
+	if (o.dir == "") != (o.sizeGB == 0) {
+		return errors.New("--cache-dir and --cache-sizeGB must be specified together to enable the disk cache (otherwise a memory cache is used)")
+	}
+	upstreamURL, err := url.Parse(o.upstream)
+	if err != nil {
+		return fmt.Errorf("failed to parse upstream URL: %v", err)
+	}
+	o.upstreamParsed = upstreamURL
+	return nil
+}
+
+func flagOptions() *options {
+	o := &options{}
+	flag.StringVar(&o.dir, "cache-dir", "", "Directory to cache to if using a disk cache.")
+	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB if using a disk cache.")
+	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")
+	flag.StringVar(&o.pushGateway, "push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
+	flag.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics are pushed.")
+	return o
+}
+
+func main() {
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "ghproxy"}),
+	)
+
+	o := flagOptions()
+	flag.Parse()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid arguments.")
+	}
+
+	var cache http.RoundTripper
+	if o.dir == "" {
+		cache = ghcache.NewMemCache(http.DefaultTransport)
+	} else {
+		cache = ghcache.NewDiskCache(http.DefaultTransport, o.dir, o.sizeGB)
+	}
+
+	if o.pushGateway != "" {
+		go metrics.PushMetrics("ghproxy", o.pushGateway, o.pushGatewayInterval)
+		go diskMonitor(o.pushGatewayInterval, o.dir)
+	}
+
+	proxy := newReverseProxy(o.upstreamParsed, cache, 30*time.Second)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(o.port), proxy))
+}
+
+func newReverseProxy(upstreamURL *url.URL, transport http.RoundTripper, timeout time.Duration) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	// Wrap the director to change the upstream request 'Host' header to the
+	// target host.
+	director := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		req.Host = req.URL.Host
+	}
+	proxy.Transport = transport
+
+	return http.TimeoutHandler(proxy, timeout, fmt.Sprintf("ghproxy timed out after %v", timeout))
+}
+
+// helper to update disk metrics (copied from greenhouse)
+func diskMonitor(interval time.Duration, diskRoot string) {
+	logger := logrus.WithField("sync-loop", "disk-monitor")
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
+		logger.Info("tick")
+		_, bytesFree, bytesUsed, err := diskutil.GetDiskUsage(diskRoot)
+		if err != nil {
+			logger.WithError(err).Error("Failed to get disk metrics")
+		} else {
+			diskFree.Set(float64(bytesFree) / 1e9)
+			diskUsed.Set(float64(bytesUsed) / 1e9)
+			diskTotal.Set(float64(bytesFree+bytesUsed) / 1e9)
+		}
+	}
+}

--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -7,6 +7,8 @@ release(
     "production",
     component("branchprotector", "cronjob"),
     component("deck", "service", "deployment"),
+    component("gce-ssd-retain", "storageclass"),
+    component("ghproxy", "service", "deployment"),
     component("hook", "service", "deployment"),
     component("horologium", "deployment"),
     component("lego", "deployment"),

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -19,6 +19,8 @@ spec:
             - --config-path=/etc/config/config
             - --github-token-path=/etc/github/oauth
             - --confirm
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
             volumeMounts:
             - name: oauth
               mountPath: /etc/github

--- a/prow/cluster/gce-ssd-retain_storageclass.yaml
+++ b/prow/cluster/gce-ssd-retain_storageclass.yaml
@@ -1,0 +1,24 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The 'gce-ssd-retain' storage class provisions a pd-ssd from GCE and
+# specifies the 'Retain' reclaim policy.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gce-ssd-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain

--- a/prow/cluster/ghproxy_deployment.yaml
+++ b/prow/cluster/ghproxy_deployment.yaml
@@ -1,0 +1,63 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  # gce-ssd-retain is specified in prow/cluster/gce-ssd-retain_storageclass.yaml
+  #
+  # If you are setting up your own Prow instance you can do any of the following:
+  # 1) Delete this to use the default storage class for your cluster.
+  # 2) Specify your own storage class.
+  # 3) If you are using GKE you can use the gce-ssd-retain storage class. It can be
+  #    created with: `kubectl create -f prow/cluster/gce-ssd-retain_storageclass.yaml
+  storageClassName: gce-ssd-retain
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ghproxy
+spec:
+  replicas: 1 
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+      - name: gh-proxy
+        image: gcr.io/k8s-testimages/ghproxy:latest
+        imagePullPolicy: Always
+        args:
+        - --cache-dir=/cache
+        - --cache-sizeGB=99
+        - --push-gateway=pushgateway
+        ports:
+        - containerPort: 8888
+        volumeMounts:
+        - name: cache
+          mountPath: /cache
+      volumes:
+      - name: cache
+        persistentVolumeClaim:
+          claimName: ghproxy

--- a/prow/cluster/ghproxy_deployment.yaml
+++ b/prow/cluster/ghproxy_deployment.yaml
@@ -37,6 +37,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: ghproxy
+  labels:
+    app: ghproxy
 spec:
   replicas: 1 
   template:
@@ -45,7 +47,7 @@ spec:
         app: ghproxy
     spec:
       containers:
-      - name: gh-proxy
+      - name: ghproxy
         image: gcr.io/k8s-testimages/ghproxy:latest
         imagePullPolicy: Always
         args:
@@ -61,3 +63,11 @@ spec:
       - name: cache
         persistentVolumeClaim:
           claimName: ghproxy
+      # run on our dedicated node
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "ghproxy"
+        effect: "NoSchedule"
+      nodeSelector:
+        dedicated: "ghproxy"

--- a/prow/cluster/ghproxy_service.yaml
+++ b/prow/cluster/ghproxy_service.yaml
@@ -1,0 +1,28 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: ghproxy
+  type: NodePort

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -38,6 +38,8 @@ spec:
         args:
         - --dry-run=false
         - --slack-token-file=/etc/slack/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -32,6 +32,8 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -32,6 +32,8 @@ spec:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -30,6 +30,8 @@ spec:
         image: gcr.io/k8s-prow/tide:v20180521-f8caf9625
         args:
         - --dry-run=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         ports:
           - name: http
             containerPort: 8888


### PR DESCRIPTION
Previous PR using nginx: #7603 
Neither nginx nor varnish respect the [HTTP caching RFC](https://tools.ietf.org/html/rfc7234) with respect to forcing revalidation of cache entries using `max-age=0`, `no-cache`, or `must-revalidate` (this is surprising, these are designed to be HTTP caches!) Neither of these caches support caching a response if it must be revalidated in the future.

Since this is the primary requirement of a Github API cache they aren't a valid option so I pieced together an HTTP reverse proxy cache in go. It enforces the caching policy we require to ensure revalidation and also includes prometheus instrumentation and concurrent request coalescing.

/cc @stevekuznetsov @BenTheElder 
/area prow