### PR TITLE
move pull-kubernetes-e2e-gce to boskos

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12527,7 +12527,6 @@
       "--env-file=jobs/env/pull-kubernetes-e2e-gce.env",
       "--extract=local",
       "--gcp-node-image=gci",
-      "--gcp-project=k8s-jkns-pr-gce-etcd3",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
       "--provider=gce",


### PR DESCRIPTION
we should have enough resources for this:
https://prow.k8s.io/?job=pull-kubernetes-e2e-gce&state=pending (16 jobs currently)
http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1 (around 80 GCE projects free at peak load)
and it should let us perform more aggressive resource cleanup since only one job at a time uses the project.

/area jobs
/area boskos