### PR TITLE
Change gcp zone for ci-kubernetes-e2e-gci-gke-autoscaling-gpu test job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5027,7 +5027,7 @@
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",
       "--gcp-project-type=gpu-project",
-      "--gcp-zone=us-central1-f",
+      "--gcp-zone=us-west1-b",
       "--gke-environment=test",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingGpu\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11727,7 +11727,7 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180510-540e0e395-master
 
-- interval: 30m
+- interval: 4h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4258,6 +4258,11 @@ dashboards:
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gke-device-plugin-gpu-autoscaling
+    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gce-device-plugin-gpu-cri-containerd
     test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'


### PR DESCRIPTION
It appears that us-central1-f does not have machines with
nvidia-tesla-k80. Changing to us-west1-b.