### PR TITLE
Add a c++ presubmit for tf/minigo.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7099,6 +7099,33 @@ presubmits:
             memory: "2Gi"
 
   tensorflow/minigo:
+  - name: pull-tf-minigo-cc
+    agent: kubernetes
+    always_run: true
+    skip_report: true
+    #context: pull-tf-minigo-cc
+    branches:
+    - master
+    rerun_command: "/test pull-tf-minigo-cc"
+    trigger: "(?m)^/test( all| pull-tf-minigo-cc),?(\\s+|$)"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/tensor-go/cc-base:latest
+        command:
+        - /bin/bash
+        - -c
+        args:
+        # Copy tensorflow libraries into repo, test with board_size=9, test with board_size=19.
+        - "cp -r /app/cc/tensorflow ./cc/tensorflow && bazel test cc:all --compilation_mode=dbg --define=board_size=9 && bazel test cc:all --compilation_mode=dbg --define=board_size=19"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "2Gi"
+      imagePullSecrets:
+      - name: minigo-image-pull
+
   - name: tf-minigo-presubmit
     context: tf-minigo-presubmit
     agent: kubernetes

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -164,7 +164,7 @@ func validateVolumesAndMounts(name string, spec *v1.PodSpec, t *testing.T) {
 }
 
 func checkContext(t *testing.T, repo string, p Presubmit) {
-	if p.Name != p.Context {
+	if !p.SkipReport && p.Name != p.Context {
 		t.Errorf("Context does not match job name: %s in %s", p.Name, repo)
 	}
 	for _, c := range p.RunAfterSuccess {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -91,7 +91,7 @@ func TestPresubmits(t *testing.T) {
 				t.Errorf("Job %v needs a name.", job)
 				continue
 			}
-			if job.Context == "" {
+			if !job.SkipReport && job.Context == "" {
 				t.Errorf("Job %s needs a context.", job.Name)
 			}
 			if job.RerunCommand == "" || job.Trigger == "" {

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2053,6 +2053,9 @@ test_groups:
 - name: tf-minigo-presubmit
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/tf-minigo-presubmit
   num_columns_recent: 30
+- name: pull-tf-minigo-cc
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-tf-minigo-cc
+  num_columns_recent: 30
 - name: tf-minigo-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/tensorflow_minigo/tf-minigo-postsubmit
 - name: spark-periodic-default-gke
@@ -4532,8 +4535,11 @@ dashboards:
     description: Postsubmit tests for Minigo.
     test_group_name: tf-minigo-postsubmit
   - name: tf-minigo-presubmit
-    description: Presumbit tests for Minigo.
+    description: Python presumbit tests for Minigo.
     test_group_name: tf-minigo-presubmit
+  - name: pull-tf-minigo-cc
+    description: C++ presubmit tests for Minigo.
+    test_group_name: pull-tf-minigo-cc
 
 - name: sig-autoscaling-cluster-autoscaler
   dashboard_tab:


### PR DESCRIPTION
Adds a new presubmit for the tensorflow/minigo repo. This presubmit will run for all PRs, but won't report to GitHub yet. That will be enabled once the job is healthy.

I made the name of this job more consistent with other Prow jobs instead of naming it like the existing minigo presubmit, but I'm happy to set this to whatever is preferred.
/hold
/cc @rmmh @krzyzacy 
cc @amj @Kashomon 