### PR TITLE
prow: plank: globally default PodSpec decoration config

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -108,6 +108,7 @@ filegroup(
         "//prow/report:all-srcs",
         "//prow/sidecar:all-srcs",
         "//prow/slack:all-srcs",
+        "//prow/test:all-srcs",
         "//prow/tide:all-srcs",
     ],
     tags = ["automanaged"],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2,6 +2,20 @@ plank:
   job_url_template: 'https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://k8s-gubernator.appspot.com/pr/{{if eq .Spec.Refs.Org "kubernetes"}}{{if eq .Spec.Refs.Repo "kubernetes"}}{{else}}{{.Spec.Refs.Repo}}/{{end}}{{else}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://k8s-gubernator.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   pod_pending_timeout: 60m
+  default_decoration_config:
+    timeout: 7200000000000 # 2h
+    grace_period: 15000000000 # 15s
+    utility_images:
+      clonerefs: "registry.svc.ci.openshift.org/ci/clonerefs:latest"
+      initupload: "registry.svc.ci.openshift.org/ci/initupload:latest"
+      entrypoint: "registry.svc.ci.openshift.org/ci/entrypoint:latest"
+      sidecar: "registry.svc.ci.openshift.org/ci/sidecar:latest"
+    gcs_configuration:
+      bucket: "kubernetes-jenkins"
+      path_strategy: "legacy"
+      default_org: "kubernetes"
+      default_repo: "kubernetes"
+    gcs_credentials_secret: "service-account"
 
 sinker:
   resync_period: 1m
@@ -5416,17 +5430,7 @@ presubmits:
     rerun_command: "/test pull-test-infra-verify-config-canary"
     trigger: "/test pull-test-infra-verify-config-canary"
     path_alias: "k8s.io/test-infra"
-    utility_images:
-      clonerefs: "registry.svc.ci.openshift.org/ci/clonerefs:latest"
-      initupload: "registry.svc.ci.openshift.org/ci/initupload:latest"
-      entrypoint: "registry.svc.ci.openshift.org/ci/entrypoint:latest"
-      sidecar: "registry.svc.ci.openshift.org/ci/sidecar:latest"
-    gcs_configuration:
-      bucket: "kubernetes-jenkins"
-      path_strategy: "legacy"
-      default_org: "kubernetes"
-      default_repo: "kubernetes"
-    gcs_credentials_secret: "service-account"
+    decorate: true
     spec:
       containers:
       - name: test

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -245,6 +245,9 @@ func (c *Config) MatchingPresubmits(fullRepoName, body string, testAll bool) []P
 }
 
 type UtilityConfig struct {
+	// Decorate determines if we decorate the PodSpec or not
+	Decorate bool `json:"decorate,omitempty"`
+
 	// PathAlias is the location under <root-dir>/src
 	// where the repository under test is cloned. If this
 	// is not set, <root-dir>/src/github.com/org/repo will

--- a/prow/test/BUILD.bazel
+++ b/prow/test/BUILD.bazel
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+sh_test(
+    name = "integration-mkpj",
+    srcs = ["integration-mkpj.sh"],
+    args = ["$(location //prow/cmd/mkpj) VALIDATE"],
+    data = [
+        "//prow/cmd/mkpj",
+        "//prow/test/data:all-srcs",
+    ],
+    tags = ["integration"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//prow/test/data:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/test/OWNERS
+++ b/prow/test/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- cjwagner
+- kargakis
+- spxtr
+- stevekuznetsov

--- a/prow/test/data/BUILD.bazel
+++ b/prow/test/data/BUILD.bazel
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -1,0 +1,47 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  creationTimestamp: null
+  name: d41f5d35-4fe1-11e8-8152-54ee753e2644
+spec:
+  agent: kubernetes
+  cluster: default
+  context: kubernetes-defaulted-decoration
+  decoration_config:
+    gcs_configuration:
+      bucket: default-bucket
+      default_org: kubernetes
+      default_repo: kubernetes
+      path_strategy: legacy
+    gcs_credentials_secret: default-service-account
+    grace_period: 15000000000
+    timeout: 7200000000000
+    utility_images:
+      clonerefs: clonerefs:default
+      entrypoint: entrypoint:default
+      initupload: initupload:default
+      sidecar: sidecar:default
+  job: kubernetes-defaulted-decoration
+  pod_spec:
+    containers:
+    - args:
+      - test
+      - ./...
+      image: golang:latest
+      name: ""
+      resources: {}
+  refs:
+    base_ref: master
+    base_sha: basesha
+    org: test-org
+    pulls:
+    - author: bob
+      number: 1
+      sha: pullsha
+    repo: test-repo
+  report: true
+  rerun_command: /test kubernetes-defaulted-decoration
+  type: presubmit
+status:
+  startTime: 2018-05-04T21:26:37Z
+  state: triggered

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  creationTimestamp: null
+  name: d429ea14-4fe1-11e8-9596-54ee753e2644
+spec:
+  agent: kubernetes
+  cluster: default
+  context: kubernetes-explicit-decoration
+  decoration_config:
+    gcs_configuration:
+      bucket: explicit-bucket
+      path_strategy: explicit
+    gcs_credentials_secret: explicit-service-account
+    grace_period: 1
+    timeout: 1
+    utility_images:
+      clonerefs: clonerefs:explicit
+      entrypoint: entrypoint:explicit
+      initupload: initupload:explicit
+      sidecar: sidecar:explicit
+  job: kubernetes-explicit-decoration
+  pod_spec:
+    containers:
+    - args:
+      - test
+      - ./...
+      image: golang:latest
+      name: ""
+      resources: {}
+  refs:
+    base_ref: master
+    base_sha: basesha
+    org: test-org
+    pulls:
+    - author: bob
+      number: 1
+      sha: pullsha
+    repo: test-repo
+  report: true
+  rerun_command: /test kubernetes-explicit-decoration
+  type: presubmit
+status:
+  startTime: 2018-05-04T21:26:38Z
+  state: triggered

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  creationTimestamp: null
+  name: d433e2df-4fe1-11e8-bd15-54ee753e2644
+spec:
+  agent: kubernetes
+  cluster: default
+  context: kubernetes-no-decoration
+  job: kubernetes-no-decoration
+  pod_spec:
+    containers:
+    - args:
+      - test
+      - ./...
+      image: golang:latest
+      name: ""
+      resources: {}
+  refs:
+    base_ref: master
+    base_sha: basesha
+    org: test-org
+    pulls:
+    - author: bob
+      number: 1
+      sha: pullsha
+    repo: test-repo
+  report: true
+  rerun_command: /test kubernetes-no-decoration
+  type: presubmit
+status:
+  startTime: 2018-05-04T21:26:38Z
+  state: triggered

--- a/prow/test/data/test-config.yaml
+++ b/prow/test/data/test-config.yaml
@@ -1,0 +1,66 @@
+plank:
+  default_decoration_config:
+    timeout: 7200000000000 # 2h
+    grace_period: 15000000000 # 15s
+    utility_images:
+      clonerefs: "clonerefs:default"
+      initupload: "initupload:default"
+      entrypoint: "entrypoint:default"
+      sidecar: "sidecar:default"
+    gcs_configuration:
+      bucket: "default-bucket"
+      path_strategy: "legacy"
+      default_org: "kubernetes"
+      default_repo: "kubernetes"
+    gcs_credentials_secret: "default-service-account"
+presubmits:
+  test-org/test-repo:
+  - name: kubernetes-no-decoration
+    agent: kubernetes
+    always_run: true
+    context: kubernetes-no-decoration
+    rerun_command: "/test kubernetes-no-decoration"
+    trigger: "(?m)^/test( all| kubernetes-no-decoration),?(\\s+|$)"
+    spec:
+      containers:
+      - image: golang:latest
+        args:
+        - "test"
+        - "./..."
+  - name: kubernetes-defaulted-decoration
+    agent: kubernetes
+    always_run: true
+    context: kubernetes-defaulted-decoration
+    rerun_command: "/test kubernetes-defaulted-decoration"
+    trigger: "(?m)^/test( all| kubernetes-defaulted-decoration),?(\\s+|$)"
+    decorate: true
+    spec:
+      containers:
+      - image: golang:latest
+        args:
+        - "test"
+        - "./..."
+  - name: kubernetes-explicit-decoration
+    agent: kubernetes
+    always_run: true
+    context: kubernetes-explicit-decoration
+    rerun_command: "/test kubernetes-explicit-decoration"
+    trigger: "(?m)^/test( all| kubernetes-explicit-decoration),?(\\s+|$)"
+    decorate: true
+    timeout: 1
+    grace_period: 1
+    utility_images:
+      clonerefs: "clonerefs:explicit"
+      initupload: "initupload:explicit"
+      entrypoint: "entrypoint:explicit"
+      sidecar: "sidecar:explicit"
+    gcs_configuration:
+      bucket: "explicit-bucket"
+      path_strategy: "explicit"
+    gcs_credentials_secret: "explicit-service-account"
+    spec:
+      containers:
+      - image: golang:latest
+        args:
+        - "test"
+        - "./..."

--- a/prow/test/integration-mkpj.sh
+++ b/prow/test/integration-mkpj.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script loads Prow configuration YAML and validates that the
+# appropriate ProwJob is created from that configuration.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# We are told where the `mkpj` binary lives by Bazel
+mkpj=$1
+# We can either validate current behavior or update
+# the recorded files
+action=$2
+if [[ "${action}" != "VALIDATE" && "${action}" != "GENERATE" ]]; then
+    echo "[ERROR] Action must be either \`VALIDATE\` or \`GENERATE\`, not ${action}"
+    exit 1
+fi
+
+output="$( mktemp -d )"
+
+function cleanup() {
+    returnCode="$?"
+    rm -rf "${output}" || true
+    exit "${returnCode}"
+}
+trap cleanup EXIT
+
+function validate() {
+    local expected=$1
+    local actual=$2
+    if ! difference="$( diff --ignore-matching-lines="name:" --ignore-matching-lines="startTime:" "${expected}" "${actual}" )"; then
+        echo "[ERROR] Generated incorrect ProwJob YAML for config:"
+        echo "${difference}"
+        exit 1
+    fi
+}
+
+for prowJob in prow/test/data/*-prow-job.yaml; do
+    prowJobName="$( basename "${prowJob}" "-prow-job.yaml" )"
+    # we always pass all possible refs but `mkpj` will use
+    # only those that are necessary for triggering the job
+    "${mkpj}" --config-path prow/test/data/test-config.yaml \
+              --job "${prowJobName}"                        \
+              --base-ref "master" --base-sha "basesha"      \
+              --pull-number "1" --pull-sha "pullsha" --pull-author "bob" > "${output}/${prowJobName}-prow-job.yaml"
+    case "${action}" in
+        "VALIDATE" )
+            validate "${prowJob}" "${output}/${prowJobName}-prow-job.yaml" ;;
+        "GENERATE" )
+            mv "${output}/${prowJobName}-prow-job.yaml" "${prowJob}" ;;
+    esac
+done


### PR DESCRIPTION
Instead of requiring that every single job provide configuration options
for decorating the PodSpec, we can have a global default and allow jobs
to provide only the options that differ from the defaults.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind enhancement
/cc @BenTheElder @krzyzacy @fejta 
/assign @cjwagner 
fixes #https://github.com/kubernetes/test-infra/issues/7806