### PR TITLE
[WIP] Command plugin framework and 'merge-blocker' plugin that uses it.

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/lifecycle:go_default_library",
+        "//prow/plugins/merge-blocker:go_default_library",
         "//prow/plugins/milestone:go_default_library",
         "//prow/plugins/milestonestatus:go_default_library",
         "//prow/plugins/override:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -35,6 +35,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/lifecycle"
+	_ "k8s.io/test-infra/prow/plugins/merge-blocker"
 	_ "k8s.io/test-infra/prow/plugins/milestone"
 	_ "k8s.io/test-infra/prow/plugins/milestonestatus"
 	_ "k8s.io/test-infra/prow/plugins/override"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -66,6 +66,7 @@ filegroup(
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",
+        "//prow/plugins/merge-blocker:all-srcs",
         "//prow/plugins/milestone:all-srcs",
         "//prow/plugins/milestonestatus:all-srcs",
         "//prow/plugins/override:all-srcs",

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -56,6 +56,7 @@ filegroup(
         "//prow/plugins/buildifier:all-srcs",
         "//prow/plugins/cat:all-srcs",
         "//prow/plugins/cla:all-srcs",
+        "//prow/plugins/commands:all-srcs",
         "//prow/plugins/docs-no-retest:all-srcs",
         "//prow/plugins/dog:all-srcs",
         "//prow/plugins/golint:all-srcs",

--- a/prow/plugins/commands/BUILD.bazel
+++ b/prow/plugins/commands/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["commands.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/commands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//prow/plugins/commands/generics:all-srcs",
+        "//prow/plugins/commands/handlers:all-srcs",
+        "//prow/plugins/commands/policies:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["commands_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
+)

--- a/prow/plugins/commands/commands.go
+++ b/prow/plugins/commands/commands.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+	Package commands provides a modular framework for defining command based Prow plugins.
+
+	Example label based commands:
+	(1) [Full Example] The `hold` plugin becomes mostly documentation:
+
+	func init() {
+		 cmd, cmdHelp := SingleLabelCommand("hold", "do-not-merge/hold", IssueTypePR, OpenAccess)
+		 plugins.RegisterGenericCommentHandler("hold", cmd, helpProvider(cmdHelp))
+	}
+
+	func helpProvider(cmdHelp *pluginhelp.Command) plugins.HelpProvider {
+		return func(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+			pluginHelp := &pluginhelp.PluginHelp{
+				Description: "The hold plugin allows anyone to add or remove the '" + label + "' label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
+			}
+			pluginHelp.AddCommand(*cmdHelp)
+			return pluginHelp, nil
+		 }
+	}
+
+	(2) The `milestonestatus` plugin:
+
+		cmd, cmdHelp := MultiLabelCommand("status", milestonestatus.statusMap, IssueTypeBoth, TeamAccess(teamId))
+		plugins.RegisterGenericCommentHandler("milestonestatus", cmd, helpProvider(cmdHelp))
+
+	(3) A `merge` plugin that gives the author control of a `mergeable` label:
+
+		cmd, cmdHelp := SingleLabelCommand("merge", "mergeable", IssueTypePR, AuthorAccess)
+		plugins.RegisterGenericCommentHandler("merge", cmd, helpProvider(cmdHelp))
+*/
+package commands
+
+// TODO(cjwagner): allow dynamically adding new commands at runtime via config
+// instead of code.
+
+import (
+	"regexp"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+// IssueType specifies whether a command applies to issues, PRs, or both.
+type IssueType string
+
+func (i IssueType) String() string {
+	return string(i)
+}
+
+const (
+	IssueTypeIssue = "issues"
+	IssueTypePR    = "pull requests"
+	IssueTypeBoth  = "issues and pull requests"
+)
+
+// Command represents a single command based plugin and is the unit that can be
+// registered to handle generic comments via the 'plugins' package.
+type Command struct {
+	issueType IssueType
+	re        *regexp.Regexp
+
+	// handler is called if the command regex matches a comment on an issue of the
+	// correct type.
+	handler MatchHandler
+}
+
+// New returns a new Command.
+// This constructor exists to allow the struct fields to be package private.
+// This prevents a plugin from changing the struct values after creation time
+// which could race with their use in GenericCommentHandler.
+func New(issueType IssueType, re *regexp.Regexp, handler MatchHandler) Command {
+	return &Command{
+		issueType: issueType,
+		re:        re,
+		handler:   handler,
+	}
+}
+
+// Context provides MatchHandlers with a PluginClient, the regexp match, and
+// data about the triggering event.
+type Context struct {
+	Client  *plugins.PluginClient
+	Event   *github.GenericCommentEvent
+	Matches [][]string
+}
+
+// MatchHandler reacts to a command match on the appropriate issue type.
+// This is where the interesting plugin logic will live.
+// See "k8s.io/test-infra/prow/plugins/commands/handlers" for some examples.
+type MatchHandler func(*Context) error
+
+// GenericCommentHandler checks for command regexp matches in freshly created
+// comments on the appropriate issue type and calls the match handler if the
+// regexp matches.
+func (c Command) GenericCommentHandler(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	if e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+	switch c.issueType {
+	case IssueTypeIssue:
+		if e.IsPR {
+			return nil
+		}
+	case IssueTypePR:
+		if !e.IsPR {
+			return nil
+		}
+	}
+	if matches := c.re.FindAllStringSubmatch(e.Body, -1); len(matches) > 0 {
+		return c.handler(&Context{
+			Client:  &pc,
+			Event:   &e,
+			Matches: matches,
+		})
+	}
+	return nil
+}

--- a/prow/plugins/commands/commands_test.go
+++ b/prow/plugins/commands/commands_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func TestGenericCommentHandler(t *testing.T) {
+	re := regexp.MustCompile(`foo`)
+
+	tcs := []struct {
+		name         string
+		issueType    IssueType
+		event        github.GenericCommentEvent
+		shouldHandle bool
+		shouldError  bool
+	}{
+		{
+			name:      "issue happy case",
+			issueType: IssueTypeIssue,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   false,
+				Body:   "foo",
+			},
+			shouldHandle: true,
+		},
+		{
+			name:      "issue handler on PR",
+			issueType: IssueTypeIssue,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "foo",
+			},
+			shouldHandle: false,
+		},
+		{
+			name:      "pr happy case",
+			issueType: IssueTypePR,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "foo",
+			},
+			shouldHandle: true,
+		},
+		{
+			name:      "pr handler on issue",
+			issueType: IssueTypePR,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   false,
+				Body:   "foo",
+			},
+			shouldHandle: false,
+		},
+		{
+			name:      "handle both (issue), expect error",
+			issueType: IssueTypeBoth,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   false,
+				Body:   "foo",
+			},
+			shouldHandle: true,
+			shouldError:  true,
+		},
+		{
+			name:      "handle both (pr)",
+			issueType: IssueTypeBoth,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "foo",
+			},
+			shouldHandle: true,
+		},
+		{
+			name:      "wrong action",
+			issueType: IssueTypeBoth,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionEdited,
+				IsPR:   true,
+				Body:   "foo",
+			},
+			shouldHandle: false,
+		},
+		{
+			name:      "no match",
+			issueType: IssueTypeBoth,
+			event: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "bar",
+			},
+			shouldHandle: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("Test case: %s", tc.name)
+
+		handled := false
+		handler := func(ctx *Context) error {
+			handled = true
+			if tc.shouldError {
+				return errors.New("Some handler error (expected by test).")
+			}
+			return nil
+		}
+		c := New(tc.issueType, re, handler)
+		err := c.GenericCommentHandler(plugins.PluginClient{}, tc.event)
+
+		if (err != nil) != tc.shouldError {
+			if tc.shouldError {
+				t.Error("Expected a handling error, but didn't get one.")
+			} else {
+				t.Errorf("Unexpected handling error: %v.", err)
+			}
+		}
+		if handled != tc.shouldHandle {
+			if tc.shouldHandle {
+				t.Error("Expected to handle the event, but didn't.")
+			} else {
+				t.Error("Didn't expect to handle the event, but did.")
+			}
+		}
+	}
+}

--- a/prow/plugins/commands/generics/BUILD.bazel
+++ b/prow/plugins/commands/generics/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["generics.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/commands/generics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/errorutil:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/commands:go_default_library",
+        "//prow/plugins/commands/handlers:go_default_library",
+        "//prow/plugins/commands/policies:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["generics_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/commands:go_default_library",
+    ],
+)

--- a/prow/plugins/commands/generics/generics.go
+++ b/prow/plugins/commands/generics/generics.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generics
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/commands"
+	"k8s.io/test-infra/prow/plugins/commands/handlers"
+	"k8s.io/test-infra/prow/plugins/commands/policies"
+)
+
+const reFormatAddRemove = `(?mi)^/(remove-)?%s(?: +(.*?))?\s*$`
+
+// AddRemoveCommands take the form `/[remove-]<command> [<args>]`.
+func AddRemoveCommand(command string, issueType commands.IssueType, add, remove commands.MatchHandler) commands.Command {
+	handler := func(ctx *commands.Context) error {
+		var addMatches, removeMatches [][]string
+		for _, match := range ctx.Matches {
+			if len(match) != 3 {
+				return fmt.Errorf("expected 3 regexp match groups, but got %d", len(match))
+			}
+			if strings.ToLower(match[1]) == "remove-" {
+				removeMatches = append(removeMatches, match)
+			} else {
+				addMatches = append(addMatches, match)
+			}
+		}
+		var err error
+		if len(removeMatches) > 0 {
+			ctx.Matches = removeMatches
+			err = remove(ctx)
+		}
+		if len(addMatches) > 0 {
+			ctx.Matches = addMatches
+			err = errorutil.NewAggregate(err, add(ctx))
+		}
+		return err
+	}
+	return commands.New(
+		issueType,
+		// TODO: Change this to return an error when switching to dynamically defined plugins.
+		regexp.MustCompile(fmt.Sprintf(reFormatAddRemove, command)),
+		handler,
+	)
+}
+
+type CommandHelpProvider func(*plugins.Configuration) pluginhelp.Command
+
+func SingleLabelCommand(command, label string, issueType commands.IssueType, policy policies.AccessPolicy) (commands.Command, CommandHelpProvider) {
+	return AddRemoveCommand(
+			command,
+			issueType,
+			policies.Apply(policy, handlers.EnsureLabel(label)),
+			policies.Apply(policy, handlers.RemoveLabel(label)),
+		),
+		func(config *plugins.Configuration) pluginhelp.Command {
+			return pluginhelp.Command{
+				Usage:       "/[remove-]" + command,
+				Description: fmt.Sprintf("Adds or removes the %q label on %s.", label, issueType),
+				Examples:    []string{"/" + command, "/remove-" + command},
+				WhoCanUse:   policy.Who(config) + " can use this command.",
+			}
+		}
+}

--- a/prow/plugins/commands/generics/generics_test.go
+++ b/prow/plugins/commands/generics/generics_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generics
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/commands"
+)
+
+func TestAddRemoveCommand(t *testing.T) {
+	argsFromMatches := func(matches [][]string) []string {
+		args := make([]string, 0, len(matches))
+		for _, match := range matches {
+			args = append(args, match[2])
+		}
+		return args
+	}
+
+	tcs := []struct {
+		name           string
+		text           string
+		expectedAdd    []string
+		expectedRemove []string
+	}{
+		{
+			name: "No command",
+			text: "blah blah\n/lgtm\n",
+		},
+		{
+			name:        "Empty add",
+			text:        "blah blah\n/do-the-thing\nblah blah",
+			expectedAdd: []string{""},
+		},
+		{
+			name:           "Empty remove",
+			text:           "blah blah\n/remove-do-the-thing\nblah blah",
+			expectedRemove: []string{""},
+		},
+		{
+			name:        "Arged add",
+			text:        "blah blah\n/do-the-thing don't mess up\nblah blah",
+			expectedAdd: []string{"don't mess up"},
+		},
+		{
+			name:           "Arged remove",
+			text:           "blah blah\n/remove-do-the-thing   don't mess up\nblah blah",
+			expectedRemove: []string{"don't mess up"},
+		},
+		{
+			name:        "Multiple adds",
+			text:        "blah blah\n/do-the-thing don't mess up\nblah blah\n/do-the-thing again",
+			expectedAdd: []string{"don't mess up", "again"},
+		},
+		{
+			name:           "Multiple removes",
+			text:           "blah blah\n/remove-do-the-thing don't mess up\nblah blah\n/remove-do-the-thing\n",
+			expectedRemove: []string{"don't mess up", ""},
+		},
+		{
+			name:           "Add and remove",
+			text:           "/lgtm\n/do-the-thing add \n/remove-do-the-thing remove\n/do-the-thing add again\n/remove-do-the-thing remove again",
+			expectedAdd:    []string{"add", "add again"},
+			expectedRemove: []string{"remove", "remove again"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("Running test case: [%s].", tc.name)
+		var adder, remover commands.MatchHandler
+		adder = func(ctx *commands.Context) error {
+			if len(tc.expectedAdd) == 0 {
+				t.Error("Did not expect add handler to be called.")
+			}
+			args := argsFromMatches(ctx.Matches)
+			if !reflect.DeepEqual(args, tc.expectedAdd) {
+				t.Errorf("Expected add handler to receive args: %q, but got %q.", tc.expectedAdd, args)
+			}
+			return nil
+		}
+		remover = func(ctx *commands.Context) error {
+			if len(tc.expectedRemove) == 0 {
+				t.Error("Did not expect remove handler to be called.")
+			}
+			args := argsFromMatches(ctx.Matches)
+			if !reflect.DeepEqual(args, tc.expectedRemove) {
+				t.Errorf("Expected remove handler to receive args: %q, but got %q.", tc.expectedRemove, args)
+			}
+			return nil
+		}
+		e := github.GenericCommentEvent{
+			Action: github.GenericCommentActionCreated,
+			IsPR:   true,
+			Body:   tc.text,
+		}
+		cmd := AddRemoveCommand("do-the-thing", commands.IssueTypePR, adder, remover)
+		if err := cmd.GenericCommentHandler(plugins.PluginClient{}, e); err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		}
+	}
+}

--- a/prow/plugins/commands/handlers/BUILD.bazel
+++ b/prow/plugins/commands/handlers/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["handlers.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/commands/handlers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins/commands:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["handlers_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)

--- a/prow/plugins/commands/handlers/handlers.go
+++ b/prow/plugins/commands/handlers/handlers.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins/commands"
+)
+
+type labelClient interface {
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+}
+
+// EnsureLabel adds the specified label if it is not already present.
+func EnsureLabel(label string) commands.MatchHandler {
+	return func(ctx *commands.Context) error {
+		return doEnsureLabel(ctx.Client.GitHubClient, ctx.Event, label)
+	}
+}
+
+func doEnsureLabel(client labelClient, e *github.GenericCommentEvent, label string) error {
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+
+	currentLabels, err := client.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("error listing labels: %v", err)
+	}
+	if github.HasLabel(label, currentLabels) {
+		return nil
+	}
+	if err := client.AddLabel(org, repo, number, label); err != nil {
+		return fmt.Errorf("error adding label %q: %v", label, err)
+	}
+	return nil
+}
+
+// RemoveLabel removes the specified label.
+// We don't check if the label is present to save API tokens. If it is not
+// present this is a no-op.
+// Note: This may actually use more tokens rather than less if the github cache
+// proxy is in use and the label is usually not present. /shrug
+func RemoveLabel(label string) commands.MatchHandler {
+	return func(ctx *commands.Context) error {
+		return doRemoveLabel(ctx.Client.GitHubClient, ctx.Event, label)
+	}
+}
+
+func doRemoveLabel(client labelClient, e *github.GenericCommentEvent, label string) error {
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+
+	if err := client.RemoveLabel(org, repo, number, label); err != nil {
+		if _, ok := err.(*github.LabelNotFound); !ok {
+			return fmt.Errorf("error removing label %q: %v", label, err)
+		}
+	}
+	return nil
+}
+
+/*
+	Additional possible handlers:
+
+	func Assign(ctx *Context) error { ... }
+	func RequestReview(ctx *Context) error { ... }
+
+	- Post to slack
+	- Add emoji reaction
+	- Set milestone
+*/

--- a/prow/plugins/commands/handlers/handlers_test.go
+++ b/prow/plugins/commands/handlers/handlers_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+)
+
+type fakeLabelClient struct {
+	current, added, removed sets.String
+}
+
+func newFakeLabelClient(initial ...string) *fakeLabelClient {
+	return &fakeLabelClient{
+		current: sets.NewString(initial...),
+		added:   sets.NewString(),
+		removed: sets.NewString(),
+	}
+}
+
+func (f *fakeLabelClient) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	if org != "org" || repo != "repo" || number != 5 {
+		return nil, fmt.Errorf("client received an unexpected org/repo#number: %s/%s#%d", org, repo, number)
+	}
+	var labels []github.Label
+	for _, l := range f.current.List() {
+		labels = append(labels, github.Label{Name: l})
+	}
+	return labels, nil
+}
+
+func (f *fakeLabelClient) AddLabel(org, repo string, number int, label string) error {
+	if org != "org" || repo != "repo" || number != 5 {
+		return nil
+	}
+	f.current.Insert(label)
+	f.added.Insert(label)
+	return nil
+}
+
+func (f *fakeLabelClient) RemoveLabel(org, repo string, number int, label string) error {
+	if org != "org" || repo != "repo" || number != 5 {
+		return nil
+	}
+	var err error
+	if !f.current.Has(label) {
+		err = &github.LabelNotFound{}
+	}
+	f.current.Delete(label)
+	f.removed.Insert(label)
+	return err
+}
+
+func TestDoEnsureLabel(t *testing.T) {
+	tcs := []struct {
+		name          string
+		initialLabels []string
+		expectedAdded sets.String
+	}{
+		{
+			name:          "has label",
+			initialLabels: []string{"foo"},
+		},
+		{
+			name:          "does not have label",
+			expectedAdded: sets.NewString("foo"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Logf("Test case: %s.", tc.name)
+
+		client := newFakeLabelClient(tc.initialLabels...)
+		e := &github.GenericCommentEvent{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "org",
+				},
+				Name: "repo",
+			},
+			Number: 5,
+		}
+		if err := doEnsureLabel(client, e, "foo"); err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		}
+		if !client.added.Equal(tc.expectedAdded) {
+			t.Errorf("Expected the following labels to be added: %q, but got %q.", tc.expectedAdded.List(), client.added.List())
+		}
+	}
+}
+
+func TestDoRemoveLabel(t *testing.T) {
+	tcs := []struct {
+		name            string
+		initialLabels   []string
+		expectedRemoved sets.String
+	}{
+		{
+			name:            "has label",
+			initialLabels:   []string{"foo"},
+			expectedRemoved: sets.NewString("foo"),
+		},
+		{
+			name:            "does not have label",
+			expectedRemoved: sets.NewString("foo"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("Test case: %s.", tc.name)
+
+		client := newFakeLabelClient(tc.initialLabels...)
+		e := &github.GenericCommentEvent{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "org",
+				},
+				Name: "repo",
+			},
+			Number: 5,
+		}
+		if err := doRemoveLabel(client, e, "foo"); err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		}
+		if !client.removed.Equal(tc.expectedRemoved) {
+			t.Errorf("Expected the following labels to be removed: %q, but got %q.", tc.expectedRemoved.List(), client.removed.List())
+		}
+	}
+}

--- a/prow/plugins/commands/policies/BUILD.bazel
+++ b/prow/plugins/commands/policies/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["policies.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/commands/policies",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/commands:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["policies_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)

--- a/prow/plugins/commands/policies/policies.go
+++ b/prow/plugins/commands/policies/policies.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package policies defines an AccessPolicy interface that can be used to
+// gate access to a MatchHandler and implements some common policies.
+package policies
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/commands"
+)
+
+// AccessPolicy describes an policy check.
+type AccessPolicy interface {
+	// CanAccess does the actual policy check and returns a value to indicate if
+	// the MatchHandler should be run.
+	CanAccess(*commands.Context) (bool, error)
+	// Who provides a description of the users who are allowed.
+	Who(config *plugins.Configuration) string
+}
+
+// Apply adds the specified policy check to the specified MatchHandler and
+// returns a new MatchHandler that includes the policy check.
+func Apply(policy AccessPolicy, handler commands.MatchHandler) commands.MatchHandler {
+	return func(ctx *commands.Context) error {
+		approved, err := policy.CanAccess(ctx)
+		if err != nil {
+			return err
+		} else if approved {
+			return handler(ctx)
+		}
+		// Commenter is not allowed to use the command.
+		msg := fmt.Sprintf("You do not have permission to use this command.\n%s can use this command.", policy.Who(ctx.Client.PluginConfig))
+		e := ctx.Event
+		return ctx.Client.GitHubClient.CreateComment(
+			e.Repo.Owner.Login,
+			e.Repo.Name,
+			e.Number,
+			plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg),
+		)
+	}
+}
+
+type union []AccessPolicy
+
+func Union(options ...AccessPolicy) AccessPolicy {
+	return union(options)
+}
+
+func (a union) CanAccess(ctx *commands.Context) (bool, error) {
+	for _, policy := range a {
+		if allowed, err := policy.CanAccess(ctx); err != nil {
+			return false, err
+		} else if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a union) Who(config *plugins.Configuration) string {
+	strs := make([]string, 0, len(a))
+	for _, policy := range a {
+		strs = append(strs, policy.Who(config))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(strs, " AND "))
+}
+
+/*
+Additional possible policies:
+- org member
+- GH team indexed by org(/repo)
+- issue/pr author
+- OWNERS alias
+- user whitelist
+- only allow on friday the 13th
+*/
+type openAccess struct{}
+
+var _ = AccessPolicy(openAccess{})
+
+// OpenAccess allows anyone to use a command. This is the 'no-op' policy.
+func OpenAccess() AccessPolicy {
+	return openAccess{}
+}
+
+func (o openAccess) CanAccess(*commands.Context) (bool, error) {
+	return true, nil
+}
+
+func (o openAccess) Who(*plugins.Configuration) string {
+	return "Everyone"
+}
+
+// TeamAccess allows members of a specific GitHub team to use a command.
+func TeamAccess(teamGetter func(*plugins.Configuration) (teamName string, teamID int)) AccessPolicy {
+	return teamAccess(teamGetter)
+}
+
+type teamClient interface {
+	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+}
+
+type teamAccess func(*plugins.Configuration) (teamName string, teamID int)
+
+var _ = AccessPolicy(TeamAccess(nil))
+
+func (t teamAccess) CanAccess(ctx *commands.Context) (bool, error) {
+	return t.doCanAccess(ctx.Client.PluginConfig, ctx.Client.GitHubClient, ctx.Event.User.Login)
+}
+
+func (t teamAccess) doCanAccess(cfg *plugins.Configuration, client teamClient, login string) (bool, error) {
+	name, id := t(cfg)
+	members, err := client.ListTeamMembers(id, github.RoleAll)
+	if err != nil {
+		return false, fmt.Errorf("error listing members of team %q (ID: %d): %v", name, id, err)
+	}
+
+	login = github.NormLogin(login)
+	for _, person := range members {
+		if github.NormLogin(person.Login) == login {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (t teamAccess) Who(config *plugins.Configuration) string {
+	name, _ := t(config)
+	return fmt.Sprintf("Members of the %q GitHub team", name)
+}

--- a/prow/plugins/commands/policies/policies_test.go
+++ b/prow/plugins/commands/policies/policies_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policies
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+type fakeClient struct {
+	teamMembers sets.String
+}
+
+func (f *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+	if id != 42 || role != github.RoleAll {
+		return nil, errors.New("uh oh")
+	}
+	var res []github.TeamMember
+	for _, member := range f.teamMembers.List() {
+		res = append(res, github.TeamMember{Login: member})
+	}
+	return res, nil
+}
+
+func TestTeamAccess(t *testing.T) {
+	var policy teamAccess
+	policy = func(cfg *plugins.Configuration) (name string, id int) {
+		return cfg.RepoMilestone[""].MaintainersTeam, cfg.RepoMilestone[""].MaintainersID
+	}
+	cfg := &plugins.Configuration{}
+	cfg.RepoMilestone = map[string]plugins.Milestone{"": {MaintainersTeam: "sig-testing", MaintainersID: 42}}
+	client := &fakeClient{teamMembers: sets.NewString("cjwagner", "BenTheElder", "stevekuznetsov")}
+
+	for _, login := range []string{"cjwagner", "BENTHEELDER", "stevekuznetsov", "bentheelder"} {
+		if allowed, err := policy.doCanAccess(cfg, client, login); err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		} else if !allowed {
+			t.Errorf("Expected %q to be allowed access.", login)
+		}
+	}
+	for _, login := range []string{"rando", "foo"} {
+		if allowed, err := policy.doCanAccess(cfg, client, login); err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		} else if allowed {
+			t.Errorf("Expected %q to be disallowed access.", login)
+		}
+	}
+}

--- a/prow/plugins/merge-blocker/BUILD.bazel
+++ b/prow/plugins/merge-blocker/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["merge-blocker.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/merge-blocker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/commands:go_default_library",
+        "//prow/plugins/commands/generics:go_default_library",
+        "//prow/plugins/commands/policies:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/merge-blocker/merge-blocker.go
+++ b/prow/plugins/merge-blocker/merge-blocker.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mergeblocker implements the `/merge-blocker` command which manages
+// the `merge-blocker` label on issues.
+package mergeblocker
+
+import (
+	"fmt"
+
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/commands"
+	"k8s.io/test-infra/prow/plugins/commands/generics"
+	"k8s.io/test-infra/prow/plugins/commands/policies"
+)
+
+const pluginName = "merge-blocker"
+
+func init() {
+	cmd, cmdProvider := generics.SingleLabelCommand(
+		pluginName, // Command
+		pluginName, // Label
+		commands.IssueTypeIssue,
+		policies.TeamAccess(func(config *plugins.Configuration) (string, int) {
+			return config.MergeBlocker.TeamName, config.MergeBlocker.TeamID
+		}),
+	)
+	plugins.RegisterGenericCommentHandler(pluginName, cmd.GenericCommentHandler, helpProvider(cmdProvider))
+}
+
+func helpProvider(cmdProvider generics.CommandHelpProvider) plugins.HelpProvider {
+	return func(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+		pluginHelp := &pluginhelp.PluginHelp{
+			Description: "The merge-blocker plugin provides the `/merge-blocker` command to manage the `merge-blocker` label on GitHub issues. Only members of the configured GitHub team may use this command.",
+			Config: map[string]string{
+				"": fmt.Sprintf("The configuration limits access to this command to members of the %q (ID: %d) GitHub team.", config.MergeBlocker.TeamName, config.MergeBlocker.TeamID),
+			},
+		}
+		pluginHelp.AddCommand(cmdProvider(config))
+		return pluginHelp, nil
+	}
+}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -175,6 +175,7 @@ type Configuration struct {
 	Label         *Label               `json:"label,omitempty"`
 	Lgtm          []Lgtm               `json:"lgtm,omitempty"`
 	Welcome       Welcome              `json:"welcome,omitempty"`
+	MergeBlocker  MergeBlocker         `json:"merge-blocker,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -189,6 +190,15 @@ type ExternalPlugin struct {
 	// server to the external plugin. If no events are specified,
 	// everything is sent.
 	Events []string `json:"events,omitempty"`
+}
+
+type MergeBlocker struct {
+	// ID of the github team allowed to use the `/merge-blocker` command.
+	// You can curl the following endpoint in order to determine the ID of your
+	// team:
+	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+	TeamID   int    `json:"team-id,omitempty"`
+	TeamName string `json:"team-name,omitempty"`
 }
 
 type Blunderbuss struct {


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1Lo1jn6DORjbj8szkE-kc2nXwooQMmrvcYpbfhr7fFnE/edit?usp=sharing (kubernetes-dev and kubernetes-sig-testing google groups can view).

This PR introduces a simple framework for defining and using modular plugin handling logic for command based plugins like `/hold`, `/milestone foo`, etc. It exposes functions for multiple levels of handling logic abstraction; simple commands that control a single label can be declared in a few lines while more complex commands could just use the command regexp matching provided by `Command`s.
I only implemented some of the possible modular components. More can be added as needed.
This framework should generalize much of the common handling logic in Prow plugins that implement commands such as regexp matching for the command, validating the access rights of the commenter, and adding or removing labels.

I'm thinking that once there are enough modular components I'll add a new Prow plugin that consumes a config that declaratively defines commands. Different command types would have different configs. A simple one might look like this:
```yaml
single-label-command:
  name: merge-blocker
  label: merge-blocker
  policy:
    team-access:
      id: 12345
      name: kubernetes-sig-testing
  # Maybe some fields to allow the plugin to be documented
```
This would let us define simple commands in config at runtime without updating or redeploying code. 

The `merge-blocker` plugin implements a command that manages a `merge-blocker` label and is only usable by members of a specific GitHub team. Tide will eventually search for this label to find issues that should block PRs from merging.
I may switch some of the simpler plugins over to using this framework in a follow up PR.

Tests still need to be added.

/area prow
/cc @kargakis @krzyzacy @BenTheElder  @fejta @stevekuznetsov @rmmh 