### PR TITLE
fix plugins page title

### DIFF
--- a/prow/cmd/deck/static/plugins.html
+++ b/prow/cmd/deck/static/plugins.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Prow Command Help</title>
+    <title>Prow Plugin Catalog</title>
     <link id="favicon" rel="icon" type="image/png" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="extensions/style.css">


### PR DESCRIPTION
[prow.k8s.io/plugins](https://prow.k8s.io/plugins) vs [prow.k8s.io/command-help](https://prow.k8s.io/command-help)
/shrug