### PR TITLE
Fix gubernator webhook time parsing

### DIFF
--- a/gubernator/github/main_test.py
+++ b/gubernator/github/main_test.py
@@ -115,7 +115,7 @@ class AppTest(TestBase):
         'pull_request': {
             'number': 123,
             'head': {'sha': 'cafe'},
-            'updated_at': '2016-07-07T02:03:12Z',
+            'updated_at': '2016-07-07T02:03:12+00:00',
             'state': 'open',
             'user': {'login': 'rmmh'},
             'assignees': [{'login': 'spxtr'}],

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import datetime
 import json
 
@@ -58,7 +59,15 @@ class GithubWebhookRaw(ndb.Model):
 
 
 def from_iso8601(t):
-    return t and datetime.datetime.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
+    if not t:
+        return t
+    if t.endswith('Z'):
+        return datetime.datetime.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
+    elif t.endswith('+00:00'):
+        return datetime.datetime.strptime(t, '%Y-%m-%dT%H:%M:%S+00:00')
+    else:
+        logging.warning('unparseable time value: %s', t)
+        return None
 
 
 def make_kwargs(body, fields):


### PR DESCRIPTION
This has been failing since yesterday.

Github started delivering hooks with 2018-05-17T15:49:33+00:00 instead of 2018-05-17T15:49:33Z.
