### PR TITLE
Make pod utils set working directory for periodic jobs when possible.

### DIFF
--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -17,3 +17,50 @@ to the user-provided `PodSpec`, as well as by overwriting the `Container` entryp
    test code to capture logs and exit status
  - [`sidecar`](./cmd/sidecar/README.md): runs alongside the test `Container`, uploads status, logs
    and test artifacts to cloud storage once the test is finished
+
+## Writing a ProwJob that uses Pod Utilities
+
+Writing a ProwJob that uses the Pod Utilites is much easier than writing one
+that doesn't because the Pod Utilities will transparently handle many of the
+tasks the job would otherwise need to do in order to prepare its environment
+and output more than pass/fail. Historically, this was achieved by wrapping
+every job with a [bootstrap.py](jenkins/bootstrap.py) script that handled cloning
+source code, preparing the test environment, and uploading job metadata, logs,
+and artifacts. This was cumbersome to configure and required every job to be
+wrapped with the script in the job image. The pod utilites achieve the same goals
+with less configuration and much simpler job images that are easier to develop
+and less coupled to Prow.
+
+### What to expect
+
+A ProwJob using the Pod Utilities can expect the following:
+- **Source Code** - Jobs can expect to begin execution with their working
+directory set as the root of the checked out repo. The commit that is checked
+out depends on the type of job:
+	- `presubmit` jobs will have the relevant PR checked out and merged with the base branch.
+	- `postsubmit` jobs will have the upstream commit that triggered the job checked out.
+	- `periodic` jobs will have the first ref in `extra_refs` checked out (if specified).
+See the `extra_refs` field if you need to clone more than one repo.
+- **Metadata and Logs** - Jobs can expect metadata about the job to be uploaded
+before the job starts, and additional metadata and logs to be uploaded when the
+job completes.
+- **Artifact Directory** - Jobs can expect an `$ARTIFACTS` environment variable
+to be specified. It indicates an existent directory where job artifacts can be
+dumped for automatic upload to GCS upon job completion.
+
+### How to configure
+
+In addition to normal ProwJob configuration, ProwJobs using the Pod Utilities
+need to specify the `command` field in the container specification (note that
+this is a string array not just a string). This should point to the test binary
+location in the container.
+
+Additional fields may be required for some use cases:
+- Private repos need to do two things:
+	- Add an ssh secret that gives the bot access to the repo to the build cluster
+	and specify the secret name in the `ssh_key_secrets` field of the job spec.
+	- Set the `clone_uri` field of the job spec to `git@github.com:<org>/<repo>.git`.
+- Repos requiring a non-standard clone path can use the `path_alias` field
+to clone the repo to a path different than the default of `/go/src/github.com/org/repo/` (e.g. `/go/src/k8s.io/kubernetes/kubernetes`).
+- Jobs that require additional repos to be checked out can arrange for that with
+the `exta_refs` field.

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -231,8 +231,16 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 		allEnv[entrypoint.JSONConfigEnvVar] = entrypointConfigEnv
 
 		spec.Containers[0].Command = []string{entrypointLocation}
-		if pj.Spec.Type != kube.PeriodicJob {
-			spec.Containers[0].WorkingDir = clone.PathForRefs(CodeMountPath, pj.Spec.Refs)
+		var checkoutRefs *kube.Refs
+		if pj.Spec.Type == kube.PeriodicJob {
+			if len(pj.Spec.ExtraRefs) > 0 {
+				checkoutRefs = pj.Spec.ExtraRefs[0]
+			}
+		} else {
+			checkoutRefs = pj.Spec.Refs
+		}
+		if checkoutRefs != nil {
+			spec.Containers[0].WorkingDir = clone.PathForRefs(CodeMountPath, checkoutRefs)
 		}
 		spec.Containers[0].Args = []string{}
 		spec.Containers[0].Env = append(spec.Containers[0].Env, kubeEnv(allEnv)...)

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -73,199 +73,17 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
-	env := kubeEnv(rawEnv)
 
 	spec := pj.Spec.PodSpec.DeepCopy()
 	spec.RestartPolicy = "Never"
 	spec.Containers[0].Name = kube.TestContainerName
 
 	if pj.Spec.DecorationConfig == nil {
-		spec.Containers[0].Env = append(spec.Containers[0].Env, env...)
+		spec.Containers[0].Env = append(spec.Containers[0].Env, kubeEnv(rawEnv)...)
 	} else {
-		rawEnv[ArtifactsEnv] = ArtifactsPath
-		rawEnv[GopathEnv] = CodeMountPath
-		logMount := kube.VolumeMount{
-			Name:      LogMountName,
-			MountPath: LogMountPath,
+		if err := decorate(spec, &pj, rawEnv); err != nil {
+			return nil, fmt.Errorf("error decorating podspec: %v", err)
 		}
-		logVolume := kube.Volume{
-			Name: LogMountName,
-			VolumeSource: kube.VolumeSource{
-				EmptyDir: &kube.EmptyDirVolumeSource{},
-			},
-		}
-
-		codeMount := kube.VolumeMount{
-			Name:      CodeMountName,
-			MountPath: CodeMountPath,
-		}
-		codeVolume := kube.Volume{
-			Name: CodeMountName,
-			VolumeSource: kube.VolumeSource{
-				EmptyDir: &kube.EmptyDirVolumeSource{},
-			},
-		}
-
-		toolsMount := kube.VolumeMount{
-			Name:      ToolsMountName,
-			MountPath: ToolsMountPath,
-		}
-		toolsVolume := kube.Volume{
-			Name: ToolsMountName,
-			VolumeSource: kube.VolumeSource{
-				EmptyDir: &kube.EmptyDirVolumeSource{},
-			},
-		}
-
-		gcsCredentialsMount := kube.VolumeMount{
-			Name:      GcsCredentialsMountName,
-			MountPath: GcsCredentialsMountPath,
-		}
-		gcsCredentialsVolume := kube.Volume{
-			Name: GcsCredentialsMountName,
-			VolumeSource: kube.VolumeSource{
-				Secret: &kube.SecretSource{
-					SecretName: pj.Spec.DecorationConfig.GCSCredentialsSecret,
-				},
-			},
-		}
-
-		var sshKeyMode int32 = 0400 // this is octal, so symbolic ref is `u+r`
-		var sshKeysMounts []kube.VolumeMount
-		var sshKeysVolumes []kube.Volume
-		var sshKeyPaths []string
-		for _, secret := range pj.Spec.DecorationConfig.SshKeySecrets {
-			name := fmt.Sprintf("%s-%s", SshKeysMountNamePrefix, secret)
-			keyPath := path.Join(SshKeysMountPathPrefix, secret)
-			sshKeyPaths = append(sshKeyPaths, keyPath)
-			sshKeysMounts = append(sshKeysMounts, kube.VolumeMount{
-				Name:      name,
-				MountPath: keyPath,
-				ReadOnly:  true,
-			})
-			sshKeysVolumes = append(sshKeysVolumes, kube.Volume{
-				Name: name,
-				VolumeSource: kube.VolumeSource{
-					Secret: &kube.SecretSource{
-						SecretName:  secret,
-						DefaultMode: &sshKeyMode,
-					},
-				},
-			})
-		}
-
-		cloneLog := fmt.Sprintf("%s/clone.json", LogMountPath)
-		var refs []*kube.Refs
-		refs = append(refs, pj.Spec.Refs)
-		refs = append(refs, pj.Spec.ExtraRefs...)
-		cloneConfigEnv, err := clonerefs.Encode(clonerefs.Options{
-			SrcRoot:      CodeMountPath,
-			Log:          cloneLog,
-			GitUserName:  clonerefs.DefaultGitUserName,
-			GitUserEmail: clonerefs.DefaultGitUserEmail,
-			GitRefs:      refs,
-			KeyFiles:     sshKeyPaths,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not encode clone configuration as JSON: %v", err)
-		}
-
-		gcsOptions := gcsupload.Options{
-			// TODO: pass the artifact dir here too once we figure that out
-			GCSConfiguration:   pj.Spec.DecorationConfig.GCSConfiguration,
-			GcsCredentialsFile: fmt.Sprintf("%s/service-account.json", GcsCredentialsMountPath),
-			DryRun:             false,
-		}
-		initUploadConfigEnv, err := initupload.Encode(initupload.Options{
-			Log:     cloneLog,
-			Options: &gcsOptions,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not encode initupload configuration as JSON: %v", err)
-		}
-
-		entrypointLocation := fmt.Sprintf("%s/entrypoint", ToolsMountPath)
-
-		spec.InitContainers = []kube.Container{
-			{
-				Name:         "clonerefs",
-				Image:        pj.Spec.DecorationConfig.UtilityImages.CloneRefs,
-				Command:      []string{"/clonerefs"},
-				Env:          kubeEnv(map[string]string{clonerefs.JSONConfigEnvVar: cloneConfigEnv}),
-				VolumeMounts: append([]kube.VolumeMount{logMount, codeMount}, sshKeysMounts...),
-			},
-			{
-				Name:    "initupload",
-				Image:   pj.Spec.DecorationConfig.UtilityImages.InitUpload,
-				Command: []string{"/initupload"},
-				Env: kubeEnv(map[string]string{
-					initupload.JSONConfigEnvVar: initUploadConfigEnv,
-					downwardapi.JobSpecEnv:      rawEnv[downwardapi.JobSpecEnv], // TODO: shouldn't need this?
-				}),
-				VolumeMounts: []kube.VolumeMount{logMount, gcsCredentialsMount},
-			},
-			{
-				Name:         "place-tools",
-				Image:        pj.Spec.DecorationConfig.UtilityImages.Entrypoint,
-				Command:      []string{"/bin/cp"},
-				Args:         []string{"/entrypoint", entrypointLocation},
-				VolumeMounts: []kube.VolumeMount{toolsMount},
-			},
-		}
-
-		wrapperOptions := wrapper.Options{
-			ProcessLog: fmt.Sprintf("%s/process-log.txt", LogMountPath),
-			MarkerFile: fmt.Sprintf("%s/marker-file.txt", LogMountPath),
-		}
-		entrypointConfigEnv, err := entrypoint.Encode(entrypoint.Options{
-			Args:        append(spec.Containers[0].Command, spec.Containers[0].Args...),
-			Options:     &wrapperOptions,
-			Timeout:     pj.Spec.DecorationConfig.Timeout,
-			GracePeriod: pj.Spec.DecorationConfig.GracePeriod,
-			ArtifactDir: ArtifactsPath,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not encode entrypoint configuration as JSON: %v", err)
-		}
-		allEnv := rawEnv
-		allEnv[entrypoint.JSONConfigEnvVar] = entrypointConfigEnv
-
-		spec.Containers[0].Command = []string{entrypointLocation}
-		var checkoutRefs *kube.Refs
-		if pj.Spec.Type == kube.PeriodicJob {
-			if len(pj.Spec.ExtraRefs) > 0 {
-				checkoutRefs = pj.Spec.ExtraRefs[0]
-			}
-		} else {
-			checkoutRefs = pj.Spec.Refs
-		}
-		if checkoutRefs != nil {
-			spec.Containers[0].WorkingDir = clone.PathForRefs(CodeMountPath, checkoutRefs)
-		}
-		spec.Containers[0].Args = []string{}
-		spec.Containers[0].Env = append(spec.Containers[0].Env, kubeEnv(allEnv)...)
-		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, logMount, codeMount, toolsMount)
-
-		gcsOptions.Items = append(gcsOptions.Items, ArtifactsPath)
-		sidecarConfigEnv, err := sidecar.Encode(sidecar.Options{
-			GcsOptions:     &gcsOptions,
-			WrapperOptions: &wrapperOptions,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not encode sidecar configuration as JSON: %v", err)
-		}
-
-		spec.Containers = append(spec.Containers, kube.Container{
-			Name:    "sidecar",
-			Image:   pj.Spec.DecorationConfig.UtilityImages.Sidecar,
-			Command: []string{"/sidecar"},
-			Env: kubeEnv(map[string]string{
-				sidecar.JSONConfigEnvVar: sidecarConfigEnv,
-				downwardapi.JobSpecEnv:   rawEnv[downwardapi.JobSpecEnv], // TODO: shouldn't need this?
-			}),
-			VolumeMounts: []kube.VolumeMount{logMount, gcsCredentialsMount},
-		})
-		spec.Volumes = append(spec.Volumes, append(sshKeysVolumes, logVolume, codeVolume, toolsVolume, gcsCredentialsVolume)...)
 	}
 
 	podLabels := make(map[string]string)
@@ -285,6 +103,195 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 		},
 		Spec: *spec,
 	}, nil
+}
+
+func decorate(spec *kube.PodSpec, pj *kube.ProwJob, rawEnv map[string]string) error {
+	rawEnv[ArtifactsEnv] = ArtifactsPath
+	rawEnv[GopathEnv] = CodeMountPath
+	logMount := kube.VolumeMount{
+		Name:      LogMountName,
+		MountPath: LogMountPath,
+	}
+	logVolume := kube.Volume{
+		Name: LogMountName,
+		VolumeSource: kube.VolumeSource{
+			EmptyDir: &kube.EmptyDirVolumeSource{},
+		},
+	}
+
+	codeMount := kube.VolumeMount{
+		Name:      CodeMountName,
+		MountPath: CodeMountPath,
+	}
+	codeVolume := kube.Volume{
+		Name: CodeMountName,
+		VolumeSource: kube.VolumeSource{
+			EmptyDir: &kube.EmptyDirVolumeSource{},
+		},
+	}
+
+	toolsMount := kube.VolumeMount{
+		Name:      ToolsMountName,
+		MountPath: ToolsMountPath,
+	}
+	toolsVolume := kube.Volume{
+		Name: ToolsMountName,
+		VolumeSource: kube.VolumeSource{
+			EmptyDir: &kube.EmptyDirVolumeSource{},
+		},
+	}
+
+	gcsCredentialsMount := kube.VolumeMount{
+		Name:      GcsCredentialsMountName,
+		MountPath: GcsCredentialsMountPath,
+	}
+	gcsCredentialsVolume := kube.Volume{
+		Name: GcsCredentialsMountName,
+		VolumeSource: kube.VolumeSource{
+			Secret: &kube.SecretSource{
+				SecretName: pj.Spec.DecorationConfig.GCSCredentialsSecret,
+			},
+		},
+	}
+
+	var sshKeyMode int32 = 0400 // this is octal, so symbolic ref is `u+r`
+	var sshKeysMounts []kube.VolumeMount
+	var sshKeysVolumes []kube.Volume
+	var sshKeyPaths []string
+	for _, secret := range pj.Spec.DecorationConfig.SshKeySecrets {
+		name := fmt.Sprintf("%s-%s", SshKeysMountNamePrefix, secret)
+		keyPath := path.Join(SshKeysMountPathPrefix, secret)
+		sshKeyPaths = append(sshKeyPaths, keyPath)
+		sshKeysMounts = append(sshKeysMounts, kube.VolumeMount{
+			Name:      name,
+			MountPath: keyPath,
+			ReadOnly:  true,
+		})
+		sshKeysVolumes = append(sshKeysVolumes, kube.Volume{
+			Name: name,
+			VolumeSource: kube.VolumeSource{
+				Secret: &kube.SecretSource{
+					SecretName:  secret,
+					DefaultMode: &sshKeyMode,
+				},
+			},
+		})
+	}
+
+	cloneLog := fmt.Sprintf("%s/clone.json", LogMountPath)
+	var refs []*kube.Refs
+	refs = append(refs, pj.Spec.Refs)
+	refs = append(refs, pj.Spec.ExtraRefs...)
+	cloneConfigEnv, err := clonerefs.Encode(clonerefs.Options{
+		SrcRoot:      CodeMountPath,
+		Log:          cloneLog,
+		GitUserName:  clonerefs.DefaultGitUserName,
+		GitUserEmail: clonerefs.DefaultGitUserEmail,
+		GitRefs:      refs,
+		KeyFiles:     sshKeyPaths,
+	})
+	if err != nil {
+		return fmt.Errorf("could not encode clone configuration as JSON: %v", err)
+	}
+
+	gcsOptions := gcsupload.Options{
+		// TODO: pass the artifact dir here too once we figure that out
+		GCSConfiguration:   pj.Spec.DecorationConfig.GCSConfiguration,
+		GcsCredentialsFile: fmt.Sprintf("%s/service-account.json", GcsCredentialsMountPath),
+		DryRun:             false,
+	}
+	initUploadConfigEnv, err := initupload.Encode(initupload.Options{
+		Log:     cloneLog,
+		Options: &gcsOptions,
+	})
+	if err != nil {
+		return fmt.Errorf("could not encode initupload configuration as JSON: %v", err)
+	}
+
+	entrypointLocation := fmt.Sprintf("%s/entrypoint", ToolsMountPath)
+
+	spec.InitContainers = []kube.Container{
+		{
+			Name:         "clonerefs",
+			Image:        pj.Spec.DecorationConfig.UtilityImages.CloneRefs,
+			Command:      []string{"/clonerefs"},
+			Env:          kubeEnv(map[string]string{clonerefs.JSONConfigEnvVar: cloneConfigEnv}),
+			VolumeMounts: append([]kube.VolumeMount{logMount, codeMount}, sshKeysMounts...),
+		},
+		{
+			Name:    "initupload",
+			Image:   pj.Spec.DecorationConfig.UtilityImages.InitUpload,
+			Command: []string{"/initupload"},
+			Env: kubeEnv(map[string]string{
+				initupload.JSONConfigEnvVar: initUploadConfigEnv,
+				downwardapi.JobSpecEnv:      rawEnv[downwardapi.JobSpecEnv], // TODO: shouldn't need this?
+			}),
+			VolumeMounts: []kube.VolumeMount{logMount, gcsCredentialsMount},
+		},
+		{
+			Name:         "place-tools",
+			Image:        pj.Spec.DecorationConfig.UtilityImages.Entrypoint,
+			Command:      []string{"/bin/cp"},
+			Args:         []string{"/entrypoint", entrypointLocation},
+			VolumeMounts: []kube.VolumeMount{toolsMount},
+		},
+	}
+
+	wrapperOptions := wrapper.Options{
+		ProcessLog: fmt.Sprintf("%s/process-log.txt", LogMountPath),
+		MarkerFile: fmt.Sprintf("%s/marker-file.txt", LogMountPath),
+	}
+	entrypointConfigEnv, err := entrypoint.Encode(entrypoint.Options{
+		Args:        append(spec.Containers[0].Command, spec.Containers[0].Args...),
+		Options:     &wrapperOptions,
+		Timeout:     pj.Spec.DecorationConfig.Timeout,
+		GracePeriod: pj.Spec.DecorationConfig.GracePeriod,
+		ArtifactDir: ArtifactsPath,
+	})
+	if err != nil {
+		return fmt.Errorf("could not encode entrypoint configuration as JSON: %v", err)
+	}
+	allEnv := rawEnv
+	allEnv[entrypoint.JSONConfigEnvVar] = entrypointConfigEnv
+
+	spec.Containers[0].Command = []string{entrypointLocation}
+	var checkoutRefs *kube.Refs
+	if pj.Spec.Type == kube.PeriodicJob {
+		if len(pj.Spec.ExtraRefs) > 0 {
+			checkoutRefs = pj.Spec.ExtraRefs[0]
+		}
+	} else {
+		checkoutRefs = pj.Spec.Refs
+	}
+	if checkoutRefs != nil {
+		spec.Containers[0].WorkingDir = clone.PathForRefs(CodeMountPath, checkoutRefs)
+	}
+	spec.Containers[0].Args = []string{}
+	spec.Containers[0].Env = append(spec.Containers[0].Env, kubeEnv(allEnv)...)
+	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, logMount, codeMount, toolsMount)
+
+	gcsOptions.Items = append(gcsOptions.Items, ArtifactsPath)
+	sidecarConfigEnv, err := sidecar.Encode(sidecar.Options{
+		GcsOptions:     &gcsOptions,
+		WrapperOptions: &wrapperOptions,
+	})
+	if err != nil {
+		return fmt.Errorf("could not encode sidecar configuration as JSON: %v", err)
+	}
+
+	spec.Containers = append(spec.Containers, kube.Container{
+		Name:    "sidecar",
+		Image:   pj.Spec.DecorationConfig.UtilityImages.Sidecar,
+		Command: []string{"/sidecar"},
+		Env: kubeEnv(map[string]string{
+			sidecar.JSONConfigEnvVar: sidecarConfigEnv,
+			downwardapi.JobSpecEnv:   rawEnv[downwardapi.JobSpecEnv], // TODO: shouldn't need this?
+		}),
+		VolumeMounts: []kube.VolumeMount{logMount, gcsCredentialsMount},
+	})
+	spec.Volumes = append(spec.Volumes, append(sshKeysVolumes, logVolume, codeVolume, toolsVolume, gcsCredentialsVolume)...)
+
+	return nil
 }
 
 // kubeEnv transforms a mapping of environment variables


### PR DESCRIPTION
If a periodic job specifies git refs to check out via `extra_refs` we should set the working directory of the test container to the root of the repo checkout for the first ref.

Also moves podspec decoration into its own function.
Review this PR by commit. Moving the decoration into a separate function produced a gross diff.

/area prow
/kind bug
/cc @BenTheElder @stevekuznetsov @kargakis 