### PR TITLE
update prow config to fix example-seldon repo name

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -119,7 +119,7 @@ tide:
     - kubeflow/tf-operator
     - kubeflow/katib
     - kubeflow/experimental-kvc
-    - kubeflow/experimental-seldon
+    - kubeflow/example-seldon
     - kubeflow/experimental-beagle
     - kubeflow/caffe2-operator
     - kubeflow/reporting


### PR DESCRIPTION
fixes https://github.com/kubeflow/example-seldon/issues/16