### PR TITLE
Make scalability presubmits blocking

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,9 +16,10 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce,\
+  pull-kubernetes-e2e-gce-100-performance,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-integration,\
-  pull-kubernetes-kubemark-e2e-gce,\
+  pull-kubernetes-kubemark-e2e-gce-big,\
   pull-kubernetes-node-e2e,\
   pull-kubernetes-typecheck,\
   pull-kubernetes-verify"


### PR DESCRIPTION
We are finally at a stage where our 2 scalability presubmits ([gce-100](https://k8s-testgrid.appspot.com/presubmits-kubernetes-scalability#pull-kubernetes-e2e-gce-100-performance) and [kubemark-500](https://k8s-testgrid.appspot.com/presubmits-kubernetes-scalability#pull-kubernetes-kubemark-e2e-gce-big)) are quite healthy.
You can see the failure rate of the jobs [here](http://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1&panelId=11&fullscreen) and neither of the two are in the top 5 (as of today 8 AM PDT).
Further, >90% of those jobs' failures are unrelated to the jobs themselves (i.e compile errors, failure to fetch some test-infra pkgs, etc)

/cc @wojtek-t @krzyzacy @AishSundar 

Fixes https://github.com/kubernetes/test-infra/issues/4445