### PR TITLE
deck: get logs from test container only

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -43,6 +43,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *May 9, 2018* `deck` logs for jobs run as `Pods` will now return logs for the
+   `"test"` container only.
  - *April 2, 2018* `updateconfig` format has been changed from
    ```yaml
    path/to/some/other/thing: configName

--- a/prow/artifact-uploader/BUILD.bazel
+++ b/prow/artifact-uploader/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//prow/gcsupload:go_default_library",
         "//prow/kube:go_default_library",
-        "//prow/pod-utils/decorate:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/prow/artifact-uploader/controller.go
+++ b/prow/artifact-uploader/controller.go
@@ -35,7 +35,6 @@ import (
 
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/kube"
-	"k8s.io/test-infra/prow/pod-utils/decorate"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
@@ -94,7 +93,7 @@ func NewController(client core.CoreV1Interface, prowJobClient *kube.Client, gcsC
 func findFinishedContainers(old, new []api.ContainerStatus) []string {
 	var containerNames []string
 	for _, oldInitContainer := range old {
-		if oldInitContainer.Name == decorate.TestContainerName {
+		if oldInitContainer.Name == kube.TestContainerName {
 			// logs from the test container will be uploaded by the
 			// sidecar, so we do not need to worry about them here
 			continue

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -37,6 +37,8 @@ import (
 )
 
 const (
+	TestContainerName = "test"
+
 	inClusterBaseURL = "https://kubernetes.default"
 	maxRetries       = 8
 	retryDelay       = 2 * time.Second
@@ -524,7 +526,8 @@ func (c *Client) CreatePod(p v1.Pod) (Pod, error) {
 func (c *Client) GetLog(pod string) ([]byte, error) {
 	c.log("GetLog", pod)
 	return c.requestRetry(&request{
-		path: fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.namespace, pod),
+		path:  fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.namespace, pod),
+		query: map[string]string{"container": TestContainerName},
 	})
 }
 

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	TestContainerName       = "test"
 	LogMountName            = "logs"
 	LogMountPath            = "/logs"
 	ArtifactsEnv            = "ARTIFACTS"
@@ -75,7 +74,7 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 
 	spec := pj.Spec.PodSpec.DeepCopy()
 	spec.RestartPolicy = "Never"
-	spec.Containers[0].Name = TestContainerName
+	spec.Containers[0].Name = kube.TestContainerName
 
 	if pj.Spec.DecorationConfig == nil {
 		spec.Containers[0].Env = append(spec.Containers[0].Env, env...)


### PR DESCRIPTION
In all cases, `plank` will create a pod in which the test logic runs in
a container named `"test"`. We should ask for the logs from this
container only when a user requests logs for a job run on Kubernetes.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @fejta @BenTheElder @kargakis 
/assign @cjwagner 
fixes #7807 