### PR TITLE
Add kubernetes-sigs to label_sync job

### DIFF
--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -32,7 +32,7 @@ spec:
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true
-              - --orgs=kubernetes
+              - --orgs=kubernetes,kubernetes-sigs
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth
@@ -49,4 +49,3 @@ spec:
           - name: config
             configMap:
               name: label-config
-

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true
-        - --orgs=kubernetes
+        - --orgs=kubernetes,kubernetes-sigs
         - --token=/etc/github/oauth
         volumeMounts:
         - name: oauth
@@ -46,4 +46,3 @@ spec:
       - name: config
         configMap:
           name: label-config
-


### PR DESCRIPTION
Adds kubernetes-sigs to the label_sync job. I've run this with my own token, and verified that it works.

/cc @fejta @cjwagner @BenTheElder 