### PR TITLE
bump prow to v20180529-e9431eaa3

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20180521-f8caf9625
+            image: gcr.io/k8s-prow/branchprotector:v20180529-e9431eaa3
             args:
             - --config-path=/etc/config/config
             - --github-token-path=/etc/github/oauth

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/deck:v20180529-e9431eaa3
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/hook:v20180529-e9431eaa3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/horologium:v20180529-e9431eaa3
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/needs-rebase:v20180529-e9431eaa3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/plank:v20180529-e9431eaa3
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/sinker:v20180529-e9431eaa3
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/splice:v20180529-e9431eaa3
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/hook:v20180529-e9431eaa3
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/plank:v20180529-e9431eaa3
         args:
         - --dry-run=false
         volumeMounts:
@@ -189,7 +189,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/sinker:v20180529-e9431eaa3
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -220,7 +220,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/deck:v20180529-e9431eaa3
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -263,7 +263,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/horologium:v20180529-e9431eaa3
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/tide:v20180529-e9431eaa3
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,7 +57,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20180521-f8caf9625
+        image: gcr.io/k8s-prow/tot:v20180529-e9431eaa3
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json


### PR DESCRIPTION
picks up https://github.com/kubernetes/test-infra/pull/8107 in particular, but also other small fixes
/area prow