### PR TITLE
add an istio pool (one project only for now)

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         image: gcr.io/k8s-testimages/janitor:v20180531-fb2d8fcb9
         args:
         - --service-account=/etc/service-account/service-account.json
-        - --resource-type=gce-project,gci-qa-project,gpu-project,ingress-project
+        - --resource-type=gce-project,gci-qa-project,gpu-project,ingress-project,istio-project
         - --pool-size=20
         volumeMounts:
         - mountPath: /etc/service-account

--- a/boskos/reaper/deployment.yaml
+++ b/boskos/reaper/deployment.yaml
@@ -17,4 +17,4 @@ spec:
       - name: boskos-reaper
         image: gcr.io/k8s-testimages/reaper:v20180402-43203f868
         args:
-        - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project,ingress-project
+        - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project,ingress-project,istio-project

--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -512,6 +512,7 @@ resources:
   - k8s-ingress-boskos-20
   state: dirty
   type: ingress-project
-
-
-
+- names:
+  - istio-gke-addon-prow-e2e-test
+  state: dirty
+  type: istio-project

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12043,7 +12043,7 @@
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=ubuntu",
-      "--gcp-project=istio-gke-addon-prow-e2e-test",
+      "--gcp-project-type=istio-project",
       "--gcp-zone=us-central1-f",
       "--gke-command-group=alpha",
       "--gke-create-command=container clusters create --quiet --num-nodes=4 --no-enable-legacy-authorization --addons=Istio --istio-config=auth=NONE",


### PR DESCRIPTION
let boskos manage resource lifecycle, so that we can always clean up ingress created from istio e2e script before next run.

(it only has one project for now, but test takes <30min and interval is 2h, so it should be suffice.)

fixes https://github.com/kubernetes/test-infra/issues/8206

/assign @BenTheElder 
cc @ostromart @yliaog 