### PR TITLE
Fixing response link for Pull Request help

### DIFF
--- a/prow/plugins/respond.go
+++ b/prow/plugins/respond.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
-const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/devel/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository."
+const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository."
 const AboutThisBotCommands = "I understand the commands that are listed [here](https://go.k8s.io/bot-commands)."
 const AboutThisBot = AboutThisBotWithoutCommands + " " + AboutThisBotCommands
 


### PR DESCRIPTION
Fixing the contextual help link in the command response to point to the "guide" section of community docs rather than the "devel" section.  The PR docs were moved from "community/contributors/devel" to "community/contributors/guide" in [February 2018](https://github.com/kubernetes/community/commit/98bea78a76c04108ed07352fc7e7c525b2b5a5b3#diff-c57e6366e0ea339933ad5843ec7b4a03).

Thanks!

/cc @guineveresaenger 