### PR TITLE
protect only main branches for kubernetes/website

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -88,6 +88,9 @@ branch-protection:
           protect-by-default: false
           require-contexts:
           - continuous-integration/travis-ci
+          branches:
+            master:
+              protect-by-default: true
     kubernetes-sigs:
       protect-by-default: true
       require-contexts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -91,6 +91,18 @@ branch-protection:
           branches:
             master:
               protect-by-default: true
+            release-1.4:
+              protect-by-default: true
+            release-1.5:
+              protect-by-default: true
+            release-1.6:
+              protect-by-default: true
+            release-1.7:
+              protect-by-default: true
+            release-1.8:
+              protect-by-default: true
+            release-1.9:
+              protect-by-default: true
     kubernetes-sigs:
       protect-by-default: true
       require-contexts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,8 +26,6 @@ branch-protection:
       - cla/linuxfoundation
       repos:
         # BLACKLIST
-        website: #only `master` branch needs protection
-          protect-by-default: false
         # dashboard - kubernetes/test-infra#7525 need required reviews
         # WHITELIST
         charts:
@@ -87,7 +85,7 @@ branch-protection:
         test-infra:
           protect-by-default: true
         website:
-          protect-by-default: true
+          protect-by-default: false
           require-contexts:
           - continuous-integration/travis-ci
     kubernetes-sigs:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,6 +26,8 @@ branch-protection:
       - cla/linuxfoundation
       repos:
         # BLACKLIST
+        website: #only `master` branch needs protection
+          protect-by-default: false
         # dashboard - kubernetes/test-infra#7525 need required reviews
         # WHITELIST
         charts:


### PR DESCRIPTION
Only the `master` branch needs to be protected in [kubernetes/website](https://github.com/kubernetes/website). Automatically making all of the branches protected has been counter-productive.