### PR TITLE
Remove the bazel tests and the nightly build for k/cluster-registry.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12097,15 +12097,6 @@
       "sig-testing"
     ]
   },
-  "cluster-registry-nightly": {
-    "args": [
-      "./hack/release.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-multicluster"
-    ]
-  },
   "fake-branch": {
     "args": [
       "./fake/fake-branch.sh"
@@ -12386,25 +12377,6 @@
     "scenario": "execute",
     "sigOwners": [
       "sig-cluster-lifecycle"
-    ]
-  },
-  "pull-cluster-registry-bazel": {
-    "args": [
-      "--build=//examples/...",
-      "--test=//... -//vendor/... -//cmd/clusterregistry:push-clusterregistry-image -//pkg/client/..."
-    ],
-    "scenario": "kubernetes_bazel",
-    "sigOwners": [
-      "sig-multicluster"
-    ]
-  },
-  "pull-cluster-registry-verify-bazel": {
-    "args": [
-      "./hack/verify-bazel.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-multicluster"
     ]
   },
   "pull-cluster-registry-verify-gensrc": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1129,52 +1129,6 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
 
   kubernetes/cluster-registry:
-  - name: pull-cluster-registry-bazel
-    agent: kubernetes
-    context: pull-cluster-registry-bazel
-    always_run: true
-    rerun_command: "/test pull-cluster-registry-bazel"
-    trigger: "(?m)^/test( all| pull-cluster-registry-bazel),?(\\s+|$)"
-    labels:
-      preset-service-account: true
-      preset-bazel-scratch-dir: true
-      preset-bazel-remote-cache-enabled: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-1.10
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "2Gi"
-  - name: pull-cluster-registry-verify-bazel
-    agent: kubernetes
-    context: pull-cluster-registry-verify-bazel
-    always_run: true
-    rerun_command: "/test pull-cluster-registry-verify-bazel"
-    trigger: "(?m)^/test( all| pull-cluster-registry-verify-bazel),?(\\s+|$)"
-    labels:
-      preset-service-account: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20180201-0184a54dc-0.8.1
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "2Gi"
   - name: pull-cluster-registry-verify-gensrc
     agent: kubernetes
     context: pull-cluster-registry-verify-gensrc
@@ -16837,27 +16791,6 @@ periodics:
     - name: service
       secret:
         secretName: triage-service-account
-
-- cron: "1 5 * * *" # Run at 21:01PST daily (05:01 UTC)
-  agent: kubernetes
-  name: cluster-registry-nightly
-  labels:
-    preset-service-account: true
-    preset-bazel-scratch-dir: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-1.10
-      args:
-      - "--job=$(JOB_NAME)"
-      - "--repo=k8s.io/cluster-registry=master"
-      - "--service-account=/etc/service-account/service-account.json"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      # Bazel needs privileged mode in order to sandbox builds.
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "2Gi"
 
 - name: issue-creator
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2363,20 +2363,12 @@ test_groups:
 - name: ci-daisy-e2e
   gcs_prefix: compute-image-tools-test/logs/ci-daisy-e2e
 # Cluster registry
-- name: pull-cluster-registry-verify-bazel
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-verify-bazel
-  num_columns_recent: 20
 - name: pull-cluster-registry-verify-gensrc
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-verify-gensrc
   num_columns_recent: 20
 - name: pull-cluster-registry-verify-gosrc
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-verify-gosrc
   num_columns_recent: 20
-- name: pull-cluster-registry-bazel
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-bazel
-  num_columns_recent: 20
-- name: cluster-registry-nightly
-  gcs_prefix: kubernetes-jenkins/logs/cluster-registry-nightly
 # k8s-beta (active release branch) jobs
 - name: ci-kubernetes-e2e-gce-cos-k8sbeta-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sbeta-default
@@ -4668,11 +4660,6 @@ dashboards:
   - name: kube-deploy pr-test
     test_group_name: pull-kube-deploy-test
 
-- name: sig-multicluster-cluster-registry
-  dashboard_tab:
-  - name: nightly
-    test_group_name: cluster-registry-nightly
-
 - name: sig-multicluster-federation-gce-old
   dashboard_tab:
   - name: gce-1.8
@@ -5935,12 +5922,6 @@ dashboards:
 
 - name: presubmits-cluster-registry
   dashboard_tab:
-  - name: bazel
-    test_group_name: pull-cluster-registry-bazel
-    base_options: 'width=10'
-  - name: verify-bazel
-    test_group_name: pull-cluster-registry-verify-bazel
-    base_options: 'width=10'
   - name: verify-gensrc
     test_group_name: pull-cluster-registry-verify-gensrc
     base_options: 'width=10'
@@ -6161,7 +6142,6 @@ dashboard_groups:
 
 - name: sig-multicluster
   dashboard_names:
-  - sig-multicluster-cluster-registry
   - sig-multicluster-federation-gce-old
   - sig-multicluster-federation-gce
   - sig-multicluster-kubemci


### PR DESCRIPTION
The repo is moving to a CRD rather than an extension API server, so there is much less code and no need for a nightly build or Bazel.