### PR TITLE
Refactor UpdateBranchProtection to update all options

### DIFF
--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -27,7 +27,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["protect.go"],
+    srcs = [
+        "protect.go",
+        "request.go",
+    ],
     importpath = "k8s.io/test-infra/prow/cmd/branchprotector",
     visibility = ["//visibility:public"],
     deps = [
@@ -40,6 +43,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "protect_test.go",
+        "request_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -129,7 +129,7 @@ func main() {
 
 type client interface {
 	RemoveBranchProtection(org, repo, branch string) error
-	UpdateBranchProtection(org, repo, branch string, contexts, pushers []string) error
+	UpdateBranchProtection(org, repo, branch string, config github.BranchProtectionRequest) error
 	GetBranches(org, repo string) ([]github.Branch, error)
 	GetRepos(org string, user bool) ([]github.Repo, error)
 }
@@ -151,9 +151,13 @@ func (p *Protector) ConfigureBranches() {
 				p.errors.add(fmt.Errorf("remove %s/%s=%s protection failed: %v", r.Org, r.Repo, r.Branch, err))
 			}
 		} else {
-			err := p.client.UpdateBranchProtection(r.Org, r.Repo, r.Branch, r.Contexts, r.Pushers)
+			req := makeRequest(config.Policy{
+				Pushers:  r.Pushers,
+				Contexts: r.Contexts,
+			})
+			err := p.client.UpdateBranchProtection(r.Org, r.Repo, r.Branch, req)
 			if err != nil {
-				p.errors.add(fmt.Errorf("update %s/%s=%s protection failed: %v", r.Org, r.Repo, r.Branch, err))
+				p.errors.add(fmt.Errorf("update %s/%s=%s protection to %v failed: %v", r.Org, r.Repo, r.Branch, req, err))
 			}
 		}
 	}

--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	branchprotection "k8s.io/test-infra/prow/config"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+// makeRequest renders a branch protection policy into the corresponding GitHub api request.
+func makeRequest(policy branchprotection.Policy) github.BranchProtectionRequest {
+	return github.BranchProtectionRequest{
+		RequiredStatusChecks: makeChecks(policy.Contexts),
+		Restrictions:         makeRestrictions(policy.Pushers),
+	}
+
+}
+
+// makeChecks renders a ContextPolicy into the corresponding GitHub api object.
+func makeChecks(contexts []string) *github.RequiredStatusChecks {
+	if contexts == nil {
+		contexts = []string{}
+	}
+	return &github.RequiredStatusChecks{
+		Contexts: contexts,
+	}
+}
+
+// makeRestrictions renders restrictions into the corresponding GitHub api object.
+func makeRestrictions(pushers []string) *github.Restrictions {
+	if pushers == nil {
+		pushers = []string{}
+	}
+	return &github.Restrictions{
+		Teams: pushers,
+		Users: []string{},
+	}
+}

--- a/prow/cmd/branchprotector/request_test.go
+++ b/prow/cmd/branchprotector/request_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	branchprotection "k8s.io/test-infra/prow/config"
+)
+
+func TestMakeRequest(t *testing.T) {
+	actual := makeRequest(branchprotection.Policy{})
+	if actual.RequiredStatusChecks.Contexts == nil {
+		t.Errorf("contexts must be non-nil (use an empty list for nil)")
+	}
+	if actual.Restrictions.Teams == nil {
+		t.Errorf("users must be non-nil (use an empty list for nil)")
+	}
+	if actual.Restrictions.Users == nil {
+		t.Errorf("users must be non-nil (use an empty list for nil)")
+	}
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -854,30 +854,13 @@ func (c *Client) RemoveBranchProtection(org, repo, branch string) error {
 	return err
 }
 
-func (c *Client) UpdateBranchProtection(org, repo, branch string, requiredContexts []string, pushers []string) error {
-	c.log("UpdateBranchProtection", org, repo, branch, requiredContexts, pushers)
-	if requiredContexts == nil {
-		return errors.New("requiredContexts cannot be nil")
-	}
-	if pushers == nil {
-		return errors.New("pushers cannot be nil")
-	}
+func (c *Client) UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error {
+	c.log("UpdateBranchProtection", org, repo, branch, config)
 	_, err := c.request(&request{
-		method: http.MethodPut,
-		path:   fmt.Sprintf("%s/repos/%s/%s/branches/%s/protection", c.base, org, repo, branch),
-		requestBody: BranchProtectionRequest{
-			RequiredStatusChecks: RequiredStatusChecks{
-				Strict:   false,
-				Contexts: requiredContexts,
-			},
-			EnforceAdmins:              false,
-			RequiredPullRequestReviews: nil,
-			Restrictions: Restrictions{
-				Teams: pushers,
-				Users: []string{},
-			},
-		},
-		exitCodes: []int{200},
+		method:      http.MethodPut,
+		path:        fmt.Sprintf("%s/repos/%s/%s/branches/%s/protection", c.base, org, repo, branch),
+		requestBody: config,
+		exitCodes:   []int{200},
 	}, nil)
 	return err
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1239,7 +1239,8 @@ func TestRemoveBranchProtection(t *testing.T) {
 
 func TestUpdateBranchProtection(t *testing.T) {
 	cases := []struct {
-		name     string
+		name string
+		// TODO(fejta): expand beyond contexts/pushers
 		contexts []string
 		pushers  []string
 		err      bool
@@ -1249,36 +1250,6 @@ func TestUpdateBranchProtection(t *testing.T) {
 			contexts: []string{"foo-pr-test", "other"},
 			pushers:  []string{"movers", "awesome-team", "shakers"},
 			err:      false,
-		},
-		{
-			name:     "empty contexts",
-			contexts: []string{"foo-pr-test", "other"},
-			pushers:  []string{},
-			err:      false,
-		},
-		{
-			name:     "empty pushers",
-			contexts: []string{},
-			pushers:  []string{"movers", "awesome-team", "shakers"},
-			err:      false,
-		},
-		{
-			name:     "nil contexts",
-			contexts: nil,
-			pushers:  []string{"movers", "awesome-team", "shakers"},
-			err:      true,
-		},
-		{
-			name:     "nil pushers",
-			contexts: []string{"foo-pr-test", "other"},
-			pushers:  nil,
-			err:      true,
-		},
-		{
-			name:     "nil both",
-			contexts: nil,
-			pushers:  nil,
-			err:      true,
 		},
 	}
 
@@ -1336,7 +1307,14 @@ func TestUpdateBranchProtection(t *testing.T) {
 		defer ts.Close()
 		c := getClient(ts.URL)
 
-		err := c.UpdateBranchProtection("org", "repo", "master", tc.contexts, tc.pushers)
+		err := c.UpdateBranchProtection("org", "repo", "master", BranchProtectionRequest{
+			RequiredStatusChecks: &RequiredStatusChecks{
+				Contexts: tc.contexts,
+			},
+			Restrictions: &Restrictions{
+				Teams: tc.pushers,
+			},
+		})
 		if tc.err && err == nil {
 			t.Errorf("%s: expected error failed to occur", tc.name)
 		}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -222,10 +222,10 @@ type Branch struct {
 // protections in place for a branch.
 // See also: https://developer.github.com/v3/repos/branches/#update-branch-protection
 type BranchProtectionRequest struct {
-	RequiredStatusChecks       RequiredStatusChecks        `json:"required_status_checks"`
-	EnforceAdmins              bool                        `json:"enforce_admins"`
+	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
+	EnforceAdmins              *bool                       `json:"enforce_admins"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
-	Restrictions               Restrictions                `json:"restrictions"`
+	Restrictions               *Restrictions               `json:"restrictions"`
 }
 
 type RequiredStatusChecks struct {


### PR DESCRIPTION
Change `UpdateBranchProtection()` to accept a `BranchProtectionRequest` instead of `pushers, contexts` lists.

Create a `makeRequest()` in `branchprotector` to render a `Policy` into this request.

/assign @BenTheElder @stevekuznetsov @cjwagner 
/area prow

Note that github [wants](https://developer.github.com/v3/repos/branches/#parameters-1) the top-level request keys to be null if unconfigured, which is why these are now pointers.