### PR TITLE
Revert "Switch gce-(large|scale)-performance jobs temporarily to etcd…

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
@@ -1,8 +1,5 @@
 # Override GCE defaults.
 
-# Switch back to older etcd temporarily to help debug #62808.
-TEST_ETCD_VERSION=3.1.12
-
 # TODO(shyamjvs): Change the cos version back to default once #62456 is fixed.
 KUBE_GCI_VERSION=cos-stable-63-10032-71-0
 

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -1,8 +1,5 @@
 ### cluster-env
 
-# Switch back to older etcd temporarily to help debug #62808.
-TEST_ETCD_VERSION=3.1.12
-
 # Reduce logs verbosity as the cluster is huge.
 TEST_CLUSTER_LOG_LEVEL=--v=1
 


### PR DESCRIPTION
… 3.1"

This reverts commit 550e36c70f342e0fcc7d9cd13d4f12994c73523d.

/cc @wojtek-t 
fyi - @krzysied 