### PR TITLE
Remove cluster-monitoring setting default in scale jobs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-scalability-common.env
+++ b/jobs/env/ci-kubernetes-e2e-scalability-common.env
@@ -11,10 +11,6 @@ LOGROTATE_MAX_SIZE=5G
 # Use IP-aliases for scalability tests.
 KUBE_GCE_ENABLE_IP_ALIASES=true
 
-# Use standalone monitoring.
-# TODO(shyamjvs): Figure out if that's the right mode.
-KUBE_ENABLE_CLUSTER_MONITORING=standalone
-
 # Switch off image puller to workaround #44701
 PREPULL_E2E_IMAGES=false
 # Increase resync period to simulate production


### PR DESCRIPTION
As this was finally made default in https://github.com/kubernetes/kubernetes/pull/62328

/cc @wojtek-t 