### PR TITLE
warn about branch protection issue in tide instead of error

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -312,12 +311,10 @@ func (c Config) GetTideContextPolicy(org, repo, branch string) (TideContextPolic
 	if options.FromBranchProtection != nil && *options.FromBranchProtection {
 		bp, err := c.GetBranchProtection(org, repo, branch)
 		if err != nil {
-			return TideContextPolicy{}, err
-		}
-		if bp == nil {
-			return TideContextPolicy{}, errors.New("branch protection is not set")
-		}
-		if bp.Protect == nil || *bp.Protect {
+			logrus.WithError(err).Warningf("Error getting branch protection for %s/%s+%s", org, repo, branch)
+		} else if bp == nil {
+			logrus.Warningf("branch protection not set for %s/%s+%s", org, repo, branch)
+		} else if bp.Protect != nil && *bp.Protect {
 			required.Insert(bp.RequiredStatusChecks.Contexts...)
 		}
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -360,7 +360,10 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 					},
 				},
 			},
-			error: "branch protection is not set",
+			expected: TideContextPolicy{
+				RequiredContexts: []string{},
+				OptionalContexts: []string{},
+			},
 		},
 		{
 			name: "invalid branch protection",


### PR DESCRIPTION
For tide, I followed further from @cjwagner comment about not failing tide if branch protection is not set or invalid so we now warn the user about the issue and keep using the combined status.