### PR TITLE
Don't uselessly gather metrics in case of correctness jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3161,7 +3161,7 @@
       "--gcp-zone=us-east1-a",
       "--ginkgo-parallel=40",
       "--provider=gce",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --gather-resource-usage=master --gather-metrics-at-teardown=master",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\]",
       "--timeout=390m",
       "--use-logexporter"
     ],
@@ -3504,7 +3504,7 @@
       "--gcp-zone=us-east1-a",
       "--ginkgo-parallel=40",
       "--provider=gce",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --gather-resource-usage=master --gather-metrics-at-teardown=master",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\]",
       "--timeout=570m",
       "--use-logexporter"
     ],


### PR DESCRIPTION
We're unnecessarily polluting artifacts with hundreds of those files (which don't even make much sense as those tests are running in parallel and we're resetting those in between).
Also I think we didn't have this setting for the jobs earlier.

/cc @wojtek-t 