### PR TITLE
added branch-specific slack notifications

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -120,11 +120,17 @@ slack:
     - k8s-ci-robot # future home of tide
     - k8s-merge-robot # submit queue
     - k8s-release-robot # anago
-    - wojtek-t # 1.7 patch release manager
-    - jpbetz # 1.8 patch release manager
-    - mbohlool # 1.9 patch release manager
-    - calebamiles # 1.10 branch manager
-    - lavalamp # feature-serverside-apply "branch manager"
+    branch_whitelist:
+        release-1.7:
+            - wojtek-t # 1.7 patch release manager
+        release-1.8:
+            - jpbetz # 1.8 patch release manager
+        release-1.9:
+            - mbohlool # 1.9 patch release manager
+        release-1.10:
+            - calebamiles # 1.10 branch manager
+        feature-serverside-apply:
+            - lavalamp # feature-serverside-apply "branch manager"
   - repos:
     - kubernetes/test-infra
     channels:

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -391,6 +391,8 @@ type MergeWarning struct {
 	Channels []string `json:"channels,omitempty"`
 	// A slack event is published if the user is not part of the WhiteList.
 	WhiteList []string `json:"whitelist,omitempty"`
+	// A slack event is published if the user is not on the branch whitelist
+	BranchWhiteList map[string][]string `json:"branch_whitelist,omitempty"`
 }
 
 // TriggerFor finds the Trigger for a repo, if one exists


### PR DESCRIPTION
Fix for #7714. Added another field to the MergeWarning Object to allow some users to be merge-whitelisted only for a specific branch. Object is a map: branch-name -> list of users. Current whitelist functionality is kept, and serves the purpose of a universal whitelist. Also updated test cases to account for new functionality.