### PR TITLE
Fix gke-large-performance-regional job's project

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6765,7 +6765,7 @@
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",
-      "--gcp-project=kubernetes-scale",
+      "--gcp-project=k8s-scale-testing",
       "--gcp-region=us-east1",
       "--gke-command-group=beta",
       "--gke-environment=staging",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11243,7 +11243,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: '1 0 25 4 *' # Run at 00:01 UTC (02:01 CEST) on 25th April
+- cron: '1 1 25 4 *' # Run at 01:01 UTC (03:01 CEST) on 25th April
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-large-performance-regional
   tags:


### PR DESCRIPTION
As the scheduled run (https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-large-performance-regional/120) failed due to using wrong project.

/cc @mborsz 