### PR TITLE
Update GetRepos GetBranches to use pagination, GetBranches to include a protected param

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -143,7 +143,7 @@ func main() {
 type client interface {
 	RemoveBranchProtection(org, repo, branch string) error
 	UpdateBranchProtection(org, repo, branch string, config github.BranchProtectionRequest) error
-	GetBranches(org, repo string) ([]github.Branch, error)
+	GetBranches(org, repo string, onlyProtected bool) ([]github.Branch, error)
 	GetRepos(org string, user bool) ([]github.Repo, error)
 }
 
@@ -238,12 +238,18 @@ func (p *Protector) UpdateOrg(orgName string, org config.Org, allRepos bool) err
 func (p *Protector) UpdateRepo(orgName string, repo string, repoDefaults config.Repo) error {
 	p.completedRepos[orgName+"/"+repo] = true
 
-	branches, err := p.client.GetBranches(orgName, repo)
-	if err != nil {
-		return fmt.Errorf("GetBranches(%s, %s) failed: %v", orgName, repo, err)
+	branches := map[string]github.Branch{}
+	for _, onlyProtected := range []bool{false, true} { // put true second so it becomes the value
+		if bs, err := p.client.GetBranches(orgName, repo, onlyProtected); err != nil {
+			return fmt.Errorf("GetBranches(%s, %s, %t) failed: %v", orgName, repo, onlyProtected, err)
+		} else {
+			for _, b := range bs {
+				branches[b.Name] = b
+			}
+		}
 	}
-	for _, branch := range branches {
-		bn := branch.Name
+
+	for bn, branch := range branches {
 		if err := p.UpdateBranch(orgName, repo, bn, branch.Protected); err != nil {
 			return fmt.Errorf("UpdateBranch(%s, %s, %s, %t) failed: %v", orgName, repo, bn, branch.Protected, err)
 		}

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -102,10 +102,26 @@ func (c fakeClient) GetRepos(org string, user bool) ([]github.Repo, error) {
 	return r, nil
 }
 
-func (c fakeClient) GetBranches(org, repo string) ([]github.Branch, error) {
+func (c fakeClient) GetBranches(org, repo string, onlyProtected bool) ([]github.Branch, error) {
 	b, ok := c.branches[org+"/"+repo]
 	if !ok {
 		return nil, fmt.Errorf("Unknown repo: %s/%s", org, repo)
+	}
+	var out []github.Branch
+	if onlyProtected {
+		for _, item := range b {
+			if !item.Protected {
+				continue
+			}
+			out = append(out, item)
+		}
+	} else {
+		// when !onlyProtected, github does not set Protected
+		// match that behavior here to ensure we handle this correctly
+		for _, item := range b {
+			item.Protected = false
+			out = append(out, item)
+		}
 	}
 	return b, nil
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1234,7 +1234,7 @@ func TestGetBranches(t *testing.T) {
 	})
 	defer ts.Close()
 	c := getClient(ts.URL)
-	branches, err := c.GetBranches("org", "repo")
+	branches, err := c.GetBranches("org", "repo", true)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	} else if len(branches) != 2 {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -215,7 +215,8 @@ type Repo struct {
 // Branch contains general branch information.
 type Branch struct {
 	Name      string `json:"name"`
-	Protected bool   `json:"protected"`
+	Protected bool   `json:"protected"` // only included for ?protection=true requests
+	// TODO(fejta): consider including undocumented protection key
 }
 
 // BranchProtectionRequest represents


### PR DESCRIPTION
/assign @cjwagner @sebastienvas 
/cc @lukaszgryglicki 

Currently if a repo has many branches we will not reconfigure all of them, just the first page. Also Seb discovered that the `protected: true` values are only returned when asking for only protected results. So we need to make two GetBranches calls to get both protected and unprotected repos.

* Change `GetRepos()` to use `readPaginatedResults()`
* Integrate `readPaginatedResults()` with `GetBranches()`
* Add `onlyProtected` param to `GetBranches()`

Also update `branchprotector` to include an `onlyProtected` call

