### PR TITLE
aws tests: skip eu-west-2, eu-west-3

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -59,12 +59,12 @@ DEFAULT_AWS_ZONES = [
     'eu-west-1a',
     'eu-west-1b',
     'eu-west-1c',
-    'eu-west-2a',
-    'eu-west-2b',
-    'eu-west-2c',
-    'eu-west-3a',
-    'eu-west-3b',
-    'eu-west-3c',
+    #'eu-west-2a', no c4.large capacity 2018-04-24
+    #'eu-west-2b', no c4.large capacity 2018-04-24
+    #'eu-west-2c', no c4.large capacity 2018-04-24
+    #'eu-west-3a', documented to not support c4 family
+    #'eu-west-3b', documented to not support c4 family
+    #'eu-west-3c', documented to not support c4 family
     'sa-east-1a',
     #'sa-east-1b', AZ does not exist, so we're breaking the 3 AZs per region target here
     'sa-east-1c',


### PR DESCRIPTION
eu-west-2 doesn't currently have sufficient c4.large capacity

eu-west-3 is documented not to support c4.larges, but we have bypassed the
kops logic which should auto-select a different instance type #7853