### PR TITLE
Make minigo c++ job log test output for failed tests.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7161,7 +7161,7 @@ presubmits:
         - -c
         args:
         # Copy tensorflow libraries into repo, test with board_size=9, test with board_size=19.
-        - "cp -r /app/cc/tensorflow ./cc/tensorflow && bazel test cc:all --compilation_mode=dbg --define=board_size=9 && bazel test cc:all --compilation_mode=dbg --define=board_size=19"
+        - "cp -r /app/cc/tensorflow ./cc/tensorflow && bazel test cc:all --test_output=errors --compilation_mode=dbg --define=board_size=9 && bazel test cc:all --test_output=errors --compilation_mode=dbg --define=board_size=19"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Adds `--test_output=errors` to the `bazel test` calls in the `pull-tf-minigo-cc` job.

This should be the default value for `--test_output` in my opinion.
/shrug

/area jobs
/kind bug
/cc @BenTheElder @fejta @rmmh 
cc @amj