### PR TITLE
Added graceful shutdown to hook

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -18,14 +18,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -51,8 +54,9 @@ type options struct {
 	cluster      string
 	pluginConfig string
 
-	dryRun  bool
-	deckURL string
+	dryRun      bool
+	gracePeriod time.Duration
+	deckURL     string
 
 	githubEndpoint  flagutil.Strings
 	githubTokenFile string
@@ -79,6 +83,7 @@ func gatherOptions() options {
 	flag.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
 
 	flag.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	flag.DurationVar(&o.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration. ")
 	flag.StringVar(&o.deckURL, "deck-url", "", "Deck URL for read-only access to the cluster.")
 
 	flag.Var(&o.githubEndpoint, "github-endpoint", "GitHub's API endpoint.")
@@ -101,11 +106,6 @@ func main() {
 	if err := configAgent.Start(o.configPath); err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
-
-	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
-	// We'll get SIGTERM first and then SIGKILL after our graceful termination
-	// deadline.
-	signal.Ignore(syscall.SIGTERM)
 
 	webhookSecretRaw, err := ioutil.ReadFile(o.webhookSecretFile)
 	if err != nil {
@@ -211,6 +211,7 @@ func main() {
 		Plugins:     pluginAgent,
 		Metrics:     promMetrics,
 	}
+	defer server.GracefulShutdown()
 
 	// Return 200 on / for health checks.
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
@@ -220,5 +221,18 @@ func main() {
 	// Serve plugin help information from /plugin-help.
 	http.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
 
-	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(o.port), nil))
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port)}
+
+	// Shutdown gracefully on SIGTERM or SIGINT
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sig
+		logrus.Info("Hook is shutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), o.gracePeriod)
+		defer cancel()
+		httpServer.Shutdown(ctx)
+	}()
+
+	logrus.WithError(httpServer.ListenAndServe()).Warn("Server exited.")
 }

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -51,6 +51,7 @@ var (
 )
 
 func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  re.Repo.Owner.Login,
 		github.RepoLogField: re.Repo.Name,
@@ -61,7 +62,9 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 	})
 	l.Infof("Review %s.", re.Action)
 	for p, h := range s.Plugins.ReviewEventHandlers(re.PullRequest.Base.Repo.Owner.Login, re.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.ReviewEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -103,6 +106,7 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 }
 
 func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewCommentEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  rce.Repo.Owner.Login,
 		github.RepoLogField: rce.Repo.Name,
@@ -113,7 +117,9 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 	})
 	l.Infof("Review comment %s.", rce.Action)
 	for p, h := range s.Plugins.ReviewCommentEventHandlers(rce.PullRequest.Base.Repo.Owner.Login, rce.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.ReviewCommentEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -155,6 +161,7 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 }
 
 func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  pr.Repo.Owner.Login,
 		github.RepoLogField: pr.Repo.Name,
@@ -164,7 +171,9 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 	})
 	l.Infof("Pull request %s.", pr.Action)
 	for p, h := range s.Plugins.PullRequestHandlers(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.PullRequestHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -208,6 +217,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 }
 
 func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  pe.Repo.Owner.Name,
 		github.RepoLogField: pe.Repo.Name,
@@ -216,7 +226,9 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 	})
 	l.Info("Push event.")
 	for p, h := range s.Plugins.PushEventHandlers(pe.Repo.Owner.Name, pe.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.PushEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -229,6 +241,7 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 }
 
 func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  i.Repo.Owner.Login,
 		github.RepoLogField: i.Repo.Name,
@@ -238,7 +251,9 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 	})
 	l.Infof("Issue %s.", i.Action)
 	for p, h := range s.Plugins.IssueHandlers(i.Repo.Owner.Login, i.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.IssueHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -282,6 +297,7 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 }
 
 func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueCommentEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  ic.Repo.Owner.Login,
 		github.RepoLogField: ic.Repo.Name,
@@ -291,7 +307,9 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 	})
 	l.Infof("Issue comment %s.", ic.Action)
 	for p, h := range s.Plugins.IssueCommentHandlers(ic.Repo.Owner.Login, ic.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.IssueCommentHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -333,6 +351,7 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 }
 
 func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  se.Repo.Owner.Login,
 		github.RepoLogField: se.Repo.Name,
@@ -343,7 +362,9 @@ func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
 	})
 	l.Infof("Status description %s.", se.Description)
 	for p, h := range s.Plugins.StatusEventHandlers(se.Repo.Owner.Login, se.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.StatusEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -372,7 +393,9 @@ func genericCommentAction(action string) github.GenericCommentEventAction {
 
 func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericCommentEvent) {
 	for p, h := range s.Plugins.GenericCommentHandlers(ce.Repo.Owner.Login, ce.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.GenericCommentHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()


### PR DESCRIPTION
A fix for #3396. Uses a WaitGroup that is incremented for every event received that needs to be handled and decremented in each handler. On shutdown, hook waits for all events in the WaitGroup to finish before exiting, or after 180 seconds, whichever comes first. Also accommodates external plugins.