### PR TITLE
cleanup bimft_misc for dind

### DIFF
--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -30,6 +30,23 @@ if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
 fi
 
 
+# used by cleanup_dind to ensure binfmt_misc entries are not persisted
+# TODO(bentheelder): consider moving *all* cleanup into a more robust program
+cleanup_binfmt_misc() {
+    # make sure the vfs is mounted
+    # TODO(bentheelder): if this logic is moved out and made more general
+    # we need to check that the host actually has binfmt_misc support first.
+    if [ ! -f /proc/sys/fs/binfmt_misc/status ]; then
+        mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+    fi
+    # https://www.kernel.org/doc/html/v4.13/admin-guide/binfmt-misc.html
+    # You can remove one entry or all entries by echoing -1 
+    # to /proc/.../the_name or /proc/sys/fs/binfmt_misc/status.
+    echo -1 >/proc/sys/fs/binfmt_misc/status
+    # list entries
+    ls -al /proc/sys/fs/binfmt_misc
+}
+
 # runs custom docker data root cleanup binary and debugs remaining resources
 cleanup_dind() {
     barnacle || true
@@ -37,6 +54,10 @@ cleanup_dind() {
     echo "Remaining docker images and volumes are:"
     docker images --all || true
     docker volume ls || true
+    # cleanup binfmt_misc
+    echo "Cleaning up binfmt_misc ..."
+    # note: we run this in a subshell so we can trace it for now
+    (set -x; cleanup_binfmt_misc || true)
 }
 
 # Check if the job has opted-in to docker-in-docker availability.


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/64329

when we clean up after docker in docker we should also unregister binfmt_misc handlers, as far as I can tell COS does not register any, so we can just unregister *all* of them in CI