### PR TITLE
prow: pod-utils: initupload: expose log through a flag

### DIFF
--- a/prow/initupload/options.go
+++ b/prow/initupload/options.go
@@ -66,6 +66,7 @@ func (o *Options) LoadConfig(config string) error {
 
 // BindOptions binds flags to options
 func (o *Options) BindOptions(flags *flag.FlagSet) {
+	flags.StringVar(&o.Log, "clone-log", "", "Path to the clone records log")
 	gcsupload.BindOptions(o.Options, flags)
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @fejta @BenTheElder 
/assign @kargakis @cjwagner 

Looks like I lost this flag in the migration to JSON config...