### PR TITLE
Change prow starter to allow services to start Prow Jobs

### DIFF
--- a/prow/getting_started.md
+++ b/prow/getting_started.md
@@ -190,6 +190,21 @@ update-config: get-cluster-credentials
 Presubmits and postsubmits are triggered by the `trigger` plugin. Be sure to
 enable that plugin by adding it to the list you created in the last section.
 
+By default, services are not granted permission to run these jobs. Run the
+following to grant permission to all services to create and run Prow Jobs (NOTE: This
+command grants a permissive policy to _all_ services in the cluster. We do this
+because the only services running in the prow starter are ones that we have
+written and trust. This is not the recommended policy for most clusters.
+See [RBAC documentation](https://kubernetes.io/docs/admin/authorization/rbac/) for more details):
+
+```
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --group=system:serviceaccounts
+```
+
 Now when you open a PR it will automatically run the presubmit that you added
 to this file. You can see it on your prow dashboard. Once you are happy that it
 is stable, switch `skip_report` to `false`. Then, it will post a status on the


### PR DESCRIPTION
Small change to the Getting Started guide for Prow. It originally did not give permissions to services to create Prow Jobs. Changed to grant permissions to all services to manage Prow Jobs.