### PR TITLE
Hide error when checking for network/firewall

### DIFF
--- a/kubetest/process/process.go
+++ b/kubetest/process/process.go
@@ -364,7 +364,14 @@ func (c *Control) Output(cmd *exec.Cmd) ([]byte, error) {
 	cmd.Stdout = &stdout
 	err := c.FinishRunning(cmd)
 	return stdout.Bytes(), err
+}
 
+// ignores all output from the command, potentially timing out in the process.
+func (c *Control) NoOutput(cmd *exec.Cmd) error {
+	var void bytes.Buffer
+	cmd.Stdout = &void
+	cmd.Stderr = &void
+	return c.FinishRunning(cmd)
 }
 
 // Get the process group to kill the entire main/child process


### PR DESCRIPTION
`Up()` and `ensureFirewall()` use `control.FinishRunning()` with `gcloud ... describe` to check whether a resource exists or not. However, since `FinishRunning` displays the output of the command, if the resource doesn't exist the log will display a misleading "ERROR" entry. For example:

```
2018/05/21 14:32:23 process.go:150: Running: gcloud compute networks describe build-e2e-net --project=adrcunha-flex-test --format=value(name)
ERROR: (gcloud.compute.networks.describe) Could not fetch resource:
 - The resource 'projects/adrcunha-flex-test/global/networks/build-e2e-net' was not found

2018/05/21 14:32:24 process.go:152: Step 'gcloud compute networks describe build-e2e-net --project=adrcunha-flex-test --format=value(name)' finished in 978.046239ms
2018/05/21 14:32:24 process.go:150: Running: gcloud compute networks create build-e2e-net --project=adrcunha-flex-test --subnet-mode=auto
```

```
2018/05/21 14:35:16 process.go:150: Running: gcloud compute firewall-rules describe e2e-ports-e6fac0a7 --project=adrcunha-flex-test --format=value(name)
ERROR: (gcloud.compute.firewall-rules.describe) Could not fetch resource:
 - The resource 'projects/adrcunha-flex-test/global/firewalls/e2e-ports-e6fac0a7' was not found

2018/05/21 14:35:17 process.go:152: Step 'gcloud compute firewall-rules describe e2e-ports-e6fac0a7 --project=adrcunha-flex-test --format=value(name)' finished in 918.535994ms
2018/05/21 14:35:19 process.go:150: Running: gcloud compute firewall-rules create e2e-ports-e6fac0a7 --project=adrcunha-flex-test --network=build-e2e-net --allow=tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767 --target-tags=gke-build-e2e-cluster-f244c468-node
```

Use `control.NoOutput()` instead of `FinishRunning()` to hide the output (and thus the misleading error message), but still check if the resource exists or not based on the return value of the command.

`control.NoOutput()` is like `control.Output()`, but it completely discards the output of the command.