### PR TITLE
Fix Mason getting its resource stolen by Reaper

### DIFF
--- a/boskos/client/BUILD.bazel
+++ b/boskos/client/BUILD.bazel
@@ -17,7 +17,12 @@ go_library(
     name = "go_default_library",
     srcs = ["client.go"],
     importpath = "k8s.io/test-infra/boskos/client",
-    deps = ["//boskos/common:go_default_library"],
+    deps = [
+        "//boskos/common:go_default_library",
+        "//boskos/storage:go_default_library",
+        "//vendor/github.com/hashicorp/go-multierror:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -23,28 +23,33 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"sync"
+	"strings"
 	"time"
 
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
-	"strings"
+	"k8s.io/test-infra/boskos/storage"
 )
 
 // Client defines the public Boskos client object
 type Client struct {
 	owner string
 	url   string
+	lock  sync.Mutex
 
-	lock      sync.Mutex
-	resources []string
+	storage storage.PersistenceLayer
 }
 
 // NewClient creates a boskos client, with boskos url and owner of the client.
 func NewClient(owner string, url string) *Client {
 
 	client := &Client{
-		url:   url,
-		owner: owner,
+		url:     url,
+		owner:   owner,
+		storage: storage.NewMemoryStorage(),
 	}
 
 	return client
@@ -59,11 +64,10 @@ func (c *Client) Acquire(rtype, state, dest string) (*common.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if r != nil {
-		c.resources = append(c.resources, r.Name)
+		c.storage.Add(*r)
 	}
 
 	return r, nil
@@ -78,8 +82,8 @@ func (c *Client) AcquireByState(state, dest string, names []string) ([]common.Re
 	}
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	for _, resource := range resources {
-		c.resources = append(c.resources, resource.Name)
+	for _, r := range resources {
+		c.storage.Add(r)
 	}
 	return resources, nil
 }
@@ -87,24 +91,23 @@ func (c *Client) AcquireByState(state, dest string, names []string) ([]common.Re
 // ReleaseAll returns all resources hold by the client back to boskos and set them to dest state.
 func (c *Client) ReleaseAll(dest string) error {
 	c.lock.Lock()
-
-	if len(c.resources) == 0 {
-		c.lock.Unlock()
+	defer c.lock.Unlock()
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
 		return fmt.Errorf("no holding resource")
 	}
-	c.lock.Unlock()
-
-	for {
-		r, ok := c.popResource()
-		if !ok {
-			break
-		}
-
-		if err := c.release(r, dest); err != nil {
-			return err
+	var allErrors error
+	for _, r := range resources {
+		c.storage.Delete(r.GetName())
+		err := c.release(r.GetName(), dest)
+		if err != nil {
+			allErrors = multierror.Append(allErrors, err)
 		}
 	}
-	return nil
+	return allErrors
 }
 
 // ReleaseOne returns one of owned resources back to boskos and set it to dest state.
@@ -112,16 +115,14 @@ func (c *Client) ReleaseOne(name, dest string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	for idx, r := range c.resources {
-		if r == name {
-			c.resources[idx] = c.resources[len(c.resources)-1]
-			c.resources = c.resources[:len(c.resources)-1]
-			err := c.release(r, dest)
-			return err
-		}
+	if _, err := c.storage.Get(name); err != nil {
+		return fmt.Errorf("no resource name %v", name)
 	}
-
-	return fmt.Errorf("no resource name %v", name)
+	c.storage.Delete(name)
+	if err := c.release(name, dest); err != nil {
+		return err
+	}
+	return nil
 }
 
 // UpdateAll signals update for all resources hold by the client.
@@ -129,17 +130,55 @@ func (c *Client) UpdateAll(state string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if len(c.resources) == 0 {
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
 		return fmt.Errorf("no holding resource")
 	}
-
-	for _, r := range c.resources {
-		if err := c.update(r, state, nil); err != nil {
-			return err
+	var allErrors error
+	for _, r := range resources {
+		if err := c.update(r.GetName(), state, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+			continue
+		}
+		if err := c.updateLocalResource(r, state, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
 		}
 	}
+	return allErrors
+}
 
-	return nil
+// SyncAll signals update for all resources hold by the client.
+func (c *Client) SyncAll() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	resources, err := c.storage.List()
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		logrus.Info("no resource to sync")
+		return nil
+	}
+	var allErrors error
+	for _, i := range resources {
+		r, err := common.ItemToResource(i)
+		if err != nil {
+			allErrors = multierror.Append(allErrors, err)
+			continue
+		}
+		if err := c.update(r.Name, r.State, nil); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+			continue
+		}
+		if err := c.storage.Update(r); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+	}
+	return allErrors
 }
 
 // UpdateOne signals update for one of the resources hold by the client.
@@ -147,14 +186,14 @@ func (c *Client) UpdateOne(name, state string, userData common.UserData) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	for _, r := range c.resources {
-		if r == name {
-			err := c.update(r, state, userData)
-			return err
-		}
+	r, err := c.storage.Get(name)
+	if err != nil {
+		return fmt.Errorf("no resource name %v", name)
 	}
-
-	return fmt.Errorf("no resource name %v", name)
+	if err := c.update(r.GetName(), state, userData); err != nil {
+		return err
+	}
+	return c.updateLocalResource(r, state, userData)
 }
 
 // Reset will scan all boskos resources of type, in state, last updated before expire, and set them to dest state.
@@ -171,22 +210,24 @@ func (c *Client) Metric(rtype string) (common.Metric, error) {
 
 // HasResource tells if current client holds any resources
 func (c *Client) HasResource() bool {
-	return len(c.resources) > 0
+	resources, _ := c.storage.List()
+	return len(resources) > 0
 }
 
 // private methods
 
-func (c *Client) popResource() (string, bool) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if len(c.resources) == 0 {
-		return "", false
+func (c *Client) updateLocalResource(i common.Item, state string, data common.UserData) error {
+	res, err := common.ItemToResource(i)
+	if err != nil {
+		return err
 	}
-
-	r := c.resources[len(c.resources)-1]
-	c.resources = c.resources[:len(c.resources)-1]
-	return r, true
+	res.State = state
+	if res.UserData == nil {
+		res.UserData = data
+	} else {
+		res.UserData.Update(data)
+	}
+	return c.storage.Update(res)
 }
 
 func (c *Client) acquire(rtype, state, dest string) (*common.Resource, error) {
@@ -251,7 +292,7 @@ func (c *Client) release(name, dest string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("status %s, statusCode %v", resp.Status, resp.StatusCode)
+		return fmt.Errorf("status %s, statusCode %v releasing %s", resp.Status, resp.StatusCode, name)
 	}
 	return nil
 }
@@ -274,7 +315,7 @@ func (c *Client) update(name, state string, userData common.UserData) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode)
+		return fmt.Errorf("status %s, status code %v updating %s", resp.Status, resp.StatusCode, name)
 	}
 	return nil
 }

--- a/boskos/mason/mason.go
+++ b/boskos/mason/mason.go
@@ -199,6 +199,25 @@ func (m *Mason) convertConfig(configEntry *common.ResourcesConfig) (Masonable, e
 	return fn(configEntry.Config.Content)
 }
 
+func (m *Mason) garbageCollect(req requirements) {
+	names := []string{req.resource.Name}
+
+	for _, resources := range req.fulfillment {
+		for _, r := range resources {
+			if r != nil {
+				names = append(names, r.Name)
+			}
+		}
+	}
+
+	for _, name := range names {
+		if err := m.client.ReleaseOne(name, common.Dirty); err != nil {
+			logrus.WithError(err).Errorf("Unable to release leased resource %s", name)
+		}
+	}
+
+}
+
 func (m *Mason) cleanAll(ctx context.Context) {
 	defer func() {
 		logrus.Info("Exiting cleanAll Thread")
@@ -210,19 +229,8 @@ func (m *Mason) cleanAll(ctx context.Context) {
 			return
 		case req := <-m.fulfilled:
 			if err := m.cleanOne(&req.resource, req.fulfillment); err != nil {
-				logrus.WithError(err).Errorf("unable to clean resource")
-				err = m.client.ReleaseOne(req.resource.Name, common.Dirty)
-				if err != nil {
-					logrus.WithError(err).Errorf("Unable to release resource %s", req.resource.Name)
-				}
-				for _, resources := range req.fulfillment {
-					for _, r := range resources {
-						err = m.client.ReleaseOne(r.Name, common.Dirty)
-						if err != nil {
-							logrus.WithError(err).Errorf("Unable to release leased resource %s", r.Name)
-						}
-					}
-				}
+				logrus.WithError(err).Errorf("unable to clean resource %s", req.resource.Name)
+				m.garbageCollect(req)
 			} else {
 				m.cleaned <- req
 			}
@@ -270,7 +278,8 @@ func (m *Mason) freeAll(ctx context.Context) {
 			return
 		case req := <-m.cleaned:
 			if err := m.freeOne(&req.resource); err != nil {
-				m.cleaned <- req
+				logrus.WithError(err).Errorf("failed to free up resource %s", req.resource.Name)
+				m.garbageCollect(req)
 			}
 		}
 	}

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -114,6 +114,16 @@ func (fb *fakeBoskos) UpdateAll(state string) error {
 	return nil
 }
 
+func (fb *fakeBoskos) ReleaseAll(state string) error {
+	// not used in this test
+	return nil
+}
+
+func (fb *fakeBoskos) SyncAll() error {
+	// not used in this test
+	return nil
+}
+
 func TestRecycleLeasedResources(t *testing.T) {
 	tc := testConfig{
 		"type1": {

--- a/boskos/storage/storage.go
+++ b/boskos/storage/storage.go
@@ -79,8 +79,8 @@ func (im *inMemoryStore) Update(i common.Item) error {
 }
 
 func (im *inMemoryStore) Get(name string) (common.Item, error) {
-	im.lock.Lock()
-	defer im.lock.Unlock()
+	im.lock.RLock()
+	defer im.lock.RUnlock()
 	i, ok := im.items[name]
 	if !ok {
 		return nil, fmt.Errorf("cannot find item %s", name)
@@ -89,8 +89,8 @@ func (im *inMemoryStore) Get(name string) (common.Item, error) {
 }
 
 func (im *inMemoryStore) List() ([]common.Item, error) {
-	im.lock.Lock()
-	defer im.lock.Unlock()
+	im.lock.RLock()
+	defer im.lock.RUnlock()
 	var items []common.Item
 	for _, i := range im.items {
 		items = append(items, i)


### PR DESCRIPTION
I noticed that ```Mason``` failed to release and update its own resources. This was mostly happening in faulty scenario, where we are failing to create a cluster per example.

One of the issue was that we assumed that we could not loose our ```Resources```, and therefore we would retry to update this resource indefinitely. The other was ```Mason``` was not actively updating its own resources, instead it was doing it in frequently for each state change (recycling to fulfiling, to clean to free)

This PR updates the client to actually cache the resource, such that we can call ```SyncAll``` which will update every resource with the same state, only updating the timestamp. To do that I use the ```InMemoryStorage``` that we use in other boskos components. I also updated ```Update``` and ```Release``` to update the local cache. Finally ```ReleaseAll, UpdateAll``` and ```SyncAll``` will attempt to work all resources, and only return failures if any as opposed to return on first failure. (This was preventing mason to update all of its resources, and therefore loosing them to ```Reaper```)

Update ```Mason``` with ```SyncAll``` and added more helpful logging all over the client and mason code to ease future debugging.