### PR TITLE
Change istio branch to k8s-prow-test

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16834,7 +16834,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180509-390060182-master
       args:
-      - --repo=github.com/ostromart/istio=fortio-fix
+      - --repo=github.com/ostromart/istio=k8s-prow-test
       - --timeout=90
       - --root=/go/src
 


### PR DESCRIPTION
Need one more change to make this work. 
fortio-fix is actually the branch based off 0.6 that has the correct fortio version, but we still need a branch based off master that switches to the correct version once the script is run. 
The istio:k8s-prow-test branch has a temporary hack to switch to the 0.6 release based branch with the fortio fix for testing.