### PR TITLE
Remove old cos version setting in scale jobs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
@@ -1,7 +1,4 @@
 # Override GCE defaults.
 
-# TODO(shyamjvs): Change the cos version back to default once #62456 is fixed.
-KUBE_GCI_VERSION=cos-stable-63-10032-71-0
-
 # Turn off advanced audit logging to simulate production
 ENABLE_APISERVER_ADVANCED_AUDIT=false

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -3,9 +3,6 @@
 # Reduce logs verbosity as the cluster is huge.
 TEST_CLUSTER_LOG_LEVEL=--v=1
 
-# TODO(shyamjvs): Change the cos version back to default once #62456 is fixed.
-KUBE_GCI_VERSION=cos-stable-63-10032-71-0
-
 # Turn off advanced audit logging to simulate production
 ENABLE_APISERVER_ADVANCED_AUDIT=false
 


### PR DESCRIPTION
As this was made default in https://github.com/kubernetes/kubernetes/pull/63672.

/cc @wojtek-t 