### PR TITLE
increase ci-kubernetes-node-kubelet-serial timeout

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11496,7 +11496,7 @@
       "--node-tests=true",
       "--provider=gce",
       "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",
-      "--timeout=180m"
+      "--timeout=220m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-serial-gce-e2e
is currently failing due to timeouts. I have some new tests in
https://github.com/kubernetes/kubernetes/pull/63221 which will further
increase the test runtime. This PR should fix the current failures and
give us a margin of safety for the new tests.