### PR TITLE
Revert "Run the triage job with the sidecar uploader for logs."

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16665,7 +16665,6 @@ periodics:
 - name: ci-test-infra-triage
   interval: 1h
   agent: kubernetes
-  decorate: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/triage:latest


### PR DESCRIPTION
This reverts commit da0dcbe82457a9554e92bedce6340eda7c354586.

This can be reverted when #8119  is deployed.