### PR TITLE
Disable influxdb in cluster upgrade tests

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
@@ -8,3 +8,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 # pin this to the lower version. The long term fix is to change
 # downgrade/upgrade to not upgrade/downgrade etcd.
 TEST_ETCD_VERSION=3.0.17
+
+# In 1.11 influxdb is no longer deployed by default.
+KUBE_ENABLE_CLUSTER_MONITORING=standalone

--- a/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-master.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-master.env
@@ -3,3 +3,5 @@
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 
+# In 1.11 influxdb is no longer deployed by default.
+KUBE_ENABLE_CLUSTER_MONITORING=standalone


### PR DESCRIPTION
This PR disables monitoring configuration on k8s upgrade tests from 1.10 to 1.11
From 1.11 influxdb is no longer default monitoring and it's test suite
was moved to separate job and tagged with Feature flag.

closes https://github.com/kubernetes/kubernetes/issues/64075
