### PR TITLE
Typo fix: bellow->below/to to->to

### DIFF
--- a/boskos/storage_test.go
+++ b/boskos/storage_test.go
@@ -53,7 +53,7 @@ func TestAddDelete(t *testing.T) {
 		}
 		items, err := s.List()
 		if err != nil {
-			t.Errorf("unable to to list resources, %v", err)
+			t.Errorf("unable to list resources, %v", err)
 		}
 		var rResources []common.Resource
 		for _, i := range items {
@@ -76,7 +76,7 @@ func TestAddDelete(t *testing.T) {
 		}
 		eResources, err := s.List()
 		if err != nil {
-			t.Errorf("unable to to list resources, %v", err)
+			t.Errorf("unable to list resources, %v", err)
 		}
 		if len(eResources) != 0 {
 			t.Error("list should return an empty list")

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -2120,7 +2120,7 @@ func (obj *MungeObject) MergePR(who string) bool {
 	)
 
 	// The github API https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button indicates
-	// we will only get the bellow error if we provided a particular sha to merge PUT. We aren't doing that
+	// we will only get the below error if we provided a particular sha to merge PUT. We aren't doing that
 	// so our best guess is that the API also provides this error message when it is recalulating
 	// "mergeable". So if we get this error, check "IsPRMergeable()" which should sleep just a bit until
 	// github is finished calculating. If my guess is correct, that also means we should be able to

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -297,7 +297,7 @@ func dupeRequest(original *http.Request) *http.Request {
 	return r2
 }
 
-// serve with handler but map extensionless URLs to to the default
+// serve with handler but map extensionless URLs to the default
 func defaultExtension(extension string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(r.URL.Path) > 0 &&


### PR DESCRIPTION
Fix 2 typos:
bellow->below
to to->to