### PR TITLE
Collect log for new container runtime monitor.

### DIFF
--- a/jobs/env/ci-containerd-e2e-gce.env
+++ b/jobs/env/ci-containerd-e2e-gce.env
@@ -1,6 +1,6 @@
 ### job-env
 # Envs for containerd.
-LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
+LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation
 KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/containerd/env
 KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/containerd/env
 KUBE_CONTAINER_RUNTIME=remote

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -1,6 +1,6 @@
 ### job-env
 # Envs for containerd.
-LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation containerd-monitor
+LOG_DUMP_SYSTEMD_SERVICES=containerd containerd-installation
 KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/env
 KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/github.com/containerd/cri/test/env
 KUBE_CONTAINER_RUNTIME=remote


### PR DESCRIPTION
Depends on https://github.com/kubernetes/kubernetes/pull/63357.

`containerd-monitor` will be removed, and `kube-container-runtime-monitor` log will be collected by default.

/hold

Please do not merge this yet.

Signed-off-by: Lantao Liu <lantaol@google.com>