### PR TITLE
Add cross builds for stable releases

### DIFF
--- a/charts/mungegithub/chart/values.kubernetes.kubernetes.yaml
+++ b/charts/mungegithub/chart/values.kubernetes.kubernetes.yaml
@@ -41,6 +41,8 @@ config:
     ci-kubernetes-bazel-test,\
     ci-kubernetes-build,\
     ci-kubernetes-cross-build,\
+    ci-kubernetes-cross-build-release-1-dot-9,\
+    ci-kubernetes-cross-build-release-1-dot-10,\
     ci-kubernetes-e2e-gci-gce-garbage,\
     ci-kubernetes-e2e-gce-etcd3,\
     ci-kubernetes-e2e-gce-examples,\

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1015,6 +1015,30 @@
       "sig-release"
     ]
   },
+  "ci-kubernetes-cross-build-release-1-dot-10": {
+    "args": [
+      "--branch=release-1.10",
+      "--hyperkube",
+      "--registry=gcr.io/kubernetes-ci-images",
+      "--suffix=-cross"
+    ],
+    "scenario": "kubernetes_build",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
+  "ci-kubernetes-cross-build-release-1-dot-9": {
+    "args": [
+      "--branch=release-1.9",
+      "--hyperkube",
+      "--registry=gcr.io/kubernetes-ci-images",
+      "--suffix=-cross"
+    ],
+    "scenario": "kubernetes_build",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
   "ci-kubernetes-e2e-autoscaling-vpa-actuation": {
     "args": [
       "--check-leaked-resources",

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -29,6 +29,8 @@ nonblocking-jobs: "\
   ci-kubernetes-bazel-test,\
   ci-kubernetes-build,\
   ci-kubernetes-cross-build,\
+  ci-kubernetes-cross-build-release-1-dot-9,\
+  ci-kubernetes-cross-build-release-1-dot-10,\
   ci-kubernetes-e2e-gci-gce-garbage,\
   ci-kubernetes-e2e-gce-etcd3,\
   ci-kubernetes-e2e-gce-examples,\

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8787,6 +8787,66 @@ periodics:
     - name: docker-graph
       emptyDir: {}
 
+- interval: 1h
+  name: ci-kubernetes-cross-build-release-1-dot-10
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
+      args:
+      - --repo=k8s.io/kubernetes=release-1.10
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=120
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      resources:
+        requests:
+          cpu: 7
+          memory: "41Gi"
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+
+- interval: 1h
+  name: ci-kubernetes-cross-build-release-1-dot-9
+  agent: kubernetes
+  labels:
+    preset-service-account: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20180215-b2a89850e
+      args:
+      - --repo=k8s.io/kubernetes=release-1.9
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=120
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      resources:
+        requests:
+          cpu: 7
+          memory: "41Gi"
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+
 - interval: 6h
   name: ci-kubernetes-dind-conformance
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -624,6 +624,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-large-deploy
 - name: ci-kubernetes-cross-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-cross-build
+- name: ci-kubernetes-cross-build-release-1-dot-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-cross-build-release-1-dot-10
+- name: ci-kubernetes-cross-build-release-1-dot-9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-cross-build-release-1-dot-9
 - name: ci-kubernetes-node-kubelet-alpha
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-alpha
   test_name_config:
@@ -3910,6 +3914,10 @@ dashboards:
   dashboard_tab:
   - name: cross-build
     test_group_name: ci-kubernetes-cross-build
+  - name: cross-build-1.10
+    test_group_name: ci-kubernetes-cross-build-release-1-dot-10
+  - name: cross-build-1.9
+    test_group_name: ci-kubernetes-cross-build-release-1-dot-9
   - name: kops-build
     test_group_name: ci-kops-build
   - name: debian-unstable


### PR DESCRIPTION
We have builds like ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10 that
depend on kubernetes-release-dev/ci-cross/latest-1.9.txt being
up-to-date. Right now we don't have any jobs that builds images and
updates that file. (See details in https://github.com/kubernetes/kubernetes/issues/61483)