### PR TITLE
 Conformance uploader : added ability to support optional metadata

### DIFF
--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -37,5 +37,7 @@ This directory contains tooling for displaying [kubernetes conformance test](htt
 
 5. Authenticate [the gcloud sdk](https://cloud.google.com/sdk/downloads) / [gsutil](https://cloud.google.com/storage/docs/gsutil) to your GCS bucket
 
-6. run `upload_e2e.py --junit=<path to junit_01.xml> --log=<path to log file> --bucket=gs://your-bucket` (optionally supplying `--year=YYYY`, otherwise the current year on the host is assumed when parsing timestamps)
+6. run `upload_e2e.py --junit=<path to junit_01.xml> --log=<path to log file> --bucket=gs://your-bucket`. Optionally you can supply the following
+  * --year=YYYY, otherwise the current year on the host is assumed when parsing timestamps
+  * --metadata='dictionary of additional key-value pairs that can be displayed to the user'. E.g: --metadata='{"testrun": "Run after master upgrade"}'.For more details please see [metadata for finished.json](https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout) and custom [column headers in TestGrid](https://github.com/kubernetes/test-infra/blob/master/testgrid/README.md#column-headers).
 

--- a/testgrid/conformance/upload_e2e.py
+++ b/testgrid/conformance/upload_e2e.py
@@ -128,18 +128,26 @@ def testgrid_started_json_contents(start_time):
         'timestamp': started
     })
 
-def testgrid_finished_json_contents(finish_time, passed):
+def testgrid_finished_json_contents(finish_time, passed, metadata):
     """returns the string contents of a testgrid finished.json file
 
     Args:
         finish_time (datetime.datetime)
         passed (bool)
+        metadata (str)
 
     Returns:
         contents (str)
     """
     finished = datetime_to_unix(finish_time)
     result = 'SUCCESS' if passed else 'FAILURE'
+    if metadata:
+        testdata = json.loads(metadata)
+        return json.dumps({
+            'timestamp': finished,
+            'result': result,
+            'metadata': testdata
+        })
     return json.dumps({
         'timestamp': finished,
         'result': result
@@ -199,6 +207,11 @@ def parse_args(cli_args=None):
         required=False,
         action='store_true',
     )
+    parser.add_argument(
+        '--metadata',
+        help='dictionary of additional key-value pairs that can be displayed to the user.',
+        default=str(),
+    )
     return parser.parse_args(args=cli_args)
 
 def main(cli_args):
@@ -218,7 +231,7 @@ def main(cli_args):
 
     # convert parsed results to testgrid json metadata blobs
     started_json = testgrid_started_json_contents(started)
-    finished_json = testgrid_finished_json_contents(finished, passed)
+    finished_json = testgrid_finished_json_contents(finished, passed, args.metadata)
 
     # use timestamp as build ID
     gcs_dir = bucket + '/' + str(datetime_to_unix(started))


### PR DESCRIPTION
When manually uploading test results post a test run, there might be a need to tag/explain what changed in the cluster or setup before the conformance run was triggered. TestGrid honors custom column headers to support displaying this custom metadata. Also updated README