### PR TITLE
Make Prow's GH client try alternate host(s) on connection error.

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -148,7 +148,7 @@ func main() {
 		log.Fatalf("cannot read file specified by --ghtoken: %v", err)
 	}
 
-	gc := github.NewClient(token, []string{o.githubEndpoint})
+	gc := github.NewClient(token, o.githubEndpoint)
 
 	pr, err := gc.GetPullRequest(o.org, o.repo, o.num)
 	if err != nil {

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -148,7 +148,7 @@ func main() {
 		log.Fatalf("cannot read file specified by --ghtoken: %v", err)
 	}
 
-	gc := github.NewClient(token, o.githubEndpoint)
+	gc := github.NewClient(token, []string{o.githubEndpoint})
 
 	pr, err := gc.GetPullRequest(o.org, o.repo, o.num)
 	if err != nil {

--- a/experiment/refresh/BUILD.bazel
+++ b/experiment/refresh/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/kube:go_default_library",

--- a/experiment/refresh/main.go
+++ b/experiment/refresh/main.go
@@ -97,9 +97,9 @@ func main() {
 	}
 	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
 
-	ghc := github.NewClient(oauthSecret, githubEndpoint.Strings())
+	ghc := github.NewClient(oauthSecret, githubEndpoint.Strings()...)
 	if *dryRun {
-		ghc = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+		ghc = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
 	}
 
 	server := &Server{

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
     importpath = "k8s.io/test-infra/label_sync",
     tags = ["automanaged"],
     deps = [
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -518,7 +518,7 @@ type client interface {
 	GetRepoLabels(string, string) ([]github.Label, error)
 }
 
-func newClient(tokenPath string, hosts []string, dryRun bool) (client, error) {
+func newClient(tokenPath string, dryRun bool, hosts ...string) (client, error) {
 	if tokenPath == "" {
 		return nil, errors.New("--token unset")
 	}
@@ -529,9 +529,9 @@ func newClient(tokenPath string, hosts []string, dryRun bool) (client, error) {
 	oauthSecret := string(bytes.TrimSpace(b))
 
 	if dryRun {
-		return github.NewDryRunClient(oauthSecret, hosts), nil
+		return github.NewDryRunClient(oauthSecret, hosts...), nil
 	}
-	c := github.NewClient(oauthSecret, hosts)
+	c := github.NewClient(oauthSecret, hosts...)
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 	return c, nil
 }
@@ -562,7 +562,7 @@ func main() {
 			logrus.WithError(err).Fatalf("failed to write docs using docs-template %s to docs-output %s", *docsTemplate, *docsOutput)
 		}
 	case *action == "sync":
-		githubClient, err := newClient(*token, endpoint.Strings(), !*confirm)
+		githubClient, err := newClient(*token, !*confirm, endpoint.Strings()...)
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to create client")
 		}

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 )
 
@@ -84,7 +85,7 @@ type RepoUpdates map[string][]Update
 var (
 	debug        = flag.Bool("debug", false, "Turn on debug to be more verbose")
 	confirm      = flag.Bool("confirm", false, "Make mutating API calls to GitHub.")
-	endpoint     = flag.String("endpoint", "https://api.github.com", "GitHub's API endpoint")
+	endpoint     = flagutil.NewStrings("https://api.github.com")
 	labelsPath   = flag.String("config", "", "Path to labels.yaml")
 	onlyRepos    = flag.String("only", "", "Only look at the following comma separated org/repos")
 	orgs         = flag.String("orgs", "", "Comma separated list of orgs to sync")
@@ -94,6 +95,10 @@ var (
 	docsTemplate = flag.String("docs-template", "", "Path to template file for label docs")
 	docsOutput   = flag.String("docs-output", "", "Path to output file for docs")
 )
+
+func init() {
+	flag.Var(&endpoint, "endpoint", "GitHub's API endpoint")
+}
 
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
@@ -513,7 +518,7 @@ type client interface {
 	GetRepoLabels(string, string) ([]github.Label, error)
 }
 
-func newClient(tokenPath, host string, dryRun bool) (client, error) {
+func newClient(tokenPath string, hosts []string, dryRun bool) (client, error) {
 	if tokenPath == "" {
 		return nil, errors.New("--token unset")
 	}
@@ -524,9 +529,9 @@ func newClient(tokenPath, host string, dryRun bool) (client, error) {
 	oauthSecret := string(bytes.TrimSpace(b))
 
 	if dryRun {
-		return github.NewDryRunClient(oauthSecret, host), nil
+		return github.NewDryRunClient(oauthSecret, hosts), nil
 	}
-	c := github.NewClient(oauthSecret, host)
+	c := github.NewClient(oauthSecret, hosts)
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 	return c, nil
 }
@@ -557,7 +562,7 @@ func main() {
 			logrus.WithError(err).Fatalf("failed to write docs using docs-template %s to docs-output %s", *docsTemplate, *docsOutput)
 		}
 	case *action == "sync":
-		githubClient, err := newClient(*token, *endpoint, !*confirm)
+		githubClient, err := newClient(*token, endpoint.Strings(), !*confirm)
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to create client")
 		}

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -85,6 +85,7 @@ filegroup(
         "//prow/errorutil:all-srcs",
         "//prow/external-plugins/cherrypicker:all-srcs",
         "//prow/external-plugins/needs-rebase:all-srcs",
+        "//prow/flagutil:all-srcs",
         "//prow/gcsupload:all-srcs",
         "//prow/genfiles:all-srcs",
         "//prow/gerrit:all-srcs",

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
@@ -50,6 +51,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/logrusutil"
 
@@ -36,7 +37,7 @@ type options struct {
 	config   string
 	token    string
 	confirm  bool
-	endpoint string
+	endpoint flagutil.Strings
 }
 
 func (o *options) Validate() error {
@@ -48,18 +49,23 @@ func (o *options) Validate() error {
 		return errors.New("empty --github-token-path")
 	}
 
-	if _, err := url.Parse(o.endpoint); err != nil {
-		return fmt.Errorf("invalid --endpoint URL: %v", err)
+	for _, ep := range o.endpoint.Strings() {
+		_, err := url.Parse(ep)
+		if err != nil {
+			return fmt.Errorf("Invalid --endpoint URL %q: %v.", ep, err)
+		}
 	}
 
 	return nil
 }
 
 func gatherOptions() options {
-	o := options{}
+	o := options{
+		endpoint: flagutil.NewStrings("https://api.github.com"),
+	}
 	flag.StringVar(&o.config, "config-path", "", "Path to prow config.yaml")
 	flag.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
-	flag.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com", "Github api endpoint, may differ for enterprise")
+	flag.Var(&o.endpoint, "github-endpoint", "Github api endpoint, may differ for enterprise")
 	flag.StringVar(&o.token, "github-token-path", "", "Path to github token")
 	flag.Parse()
 	return o
@@ -107,9 +113,9 @@ func main() {
 	var c *github.Client
 	tok := strings.TrimSpace(string(b))
 	if o.confirm {
-		c = github.NewClient(tok, o.endpoint)
+		c = github.NewClient(tok, o.endpoint.Strings())
 	} else {
-		c = github.NewDryRunClient(tok, o.endpoint)
+		c = github.NewDryRunClient(tok, o.endpoint.Strings())
 	}
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -113,9 +113,9 @@ func main() {
 	var c *github.Client
 	tok := strings.TrimSpace(string(b))
 	if o.confirm {
-		c = github.NewClient(tok, o.endpoint.Strings())
+		c = github.NewClient(tok, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(tok, o.endpoint.Strings())
+		c = github.NewDryRunClient(tok, o.endpoint.Strings()...)
 	}
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 )
 
@@ -42,7 +43,7 @@ func TestOptions_Validate(t *testing.T) {
 			opt: options{
 				config:   "dummy",
 				token:    "fake",
-				endpoint: "https://api.github.com",
+				endpoint: flagutil.NewStrings("https://api.github.com"),
 			},
 			expectedErr: false,
 		},
@@ -51,7 +52,7 @@ func TestOptions_Validate(t *testing.T) {
 			opt: options{
 				config:   "",
 				token:    "fake",
-				endpoint: "https://api.github.com",
+				endpoint: flagutil.NewStrings("https://api.github.com"),
 			},
 			expectedErr: true,
 		},
@@ -60,7 +61,7 @@ func TestOptions_Validate(t *testing.T) {
 			opt: options{
 				config:   "dummy",
 				token:    "",
-				endpoint: "https://api.github.com",
+				endpoint: flagutil.NewStrings("https://api.github.com"),
 			},
 			expectedErr: true,
 		},
@@ -69,7 +70,7 @@ func TestOptions_Validate(t *testing.T) {
 			opt: options{
 				config:   "dummy",
 				token:    "fake",
-				endpoint: ":",
+				endpoint: flagutil.NewStrings(":"),
 			},
 			expectedErr: true,
 		},

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/hook",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -138,10 +138,10 @@ func main() {
 	var githubClient *github.Client
 	var kubeClient *kube.Client
 	if o.dryRun {
-		githubClient = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings())
+		githubClient = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings()...)
 		kubeClient = kube.NewFakeClient(o.deckURL)
 	} else {
-		githubClient = github.NewClient(oauthSecret, o.githubEndpoint.Strings())
+		githubClient = github.NewClient(oauthSecret, o.githubEndpoint.Strings()...)
 		if o.cluster == "" {
 			kubeClient, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)
 			if err != nil {

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -186,10 +186,10 @@ func main() {
 
 	var ghc *github.Client
 	if o.dryRun {
-		ghc = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings())
+		ghc = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings()...)
 		kc = kube.NewFakeClient(o.deckURL)
 	} else {
-		ghc = github.NewClient(oauthSecret, o.githubEndpoint.Strings())
+		ghc = github.NewClient(oauthSecret, o.githubEndpoint.Strings()...)
 	}
 
 	c, err := jenkins.NewController(kc, jc, ghc, nil, configAgent, o.totURL, o.selector)

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/config/org:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
     ],
 )
@@ -36,4 +37,5 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/flagutil:go_default_library"],
 )

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -96,9 +96,9 @@ func main() {
 	var c *github.Client
 	tok := strings.TrimSpace(string(b))
 	if o.confirm {
-		c = github.NewClient(tok, o.endpoint.Strings())
+		c = github.NewClient(tok, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(tok, o.endpoint.Strings())
+		c = github.NewDryRunClient(tok, o.endpoint.Strings()...)
 	}
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"reflect"
 	"testing"
+
+	"k8s.io/test-infra/prow/flagutil"
 )
 
 func TestOptions(t *testing.T) {
@@ -46,7 +48,7 @@ func TestOptions(t *testing.T) {
 			expected: &options{
 				config:   "foo",
 				token:    "bar",
-				endpoint: defaultEndpoint,
+				endpoint: flagutil.NewStrings(defaultEndpoint),
 			},
 		},
 		{
@@ -55,7 +57,7 @@ func TestOptions(t *testing.T) {
 			expected: &options{
 				config:   "foo",
 				token:    "bar",
-				endpoint: "weird://url",
+				endpoint: flagutil.NewStrings("weird://url"),
 				confirm:  true,
 			},
 		},

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/plank",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/logrusutil"
@@ -48,11 +49,15 @@ var (
 	buildCluster = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	selector     = flag.String("label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 
-	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubEndpoint  = flagutil.NewStrings("https://api.github.com")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 	dryRun          = flag.Bool("dry-run", true, "Whether or not to make mutating API calls to GitHub.")
 	deckURL         = flag.String("deck-url", "", "Deck URL for read-only access to the cluster.")
 )
+
+func init() {
+	flag.Var(&githubEndpoint, "github-endpoint", "GitHub's API endpoint.")
+}
 
 func main() {
 	flag.Parse()
@@ -77,9 +82,11 @@ func main() {
 			logrus.WithError(err).Fatalf("Could not read oauth secret file.")
 		}
 
-		_, err = url.Parse(*githubEndpoint)
-		if err != nil {
-			logrus.WithError(err).Fatalf("Must specify a valid --github-endpoint URL.")
+		for _, ep := range githubEndpoint.Strings() {
+			_, err = url.Parse(ep)
+			if err != nil {
+				logrus.WithError(err).Fatalf("Invalid --endpoint URL %q.", ep)
+			}
 		}
 
 		oauthSecret = string(bytes.TrimSpace(oauthSecretRaw))
@@ -90,13 +97,13 @@ func main() {
 	var pkcs map[string]*kube.Client
 	if *dryRun {
 		if oauthSecret != "" {
-			ghc = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+			ghc = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
 		}
 		kc = kube.NewFakeClient(*deckURL)
 		pkcs = map[string]*kube.Client{kube.DefaultClusterAlias: kc}
 	} else {
 		if oauthSecret != "" {
-			ghc = github.NewClient(oauthSecret, *githubEndpoint)
+			ghc = github.NewClient(oauthSecret, githubEndpoint.Strings())
 		}
 		if *cluster == "" {
 			kc, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -97,13 +97,13 @@ func main() {
 	var pkcs map[string]*kube.Client
 	if *dryRun {
 		if oauthSecret != "" {
-			ghc = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+			ghc = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
 		}
 		kc = kube.NewFakeClient(*deckURL)
 		pkcs = map[string]*kube.Client{kube.DefaultClusterAlias: kc}
 	} else {
 		if oauthSecret != "" {
-			ghc = github.NewClient(oauthSecret, githubEndpoint.Strings())
+			ghc = github.NewClient(oauthSecret, githubEndpoint.Strings()...)
 		}
 		if *cluster == "" {
 			kc, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -86,12 +86,12 @@ func main() {
 	var ghcSync, ghcStatus *github.Client
 	var kc *kube.Client
 	if *dryRun {
-		ghcSync = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
-		ghcStatus = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+		ghcSync = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
+		ghcStatus = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
 		kc = kube.NewFakeClient(*deckURL)
 	} else {
-		ghcSync = github.NewClient(oauthSecret, githubEndpoint.Strings())
-		ghcStatus = github.NewClient(oauthSecret, githubEndpoint.Strings())
+		ghcSync = github.NewClient(oauthSecret, githubEndpoint.Strings()...)
+		ghcStatus = github.NewClient(oauthSecret, githubEndpoint.Strings()...)
 		if *cluster == "" {
 			kc, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)
 			if err != nil {

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
@@ -50,9 +51,13 @@ var (
 	configPath = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
 	cluster    = flag.String("cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 
-	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubEndpoint  = flagutil.NewStrings("https://api.github.com")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 )
+
+func init() {
+	flag.Var(&githubEndpoint, "github-endpoint", "GitHub's API endpoint.")
+}
 
 func main() {
 	flag.Parse()
@@ -71,20 +76,22 @@ func main() {
 	}
 	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
 
-	_, err = url.Parse(*githubEndpoint)
-	if err != nil {
-		logrus.WithError(err).Fatalf("Must specify a valid --github-endpoint URL.")
+	for _, ep := range githubEndpoint.Strings() {
+		_, err = url.Parse(ep)
+		if err != nil {
+			logrus.WithError(err).Fatalf("Invalid --endpoint URL %q.", ep)
+		}
 	}
 
 	var ghcSync, ghcStatus *github.Client
 	var kc *kube.Client
 	if *dryRun {
-		ghcSync = github.NewDryRunClient(oauthSecret, *githubEndpoint)
-		ghcStatus = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+		ghcSync = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+		ghcStatus = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
 		kc = kube.NewFakeClient(*deckURL)
 	} else {
-		ghcSync = github.NewClient(oauthSecret, *githubEndpoint)
-		ghcStatus = github.NewClient(oauthSecret, *githubEndpoint)
+		ghcSync = github.NewClient(oauthSecret, githubEndpoint.Strings())
+		ghcStatus = github.NewClient(oauthSecret, githubEndpoint.Strings())
 		if *cluster == "" {
 			kc, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)
 			if err != nil {

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/external-plugins/cherrypicker",
     visibility = ["//visibility:private"],
     deps = [
+        "//prow/flagutil:go_default_library",
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -79,9 +79,9 @@ func main() {
 		}
 	}
 
-	githubClient := github.NewClient(oauthSecret, githubEndpoint.Strings())
+	githubClient := github.NewClient(oauthSecret, githubEndpoint.Strings()...)
 	if *dryRun {
-		githubClient = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+		githubClient = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
 	}
 
 	gitClient, err := git.NewClient()

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/external-plugins/needs-rebase/plugin:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/external-plugins/needs-rebase/plugin"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
@@ -42,11 +43,15 @@ var (
 	port              = flag.Int("port", 8888, "Port to listen on.")
 	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	pluginConfig      = flag.String("plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
-	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubEndpoint    = flagutil.NewStrings("https://api.github.com")
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 	updatePeriod      = flag.Duration("update-period", time.Hour*24, "Period duration for periodic scans of all PRs.")
 )
+
+func init() {
+	flag.Var(&githubEndpoint, "github-endpoint", "GitHub's API endpoint.")
+}
 
 func main() {
 	flag.Parse()
@@ -72,9 +77,11 @@ func main() {
 	}
 	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
 
-	_, err = url.Parse(*githubEndpoint)
-	if err != nil {
-		log.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
+	for _, ep := range githubEndpoint.Strings() {
+		_, err = url.Parse(ep)
+		if err != nil {
+			logrus.WithError(err).Fatalf("Invalid --endpoint URL %q.", ep)
+		}
 	}
 
 	pa := &plugins.PluginAgent{}
@@ -82,9 +89,9 @@ func main() {
 		log.WithError(err).Fatalf("Error loading plugin config from %q.", *pluginConfig)
 	}
 
-	githubClient := github.NewClient(oauthSecret, *githubEndpoint)
+	githubClient := github.NewClient(oauthSecret, githubEndpoint.Strings())
 	if *dryRun {
-		githubClient = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+		githubClient = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
 	}
 	githubClient.Throttle(360, 360)
 

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -89,9 +89,9 @@ func main() {
 		log.WithError(err).Fatalf("Error loading plugin config from %q.", *pluginConfig)
 	}
 
-	githubClient := github.NewClient(oauthSecret, githubEndpoint.Strings())
+	githubClient := github.NewClient(oauthSecret, githubEndpoint.Strings()...)
 	if *dryRun {
-		githubClient = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings())
+		githubClient = github.NewDryRunClient(oauthSecret, githubEndpoint.Strings()...)
 	}
 	githubClient.Throttle(360, 360)
 

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["flagutil.go"],
+    importpath = "k8s.io/test-infra/prow/flagutil",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/flagutil/flagutil.go
+++ b/prow/flagutil/flagutil.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import "strings"
+
+type Strings struct {
+	vals    []string
+	beenSet bool
+}
+
+// NewStrings returns a Strings struct that defaults to the value of def if left
+// unset.
+func NewStrings(def ...string) Strings {
+	return Strings{
+		vals:    def,
+		beenSet: false,
+	}
+}
+
+func (s *Strings) Strings() []string {
+	return s.vals
+}
+
+func (s *Strings) String() string {
+	return strings.Join(s.vals, ",")
+}
+
+// Set records the value passed
+func (s *Strings) Set(value string) error {
+	if !s.beenSet {
+		// Value is being set, don't use default.
+		s.vals = nil
+	}
+	s.vals = append(s.vals, value)
+	return nil
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -178,11 +178,11 @@ func (c *Client) Throttle(hourlyTokens, burst int) {
 
 // NewClient creates a new fully operational GitHub client.
 // 'token' is the GitHub access token to use.
-// 'bases' is a ';' delimited array of endpoints to use in order of preference.
+// 'bases' is a variadic slice of endpoints to use in order of preference.
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewClient(token string, bases []string) *Client {
+func NewClient(token string, bases ...string) *Client {
 	return &Client{
 		logger: logrus.WithField("client", "github"),
 		time:   &standardTime{},
@@ -198,11 +198,11 @@ func NewClient(token string, bases []string) *Client {
 // such as setting statuses or commenting, but it will still query GitHub and
 // use up API tokens.
 // 'token' is the GitHub access token to use.
-// 'bases' is a ';' delimited array of endpoints to use in order of preference.
+// 'bases' is a variadic slice of endpoints to use in order of preference.
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClient(token string, bases []string) *Client {
+func NewDryRunClient(token string, bases ...string) *Client {
 	return &Client{
 		logger: logrus.WithField("client", "github"),
 		time:   &standardTime{},

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -182,14 +182,14 @@ func (c *Client) Throttle(hourlyTokens, burst int) {
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewClient(token, bases string) *Client {
+func NewClient(token string, bases []string) *Client {
 	return &Client{
 		logger: logrus.WithField("client", "github"),
 		time:   &standardTime{},
 		gqlc:   githubql.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))),
 		client: &http.Client{},
 		token:  token,
-		bases:  strings.Split(bases, ";"),
+		bases:  bases,
 		dry:    false,
 	}
 }
@@ -202,14 +202,14 @@ func NewClient(token, bases string) *Client {
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClient(token, bases string) *Client {
+func NewDryRunClient(token string, bases []string) *Client {
 	return &Client{
 		logger: logrus.WithField("client", "github"),
 		time:   &standardTime{},
 		gqlc:   githubql.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))),
 		client: &http.Client{},
 		token:  token,
-		bases:  strings.Split(bases, ";"),
+		bases:  bases,
 		dry:    true,
 	}
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -104,7 +104,7 @@ func TestRetryBase(t *testing.T) {
 	defer ts.Close()
 	c := getClient(ts.URL)
 	// One good endpoint:
-	c.bases = NewClient("", c.bases[0]).bases
+	c.bases = []string{c.bases[0]}
 	resp, err := c.requestRetry(http.MethodGet, "/", "", nil)
 	if err != nil {
 		t.Errorf("Error from request: %v", err)
@@ -112,7 +112,7 @@ func TestRetryBase(t *testing.T) {
 		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
 	}
 	// Bad endpoint followed by good endpoint:
-	c.bases = NewClient("", "not-a-valid-base;"+c.bases[0]).bases
+	c.bases = []string{"not-a-valid-base", c.bases[0]}
 	resp, err = c.requestRetry(http.MethodGet, "/", "", nil)
 	if err != nil {
 		t.Errorf("Error from request: %v", err)
@@ -120,7 +120,7 @@ func TestRetryBase(t *testing.T) {
 		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
 	}
 	// One bad endpoint:
-	c.bases = NewClient("", "not-a-valid-base").bases
+	c.bases = []string{"not-a-valid-base"}
 	resp, err = c.requestRetry(http.MethodGet, "/", "", nil)
 	if err == nil {
 		t.Error("Expected an error from a request to an invalid base, but succeeded!?")

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -52,7 +52,7 @@ func getClient(url string) *Client {
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		},
-		base: url,
+		bases: []string{url},
 	}
 }
 
@@ -68,7 +68,7 @@ func TestRequestRateLimit(t *testing.T) {
 	defer ts.Close()
 	c := getClient(ts.URL)
 	c.time = tc
-	resp, err := c.requestRetry(http.MethodGet, c.base, "", nil)
+	resp, err := c.requestRetry(http.MethodGet, "/", "", nil)
 	if err != nil {
 		t.Errorf("Error from request: %v", err)
 	} else if resp.StatusCode != 200 {
@@ -88,11 +88,42 @@ func TestRetry404(t *testing.T) {
 	defer ts.Close()
 	c := getClient(ts.URL)
 	c.time = tc
-	resp, err := c.requestRetry(http.MethodGet, c.base, "", nil)
+	resp, err := c.requestRetry(http.MethodGet, "/", "", nil)
 	if err != nil {
 		t.Errorf("Error from request: %v", err)
 	} else if resp.StatusCode != 200 {
 		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryBase(t *testing.T) {
+	defer func(orig time.Duration) { initialDelay = orig }(initialDelay)
+	initialDelay = time.Microsecond
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	// One good endpoint:
+	c.bases = NewClient("", c.bases[0]).bases
+	resp, err := c.requestRetry(http.MethodGet, "/", "", nil)
+	if err != nil {
+		t.Errorf("Error from request: %v", err)
+	} else if resp.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+	// Bad endpoint followed by good endpoint:
+	c.bases = NewClient("", "not-a-valid-base;"+c.bases[0]).bases
+	resp, err = c.requestRetry(http.MethodGet, "/", "", nil)
+	if err != nil {
+		t.Errorf("Error from request: %v", err)
+	} else if resp.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+	// One bad endpoint:
+	c.bases = NewClient("", "not-a-valid-base").bases
+	resp, err = c.requestRetry(http.MethodGet, "/", "", nil)
+	if err == nil {
+		t.Error("Expected an error from a request to an invalid base, but succeeded!?")
 	}
 }
 

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -218,7 +218,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 				return
 			}
 			// Construct query
-			ghc := github.NewClient(token.AccessToken, githubEndpoint)
+			ghc := github.NewClient(token.AccessToken, []string{githubEndpoint})
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -218,7 +218,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 				return
 			}
 			// Construct query
-			ghc := github.NewClient(token.AccessToken, []string{githubEndpoint})
+			ghc := github.NewClient(token.AccessToken, githubEndpoint)
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -36,7 +36,10 @@ go_library(
     name = "go_default_library",
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/robots/commenter",
-    deps = ["//prow/github:go_default_library"],
+    deps = [
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
+    ],
 )
 
 filegroup(

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -156,9 +156,9 @@ func main() {
 	var c client
 	tok := strings.TrimSpace(string(b))
 	if o.confirm {
-		c = github.NewClient(tok, o.endpoint.Strings())
+		c = github.NewClient(tok, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(tok, o.endpoint.Strings())
+		c = github.NewDryRunClient(tok, o.endpoint.Strings()...)
 	}
 
 	query, err := makeQuery(o.query, o.includeClosed, o.updated)


### PR DESCRIPTION
The endpoint string provided to Prow's GitHub client can now be a semicolon separated list of endpoints, ordered by preference. This is backwards compatible.

The main motivation for this is to allow us to configure Prow components to use `https://api.github.com` as a fall back alternative to the GitHub proxy cache (#7848). If the cache is unavailable, Prow components will bypass the cache and talk directly to the API instead of being prevented from using the API entirely.

/area prow
/cc @BenTheElder @kargakis 
/assign @fejta 