### PR TITLE
Added release-note-feature

### DIFF
--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -37,6 +37,7 @@ const (
 	releaseNote               = "release-note"
 	releaseNoteNone           = "release-note-none"
 	releaseNoteActionRequired = "release-note-action-required"
+        releaseNoteFeature        = "release-note-feature"
 
 	releaseNoteFormat       = `Adding the "%s" label because no release-note block was detected, please follow our [release note process](https://git.k8s.io/community/contributors/guide/release-notes.md) to remove it.`
 	parentReleaseNoteFormat = `All 'parent' PRs of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement.`
@@ -57,11 +58,13 @@ var (
 		releaseNoteActionRequired,
 		releaseNoteLabelNeeded,
 		releaseNote,
+                releaseNoteFeature,
 	}
 
 	releaseNoteRe               = regexp.MustCompile(`(?mi)^/release-note\s*$`)
 	releaseNoteNoneRe           = regexp.MustCompile(`(?mi)^/release-note-none\s*$`)
 	releaseNoteActionRequiredRe = regexp.MustCompile(`(?mi)^/release-note-action-required\s*$`)
+        releaseNoteFeatureRe        = regexp.MustCompile(`(?mi)^/release-note-feature\s*$`)
 )
 
 func init() {
@@ -113,6 +116,8 @@ func handleComment(gc githubClient, log *logrus.Entry, ic github.IssueCommentEve
 		nl = releaseNote
 	case releaseNoteNoneRe.MatchString(ic.Comment.Body):
 		nl = releaseNoteNone
+	case releaseNoteFeatureRe.MatchString(ic.Comment.Body):
+		nl = releaseNoteFeature
 	case releaseNoteActionRequiredRe.MatchString(ic.Comment.Body):
 		nl = releaseNoteActionRequired
 	default:
@@ -120,9 +125,9 @@ func handleComment(gc githubClient, log *logrus.Entry, ic github.IssueCommentEve
 	}
 
 	// Emit deprecation warning for /release-note and /release-note-action-required.
-	if nl == releaseNote || nl == releaseNoteActionRequired {
-		format := "the `/%s` and `/%s` commands have been deprecated.\nPlease edit the `release-note` block in the PR body text to include the release note. If the release note requires additional action include the string `action required` in the release note. For example:\n````\n```release-note\nSome release note with action required.\n```\n````"
-		resp := fmt.Sprintf(format, releaseNote, releaseNoteActionRequired)
+	if nl == releaseNote || nl == releaseNoteActionRequired || nl == releaseNoteFeature {
+		format := "the `/%s`, `/%s` and `/%s` commands have been deprecated.\nPlease edit the `release-note` block in the PR body text to include the release note. If the release note requires additional action include the string `action required` in the release note. For example:\n````\n```release-note\nSome release note with action required.\n```\n````"
+		resp := fmt.Sprintf(format, releaseNote, releaseNoteActionRequired, releaseNoteFeature)
 		return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 	}
 

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -37,7 +37,7 @@ const (
 	releaseNote               = "release-note"
 	releaseNoteNone           = "release-note-none"
 	releaseNoteActionRequired = "release-note-action-required"
-        releaseNoteFeature        = "release-note-feature"
+	releaseNoteFeature        = "release-note-feature"
 
 	releaseNoteFormat       = `Adding the "%s" label because no release-note block was detected, please follow our [release note process](https://git.k8s.io/community/contributors/guide/release-notes.md) to remove it.`
 	parentReleaseNoteFormat = `All 'parent' PRs of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement.`
@@ -58,13 +58,13 @@ var (
 		releaseNoteActionRequired,
 		releaseNoteLabelNeeded,
 		releaseNote,
-                releaseNoteFeature,
+		releaseNoteFeature,
 	}
 
 	releaseNoteRe               = regexp.MustCompile(`(?mi)^/release-note\s*$`)
 	releaseNoteNoneRe           = regexp.MustCompile(`(?mi)^/release-note-none\s*$`)
 	releaseNoteActionRequiredRe = regexp.MustCompile(`(?mi)^/release-note-action-required\s*$`)
-        releaseNoteFeatureRe        = regexp.MustCompile(`(?mi)^/release-note-feature\s*$`)
+	releaseNoteFeatureRe        = regexp.MustCompile(`(?mi)^/release-note-feature\s*$`)
 )
 
 func init() {

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -325,7 +325,7 @@ func getReleaseNote(body string) string {
 }
 
 func releaseNoteAlreadyAdded(prLabels sets.String) bool {
-	return prLabels.HasAny(releaseNote, releaseNoteActionRequired, releaseNoteNone)
+	return prLabels.HasAny(releaseNote, releaseNoteActionRequired, releaseNoteNone, releaseNoteFeature)
 }
 
 func prMustFollowRelNoteProcess(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, prLabels sets.String, comment bool) bool {
@@ -351,7 +351,8 @@ func prMustFollowRelNoteProcess(gc githubClient, log *logrus.Entry, pr *github.P
 			continue
 		}
 		if !github.HasLabel(releaseNote, parentLabels) &&
-			!github.HasLabel(releaseNoteActionRequired, parentLabels) {
+			!github.HasLabel(releaseNoteActionRequired, parentLabels) &&
+				!github.HasLabel(releaseNoteFeature, parentLabels) {
 			notelessParents = append(notelessParents, "#"+strconv.Itoa(parent))
 		}
 	}

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -352,7 +352,7 @@ func prMustFollowRelNoteProcess(gc githubClient, log *logrus.Entry, pr *github.P
 		}
 		if !github.HasLabel(releaseNote, parentLabels) &&
 			!github.HasLabel(releaseNoteActionRequired, parentLabels) &&
-				!github.HasLabel(releaseNoteFeature, parentLabels) {
+			!github.HasLabel(releaseNoteFeature, parentLabels) {
 			notelessParents = append(notelessParents, "#"+strconv.Itoa(parent))
 		}
 	}

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -129,13 +129,22 @@ func TestReleaseNoteComment(t *testing.T) {
 			shouldComment: true,
 		},
 		{
+			name:          "author release-note-feature",
+			action:        github.IssueCommentActionCreated,
+			isAuthor:      true,
+			commentBody:   "/release-note-feature",
+			currentLabels: []string{releaseNoteLabelNeeded, "other"},
+			shouldComment: true,
+		},
+
+		{
 			name:          "release-note-none, delete multiple labels",
 			action:        github.IssueCommentActionCreated,
 			isMember:      true,
 			commentBody:   "/release-note-none",
 			currentLabels: []string{releaseNote, releaseNoteLabelNeeded, releaseNoteActionRequired, releaseNoteNone, "other"},
 
-			deletedLabels: []string{releaseNoteLabelNeeded, releaseNoteActionRequired, releaseNote},
+			deletedLabels: []string{releaseNoteLabelNeeded, releaseNoteActionRequired, releaseNote, releaseNoteFeature},
 		},
 		{
 			name:        "no label present",
@@ -288,6 +297,11 @@ func TestReleaseNotePR(t *testing.T) {
 			name:          "LGTM with release-note-action-required",
 			initialLabels: []string{lgtmLabel, releaseNoteActionRequired},
 			body:          "```release-note\n Action required.\n```",
+		},
+		{
+			name:          "LGTM with release-note-feature",
+			initialLabels: []string{lgtmLabel, releaseNoteFeature},
+			body:          "```release-note\n Feature.\n```",
 		},
 		{
 			name:          "LGTM with release-note-action-required, /release-note-none comment",


### PR DESCRIPTION
This change adds release-note-feature as an option for a release note tag, making the four options release-note-none, release-note, release-note-feature and release-note-action-required.