### PR TITLE
Add a CI periodic job for conformance tests with containerized kubelet

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11477,6 +11477,21 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-local-e2e-containerized": {
+    "args": [
+      "--deployment=local",
+      "--extract=ci/latest",
+      "--extract-source",
+      "--ginkgo-parallel=1",
+      "--provider=local",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-kubernetes-multicluster-ingress-test": {
     "args": [
       "make",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14698,6 +14698,33 @@ periodics:
     - name: docker-graph
       emptyDir: {}
 
+- name: ci-kubernetes-local-e2e-containerized
+  agent: kubernetes
+  interval: 60m
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+      args:
+      - "--timeout=140"
+      - "--bare"
+      env:
+      - name: DOCKERIZE_KUBELET
+        value: true
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+
 - interval: 6h
   name: ci-kubernetes-multicluster-ingress-test
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -558,6 +558,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-local-e2e
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
+- name: ci-kubernetes-local-e2e-containerized
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-local-e2e-containerized
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
 - name: ci-kubernetes-soak-cos-docker-validation
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-cos-docker-validation
 - name: ci-kubernetes-soak-gce-gci
@@ -2672,6 +2676,9 @@ dashboards:
   - name: "local-up-cluster, master (dev)"
     description: Runs conformance tests using kubetest with hack/local-up-cluster.sh
     test_group_name: ci-kubernetes-local-e2e
+  - name: "local-up-cluster-containerized, master (dev)"
+    description: Runs conformance tests using kubetest with hack/local-up-cluster.sh (containerized kubelet)
+    test_group_name: ci-kubernetes-local-e2e-containerized
   - name: "OpenStack, master (dev)"
     description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
@@ -2729,6 +2736,9 @@ dashboards:
   - name: "local-up-cluster, master (dev)"
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e
+  - name: "local-up-cluster-containerized, master (dev)"
+    description: Runs conformance tests using kubetest with local-up-cluster (containerized kubelet)
+    test_group_name: ci-kubernetes-local-e2e-containerized
 
 - name: conformance-cloud-provider-openstack
   dashboard_tab:
@@ -5414,6 +5424,11 @@ dashboards:
   - name: ci-kubernetes-local-e2e
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: ci-kubernetes-local-e2e-containerized
+    description: Runs conformance tests using kubetest with local-up-cluster (containerized kubelet)
+    test_group_name: ci-kubernetes-local-e2e-containerized
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: pull-kubernetes-local-e2e


### PR DESCRIPTION
- Uses local-up-cluster with DOCKERIZE_KUBELET=true
- Uses the kubetest's built in support for running local-up-cluster.sh
- Same as the existing job pull-kubernetes-local-e2e-containerized but
  run periodically

Fixes https://github.com/kubernetes/kubernetes/issues/62342