### PR TITLE
Update glbc image url for kubemci conformance CI

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -840,7 +840,7 @@
   "ci-kubemci-ingress-conformance": {
     "args": [
       "--check-leaked-resources",
-      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:latest",
+      "--env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-e2e-glbc-amd64:master",
       "--extract=ci/latest",
       "--gcp-node-image=gci",
       "--gcp-project-type=ingress-project",


### PR DESCRIPTION
Ref #7925, kubemci CI is failing to pull from a not exist GLBC image URL.
/assign @nikhiljindal @BenTheElder 
cc @rramkumar1 