### PR TITLE
Extend peribolos to manage org memberships

### DIFF
--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -10,6 +10,9 @@ go_library(
         "//prow/config/org:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/logrusutil:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -37,5 +40,10 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/flagutil:go_default_library"],
+    deps = [
+        "//prow/config/org:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
 )

--- a/prow/cmd/peribolos/README.md
+++ b/prow/cmd/peribolos/README.md
@@ -33,7 +33,7 @@ orgs:
     - bob
     admins:
     - carl
-    
+
     # team settings
     teams:
       node:
@@ -67,14 +67,16 @@ This config will:
   - Set node's description and privacy setting.
   - Rename the backend team to node
   - Add anne as a member and jane as a maintainer to node
-  - Similar things for another-team (detailed elided)
+  - Similar things for another-team (details elided)
 
 Note that any fields missing from the config will not be managed by peribolos. So if description is missing from the org setting, the current value will remain.
 
 For more details please see GitHub documentation around [edit org], [update org membership], [edit team], [update team membership].
 
 
+[`config.yaml`]: /prow/config.yaml
 [edit team]: https://developer.github.com/v3/teams/#edit-team
+[edit org]: https://developer.github.com/v3/orgs/#edit-an-organization
 [peribolos]: https://en.wikipedia.org/wiki/Peribolos
 [update org membership]: https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
 [update team membership]: https://developer.github.com/v3/teams/members/#add-or-update-team-membership

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/url"
 	"os"
 	"strings"
@@ -30,30 +29,47 @@ import (
 	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/logrusutil"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-const defaultEndpoint = "https://api.github.com"
+const (
+	defaultEndpoint  = "https://api.github.com"
+	defaultMinAdmins = 5
+	defaultDelta     = 0.25
+)
 
 type options struct {
-	config   string
-	token    string
-	confirm  bool
-	endpoint flagutil.Strings
+	config         string
+	token          string
+	confirm        bool
+	minAdmins      int
+	requiredAdmins flagutil.Strings
+	requireSelf    bool
+	maximumDelta   float64
+	endpoint       flagutil.Strings
 }
 
 func parseOptions() options {
 	var o options
 	if err := o.parseArgs(flag.CommandLine, os.Args[1:]); err != nil {
-		log.Fatalf("Invalid flags: %v", err)
+		logrus.Fatalf("Invalid flags: %v", err)
 	}
 	return o
 }
 
 func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	o.endpoint = flagutil.NewStrings(defaultEndpoint)
+	flags.Var(&o.endpoint, "github-endpoint", "Github api endpoint, may differ for enterprise")
+	o.requiredAdmins = flagutil.NewStrings()
+	flags.Var(&o.requiredAdmins, "required-admins", "Ensure config specifies these users as admins")
+	flags.IntVar(&o.minAdmins, "min-admins", defaultMinAdmins, "Ensure config specifies at least this many admins")
+	flags.BoolVar(&o.requireSelf, "require-self", true, "Ensure --github-token-path user is an admin")
+	flags.Float64Var(&o.maximumDelta, "maximum-removal-delta", defaultDelta, "Fail if config removes more than this fraction of current members")
 	flags.StringVar(&o.config, "config-path", "", "Path to prow config.yaml")
 	flags.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
-	flags.Var(&o.endpoint, "github-endpoint", "Github api endpoint, may differ for enterprise")
 	flags.StringVar(&o.token, "github-token-path", "", "Path to github token")
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -72,25 +88,34 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 			return fmt.Errorf("Invalid --endpoint URL %q: %v.", ep, err)
 		}
 	}
+	if o.minAdmins < 2 {
+		return fmt.Errorf("--min-admins=%d must be at least 2", o.minAdmins)
+	}
+	if o.maximumDelta > 1 || o.maximumDelta < 0 {
+		return fmt.Errorf("--maximum-removal-delta=%f must be a non-negative number less than 1.0", o.maximumDelta)
+	}
 
 	return nil
 }
 
 func main() {
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "peribolos"}),
+	)
 	o := parseOptions()
 
 	if o.config != "TODO(fejta): implement me" {
-		log.Fatalf("This program is not yet implemented")
+		logrus.Fatalf("This program is not yet implemented") // still true
 	}
 
 	cfg, err := config.Load(o.config)
 	if err != nil {
-		log.Fatalf("Failed to load --config=%s: %v", o.config, err)
+		logrus.Fatalf("Failed to load --config=%s: %v", o.config, err)
 	}
 
 	b, err := ioutil.ReadFile(o.token)
 	if err != nil {
-		log.Fatalf("cannot read --token: %v", err)
+		logrus.Fatalf("cannot read --token: %v", err)
 	}
 
 	var c *github.Client
@@ -103,21 +128,130 @@ func main() {
 	c.Throttle(300, 100) // 300 hourly tokens, bursts of 100
 
 	for name, orgcfg := range cfg.Orgs {
-		if err := configureOrg(c, name, orgcfg); err != nil {
-			log.Fatalf("Configuration failed: %v", err)
+		if err := configureOrg(o, c, name, orgcfg); err != nil {
+			logrus.Fatalf("Configuration failed: %v", err)
 		}
 	}
 }
 
-func configureOrg(client *github.Client, orgName string, orgConfig org.Config) error {
+type configureOrgMembersClient interface {
+	BotName() (string, error)
+	ListOrgMembers(org, role string) ([]github.TeamMember, error)
+	RemoveOrgMembership(org, user string) error
+	UpdateOrgMembership(org, user string, admin bool) (*github.OrgMembership, error)
+}
+
+func configureOrgMembers(opt options, client configureOrgMembersClient, orgName string, orgConfig org.Config) error {
+	// Get desired state
+	wantAdmins := sets.NewString(orgConfig.Admins...)
+	wantMembers := sets.NewString(orgConfig.Members...)
+
+	// Sanity desired state
+	if n := len(wantAdmins); n < opt.minAdmins {
+		return fmt.Errorf("%s must specify at least %d admins, only found %d", orgName, opt.minAdmins, n)
+	}
+	var missing []string
+	for _, r := range opt.requiredAdmins.Strings() {
+		if !wantAdmins.Has(r) {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%s must specify %v as admins, missing %v", orgName, opt.requiredAdmins, missing)
+	}
+	if opt.requireSelf {
+		if me, err := client.BotName(); err != nil {
+			return fmt.Errorf("cannot determine user making requests for %s: %v", opt.token, err)
+		} else if !wantAdmins.Has(me) {
+			return fmt.Errorf("authenticated user %s is not an admin of %s", me, orgName)
+		}
+	}
+
+	// Get current state
+	haveAdmins := sets.String{}
+	haveMembers := sets.String{}
+	ms, err := client.ListOrgMembers(orgName, "admin")
+	if err != nil {
+		return fmt.Errorf("failed to list %s admins: %v", orgName, err)
+	}
+	for _, m := range ms {
+		haveAdmins.Insert(m.Login)
+	}
+	if ms, err = client.ListOrgMembers(orgName, "member"); err != nil {
+		return fmt.Errorf("failed to list %s members: %v", orgName, err)
+	}
+	for _, m := range ms {
+		haveMembers.Insert(m.Login)
+	}
+
+	// Ensure desired state is sane
+	both := wantAdmins.Intersection(wantMembers)
+	if n := len(both); n > 0 {
+		return fmt.Errorf("%d users are both a member and admin: %v", n, both)
+	}
+
+	// Figure out who to remove
+	have := haveMembers.Union(haveAdmins)
+	want := wantMembers.Union(wantAdmins)
+	remove := have.Difference(want)
+
+	// Figure out who to invite and/or reconfigure
+	makeMember := wantMembers.Difference(haveMembers)
+	makeAdmin := wantAdmins.Difference(haveAdmins)
+
+	// Sanity check changes
+	if d := float64(len(remove)) / float64(len(have)); d > opt.maximumDelta {
+		return fmt.Errorf("cannot delete %d memberships or %.3f of %s (exceeds limit of %.3f)", len(remove), d, orgName, opt.maximumDelta)
+	}
+
+	var errs []error
+
+	// March towards desired state
+	for u := range remove {
+		if err := client.RemoveOrgMembership(orgName, u); err != nil {
+			logrus.WithError(err).Warnf("RemoveOrgMembership(%s, %s) failed", orgName, u)
+			errs = append(errs, err)
+		} else {
+			logrus.Infof("Removed %s from %s", u, orgName)
+		}
+	}
+
+	for u := range makeMember {
+		if m, err := client.UpdateOrgMembership(orgName, u, false); err != nil {
+			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, false) failed", orgName, u)
+			errs = append(errs, err)
+		} else if m.State == github.StatePending {
+			logrus.Infof("Invited %s to %s", u, orgName)
+		} else {
+			logrus.Infof("Demoted %s to a %s member", u, orgName)
+		}
+	}
+
+	for u := range makeAdmin {
+		if m, err := client.UpdateOrgMembership(orgName, u, true); err != nil {
+			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, true) failed", orgName, u)
+			errs = append(errs, err)
+		} else if m.State == github.StatePending {
+			logrus.Infof("Invited %s to %s", u, orgName)
+		} else {
+			logrus.Infof("Promoted %s to a %s admin", u, orgName)
+		}
+	}
+
+	if n := len(errs); n > 0 {
+		return fmt.Errorf("%d errors: %v", n, errs)
+	}
+	return nil
+}
+
+func configureOrg(opt options, client *github.Client, orgName string, orgConfig org.Config) error {
 	// get meta
 	// diff meta
 	// patch meta
 
-	// people = set(all org members)
-	// remove = people - orgConfig.members - orgConfig.admins
-	// update = oc.members - [p for p in people if member]
-	// update = oc.admins - [p for p in people if admin]
+	if err := configureOrgMembers(opt, client, orgName, orgConfig); err != nil {
+		return fmt.Errorf("failed to configure %s members: %v", orgName, err)
+	}
 
 	// teams = set(all teams)
 	for name, team := range orgConfig.Teams {

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -18,10 +18,16 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
+	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestOptions(t *testing.T) {
@@ -45,22 +51,76 @@ func TestOptions(t *testing.T) {
 			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=ht!tp://:dumb"},
 		},
 		{
+			name: "--minAdmins too low",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--min-admins=1"},
+		},
+		{
+			name: "--maximum-removal-delta too high",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--maximum-removal-delta=1.1"},
+		},
+		{
+			name: "--maximum-removal-delta too low",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--maximum-removal-delta=-0.1"},
+		},
+		{
+			name: "maximal delta",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--maximum-removal-delta=1"},
+			expected: &options{
+				config:       "foo",
+				token:        "bar",
+				endpoint:     flagutil.NewStrings(defaultEndpoint),
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: 1,
+			},
+		},
+		{
+			name: "minimal delta",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--maximum-removal-delta=0"},
+			expected: &options{
+				config:       "foo",
+				token:        "bar",
+				endpoint:     flagutil.NewStrings(defaultEndpoint),
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: 0,
+			},
+		},
+		{
+			name: "minimal admins",
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--min-admins=2"},
+			expected: &options{
+				config:       "foo",
+				token:        "bar",
+				endpoint:     flagutil.NewStrings(defaultEndpoint),
+				minAdmins:    2,
+				requireSelf:  true,
+				maximumDelta: defaultDelta,
+			},
+		},
+		{
 			name: "minimal",
 			args: []string{"--config-path=foo", "--github-token-path=bar"},
 			expected: &options{
-				config:   "foo",
-				token:    "bar",
-				endpoint: flagutil.NewStrings(defaultEndpoint),
+				config:       "foo",
+				token:        "bar",
+				endpoint:     flagutil.NewStrings(defaultEndpoint),
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: defaultDelta,
 			},
 		},
 		{
 			name: "full",
-			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true"},
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false"},
 			expected: &options{
-				config:   "foo",
-				token:    "bar",
-				endpoint: weirdFlags,
-				confirm:  true,
+				config:       "foo",
+				token:        "bar",
+				endpoint:     weirdFlags,
+				confirm:      true,
+				requireSelf:  false,
+				minAdmins:    defaultMinAdmins,
+				maximumDelta: defaultDelta,
 			},
 		},
 	}
@@ -78,5 +138,235 @@ func TestOptions(t *testing.T) {
 			t.Errorf("%s: actual %v != expected %v", tc.name, actual, *tc.expected)
 		}
 	}
+}
 
+type fakeClient struct {
+	admins     sets.String
+	members    sets.String
+	removed    sets.String
+	newAdmins  sets.String
+	newMembers sets.String
+}
+
+func (c *fakeClient) BotName() (string, error) {
+	return "me", nil
+}
+
+func (c *fakeClient) ListOrgMembers(org, role string) ([]github.TeamMember, error) {
+	var ret []github.TeamMember
+	switch role {
+	case github.RoleMember:
+		for m := range c.members {
+			ret = append(ret, github.TeamMember{Login: m})
+		}
+		return ret, nil
+	case github.RoleAdmin:
+		for m := range c.admins {
+			ret = append(ret, github.TeamMember{Login: m})
+		}
+		return ret, nil
+	default:
+		// RoleAll: implmenent when/if necessary
+		return nil, fmt.Errorf("bad role: %s", role)
+	}
+}
+
+func (c *fakeClient) RemoveOrgMembership(org, user string) error {
+	if user == "fail" {
+		return fmt.Errorf("injected failure for %s", user)
+	}
+	c.removed.Insert(user)
+	c.admins.Delete(user)
+	c.members.Delete(user)
+	return nil
+}
+
+func (c *fakeClient) UpdateOrgMembership(org, user string, admin bool) (*github.OrgMembership, error) {
+	if user == "fail" {
+		return nil, fmt.Errorf("injected failure for %s", user)
+	}
+	var state string
+	if c.members.Has(user) || c.admins.Has(user) {
+		state = github.StateActive
+	} else {
+		state = github.StatePending
+	}
+	var role string
+	if admin {
+		c.newAdmins.Insert(user)
+		c.admins.Insert(user)
+		role = github.RoleAdmin
+	} else {
+		c.newMembers.Insert(user)
+		c.members.Insert(user)
+		role = github.RoleMember
+	}
+	return &github.OrgMembership{
+		Role:  role,
+		State: state,
+	}, nil
+}
+
+func TestConfigureOrgMembers(t *testing.T) {
+	cases := []struct {
+		name       string
+		opt        options
+		config     org.Config
+		admins     []string
+		members    []string
+		err        bool
+		remove     []string
+		addAdmins  []string
+		addMembers []string
+	}{
+		{
+			name: "too few admins",
+			opt: options{
+				minAdmins: 5,
+			},
+			config: org.Config{
+				Admins: []string{"joe"},
+			},
+			err: true,
+		},
+		{
+			name: "remove too many admins",
+			opt: options{
+				maximumDelta: 0.3,
+			},
+			config: org.Config{
+				Admins: []string{"keep", "me"},
+			},
+			admins: []string{"a", "b", "c", "keep"},
+			err:    true,
+		},
+		{
+			name: "forgot to add self",
+			opt: options{
+				requireSelf: true,
+			},
+			config: org.Config{
+				Admins: []string{"other"},
+			},
+			err: true,
+		},
+		{
+			name: "forgot to add required admins",
+			opt: options{
+				requiredAdmins: flagutil.NewStrings("francis"),
+			},
+			err: true,
+		},
+		{
+			name:   "can remove self with flag",
+			config: org.Config{},
+			opt: options{
+				maximumDelta: 1,
+			},
+			admins: []string{"me"},
+			remove: []string{"me"},
+		},
+		{
+			name: "forgot to remove duplicate entry",
+			config: org.Config{
+				Admins:  []string{"me"},
+				Members: []string{"me"},
+			},
+			err: true,
+		},
+		{
+			name:   "removal fails",
+			admins: []string{"fail"},
+			err:    true,
+		},
+		{
+			name: "adding admin fails",
+			config: org.Config{
+				Admins: []string{"fail"},
+			},
+			err: true,
+		},
+		{
+			name: "adding member fails",
+			config: org.Config{
+				Members: []string{"fail"},
+			},
+			err: true,
+		},
+		{
+			name: "promote to admin",
+			config: org.Config{
+				Admins: []string{"promote"},
+			},
+			members:   []string{"promote"},
+			addAdmins: []string{"promote"},
+		},
+		{
+			name: "downgrade to member",
+			config: org.Config{
+				Members: []string{"downgrade"},
+			},
+			admins:     []string{"downgrade"},
+			addMembers: []string{"downgrade"},
+		},
+		{
+			name: "some of everything",
+			config: org.Config{
+				Admins:  []string{"keep-admin", "new-admin"},
+				Members: []string{"keep-member", "new-member"},
+			},
+			opt: options{
+				maximumDelta: 0.5,
+			},
+			admins:     []string{"keep-admin", "drop-admin"},
+			members:    []string{"keep-member", "drop-member"},
+			remove:     []string{"drop-admin", "drop-member"},
+			addMembers: []string{"new-member"},
+			addAdmins:  []string{"new-admin"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				admins:     sets.NewString(tc.admins...),
+				members:    sets.NewString(tc.members...),
+				removed:    sets.String{},
+				newAdmins:  sets.String{},
+				newMembers: sets.String{},
+			}
+			err := configureOrgMembers(tc.opt, fc, "random-org", tc.config)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("Failed to receive error")
+			default:
+				if err := cmpLists(tc.remove, fc.removed.List()); err != nil {
+					t.Errorf("Wrong users removed: %v", err)
+				} else if err := cmpLists(tc.addMembers, fc.newMembers.List()); err != nil {
+					t.Errorf("Wrong members added: %v", err)
+				} else if err := cmpLists(tc.addAdmins, fc.newAdmins.List()); err != nil {
+					t.Errorf("Wrong admins added: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func cmpLists(a, b []string) error {
+	if a == nil {
+		a = []string{}
+	}
+	if b == nil {
+		b = []string{}
+	}
+	sort.Strings(a)
+	sort.Strings(b)
+	if !reflect.DeepEqual(a, b) {
+		return fmt.Errorf("%v != %v", a, b)
+	}
+	return nil
 }

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -51,7 +51,7 @@ type githubClient interface {
 	GetRepo(owner, name string) (github.Repo, error)
 	IsMember(org, user string) (bool, error)
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
-	ListOrgMembers(org string) ([]github.TeamMember, error)
+	ListOrgMembers(org, role string) ([]github.TeamMember, error)
 }
 
 func HelpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -272,7 +272,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	// Figure out membership.
 	if !s.allowAll {
 		// TODO: Possibly cache this.
-		members, err := s.ghc.ListOrgMembers(org)
+		members, err := s.ghc.ListOrgMembers(org, "all")
 		if err != nil {
 			return err
 		}

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -92,9 +92,12 @@ func (f *fghc) ListIssueComments(org, repo string, number int) ([]github.IssueCo
 	return f.prComments, nil
 }
 
-func (f *fghc) ListOrgMembers(org string) ([]github.TeamMember, error) {
+func (f *fghc) ListOrgMembers(org, role string) ([]github.TeamMember, error) {
 	f.Lock()
 	defer f.Unlock()
+	if role != "all" {
+		return nil, fmt.Errorf("all is only supported role, not: %s", role)
+	}
 	return f.orgMembers, nil
 }
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -467,16 +467,22 @@ func (c *Client) IsMember(org, user string) (bool, error) {
 // user is also a member of this organization then both concealed and public members
 // will be returned.
 //
+// Role options are "all", "admin" and "member"
+//
 // https://developer.github.com/v3/orgs/members/#members-list
-func (c *Client) ListOrgMembers(org string) ([]TeamMember, error) {
-	c.log("ListOrgMembers", org)
+func (c *Client) ListOrgMembers(org, role string) ([]TeamMember, error) {
+	c.log("ListOrgMembers", org, role)
 	if c.fake {
 		return nil, nil
 	}
 	path := fmt.Sprintf("/orgs/%s/members", org)
 	var teamMembers []TeamMember
-	err := c.readPaginatedResults(
+	err := c.readPaginatedResultsWithValues(
 		path,
+		url.Values{
+			"per_page": []string{"100"},
+			"role":     []string{role},
+		},
 		"",
 		func() interface{} {
 			return &[]TeamMember{}
@@ -489,6 +495,41 @@ func (c *Client) ListOrgMembers(org string) ([]TeamMember, error) {
 		return nil, err
 	}
 	return teamMembers, nil
+}
+
+// UpdateOrgMembership invites a user to the org and/or updates their permission level.
+//
+// If the user is not already a member, this will invite them.
+// This will also change the role to/from admin, on either the invitation or membership setting.
+//
+// https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
+func (c *Client) UpdateOrgMembership(org, user string, admin bool) (*OrgMembership, error) {
+	c.log("UpdateOrgMembership", org, user, admin)
+	om := OrgMembership{}
+	if admin {
+		om.Role = RoleAdmin
+	}
+
+	_, err := c.request(&request{
+		method:      http.MethodPut,
+		path:        fmt.Sprintf("/orgs/%s/memberships/%s", org, user),
+		requestBody: &om,
+		exitCodes:   []int{204},
+	}, &om)
+	return &om, err
+}
+
+// RemoveOrgMembership removes the user from the org.
+//
+// https://developer.github.com/v3/orgs/members/#remove-organization-membership
+func (c *Client) RemoveOrgMembership(org, user string) error {
+	c.log("RemoveOrgMembership", org, user)
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/memberships/%s", org, user),
+		exitCodes: []int{204},
+	}, nil)
+	return err
 }
 
 // CreateComment creates a comment on the issue.

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -538,6 +538,27 @@ type TeamMember struct {
 	Login string `json:"login"`
 }
 
+const (
+	// List members and admins
+	RoleAll = "all"
+	// User is an admin, or list admins
+	RoleAdmin = "admin"
+	// User is a regular member, or list members
+	RoleMember = "member"
+	// User has a pending invitation to the org
+	StatePending = "pending"
+	// User accepted the invitation, is in the org
+	StateActive = "active"
+)
+
+// OrgMembership specifies the org membership details
+type OrgMembership struct {
+	// admin or member
+	Role string `json:"role"`
+	// pending or active
+	State string `json:"state,omitempty"`
+}
+
 type GenericCommentEventAction string
 
 // Comments indicate values that are coerced to the specified value.


### PR DESCRIPTION
/assign @cblecker @BenTheElder @stevekuznetsov 


Change prow's github client to:
* Accept a `role` parameter in `ListOrgMembers`
* Add `UpdateOrgMembership()` and `RemoveOrgMembership()` methods

Update cherrypicker plugin to send `"all"` for the value of `role`

Add sanity checks for `--required-admins`, `--min-admins`, `--require-self` and `--maximum-removal-delta` with safe defaults.

Create a `configureOrgMembers()` function which will get the current list of members and admins and:
* Reconfigure anyone with the wrong permissions level
* Invite anyone into the org who is missing
* Remove anyone from the org who shouldn't be there

Unit tests