### PR TITLE
Add ProwJob name as a label on Pods

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -63,6 +63,12 @@ const (
 	// carries the job type (presubmit, postsubmit, periodic, batch)
 	// that the pod is running.
 	ProwJobTypeLabel = "prow.k8s.io/type"
+	// ProwJobIDLabel is added in pods created by prow and
+	// carries the ID of the ProwJob that the pod is fulfilling.
+	// We also name pods after the ProwJob that spawned them but
+	// this allows for multiple resources to be linked to one
+	// ProwJob.
+	ProwJobIDLabel = "prow.k8s.io/id"
 	// ProwJobAnnotation is added in pods created by prow and
 	// carries the name of the job that the pod is running. Since
 	// job names can be arbitrarily long, this is added as

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -49,7 +49,7 @@ const (
 )
 
 func Labels() []string {
-	return []string{kube.ProwJobTypeLabel, kube.CreatedByProw}
+	return []string{kube.ProwJobTypeLabel, kube.CreatedByProw, kube.ProwJobIDLabel}
 }
 
 func VolumeMounts() []string {
@@ -236,6 +236,7 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	}
 	podLabels[kube.CreatedByProw] = "true"
 	podLabels[kube.ProwJobTypeLabel] = string(pj.Spec.Type)
+	podLabels[kube.ProwJobIDLabel] = pj.ObjectMeta.Name
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   pj.ObjectMeta.Name,

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -74,6 +74,7 @@ func TestProwJobToPod(t *testing.T) {
 					Labels: map[string]string{
 						kube.CreatedByProw:    "true",
 						kube.ProwJobTypeLabel: "presubmit",
+						kube.ProwJobIDLabel:   "pod",
 						"needstobe":           "inherited",
 					},
 					Annotations: map[string]string{
@@ -164,6 +165,7 @@ func TestProwJobToPod(t *testing.T) {
 					Labels: map[string]string{
 						kube.CreatedByProw:    "true",
 						kube.ProwJobTypeLabel: "presubmit",
+						kube.ProwJobIDLabel:   "pod",
 						"needstobe":           "inherited",
 					},
 					Annotations: map[string]string{


### PR DESCRIPTION
Complex workloads on test/build clusters where more than one Kubernetes
object is used to fulfill a test request should be possible for
downstream consumers of Prow. Instead of enforcing that the object names
must match the `ProwJob` ID, we should instead allow for a label to be
used to identify these objects as well as the original method.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind enhancement
/cc @kargakis @fejta 
/assign @BenTheElder @cjwagner 