### PR TITLE
 Use kubetest directly

### DIFF
--- a/experiment/coverage/README.md
+++ b/experiment/coverage/README.md
@@ -7,8 +7,7 @@ by comparing the e2e test log and swagger spec of k8s.
 
 Run e2e tests with API operation detail(-v=8 option):
 ```
-$ go run hack/e2e.go -- -v --test \
-  --test_args="--ginkgo.focus=[Conformance] -v=8" > api.log
+$ kubetest --test --test_args="--ginkgo.focus=\[Conformance\] -v=8" | tee api.log
 ```
 Then run the tool:
 ```


### PR DESCRIPTION
-v option became unnecessary on e2e operation on hack/e2e.go, then if
specifying it e2e fails due to "invalid argument". So the README.md
gets old today.
In addition, hack/e2e.go is just a shim and it is better to use kubetest
directly. So this updates the README.md.