### PR TITLE
Add presubmit-health bigquery metrics.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12055,6 +12055,7 @@
   "metrics-bigquery": {
     "args": [
       "test-infra/metrics/bigquery.py",
+      "--bucket=gs://k8s-metrics",
       "--",
       "--backfill-days=90"
     ],

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -274,6 +274,7 @@ def remove_system_out(data):
 
 def download_junit(db, threads, client_class):
     """Download junit results for builds without them."""
+    print("Downloading JUnit artifacts.")
     builds_to_grab = db.get_builds_missing_junit()
     pool = None
     if threads > 1:

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -222,10 +222,11 @@ def get_builds(db, jobs_dir, metadata, threads, client_class):
     gcs = client_class(jobs_dir, metadata)
 
     print('Loading builds from %s' % jobs_dir)
+    sys.stdout.flush()
 
     builds_have = db.get_existing_builds(jobs_dir)
-    if builds_have:
-        print('already have %d builds' % len(builds_have))
+    print('already have %d builds' % len(builds_have))
+    sys.stdout.flush()
 
     jobs_and_builds = gcs.get_builds(builds_have)
     pool = None
@@ -275,6 +276,7 @@ def remove_system_out(data):
 def download_junit(db, threads, client_class):
     """Download junit results for builds without them."""
     print("Downloading JUnit artifacts.")
+    sys.stdout.flush()
     builds_to_grab = db.get_builds_missing_junit()
     pool = None
     if threads > 1:

--- a/kettle/model.py
+++ b/kettle/model.py
@@ -50,17 +50,17 @@ class Database(object):
         """
         builds_have_paths = self.db.execute(
             'select gcs_path from build'
-            ' where gcs_path LIKE ?'
+            ' where gcs_path between ? and ?'
             ' and finished_json IS NOT NULL'
             ,
-            (jobs_dir + '%',)).fetchall()
+            (jobs_dir + '\x00', jobs_dir + '\x7f')).fetchall()
         path_tuple = lambda path: tuple(path[len(jobs_dir):].split('/')[-2:])
         builds_have = {path_tuple(path) for (path,) in builds_have_paths}
         for path, started_json in self.db.execute(
                 'select gcs_path, started_json from build'
-                ' where gcs_path LIKE ?'
+                ' where gcs_path between ? and ?'
                 ' and started_json IS NOT NULL and finished_json IS NULL',
-                (jobs_dir + '%',)):
+                (jobs_dir + '\x00', jobs_dir + '\x7f')):
             started = json.loads(started_json)
             if int(started['timestamp']) < time.time() - 60*60*24*5:
                 # over 5 days old, no need to try looking for finished any more.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -72,6 +72,9 @@ jq filter to filter the data for the daily and latest files (`jqfilter`).
 *Optionally*: Include a jqfilter to extract influxdb timeseries measurements
 from the raw query results (`jqmeasurements`).
 
+Run `./bigquery.py --config configs/my-new-config.yaml` and verify that the
+output is what you expect.
+
 Add the new metric to the list above.
 
 After merging, find the new metric on GCS within 24 hours.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -45,6 +45,9 @@ jqmeasurements: |
 * build-stats - number of daily builds and pass rate
     - [Config](configs/build-stats.yaml)
     - [build-stats-latest.json](http://storage.googleapis.com/k8s-metrics/build-stats-latest.json)
+* presubmit-health - presubmit failure rate and timing across PRs
+    - [Config](configs/presubmit-health.yaml)
+    - [presubmit-health-latest.json](http://storage.googleapis.com/k8s-metrics/presubmit-health-latest.json)
 * failures - find jobs that have been failing the longest
     - [Config](configs/failures-config.yaml)
     - [failures-latest.json](http://storage.googleapis.com/k8s-metrics/failures-latest.json)

--- a/metrics/bigquery_test.py
+++ b/metrics/bigquery_test.py
@@ -62,7 +62,7 @@ class TestBigquery(unittest.TestCase):
 
         # Check that config files correlate with metrics listed in
         # test-infra/metrics/README.md.
-        with open('metrics/README.md') as readme_file:
+        with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme_file:
             readme = readme_file.read()
 
         readme_metrics = set(re.findall(
@@ -73,13 +73,13 @@ class TestBigquery(unittest.TestCase):
         if missing:
             self.fail(
                 'test-infra/metrics/README.md is missing entries for metrics: %s.'
-                % missing,
+                % ', '.join(sorted(missing)),
             )
         extra = readme_metrics - config_metrics
         if extra:
             self.fail(
                 'test-infra/metrics/README.md includes metrics that are missing config files: %s.'
-                % extra,
+                % ', '.join(sorted(extra)),
             )
 
         # Check that all configs are linked in readme.

--- a/metrics/configs/presubmit-health.yaml
+++ b/metrics/configs/presubmit-health.yaml
@@ -1,0 +1,91 @@
+metric: presubmit-health
+description: Calculate daily health metrics for presubmits
+query: |
+  #standardSQL
+  SELECT
+    UNIX_SECONDS(day) day,
+    job,
+    ROUND(prs_failed/prs * 100, 1) pr_failure_perc,
+    prs,
+    prs_failed,
+    total_runs,
+    ROUND(total_elapsed / total_runs / 60, 1) avg_run_time_minutes,
+    IF(total_passes>0,
+      ROUND(total_pass_elapsed / total_passes / 60, 1),
+      0) avg_pass_time_minutes
+  FROM (
+    SELECT
+      day,
+      job,
+      COUNT(job) prs,
+      SUM(IF(passes<runs,
+          1,
+          0)) prs_failed,
+      SUM(passes_elapsed) total_pass_elapsed,
+      SUM(passes) total_passes,
+      SUM(total_elapsed) total_elapsed,
+      SUM(runs) total_runs
+    FROM (
+      SELECT
+        day,
+        job,
+        pr,
+        COUNTIF(result='SUCCESS') passes,
+        COUNT(result) runs,
+        SUM(elapsed) total_elapsed,
+        SUM(IF(result='SUCCESS',elapsed,0)) passes_elapsed
+      FROM (
+        SELECT
+          TIMESTAMP_TRUNC(started, day) day,
+          path,
+          job,
+          result,
+          elapsed,
+          REGEXP_EXTRACT(path, "/(\\d+)/") pr
+        FROM
+          `k8s-gubernator.build.all`
+        WHERE
+          REGEXP_CONTAINS(job, '^pr:')
+          AND started > TIMESTAMP_SECONDS(<LAST_DATA_TIME>)
+          AND started < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), day)
+          AND elapsed IS NOT NULL)
+      GROUP BY
+        day,
+        job,
+        pr)
+    GROUP BY
+      day,
+      job)
+  ORDER BY
+    day DESC,
+    pr_failure_perc DESC
+jqfilter: |
+  ([(.[] | .day|tonumber)] | max) as $newestday |
+  [(.[] | select((.day|tonumber)==$newestday) | {
+    day: (.day|tonumber|todateiso8601[:10]),
+    job: .job,
+    pr_failure_perc: (.pr_failure_perc|tonumber),
+    prs: (.prs|tonumber),
+    prs_failed: (.prs_failed|tonumber),
+    total_runs: (.total_runs|tonumber),
+    avg_run_time_minutes: (.avg_run_time_minutes|tonumber),
+    avg_pass_time_minutes: (.avg_pass_time_minutes|tonumber),
+  })]
+measurements:
+  backfill: presubmit-health
+  jq: |
+    [(.[] | {
+      measurement: "presubmit-health",
+      time: (.day|tonumber),
+      tags: {
+        job: .job,
+      },
+      fields: {
+        pr_failure_perc: (.pr_failure_perc|tonumber),
+        prs: (.prs|tonumber),
+        prs_failed: (.prs_failed|tonumber),
+        total_runs: (.total_runs|tonumber),
+        avg_run_time_minutes: (.avg_run_time_minutes|tonumber),
+        avg_pass_time_minutes: (.avg_pass_time_minutes|tonumber),
+      }
+    })]


### PR DESCRIPTION
This tracks how much different presubmits might be impacting merge rates.
Example row:

  {
   "day": "2018-04-25",
   "job": "pr:pull-kubernetes-e2e-gke",
   "pr_failure_perc": 33.3,
   "prs": 12,
   "prs_failed": 4,
   "total_runs": 23,
   "avg_run_time_minutes": 45.8,
   "avg_pass_time_minutes": 47.8
 },

This shows that of the 12 PRs the job ran on, it failed (at least once) on
4 of them.

Also, make kettle slightly faster in batch mode and make bigquery local
debugging more straightforward.

/cc @justinsb 