### PR TITLE
Fix utlity_images: set pure to on

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -24,8 +24,8 @@ go_image(
 go_binary(
     name = "clonerefs",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
     pure = "on",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -25,6 +25,7 @@ go_binary(
     name = "clonerefs",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    pure = "on",
 )
 
 filegroup(

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -31,4 +31,5 @@ go_binary(
     name = "entrypoint",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    pure = "on",
 )

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -30,6 +30,6 @@ filegroup(
 go_binary(
     name = "entrypoint",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
     pure = "on",
+    visibility = ["//visibility:public"],
 )

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -18,6 +18,7 @@ go_binary(
     name = "gcsupload",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    pure = "on",
 )
 
 filegroup(

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -17,8 +17,8 @@ go_library(
 go_binary(
     name = "gcsupload",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
     pure = "on",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -25,6 +25,7 @@ go_binary(
     name = "initupload",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    pure = "on",
 )
 
 filegroup(

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -24,8 +24,8 @@ go_library(
 go_binary(
     name = "initupload",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
     pure = "on",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -17,6 +17,7 @@ go_binary(
     name = "sidecar",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    pure = "on",
 )
 
 filegroup(

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -16,8 +16,8 @@ go_library(
 go_binary(
     name = "sidecar",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
     pure = "on",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
the utility images are currently broken:
```
user@unknown:~/dev/kubrnetes/test-infra/prow$ docker run -it gcr.io/k8s-prow/clonerefs:latest
standard_init_linux.go:195: exec user process caused "no such file or directory"
```

To fix this, pure needs to be set to on.
This option ensure that the binaries are compiled with CGO_ENABLED=0 like all the other binaries.