### PR TITLE
Add `ssh` to the `git` image

### DIFF
--- a/prow/cmd/images/git/Dockerfile
+++ b/prow/cmd/images/git/Dockerfile
@@ -14,4 +14,4 @@
 
 FROM gcr.io/k8s-prow/alpine:0.1
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git openssh


### PR DESCRIPTION
We need the `git` container image to be able to pull both public and
private repos, so we need the container image to contain both `git` and
`ssh`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @fejta @BenTheElder 
/assign @cjwagner 