### PR TITLE
Switch kubeflow Tide query to use new 'org' field.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -119,23 +119,8 @@ branch-protection:
 
 tide:
   queries:
-  - repos:
-    - kubeflow/batch-predict
-    - kubeflow/caffe2-operator
-    - kubeflow/community
-    - kubeflow/examples
-    - kubeflow/example-seldon
-    - kubeflow/experimental-beagle
-    - kubeflow/experimental-kvc
-    - kubeflow/internal-acls
-    - kubeflow/katib
-    - kubeflow/kubebench
-    - kubeflow/kubeflow
-    - kubeflow/pytorch-operator
-    - kubeflow/reporting
-    - kubeflow/testing
-    - kubeflow/tf-operator
-    - kubeflow/website
+  - orgs:
+    - kubeflow
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
All 16 repos in the org are already included in this query so this shouldn't change behavior at all.
/area prow
/cc @fejta @krzyzacy 