### PR TITLE
Add old cos test to compare with new cos.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10337,6 +10337,48 @@
       "sig-gcp"
     ]
   },
+  "ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features-compare": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=ci/k8s-stable1",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel",
+      "--gke-create-command=container clusters create --quiet --enable-kubernetes-alpha",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-new-cos-gke-k8sstable1-compare": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=ci/k8s-stable1",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel",
+      "--gke-create-command=container clusters create --quiet --enable-kubernetes-alpha",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
   "ci-kubernetes-e2e-node-canary": {
     "args": [
       "--deployment=node",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15077,6 +15077,32 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180510-540e0e395-master
 
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features-compare
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=200
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180503-1fa9a8040-master
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-compare
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180503-1fa9a8040-master
+
 - name: ci-kubernetes-e2e-node-canary
   interval: 1h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -535,8 +535,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-new-cos-gke
 - name: ci-kubernetes-e2e-new-cos-gke-k8sstable1
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-new-cos-gke-k8sstable1
+- name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-compare
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-new-cos-gke-k8sstable1-compare
 - name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features
+- name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features-compare
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features-compare
 - name: ci-kubernetes-kubemark-100-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kubemark-100-gce
   num_failures_to_alert: 1
@@ -3293,8 +3297,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable1-slow
   - name: gke-new-cos-1.10
     test_group_name: ci-kubernetes-e2e-new-cos-gke-k8sstable1
+  - name: gke-new-cos-1.10-compare
+    test_group_name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-compare
   - name: gke-new-cos-alpha-features-1.10
     test_group_name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features
+  - name: gke-new-cos-alpha-features-1.10-compare
+    test_group_name: ci-kubernetes-e2e-new-cos-gke-k8sstable1-alpha-features-compare
 
 - name: google-gke-stackdriver
   dashboard_tab:


### PR DESCRIPTION
Add old cos gke alpha cluster test to compare with new cos.

We don't have test coverage for gke alpha cluster for 1.10 now.

Signed-off-by: Lantao Liu <lantaol@google.com>