### PR TITLE
Ensure no nil fields exist in options structs

### DIFF
--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	o := &entrypoint.Options{}
+	o := entrypoint.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 func main() {
-	o := &gcsupload.Options{}
+	o := gcsupload.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}

--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	o := &initupload.Options{}
+	o := initupload.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}

--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	o := &sidecar.Options{}
+	o := sidecar.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
 	}

--- a/prow/entrypoint/options.go
+++ b/prow/entrypoint/options.go
@@ -25,6 +25,13 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
 )
 
+// NewOptions returns an empty Options with no nil fields
+func NewOptions() *Options {
+	return &Options{
+		Options: &wrapper.Options{},
+	}
+}
+
 // Options exposes the configuration necessary
 // for defining the process being watched and
 // where in GCS an upload will land.

--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -26,6 +26,13 @@ import (
 	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
+// NewOptions returns an empty Options with no nil fields
+func NewOptions() *Options {
+	return &Options{
+		GCSConfiguration: &kube.GCSConfiguration{},
+	}
+}
+
 // Options exposes the configuration necessary
 // for defining where in GCS an upload will land.
 type Options struct {

--- a/prow/initupload/options.go
+++ b/prow/initupload/options.go
@@ -31,6 +31,13 @@ const (
 	JSONConfigEnvVar = "INITUPLOAD_OPTIONS"
 )
 
+// NewOptions returns an empty Options with no nil fields
+func NewOptions() *Options {
+	return &Options{
+		Options: gcsupload.NewOptions(),
+	}
+}
+
 type Options struct {
 	*gcsupload.Options
 

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -24,6 +24,14 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
 )
 
+// NewOptions returns an empty Options with no nil fields
+func NewOptions() *Options {
+	return &Options{
+		GcsOptions:     gcsupload.NewOptions(),
+		WrapperOptions: &wrapper.Options{},
+	}
+}
+
 // Options exposes the configuration necessary
 // for defining the process being watched and
 // where in GCS an upload will land.


### PR DESCRIPTION
When the pod utilities use flags to fill out options, they need
underlying structs with non-nil embedded fields to bind options onto.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @kargakis @fejta 
/assign @cjwagner @BenTheElder 