### PR TITLE
Remove the c-m qps bump in 100-node job

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
@@ -7,6 +7,3 @@ CREATE_CUSTOM_NETWORK=true
 
 # Reduce logs verbosity
 TEST_CLUSTER_LOG_LEVEL=--v=2
-
-# Temporarily bump the qps before we reset c-m defaults (#63610).
-CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/kubernetes/issues/63610#issuecomment-388008400, increasing the qps doesn't seem to be the right direction to fix the problem.

/cc @wojtek-t 
fyi - @deads2k 

