### PR TITLE
add copy button to prowjob rerun info

### DIFF
--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -102,5 +102,9 @@
                 </div>
             </main>
         </div>
+        <div id="toast" class="mdl-js-snackbar mdl-snackbar">
+            <div class="mdl-snackbar__text"></div>
+            <button class="mdl-snackbar__action" type="button"></button>
+        </div>
     </body>
 </html>

--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -587,12 +587,52 @@ function createRerunCell(modal, rerun_command, prowjob) {
     const icon = createIcon("refresh", "Show instructions for rerunning this job");
     icon.onclick = function () {
         modal.style.display = "block";
-        rerun_command.innerHTML = "kubectl create -f \"<a href='" + url + "'>"
-            + url + "</a>\"";
+        const rerun_html = "kubectl create -f \"<a href='" + url + "'>"
+        + url + "</a>\" " 
+        + "<a class='mdl-button mdl-js-button mdl-button--icon' onclick=\""+
+        "copyToClipboardWithToast('kubectl create -f " + url + "')\">"
+        + "<i class='material-icons state triggered' style='color: gray'>file_copy</i></a>";
+        rerun_command.innerHTML = rerun_html;
     };
     c.appendChild(icon);
     c.classList.add("icon-cell");
     return c;
+}
+
+// copyToClipboard is from https://stackoverflow.com/a/33928558
+// Copies a string to the clipboard. Must be called from within an 
+// event handler such as click. May return false if it failed, but
+// this is not always possible. Browser support for Chrome 43+, 
+// Firefox 42+, Safari 10+, Edge and IE 10+.
+// IE: The clipboard feature may be disabled by an administrator. By
+// default a prompt is shown the first time the clipboard is 
+// used (per session).
+function copyToClipboard(text) {
+    if (window.clipboardData && window.clipboardData.setData) {
+        // IE specific code path to prevent textarea being shown while dialog is visible.
+        return clipboardData.setData("Text", text); 
+
+    } else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
+        var textarea = document.createElement("textarea");
+        textarea.textContent = text;
+        textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in MS Edge.
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            return document.execCommand("copy");  // Security exception may be thrown by some browsers.
+        } catch (ex) {
+            console.warn("Copy to clipboard failed.", ex);
+            return false;
+        } finally {
+            document.body.removeChild(textarea);
+        }
+    }
+}
+
+function copyToClipboardWithToast(text) {
+    copyToClipboard(text);
+    const toast = document.body.querySelector("#toast");
+    toast.MaterialSnackbar.showSnackbar({message: "Copied to clipboard"});
 }
 
 function stateCell(state) {


### PR DESCRIPTION
This isn't perfect, but it adds a copy button to the ProwJob rerun cells which I find to be pretty handy.

<img width="1604" alt="screen shot 2018-05-18 at 1 16 25 am" src="https://user-images.githubusercontent.com/917931/40223828-27e53e0a-5a39-11e8-9b80-2bca13c4cfd7.png">

/area prow
/kind enhancement