### PR TITLE
Add more containerized tests.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11492,7 +11492,7 @@
       "--extract-source",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --skip=\"\\[Disruptive\\]\"",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
I want to enable some tests in ci-kubernetes-local-e2e-containerized to check the code paths that are different in "normal" kubelet and in kubelet running in a container. I propose tagging the tests as `[ContainerizedKubelet]`.

There are no tests with this tag yet, IMO it would be better to get the test suite fixed first and then enable tests so we can see see the tests are still green.

Subpath tests in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/subpath.go will be the first candidate because of pr https://github.com/kubernetes/kubernetes/pull/63143.

Don't run `[Disruptive]` for now, we don't have capability to restart kubelet in a container that some subpath tests require.