### PR TITLE
Define test groups related to testing autoscaling with gpus

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5016,6 +5016,26 @@
       "sig-autoscaling"
     ]
   },
+  "ci-kubernetes-e2e-gci-gke-autoscaling-gpu": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=ca-gpu",
+      "--deployment=gke",
+      "--extract=ci/latest",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingGpu\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=150m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-autoscaling"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gke-autoscaling-hpa": {
     "args": [
       "--check-leaked-resources",

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -53,6 +53,7 @@ nonblocking-jobs: "\
   ci-kubernetes-e2e-gci-gke,\
   ci-kubernetes-e2e-gci-gke-alpha-features,\
   ci-kubernetes-e2e-gci-gke-autoscaling,\
+  ci-kubernetes-e2e-gci-gke-autoscaling-gpu,\
   ci-kubernetes-e2e-gci-gke-ingress,\
   ci-kubernetes-e2e-gci-gke-multizone,\
   ci-kubernetes-e2e-gci-gke-pre-release,\

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11727,6 +11727,19 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180418-79a97ca02-master
+
+- interval: 30m
+  agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
   labels:
     preset-gke-alpha-service: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -424,6 +424,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-alpha-features
 - name: ci-kubernetes-e2e-gci-gke-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling
+- name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling-gpu
 - name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling-regional
 - name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
@@ -4449,6 +4451,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
   - name: gci-gke-autoscaling
     test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling
+  - name: gci-gke-autoscaling-gpu
+    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu
   - name: gci-gke-autoscaling-regional
     test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
   - name: gke-ubuntu1-k8sbeta-autoscaling


### PR DESCRIPTION
Tested to some locally to some extent following 
https://github.com/kubernetes/test-infra#create-a-new-job
What could be tested seems to work correctly. The actual tests are not yet pushed to k8s.io/kuberenets master so none were executed but other than that `bootstrap.py` call completed fine.