### PR TITLE
Allow blunderbuss config to specify a maximum number of reviewers.

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -86,11 +86,12 @@ func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) err
 		oc, pc.Logger,
 		pc.PluginConfig.Blunderbuss.ReviewerCount,
 		pc.PluginConfig.Blunderbuss.FileWeightCount,
+		pc.PluginConfig.Blunderbuss.MaxReviewerCount,
 		&pre,
 	)
 }
 
-func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount, oldReviewCount *int, pre *github.PullRequestEvent) error {
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount, oldReviewCount *int, maxReviewers int, pre *github.PullRequestEvent) error {
 	changes, err := ghc.GetPullRequestChanges(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
 	if err != nil {
 		return fmt.Errorf("error getting PR changes: %v", err)
@@ -111,6 +112,9 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 	}
 
 	if len(reviewers) > 0 {
+		if maxReviewers > 0 && len(reviewers) > maxReviewers {
+			reviewers = reviewers[:maxReviewers]
+		}
 		log.Infof("Requesting reviews from users %s.", reviewers)
 		return ghc.RequestReview(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, reviewers)
 	}

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -121,6 +121,7 @@ func TestHandle(t *testing.T) {
 		name                       string
 		filesChanged               []string
 		reviewerCount              int
+		maxReviewerCount           int
 		expectedRequested          []string
 		alternateExpectedRequested []string
 	}{
@@ -173,6 +174,20 @@ func TestHandle(t *testing.T) {
 			reviewerCount:     1,
 			expectedRequested: []string{"bob", "ben"},
 		},
+		{
+			name:              "two files, 2 leaf reviewers, 1 common parent, request 1",
+			filesChanged:      []string{"a.go", "b.go"},
+			reviewerCount:     1,
+			expectedRequested: []string{"alice", "bob"},
+		},
+		{
+			name:                       "two files, 2 leaf reviewers, 1 common parent, request 1, limit 1",
+			filesChanged:               []string{"a.go", "b.go"},
+			reviewerCount:              1,
+			maxReviewerCount:           1,
+			expectedRequested:          []string{"alice"},
+			alternateExpectedRequested: []string{"bob"},
+		},
 	}
 	for _, tc := range testcases {
 		fghc := newFakeGithubClient(tc.filesChanged)
@@ -181,7 +196,7 @@ func TestHandle(t *testing.T) {
 			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
-		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), &tc.reviewerCount, nil, pre); err != nil {
+		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), &tc.reviewerCount, nil, tc.maxReviewerCount, pre); err != nil {
 			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
 			continue
 		}
@@ -272,7 +287,7 @@ func TestHandleOld(t *testing.T) {
 			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
-		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), nil, &tc.reviewerCount, pre); err != nil {
+		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), nil, &tc.reviewerCount, 0, pre); err != nil {
 			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
 			continue
 		}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -189,8 +189,11 @@ type ExternalPlugin struct {
 type Blunderbuss struct {
 	// ReviewerCount is the minimum number of reviewers to request
 	// reviews from. Defaults to requesting reviews from 2 reviewers
-	// if none of the given options is set.
+	// if FileWeightCount is not set.
 	ReviewerCount *int `json:"request_count,omitempty"`
+	// MaxReviewerCount is the maximum number of reviewers to request
+	// reviews from. Defaults to 0 meaning no limit.
+	MaxReviewerCount int `json:"max_request_count,omitempty"`
 	// FileWeightCount is the maximum number of reviewers to request
 	// reviews from. Selects reviewers based on file weighting.
 	// This and request_count are mutually exclusive options.


### PR DESCRIPTION
fixes #6295 
/area prow
/cc @kargakis 