### PR TITLE
Protect all kubernetes/* repos by default

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -35,119 +35,57 @@ branch-protection:
   allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
   orgs:
     kubernetes:
-      # TODO(fejta): build blacklist and then protect
-      # protect: true
+      protect: true
       required_status_checks:
         contexts:
         - cla/linuxfoundation
       repos:
-        # BLACKLIST
-        # TODO(fejta): add yourself here
-        # WHITELIST
         charts:
-          protect: true
           required_status_checks:
             contexts:
             - ci/circleci
         client-go:
-          protect: true
           restrictions:
             users:
             - k8s-publishing-bot
             teams:
             - kubernetes/client-go-maintainers
-        cloud-provider-aws:
-          protect: true
-        cloud-provider-azure:
-          protect: true
-        cloud-provider-gcp:
-          protect: true
-        cloud-provider-openstack:
-          protect: true
-        cluster-registry:
-          protect: true
-        community:
-          protect: true
-        contrib:
-          protect: true
         dashboard:
-          protect: true
           required_pull_request_reviews:
             required_approving_review_count: 1
         dns:
-          protect: true
           required_status_checks:
             strict: true
             contexts:
             - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
-        examples:
-          protect: true
-        features:
-          protect: true
-        federation:
-          protect: true
-        gengo:
-          protect: true
         git-sync:
-          protect: true
           enforce_admins: true
           required_status_checks:
             strict: true
           restrictions: # only allow admins
             users: []
             teams: []
-        heapster:
-          protect: true
-        ingress-nginx:
-          protect: true
         kompose:
-          protect: true
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
-        kops:
-          protect: true
-        kube-deploy:
-          protect: true
-        kube-state-metrics:
-          protect: true
         kubectl:
-          protect: true
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
         kubernetes:
-          protect: true
           restrictions: # only allow admins
             users: []
             teams: []
-        kubernetes-anywhere:
-          protect: true
-        kubernetes-bootcamp:
-          protect: true
-        kubernetes-template-project:
-          protect: true
-        minikube:
-          protect: true
-        node-problem-detector:
-          protect: true
         repo-infra:
-          protect: true
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
-        sig-release:
-          protect: true
-        steering:
-          protect: true
-        test-infra:
-          protect: true
         utils:
-          protect: true
           required_pull_request_reviews:
             required_approving_review_count: 1
           required_status_checks:


### PR DESCRIPTION
/assign @cblecker @BenTheElder @cjwagner 

* Set `protect: true` to enable branch protection by default for all kubernetes repos. 
  - Repos/branches may augment this policy with [additional criteria](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector#advanced-configuration) (such as checks from external CI systems like Travis)
  - Repos/branches may override this default and disable protection
* Remove redundant `protect: true` for existing repos as we will inherit the org value (keep any additional config)

Sent [announcement](https://groups.google.com/d/msg/kubernetes-sig-testing/7mj3boROEOo/PewPyFuFCgAJ), intend to merge end of the month
/hold




ref https://github.com/kubernetes/release/issues/364