### PR TITLE
Add manual test for coredns

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12556,6 +12556,30 @@
       "sig-scalability"
     ]
   },
+  "pull-kubernetes-e2e-gce-large-performance-coredns": {
+    "args": [
+      "--build=bazel",
+      "--cluster=",
+      "--env=CLUSTER_DNS_CORE_DNS=true",
+      "--env=HEAPSTER_MACHINE_TYPE=n1-standard-8",
+      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-large-performance.env",
+      "--extract=local",
+      "--gcp-nodes=2000",
+      "--gcp-project=k8s-scale-testing",
+      "--gcp-zone=us-east1-a",
+      "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-large-performance-coredns",
+      "--test_args=--ginkgo.focus=\\[Feature:PerformanceDNS\\] --gather-resource-usage=master --gather-metrics-at-teardown=master",
+      "--timeout=540m",
+      "--use-logexporter"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-scalability"
+    ]
+  },
   "pull-kubernetes-e2e-gke": {
     "args": [
       "--build=bazel",


### PR DESCRIPTION
This adds a job to run a dns scale record test against coredns.  The intent is that this would be run manually in a PR, not automatically run.

See discussion in #8078