### PR TITLE
bazel: Move binaries into root of docker image

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -18,6 +18,7 @@ go_image(
     name = "image",
     base = "@git-base//image",
     binary = ":clonerefs",
+    directory = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -32,6 +32,7 @@ go_image(
     name = "image",
     base = "@git-base//image",
     binary = ":entrypoint",
+    directory = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -5,6 +5,7 @@ go_image(
     name = "image",
     base = "@alpine-base//image",
     binary = ":initupload",
+    directory = "/",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -18,6 +18,7 @@ go_image(
     name = "image",
     base = "@git-base//image",
     binary = ":sidecar",
+    directory = "/",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
to match Dockerfile and hardcoded paths.

Closes: #7947