### PR TITLE
Skip retest for SECURITY_CONTACTS changes

### DIFF
--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -35,9 +35,10 @@ const (
 )
 
 var (
-	docFilesRegex     = regexp.MustCompile(`^.*\.(md|png|svg|dia)$`)
-	ownersFilesRegex  = regexp.MustCompile(`^OWNERS$`)
-	licenseFilesRegex = regexp.MustCompile(`^LICENSE$`)
+	docFilesRegex         = regexp.MustCompile(`^.*\.(md|png|svg|dia)$`)
+	ownersFilesRegex      = regexp.MustCompile(`^OWNERS$`)
+	licenseFilesRegex     = regexp.MustCompile(`^LICENSE$`)
+	securityContactsRegex = regexp.MustCompile(`^SECURITY_CONTACTS$`)
 )
 
 func init() {
@@ -94,6 +95,9 @@ func handlePR(gc githubClient, pe github.PullRequestEvent) error {
 			continue
 		}
 		if licenseFilesRegex.MatchString(basename) {
+			continue
+		}
+		if securityContactsRegex.MatchString(basename) {
 			continue
 		}
 		docsOnly = false

--- a/prow/plugins/docs-no-retest/docs-no-retest_test.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest_test.go
@@ -122,6 +122,17 @@ func TestHandlePR(t *testing.T) {
 			shouldSkipRetest: true,
 		},
 		{
+			name:   "change SECURITY_CONTACTS, no label, needs label",
+			labels: sets.NewString(),
+			prChanges: []github.PullRequestChange{
+				{
+					Filename: "/path/to/file/SECURITY_CONTACTS",
+				},
+			},
+			action:           github.PullRequestActionOpened,
+			shouldSkipRetest: true,
+		},
+		{
 			name:   "change non doc, no label, needs no label",
 			labels: sets.NewString(),
 			prChanges: []github.PullRequestChange{
@@ -186,6 +197,17 @@ func TestHandlePR(t *testing.T) {
 			prChanges: []github.PullRequestChange{
 				{
 					Filename: "/path/to/file/LICENSE",
+				},
+			},
+			action:           github.PullRequestActionOpened,
+			shouldSkipRetest: true,
+		},
+		{
+			name:   "change SECURITY_CONTACTS, has label, needs label",
+			labels: sets.NewString(labelSkipRetest),
+			prChanges: []github.PullRequestChange{
+				{
+					Filename: "/path/to/file/SECURITY_CONTACTS",
 				},
 			},
 			action:           github.PullRequestActionOpened,


### PR DESCRIPTION
We now have a new file `SECURITY_CONTACTS` in the Kubernetes repo. We should avoid retesting for changes to this file. See https://github.com/kubernetes/kubernetes/pull/64262#issuecomment-393994786 for more details.

/cc @jessfraz 