### PR TITLE
Add ci-poseidon-e2e-gce for Poseidon project

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11909,6 +11909,22 @@
       "sig-scalability"
     ]
   },
+  "ci-poseidon-e2e-gce": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--extract=ci/latest",
+      "--gcp-node-image=ubuntu",
+      "--test=false",
+      "--test-cmd=./test/e2e-poseidon-gce.sh",
+      "--test-cmd-args=",
+      "--timeout=60m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-scheduling"
+    ]
+  },
   "ci-test-infra-bazel": {
     "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
     "args": [],

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11915,9 +11915,9 @@
       "--cluster=",
       "--extract=ci/latest",
       "--gcp-node-image=ubuntu",
+      "--provider=gce",
       "--test=false",
-      "--test-cmd=./test/e2e-poseidon-gce.sh",
-      "--test-cmd-args=",
+      "--test-cmd=../test/e2e-poseidon-gce.sh",
       "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5175,6 +5175,22 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
 
   kubernetes-sigs/poseidon:
+  - name: ci-poseidon-e2e-gce
+    interval: 24h
+    always_run: true
+    rerun_command: "/test ci-poseidon-e2e-gce"
+    trigger: "(?m)^/test( all| pull-poseidon-bazel),?(\\s+|$)"
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+      preset-k8s-ssh: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+
   - name: pull-poseidon-bazel
     agent: kubernetes
     context: pull-poseidon-bazel
@@ -5219,7 +5235,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
         - "--timeout=45"
-
   kubernetes/release:
   - name: pull-release-cluster-up
     agent: kubernetes

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5177,7 +5177,6 @@ presubmits:
   kubernetes-sigs/poseidon:
   - name: ci-poseidon-e2e-gce
     context: ci-poseidon-e2e-gce
-    interval: 24h
     always_run: true
     rerun_command: "/test ci-poseidon-e2e-gce"
     trigger: "(?m)^/test( all| ci-poseidon-e2e-gce),?(\\s+|$)"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5194,7 +5194,7 @@ presubmits:
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=60"
+        - "--timeout=110"
   - name: pull-poseidon-bazel
     agent: kubernetes
     context: pull-poseidon-bazel

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5179,7 +5179,7 @@ presubmits:
     interval: 24h
     always_run: true
     rerun_command: "/test ci-poseidon-e2e-gce"
-    trigger: "(?m)^/test( all| pull-poseidon-bazel),?(\\s+|$)"
+    trigger: "(?m)^/test( all| ci-poseidon-e2e-gce),?(\\s+|$)"
     agent: kubernetes
     labels:
       preset-service-account: true
@@ -5188,9 +5188,11 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
         args:
+        - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
-
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
   - name: pull-poseidon-bazel
     agent: kubernetes
     context: pull-poseidon-bazel
@@ -5200,7 +5202,6 @@ presubmits:
     labels:
       preset-service-account: true
       preset-bazel-scratch-dir: true
-      preset-bazel-remote-cache-enabled: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-1.10

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5176,6 +5176,7 @@ presubmits:
 
   kubernetes-sigs/poseidon:
   - name: ci-poseidon-e2e-gce
+    context: ci-poseidon-e2e-gce
     interval: 24h
     always_run: true
     rerun_command: "/test ci-poseidon-e2e-gce"
@@ -5193,6 +5194,7 @@ presubmits:
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=60"
   - name: pull-poseidon-bazel
     agent: kubernetes
     context: pull-poseidon-bazel

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2540,13 +2540,15 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cadvisor-e2e
   num_columns_recent: 20
 # Poseidon
+- name: ci-poseidon-e2e-gce
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/ci-poseidon-e2e-gce
+  num_columns_recent: 20
 - name: pull-poseidon-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-poseidon-bazel
   num_columns_recent: 20
 - name: pull-poseidon-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-poseidon-verify
   num_columns_recent: 20
-
 
 # Prow hosted conformance tests
 - name: ci-kubernetes-gce-conformance
@@ -5900,6 +5902,8 @@ dashboards:
     test_group_name: pull-poseidon-bazel
   - name: verify
     test_group_name: pull-poseidon-verify
+  - name: e2e
+    test_group_name: ci-poseidon-e2e-gce
 
 - name: istio
   dashboard_tab:


### PR DESCRIPTION
This PR adds the E2E test job for Poseidon project.
I have verified it with kubetest, but with ```test-infra/jenkins/bootstrap.py``` i get this below error.
Is this because of some script error or some problem with my env?
This error happens on call to **'check_env'*** function.

```
W0426 14:41:14.484] NODE_NAMES=
I0426 14:41:14.584] Bringing down cluster
W0426 14:41:28.519] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/zones/us-central1-b/disks/e2e-0-7de10-master-pd].
W0426 14:41:48.647] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/firewalls/e2e-0-7de10-master-https].
W0426 14:41:49.984] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/firewalls/e2e-0-7de10-master-etcd].
W0426 14:42:14.359] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/firewalls/e2e-0-7de10-default-internal-master].
W0426 14:42:15.573] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/firewalls/e2e-0-7de10-default-internal-node].
W0426 14:42:21.697] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/firewalls/e2e-0-7de10-default-ssh].
I0426 14:42:23.220] Deleting firewall rules remaining in network e2e-0-7de10:
W0426 14:43:18.571] Deleted [https://www.googleapis.com/compute/v1/projects/poseidon-201815/global/networks/e2e-0-7de10].
I0426 14:43:18.978] Property "clusters.poseidon-201815_e2e-0-7de10" unset.
I0426 14:43:19.124] Property "users.poseidon-201815_e2e-0-7de10" unset.
I0426 14:43:19.262] Property "users.poseidon-201815_e2e-0-7de10-basic-auth" unset.
I0426 14:43:19.416] Property "contexts.poseidon-201815_e2e-0-7de10" unset.
I0426 14:43:19.420] Cleared config for poseidon-201815_e2e-0-7de10 from /tmp/whatever/github.com/kubernetes-sigs/poseidon/.kube/config
I0426 14:43:19.421] Done
W0426 14:43:19.433] 2018/04/26 14:43:19 process.go:152: Step './hack/e2e-internal/e2e-down.sh' finished in 2m9.429617194s
W0426 14:43:19.433] 2018/04/26 14:43:19 process.go:93: Saved XML output to /tmp/whatever/github.com/kubernetes-sigs/poseidon/_artifacts/junit_runner.xml.
W0426 14:43:19.434] 2018/04/26 14:43:19 main.go:309: Something went wrong: starting e2e cluster: error during ./hack/e2e-internal/e2e-up.sh: exit status 2
W0426 14:43:19.434] Traceback (most recent call last):
W0426 14:43:19.434]   File "/home/ubuntu/poseidongopathTest/src/k8s.io/test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 729, in <module>
W0426 14:43:19.434]     main(parse_args())
W0426 14:43:19.434]   File "/home/ubuntu/poseidongopathTest/src/k8s.io/test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 589, in main
W0426 14:43:19.434]     mode.start(runner_args)
W0426 14:43:19.435]   File "/home/ubuntu/poseidongopathTest/src/k8s.io/test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 262, in start
W0426 14:43:19.435]     check_env(env, self.command, *args)
W0426 14:43:19.435]   File "/home/ubuntu/poseidongopathTest/src/k8s.io/test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 111, in check_env
W0426 14:43:19.435]     subprocess.check_call(cmd, env=env)
W0426 14:43:19.435]   File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
W0426 14:43:19.435]     raise CalledProcessError(retcode, cmd)
W0426 14:43:19.436] subprocess.CalledProcessError: Command '('kubetest', '--dump=/tmp/whatever/github.com/kubernetes-sigs/poseidon/_artifacts', '--gcp-service-account=/home/ubuntu/service-account.json', '--up', '--down', '--provider=gce', '--cluster=e2e-0-7de10', '--gcp-network=e2e-0-7de10', '--check-leaked-resources', '--extract=ci/latest', '--gcp-node-image=ubuntu', '--gcp-project=poseidon-201815', '--test-cmd=../test/e2e-poseidon-gce.sh', '--timeout=60m')' returned non-zero exit status 1
E0426 14:43:19.436] Command failed
I0426 14:43:19.436] process 29366 exited with code 1 after 9.0m
E0426 14:43:19.436] FAIL: ci-poseidon-e2e-gce
I0426 14:43:19.436] Call:  gcloud auth activate-service-account --key-file=/home/ubuntu/service-account.json
W0426 14:43:20.356] Activated service account credentials for: [poseidoncontainer@poseidon-201815.iam.gserviceaccount.com]
I0426 14:43:20.419] process 1141 exited with code 0 after 0.0m
I0426 14:43:20.420] Call:  gcloud config get-value account
I0426 14:43:21.032] process 1153 exited with code 0 after 0.0m
I0426 14:43:21.032] Will upload results to None using poseidoncontainer@poseidon-201815.iam.gserviceaccount.com

```