### PR TITLE
Refactor Users, Teams to *[]string

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -473,8 +473,8 @@ branch-protection:
 					Branch: "master",
 					Request: &github.BranchProtectionRequest{
 						Restrictions: &github.Restrictions{
-							Users: []string{},
-							Teams: []string{"config-team", "org-team", "repo-team", "branch-team"},
+							Users: &[]string{},
+							Teams: &[]string{"config-team", "org-team", "repo-team", "branch-team"},
 						},
 					},
 				},
@@ -532,13 +532,13 @@ branch-protection:
 							RequireCodeOwnerReviews:      true,
 							RequiredApprovingReviewCount: 3,
 							DismissalRestrictions: github.Restrictions{
-								Users: []string{"bob", "jane"},
-								Teams: []string{"oncall", "sres"},
+								Users: &[]string{"bob", "jane"},
+								Teams: &[]string{"oncall", "sres"},
 							},
 						},
 						Restrictions: &github.Restrictions{
-							Users: []string{"cindy"},
-							Teams: []string{"config-team", "org-team"},
+							Users: &[]string{"cindy"},
+							Teams: &[]string{"config-team", "org-team"},
 						},
 					},
 				},
@@ -607,8 +607,8 @@ branch-protection:
 							Contexts: []string{"config-presubmit", "org-presubmit"},
 						},
 						Restrictions: &github.Restrictions{
-							Users: []string{},
-							Teams: []string{"config-team", "org-team"},
+							Users: &[]string{},
+							Teams: &[]string{"config-team", "org-team"},
 						},
 					},
 				},
@@ -726,7 +726,7 @@ func fixup(r *Requirements) {
 		sort.Strings(req.RequiredStatusChecks.Contexts)
 	}
 	if restr := req.Restrictions; restr != nil {
-		sort.Strings(restr.Teams)
-		sort.Strings(restr.Users)
+		sort.Strings(*restr.Teams)
+		sort.Strings(*restr.Users)
 	}
 }

--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -69,9 +69,11 @@ func makeRestrictions(rp *branchprotection.Restrictions) *github.Restrictions {
 	if rp == nil {
 		return nil
 	}
+	teams := append([]string{}, rp.Teams...)
+	users := append([]string{}, rp.Users...)
 	return &github.Restrictions{
-		Teams: append([]string{}, rp.Teams...),
-		Users: append([]string{}, rp.Users...),
+		Teams: &teams,
+		Users: &users,
 	}
 }
 

--- a/prow/cmd/branchprotector/request_test.go
+++ b/prow/cmd/branchprotector/request_test.go
@@ -101,8 +101,8 @@ func TestMakeReviews(t *testing.T) {
 				RequireCodeOwnerReviews:      true,
 				DismissStaleReviews:          true,
 				DismissalRestrictions: github.Restrictions{
-					Teams: []string{"megacorp", "startup"},
-					Users: []string{"fred", "jane"},
+					Teams: &[]string{"megacorp", "startup"},
+					Users: &[]string{"fred", "jane"},
 				},
 			},
 		},
@@ -135,8 +135,8 @@ func TestMakeRequest(t *testing.T) {
 			},
 			expected: github.BranchProtectionRequest{
 				Restrictions: &github.Restrictions{
-					Teams: []string{"hello"},
-					Users: []string{},
+					Teams: &[]string{"hello"},
+					Users: &[]string{},
 				},
 			},
 		},
@@ -149,8 +149,8 @@ func TestMakeRequest(t *testing.T) {
 			},
 			expected: github.BranchProtectionRequest{
 				Restrictions: &github.Restrictions{
-					Users: []string{"there"},
-					Teams: []string{},
+					Users: &[]string{"there"},
+					Teams: &[]string{},
 				},
 			},
 		},

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1301,10 +1301,12 @@ func TestUpdateBranchProtection(t *testing.T) {
 				t.Errorf("Could not unmarshal request: %v", err)
 			}
 			switch {
+			case bpr.Restrictions != nil && bpr.Restrictions.Teams == nil:
+				t.Errorf("Teams unset")
 			case len(bpr.RequiredStatusChecks.Contexts) != len(tc.contexts):
 				t.Errorf("Bad contexts: %v", bpr.RequiredStatusChecks.Contexts)
-			case len(bpr.Restrictions.Teams) != len(tc.pushers):
-				t.Errorf("Bad teams: %v", bpr.Restrictions.Teams)
+			case len(*bpr.Restrictions.Teams) != len(tc.pushers):
+				t.Errorf("Bad teams: %v", *bpr.Restrictions.Teams)
 			default:
 				mc := map[string]bool{}
 				for _, k := range tc.contexts {
@@ -1324,7 +1326,7 @@ func TestUpdateBranchProtection(t *testing.T) {
 					mp[k] = true
 				}
 				missing = nil
-				for _, k := range bpr.Restrictions.Teams {
+				for _, k := range *bpr.Restrictions.Teams {
 					if mp[k] != true {
 						missing = append(missing, k)
 					}
@@ -1343,7 +1345,7 @@ func TestUpdateBranchProtection(t *testing.T) {
 				Contexts: tc.contexts,
 			},
 			Restrictions: &Restrictions{
-				Teams: tc.pushers,
+				Teams: &tc.pushers,
 			},
 		})
 		if tc.err && err == nil {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -241,9 +241,14 @@ type RequiredPullRequestReviews struct {
 	RequiredApprovingReviewCount int          `json:"required_approving_review_count"`
 }
 
+// Restrictions tells github to restrict an activity to people/teams.
+//
+// Use *[]string in order to distinguish unset and empty list.
+// This is needed by dismissal_restrictions to distinguish
+// do not restrict (empty object) and restrict everyone (nil user/teams list)
 type Restrictions struct {
-	Users []string `json:"users"`
-	Teams []string `json:"teams"`
+	Users *[]string `json:"users,omitempty"`
+	Teams *[]string `json:"teams,omitempty"`
 }
 
 // IssueEventAction enumerates the triggers for this


### PR DESCRIPTION
/assign @cjwagner @BenTheElder 

Fixes https://github.com/kubernetes/test-infra/issues/8097

Need a way to distinguish "unrestricted dismissal restrictions, aka `dismissal_restrictions: {}`" from "restrict everyone, aka `dismissal_restrictions: {"users": [], "teams": []}` which requires us to user pointers to distinguish these two states (otherwise golang will drop these keys for both `nil` and `[]`)

```yaml
{
  "restrictions": nil  # unrestricted push policy
  "restrictions": {} # invalid
  "restrictions": {"users": [], "teams": []}  # disallow anyone from pushing
  "required_pull_request_reviews": {
    dismissal_restrictions: nil # invalid/ignored
    dismissal_restrictions: {} # unrestricted
    dismissal_restrictions: {"users": [], "teams": []}, # disallow anyone from dismissing
  }
}
```
    