### PR TITLE
Running All perf-tests from Kubetest

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -549,8 +549,9 @@ func dumpFederationLogs(location string) error {
 }
 
 func perfTest() error {
-	// Run perf tests
-	cmdline := util.K8s("perf-tests", "clusterloader", "run-e2e.sh")
+	// Run Perf-tests -ClusterLoader, DNS and Network Test
+	// PR- https://github.com/kubernetes/perf-tests/pull/101
+	cmdline := util.K8s("perf-tests","run-e2e.sh")
 	if err := control.FinishRunning(exec.Command(cmdline)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously PR: https://github.com/kubernetes/test-infra/pull/2652 allowed Cluster Loader from Perf test repo to be executed from kubetest as part of e2e framework. 
This PR will allow kubetest to run Cluster Loader, DNS and Network tests from perf-tests repo
The relevant PR in perf-tests repo is already merged https://github.com/kubernetes/perf-tests/pull/101