### PR TITLE
fix branch defaulting in verify scenario

### DIFF
--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -79,9 +79,10 @@ def get_git_cache(k8s):
 
 def branch_to_tag(branch):
     verify_branch = re.match(r'release-(\d+\.\d+)', branch)
-    if not verify_branch:
-        return VERSION_TAG['default']
-    return VERSION_TAG[verify_branch.group(1)]
+    key = 'default'
+    if verify_branch:
+        key = verify_branch.group(1)
+    return VERSION_TAG[key]
 
 
 def main(branch, script, force, on_prow):


### PR DESCRIPTION
I don't know why I didn't make this change last time I touched this, but this bug is blocking 1.11 CI testing currently

/area verify is terrible
/area scenarios
/kind bug