### PR TITLE
prow: Provide GOPATH when decorating PodSpec

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -41,6 +41,7 @@ const (
 	ArtifactsPath           = LogMountPath + "/artifacts"
 	CodeMountName           = "code"
 	CodeMountPath           = "/home/prow/go"
+	GopathEnv               = "GOPATH"
 	ToolsMountName          = "tools"
 	ToolsMountPath          = "/tools"
 	GcsCredentialsMountName = "gcs-credentials"
@@ -79,6 +80,7 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 		spec.Containers[0].Env = append(spec.Containers[0].Env, env...)
 	} else {
 		rawEnv[ArtifactsEnv] = ArtifactsPath
+		rawEnv[GopathEnv] = CodeMountPath
 		logMount := kube.VolumeMount{
 			Name:      LogMountName,
 			MountPath: LogMountPath,

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -239,6 +239,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "ENTRYPOINT_OPTIONS", Value: `{"args":["/bin/thing","some","args"],"timeout":7200000000000,"grace_period":10000000000,"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt"}`},
+								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
 								{Name: "JOB_TYPE", Value: "presubmit"},


### PR DESCRIPTION
When we clone code into a specific location in the test pod, we need to
provide a `$GOPATH` for the cloned code as well so that the Go toolchain
can operate on it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area plank
/kind bug
/cc @BenTheElder @fejta @kargakis 
/assign @cjwagner 