### PR TITLE
Optionally allow children to disable parent policies

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/util/diff"
+
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
-
-	"github.com/ghodss/yaml"
 )
 
 func TestOptions_Validate(t *testing.T) {
@@ -523,6 +523,39 @@ branch-protection:
 							Teams: []string{"config-team", "org-team"},
 						},
 					},
+				},
+			},
+		},
+		{
+			name:     "child cannot disable parent policy by default",
+			branches: []string{"parent/child=unprotected"},
+			config: `
+branch-protection:
+  protect: true
+  enforce_admins: true
+  orgs:
+    parent:
+      protect: false
+`,
+			errors: 1,
+		},
+		{
+			name:     "child disables parent",
+			branches: []string{"parent/child=unprotected"},
+			config: `
+branch-protection:
+  allow_disabled_policies: true
+  protect: true
+  enforce_admins: true
+  orgs:
+    parent:
+      protect: false
+`,
+			expected: []Requirements{
+				{
+					Org:    "parent",
+					Repo:   "child",
+					Branch: "unprotected",
 				},
 			},
 		},

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,6 +32,7 @@ pod_namespace: test-pods
 log_level: info
 
 branch-protection:
+  allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
   orgs:
     kubernetes:
       # TODO(fejta): build blacklist and then protect-by-default

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -587,6 +587,30 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "child policy with defined parent can disable protection",
+			config: Config{
+				BranchProtection: BranchProtection{
+					AllowDisabledPolicies: true,
+					Policy: Policy{
+						Protect: yes,
+						Restrictions: &Restrictions{
+							Teams: []string{"oncall"},
+						},
+					},
+					Orgs: map[string]Org{
+						"org": {
+							Policy: Policy{
+								Protect: no,
+							},
+						},
+					},
+				},
+			},
+			expected: &Policy{
+				Protect: no,
+			},
+		},
+		{
 			name: "Make required presubmits required",
 			config: Config{
 				BranchProtection: BranchProtection{


### PR DESCRIPTION
Fixed the import order per @stevekuznetsov feedback on previous PR.

We need this because `kubernetes/website` sets `protect-by-default: false`.