### PR TITLE
prow: pod-utils: improve no-clone behavior

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -151,6 +151,9 @@ type DecorationConfig struct {
 	// SshKeySecrets are the names of Kubernetes secrets that contain
 	// SSK keys which should be used during the cloning process
 	SshKeySecrets []string `json:"ssh_key_secrets,omitempty"`
+	// SkipCloning determines if we should clone source code in the
+	// initcontainers for jobs that specify refs
+	SkipCloning bool `json:"skip_cloning,omitempty"`
 }
 
 // UtilityImages holds pull specs for the utility images


### PR DESCRIPTION
This patch adds the `skip_cloning` option to decorated jobs, which will
not add the `clonerefs` container even if there are refs to clone. Refs
will continue to be communiated in `$JOB_SPEC`, etc, so that the job can
do with them what it may.

Code volumes and working directories are also now not created on the Pod
when no cloning is occurring to clean up the `PodSpec`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind enhancement
/cc @fejta @BenTheElder @smarterclayton 
/assign @cjwagner 