### PR TITLE
Tide improvements

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -34,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -194,16 +193,6 @@ func checkRetest(t *testing.T, repo string, presubmits []Presubmit) {
 func TestRetestMatchJobsName(t *testing.T) {
 	for repo, presubmits := range c.Presubmits {
 		checkRetest(t, repo, presubmits)
-	}
-}
-
-func TestTideMergeMethod(t *testing.T) {
-	for name, method := range c.Tide.MergeType {
-		if method != github.MergeMerge &&
-			method != github.MergeRebase &&
-			method != github.MergeSquash {
-			t.Errorf("Merge type %q for %s is not a valid type", method, name)
-		}
 	}
 }
 

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 var testQuery = TideQuery{
+	Orgs:                   []string{"org"},
 	Repos:                  []string{"k/k", "k/t-i"},
 	Labels:                 []string{"lgtm", "approved"},
 	MissingLabels:          []string{"foo"},
@@ -41,6 +42,7 @@ func TestTideQuery(t *testing.T) {
 
 	checkTok("is:pr")
 	checkTok("state:open")
+	checkTok("org:\"org\"")
 	checkTok("repo:\"k/k\"")
 	checkTok("repo:\"k/t-i\"")
 	checkTok("label:\"lgtm\"")
@@ -73,6 +75,7 @@ func TestAllPRsSince(t *testing.T) {
 	queries := TideQueries([]TideQuery{
 		testQuery,
 		{
+			Orgs:   []string{"foo"},
 			Repos:  []string{"k/foo"},
 			Labels: []string{"lgtm", "mergeable"},
 		},
@@ -80,6 +83,8 @@ func TestAllPRsSince(t *testing.T) {
 	q = " " + queries.AllPRsSince(testTime) + " "
 	checkTok("is:pr", true)
 	checkTok("state:open", true)
+	checkTok("org:\"org\"", true)
+	checkTok("org:\"foo\"", true)
 	checkTok("repo:\"k/k\"", true)
 	checkTok("repo:\"k/t-i\"", true)
 	checkTok("repo:\"k/foo\"", true)

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -589,7 +589,7 @@ func TestExpectedStatus(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Logf("Test Case: %q\n", tc.name)
-		queriesByRepo := map[string]config.TideQueries{
+		queriesByRepo := config.QueryMap(map[string]config.TideQueries{
 			"": {
 				config.TideQuery{
 					ExcludedBranches: tc.branchBlacklist,
@@ -601,7 +601,7 @@ func TestExpectedStatus(t *testing.T) {
 					Labels: []string{"1", "2", "3", "4", "5", "6", "7"}, // lots of requirements
 				},
 			},
-		}
+		})
 		var pr PullRequest
 		pr.BaseRef = struct {
 			Name   githubql.String

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -735,9 +735,9 @@ func TestSetStatuses(t *testing.T) {
 				},
 			}
 		}
-		var pool []PullRequest
+		pool := make(map[string]PullRequest)
 		if tc.inPool {
-			pool = []PullRequest{pr}
+			pool[prKey(&pr)] = pr
 		}
 		fc := &fgc{}
 		ca := &config.Agent{}
@@ -859,14 +859,14 @@ func TestDividePool(t *testing.T) {
 		ghc:    fc,
 		logger: logrus.WithField("component", "tide"),
 	}
-	var pulls []PullRequest
+	pulls := make(map[string]PullRequest)
 	for _, p := range testPulls {
 		npr := PullRequest{Number: githubql.Int(p.number)}
 		npr.BaseRef.Name = githubql.String(p.branch)
 		npr.BaseRef.Prefix = "refs/heads/"
 		npr.Repository.Name = githubql.String(p.repo)
 		npr.Repository.Owner.Login = githubql.String(p.org)
-		pulls = append(pulls, npr)
+		pulls[prKey(&npr)] = npr
 	}
 	var pjs []kube.ProwJob
 	for _, pj := range testPJs {
@@ -1525,6 +1525,18 @@ func TestSync(t *testing.T) {
 		{
 			name: "1 mergeable, 1 unmergeable (same pool)",
 			prs:  []PullRequest{mergeableA, unmergeableA},
+			expectedPools: []Pool{{
+				Org:        "org",
+				Repo:       "repo",
+				Branch:     "A",
+				SuccessPRs: []PullRequest{mergeableA},
+				Action:     Merge,
+				Target:     []PullRequest{mergeableA},
+			}},
+		},
+		{
+			name: "1 mergeable PR (satisfies multiple queries)",
+			prs:  []PullRequest{mergeableA, mergeableA},
 			expectedPools: []Pool{{
 				Org:        "org",
 				Repo:       "repo",


### PR DESCRIPTION
Broken into 3 commits:
- Adds support for `org:foo` search tokens.
- De-dups query results to allow for query overlap.
- Adds `TideQuery` validation.

Ref #7953 #7939 
/area prow
/cc @stevekuznetsov @kargakis 