### PR TITLE
lower-case ubuntu

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11984,7 +11984,7 @@
       "--env=TAG=0.6.0",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
-      "--gcp-node-image=UBUNTU",
+      "--gcp-node-image=ubuntu",
       "--gcp-project=istio-gke-addon-prow-e2e-test",
       "--gcp-zone=us-central1-f",
       "--gke-command-group=alpha",


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/a762ea1beb2ad012c22b6d4b9d4d4cf8834e1aa9/cluster/gce/util.sh#L28-L33

/shrug

/assign @yliaog @ostromart 
cc @yguo0905 we probably should support upper cased image name there?