### PR TITLE
Pass job spec explicitly to GCS code

### DIFF
--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/gcsupload:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/pod-utils/options:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/pod-utils/options"
 
 	"k8s.io/test-infra/prow/gcsupload"
@@ -41,7 +42,12 @@ func main() {
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "gcsupload"}),
 	)
 
-	if err := o.Run(map[string]gcs.UploadFunc{}); err != nil {
+	spec, err := downwardapi.ResolveSpecFromEnv()
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not resolve job spec")
+	}
+
+	if err := o.Run(spec, map[string]gcs.UploadFunc{}); err != nil {
 		logrus.WithError(err).Fatal("Failed to upload to GCS")
 	}
 }

--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -37,12 +37,7 @@ import (
 // a parameter and will have the prefix prepended
 // to their destination in GCS, so the caller can
 // operate relative to the base of the GCS dir.
-func (o Options) Run(extra map[string]gcs.UploadFunc) error {
-	spec, err := downwardapi.ResolveSpecFromEnv() // TODO: pass in all the config instead of needing this?
-	if err != nil {
-		return fmt.Errorf("could not resolve job spec: %v", err)
-	}
-
+func (o Options) Run(spec *downwardapi.JobSpec, extra map[string]gcs.UploadFunc) error {
 	uploadTargets := o.assembleTargets(spec, extra)
 
 	if !o.DryRun {

--- a/prow/initupload/BUILD.bazel
+++ b/prow/initupload/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//prow/gcsupload:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
     ],
 )

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -25,10 +25,16 @@ import (
 	"time"
 
 	"k8s.io/test-infra/prow/pod-utils/clone"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
 
 func (o Options) Run() error {
+	spec, err := downwardapi.ResolveSpecFromEnv()
+	if err != nil {
+		return fmt.Errorf("could not resolve job spec: %v", err)
+	}
+
 	var cloneRecords []clone.Record
 	data, err := ioutil.ReadFile(o.Log)
 	if err != nil {
@@ -81,7 +87,7 @@ func (o Options) Run() error {
 		}
 	}
 
-	if err := o.Options.Run(uploadTargets); err != nil {
+	if err := o.Options.Run(spec, uploadTargets); err != nil {
 		return fmt.Errorf("failed to upload to GCS: %v", err)
 	}
 

--- a/prow/sidecar/BUILD.bazel
+++ b/prow/sidecar/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/gcsupload:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/pod-utils/wrapper:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",


### PR DESCRIPTION
We need to pass job specification explicitly to the GCS uploading code
that we move to passing the minimum set of information as well as so
that we can support modes of calling the GCS library where `$JOB_SPEC`
is not set.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind feature
/cc @kargakis @fejta 
/assign @cjwagner @BenTheElder