### PR TITLE
Trivial: Fix nonexistent AZ name

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -41,7 +41,7 @@ DEFAULT_AWS_ZONES = [
     'ap-northeast-1c',
     'ap-northeast-1d',
     #'ap-northeast-2a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-northeast-2a' - AZ does not exist, so we're breaking the 3 AZs per region target here
+    #'ap-northeast-2b' - AZ does not exist, so we're breaking the 3 AZs per region target here
     #'ap-northeast-2c', InsufficientInstanceCapacity for c4.large 2018-05-30
     #'ap-south-1a', InsufficientInstanceCapacity for c4.large 2018-05-30
     #'ap-south-1b', InsufficientInstanceCapacity for c4.large 2018-05-30


### PR DESCRIPTION
When seeing the list of AZ on the code, it seemed confusable.
One was considerd as InsufficientInstanceCapacity, but the other
same AZ was nonexistent. According to [1], ap-northeast-2b doesn't
exit. So this updates the name.

[1]: https://gist.github.com/neilstuartcraig/0ccefcf0887f29b7f240