### PR TITLE
Add org configuration skeleton

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -70,6 +70,7 @@ filegroup(
         "//prow/cmd/jenkins-operator:all-srcs",
         "//prow/cmd/mkpj:all-srcs",
         "//prow/cmd/mkpod:all-srcs",
+        "//prow/cmd/peribolos:all-srcs",
         "//prow/cmd/phony:all-srcs",
         "//prow/cmd/plank:all-srcs",
         "//prow/cmd/sidecar:all-srcs",

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/peribolos",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/config/org:go_default_library",
+        "//prow/github:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "peribolos",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+)

--- a/prow/cmd/peribolos/README.md
+++ b/prow/cmd/peribolos/README.md
@@ -1,0 +1,80 @@
+# Not implemented
+
+WARNING: none of this code works yet. Implementation will follow later
+
+# Peribolos Documentation
+
+Peribolos allows the org settings, teams and memberships to be declared in a yaml file. Github is then updated to match the declared configuration.
+
+### Etymology
+
+A [peribolos] is a wall that encloses a court in Greek/Roman architecture.
+
+## Org configuration
+
+Extend the primary prow [`config.yaml`] document to include a top-level `orgs` key that looks like the following:
+
+```yaml
+orgs:
+  this-org:
+    # org settings
+    company: foo
+    email: foo
+    name: foo
+    description: foo
+    has_organization_projects: true
+    has_repository_projects: true
+    default_repository_permission: read
+    members_can_create_repositories: false
+
+    # org member settings
+    members:
+    - anne
+    - bob
+    admins:
+    - carl
+    
+    # team settings
+    teams:
+      node:
+        # team config
+        description: people working on node backend
+        privacy: closed
+        previously:
+        - backend  # If a backend team exists, rename it to node
+
+        # team members
+        members:
+        - anne
+        maintainers:
+        - jane
+      another-team:
+        ...
+      ...
+  that-org:
+    ...
+```
+
+This config will:
+* Ensure the org settings match the following:
+  - Set the company, email, name and descriptions fields for the org to foo
+  - Allow projects to be created at the org and repo levels
+  - Give everyone read access to repos by default
+  - Disallow members from creating repositories
+* Ensure the following memberships exist:
+  - anne and bob are members, carl is an admin
+* Configure the node and another-team in the following manner:
+  - Set node's description and privacy setting.
+  - Rename the backend team to node
+  - Add anne as a member and jane as a maintainer to node
+  - Similar things for another-team (detailed elided)
+
+Note that any fields missing from the config will not be managed by peribolos. So if description is missing from the org setting, the current value will remain.
+
+For more details please see GitHub documentation around [edit org], [update org membership], [edit team], [update team membership].
+
+
+[edit team]: https://developer.github.com/v3/teams/#edit-team
+[peribolos]: https://en.wikipedia.org/wiki/Peribolos
+[update org membership]: https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
+[update team membership]: https://developer.github.com/v3/teams/members/#add-or-update-team-membership

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/org"
+	"k8s.io/test-infra/prow/github"
+)
+
+const defaultEndpoint = "https://api.github.com"
+
+type options struct {
+	config   string
+	token    string
+	confirm  bool
+	endpoint string
+}
+
+func parseOptions() options {
+	var o options
+	if err := o.parseArgs(flag.CommandLine, os.Args[1:]); err != nil {
+		log.Fatalf("Invalid flags: %v", err)
+	}
+	return o
+}
+
+func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
+	flags.StringVar(&o.config, "config-path", "", "Path to prow config.yaml")
+	flags.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
+	flags.StringVar(&o.endpoint, "github-endpoint", defaultEndpoint, "Github api endpoint, may differ for enterprise")
+	flags.StringVar(&o.token, "github-token-path", "", "Path to github token")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if o.config == "" {
+		return errors.New("empty --config")
+	}
+
+	if o.token == "" {
+		return errors.New("empty --github-token-path")
+	}
+
+	if _, err := url.Parse(o.endpoint); err != nil {
+		return fmt.Errorf("invalid --endpoint URL: %v", err)
+	}
+	return nil
+}
+
+func main() {
+	o := parseOptions()
+
+	if o.config != "TODO(fejta): implement me" {
+		log.Fatalf("This program is not yet implemented")
+	}
+
+	cfg, err := config.Load(o.config)
+	if err != nil {
+		log.Fatalf("Failed to load --config=%s: %v", o.config, err)
+	}
+
+	b, err := ioutil.ReadFile(o.token)
+	if err != nil {
+		log.Fatalf("cannot read --token: %v", err)
+	}
+
+	var c *github.Client
+	tok := strings.TrimSpace(string(b))
+	if o.confirm {
+		c = github.NewClient(tok, o.endpoint)
+	} else {
+		c = github.NewDryRunClient(tok, o.endpoint)
+	}
+	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
+
+	for name, orgcfg := range cfg.Orgs {
+		if err := configureOrg(c, name, orgcfg); err != nil {
+			log.Fatalf("Configuration failed: %v", err)
+		}
+	}
+}
+
+func configureOrg(client *github.Client, orgName string, orgConfig org.Config) error {
+	// get meta
+	// diff meta
+	// patch meta
+
+	// people = set(all org members)
+	// remove = people - orgConfig.members - orgConfig.admins
+	// update = oc.members - [p for p in people if member]
+	// update = oc.admins - [p for p in people if admin]
+
+	// teams = set(all teams)
+	for name, team := range orgConfig.Teams {
+		team.Name = name
+		num := -1
+		// find team name in teams (or previous name)
+		if err := configureTeam(client, num, team); err != nil {
+			return fmt.Errorf("failed to update %s: %v", orgName, err)
+		}
+	}
+	return nil
+}
+
+func configureTeam(client *github.Client, num int, team org.Team) error {
+	// create team if num < 0
+	// else diff and patch
+
+	// people = set(all org members)
+	// remove = people - orgConfig.members - orgConfig.admins
+	// update = oc.members - [p for p in people if member]
+	// update = oc.admins - [p for p in people if admin]
+	return errors.New("implement")
+}

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		expected *options
+	}{
+		{
+			name: "missing --config",
+			args: []string{"--github-token-path=fake"},
+		},
+		{
+			name: "missing --github-token-path",
+			args: []string{"--config-path=fake"},
+		},
+		{
+			name: "bad --github-endpoint",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=ht!tp://:dumb"},
+		},
+		{
+			name: "minimal",
+			args: []string{"--config-path=foo", "--github-token-path=bar"},
+			expected: &options{
+				config:   "foo",
+				token:    "bar",
+				endpoint: defaultEndpoint,
+			},
+		},
+		{
+			name: "full",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true"},
+			expected: &options{
+				config:   "foo",
+				token:    "bar",
+				endpoint: "weird://url",
+				confirm:  true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+		var actual options
+		err := actual.parseArgs(flags, tc.args)
+		switch {
+		case err == nil && tc.expected == nil:
+			t.Errorf("%s: failed to return an error", tc.name)
+		case err != nil && tc.expected != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
+			t.Errorf("%s: actual %v != expected %v", tc.name, actual, tc.expected)
+		}
+	}
+
+}

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
+        "//prow/config/org:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
@@ -67,6 +68,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/config/org:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
@@ -49,12 +50,13 @@ type Config struct {
 	// Periodics are not associated with any repo.
 	Periodics []Periodic `json:"periodics,omitempty"`
 
-	Tide             Tide             `json:"tide,omitempty"`
-	Plank            Plank            `json:"plank,omitempty"`
-	Sinker           Sinker           `json:"sinker,omitempty"`
-	Deck             Deck             `json:"deck,omitempty"`
-	BranchProtection BranchProtection `json:"branch-protection,omitempty"`
-	Gerrit           Gerrit           `json:"gerrit,omitempty"`
+	Tide             Tide                  `json:"tide,omitempty"`
+	Plank            Plank                 `json:"plank,omitempty"`
+	Sinker           Sinker                `json:"sinker,omitempty"`
+	Deck             Deck                  `json:"deck,omitempty"`
+	BranchProtection BranchProtection      `json:"branch-protection,omitempty"`
+	Orgs             map[string]org.Config `json:"orgs,omitempty"`
+	Gerrit           Gerrit                `json:"gerrit,omitempty"`
 
 	// TODO: Move this out of the main config.
 	JenkinsOperators []JenkinsOperator `json:"jenkins_operators,omitempty"`

--- a/prow/config/org/BUILD.bazel
+++ b/prow/config/org/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["org.go"],
+    importpath = "k8s.io/test-infra/prow/config/org",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["org_test.go"],
+    embed = [":go_default_library"],
+)

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org
+
+import (
+	"fmt"
+)
+
+// Metadata declares metadata about the GitHub org.
+//
+// See https://developer.github.com/v3/orgs/#edit-an-organization
+type Metadata struct {
+	BillingEmail                 *string              `json:"billing_email,omitempty"`
+	Company                      *string              `json:"company,omitempty"`
+	Email                        *string              `json:"email,omitempty"`
+	Name                         *string              `json:"name,omitempty"`
+	Description                  *string              `json:"description,omitempty"`
+	Location                     *string              `json:"location,omitempty"`
+	HasOrganizationProjects      *bool                `json:"has_organization_projects,omitempty"`
+	HasRepositoryProjects        *bool                `json:"has_repository_projects,omitempty"`
+	DefaultRepositoryPermission  *RepoPermissionLevel `json:"default_repository_permission,omitempty"`
+	MembersCanCreateRepositories *bool                `json:"members_can_create_repositories,omitempty"`
+}
+
+// Config declares org metadata as well as its people and teams.
+type Config struct {
+	Metadata
+	Teams   map[string]Team `json:"teams,omitempty"`
+	Members []string        `json:"members,omitempty"`
+	Admins  []string        `json:"admins,omitempty"`
+}
+
+// TeamMetadata declares metadata about the github team.
+//
+// See https://developer.github.com/v3/teams/#edit-team
+type TeamMetadata struct {
+	Name        string   `json:"name,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Privacy     *Privacy `json:"privacy,omitempty"`
+}
+
+// Team declares metadata as well as its poeple.
+type Team struct {
+	TeamMetadata
+	Members     []string `json:"members,omitempty"`
+	Maintainers []string `json:"maintainers,omitempty"`
+
+	Previously []string `json:"previously,omitempty"`
+}
+
+// RepoPermissionLevel is admin, write, read or none.
+//
+// See https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
+type RepoPermissionLevel string
+
+const (
+	Read  RepoPermissionLevel = "read"
+	Write RepoPermissionLevel = "write"
+	Admin RepoPermissionLevel = "admin"
+	None  RepoPermissionLevel = "none"
+)
+
+var repoPermissionLevels = map[RepoPermissionLevel]bool{
+	Read:  true,
+	Write: true,
+	Admin: true,
+	None:  true,
+}
+
+// MashalText returns the byte representation of the permission
+func (l RepoPermissionLevel) MarshalText() ([]byte, error) {
+	return []byte(l), nil
+}
+
+// UnmarshalText validates the text is a valid string
+func (l *RepoPermissionLevel) UnmarshalText(text []byte) error {
+	v := RepoPermissionLevel(text)
+	if _, ok := repoPermissionLevels[v]; !ok {
+		return fmt.Errorf("bad repo permission: %s not in %v", v, repoPermissionLevels)
+	}
+	*l = v
+	return nil
+}
+
+// Privacy is secret or closed.
+//
+// See https://developer.github.com/v3/teams/#edit-team
+type Privacy string
+
+const (
+	Closed Privacy = "closed"
+	Secret Privacy = "secret"
+)
+
+var privacySettings = map[Privacy]bool{
+	Closed: true,
+	Secret: true,
+}
+
+// MarshalText returns bytes that equal secret or closed
+func (p Privacy) MarshalText() ([]byte, error) {
+	return []byte(p), nil
+}
+
+// UnmarshalText returns an error if text != secret or closed
+func (p *Privacy) UnmarshalText(text []byte) error {
+	v := Privacy(text)
+	if _, ok := privacySettings[v]; !ok {
+		return fmt.Errorf("bad privacy setting: %s", v)
+	}
+	*p = v
+	return nil
+}

--- a/prow/config/org/org_test.go
+++ b/prow/config/org/org_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRepoPermissionLevel(t *testing.T) {
+	get := func(v RepoPermissionLevel) *RepoPermissionLevel {
+		return &v
+	}
+	cases := []struct {
+		input    string
+		expected *RepoPermissionLevel
+	}{
+		{
+			"admin",
+			get(Admin),
+		},
+		{
+			"write",
+			get(Write),
+		},
+		{
+			"read",
+			get(Read),
+		},
+		{
+			"none",
+			get(None),
+		},
+		{
+			"",
+			nil,
+		},
+		{
+			"unknown",
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		var actual RepoPermissionLevel
+		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
+		switch {
+		case err == nil && tc.expected == nil:
+			t.Errorf("%s: failed to receieve an error", tc.input)
+		case err != nil && tc.expected != nil:
+			t.Errorf("%s: unexpected error: %v", tc.input, err)
+		case err == nil && *tc.expected != actual:
+			t.Errorf("%s: actual %v != expected %v", tc.input, tc.expected, actual)
+		}
+	}
+}
+
+func TestPrivacy(t *testing.T) {
+	get := func(v Privacy) *Privacy {
+		return &v
+	}
+	cases := []struct {
+		input    string
+		expected *Privacy
+	}{
+		{
+			"secret",
+			get(Secret),
+		},
+		{
+			"closed",
+			get(Closed),
+		},
+		{
+			"",
+			nil,
+		},
+		{
+			"unknown",
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		var actual Privacy
+		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
+		switch {
+		case err == nil && tc.expected == nil:
+			t.Errorf("%s: failed to receieve an error", tc.input)
+		case err != nil && tc.expected != nil:
+			t.Errorf("%s: unexpected error: %v", tc.input, err)
+		case err == nil && *tc.expected != actual:
+			t.Errorf("%s: actual %v != expected %v", tc.input, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Implements the config structure specified in https://docs.google.com/document/d/18Kw8InxYk4OF14iTXXfvD2oy3AuoDxfqAmtvf6NbwBI/edit

Creates a skeleton peribolos binary that applies the config (will implement in subsequent PRs)

/assign @krzyzacy @cblecker @stevekuznetsov @kargakis 