### PR TITLE
fix kustomize tests after move to its own repo

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -775,26 +775,6 @@
       "sig-network"
     ]
   },
-  "ci-kinflate-periodic-default-gke": {
-    "args": [
-      "--check-leaked-resources",
-      "--cluster=",
-      "--deployment=gke",
-      "--extract=gke",
-      "--gcp-node-image=gci",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=prod",
-      "--provider=gke",
-      "--test=false",
-      "--test-cmd=../cmd/kustomize/test/main.sh",
-      "--test-cmd-name=kinflate-integration",
-      "--timeout=120m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cli"
-    ]
-  },
   "ci-kops-build": {
     "args": [
       "make",
@@ -12045,6 +12025,26 @@
     "scenario": "kubernetes_verify",
     "sigOwners": [
       "sig-testing"
+    ]
+  },
+  "ci-kustomize-periodic-default-gke": {
+    "args": [
+      "--check-leaked-resources",
+      "--cluster=",
+      "--deployment=gke",
+      "--extract=gke",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=prod",
+      "--provider=gke",
+      "--test=false",
+      "--test-cmd=demos/integration_tests.sh",
+      "--test-cmd-name=kustomize-integration",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cli"
     ]
   },
   "ci-perf-tests-e2e-gce-clusterloader": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8332,22 +8332,6 @@ periodics:
       args:
       - "--timeout=340"
       - "--bare"
-- interval: 2h
-  agent: kubernetes
-  name: ci-kinflate-periodic-default-gke
-  labels:
-    preset-service-account: true
-    preset-k8s-ssh: true
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-master
-      args:
-      - "--job=$(JOB_NAME)"
-      - "--root=/go/src"
-      - "--repo=k8s.io/kubectl"
-      - "--upload=gs://kubernetes-jenkins/logs/"
-      - "--timeout=150"
-
 - interval: 30m
   name: ci-kops-build
   agent: kubernetes
@@ -16774,6 +16758,22 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-kustomize-periodic-default-gke
+  labels:
+    preset-service-account: true
+    preset-k8s-ssh: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-master
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=github.com/kubernetes-sigs/kustomize"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=150"
 
 - name: ci-perf-tests-e2e-gce-clusterloader
   interval: 2h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2061,8 +2061,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/spark-periodic-default-gke
 - name: spark-periodic-latest-gke
   gcs_prefix: kubernetes-jenkins/logs/spark-periodic-latest-gke
-- name: ci-kinflate-periodic-default-gke
-  gcs_prefix: kubernetes-jenkins/logs/ci-kinflate-periodic-default-gke
+- name: ci-kustomize-periodic-default-gke
+  gcs_prefix: kubernetes-jenkins/logs/ci-kustomize-periodic-default-gke
 - name: application-periodic-default-gke
   gcs_prefix: kubernetes-jenkins/logs/application-periodic-default-gke
 # kube-proxy daemonset migration jobs
@@ -4592,9 +4592,9 @@ dashboards:
 
 - name: sig-cli-misc
   dashboard_tab:
-  - name: kinflate-periodic-default-gke
-    description: Periodic integration testing of kinflate.
-    test_group_name: ci-kinflate-periodic-default-gke
+  - name: kustomize-periodic-default-gke
+    description: Periodic integration testing of kustomize.
+    test_group_name: ci-kustomize-periodic-default-gke
 
 - name: sig-cluster-lifecycle-all
   dashboard_tab:


### PR DESCRIPTION
Program's name changed from kinflate to kustomize, so updating labels.

Also updated path to and name of the script to run in the kustomize repo.

It's supposed to run https://github.com/kubernetes-sigs/kustomize/blob/master/demos/integration_tests.sh

Not sure about the environment expected by the test runner...
 *  what is the expected working directory when the arg to --test-cmd is run?
 * Is that command modified or prefixed?
