### PR TITLE
Allow approving+lgtming based solely on OWNERS files

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -177,6 +177,7 @@ func main() {
 	ownersClient := repoowners.NewClient(
 		gitClient, githubClient,
 		configAgent, pluginAgent.MDYAMLEnabled,
+		pluginAgent.SkipCollaborators,
 	)
 
 	pluginAgent.PluginClient = plugins.PluginClient{

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -13,8 +13,11 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -26,7 +29,9 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Add an option in `hook` to avoid org membership checks for approving+lgtming PRs. This enables work on github repos based solely on OWNERS files without needing access in the owning org (we may never have access to the org due to internal policies).

This also paves the way for allowing `/lgtm` in general to be restricted only to reviewers+approvers in OWNERS files as opposed to all members in the org although we would need to cross-check with org members (also more work may be necessary to move `prow/plugins/approve/approvers` into a more generic library that can work for both `approve` and `lgtm`).

~~Tests need to be added/fixed but this should be~~ ready for a review.

/cc @cjwagner 
/assign @fejta 