### PR TITLE
Makefiles: avoid repeated shell evaluations

### DIFF
--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -18,7 +18,7 @@ CLUSTER ?= prow
 NAMESPACE ?= test-pods
 HUB ?= gcr.io/k8s-testimages
 
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 boskos:
 	go build k8s.io/test-infra/boskos/

--- a/gubernator/Makefile
+++ b/gubernator/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 PROJECT ?= k8s-gubernator
 
 # TODO(fejta): convert these to bazel rules

--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/bazelbuild
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # TODO(bentheelder): retire some of these as they become unnecessary
 LATEST_BAZEL_VERSION=0.10.0

--- a/images/bigquery/Makefile
+++ b/images/bigquery/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bigquery:$(VERSION)" .

--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/bootstrap
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build
 

--- a/images/gcloud/Makefile
+++ b/images/gcloud/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 IMG="gcr.io/k8s-testimages/gcloud-in-go"
 

--- a/images/kube-deploy/Makefile
+++ b/images/kube-deploy/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 IMG="gcr.io/k8s-testimages/kube-deploy"
 

--- a/images/kubeadm/Makefile
+++ b/images/kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 IMG = "gcr.io/k8s-testimages/e2e-kubeadm"
 

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/kubekins-e2e
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # kubernetes master branch config
 K8S ?= master

--- a/images/kubekins-test/Makefile
+++ b/images/kubekins-test/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/kubekins-test
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 VERSIONS := $(wildcard ./Dockerfile-*)
 
 do_build = \

--- a/images/kubemci/Makefile
+++ b/images/kubemci/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 IMG = "gcr.io/k8s-testimages/e2e-kubemci"
 

--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/kettle
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-gubernator

--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -33,10 +33,10 @@ KUBECONFIG ?= $(HOME)/.kube/config
 TARGET ?= kubernetes
 
 TOKEN ?= "./token"
-token64=$(shell base64 $(TOKEN))
+token64:=$(shell base64 $(TOKEN))
 
 HOOKSECRET ?= "./hook-secret"
-hooksecret64=$(shell base64 $(HOOKSECRET))
+hooksecret64:=$(shell base64 $(HOOKSECRET))
 
 READONLY ?= true
 

--- a/mungegithub/path.mk
+++ b/mungegithub/path.mk
@@ -1,5 +1,5 @@
-TARGET=$(shell basename $(shell pwd))
-APP=$(shell basename $(shell dirname $(shell dirname $(shell pwd))))
+TARGET:=$(shell basename $(shell pwd))
+APP:=$(shell basename $(shell dirname $(shell dirname $(shell pwd))))
 READONLY ?= false
 
 include ../../../Makefile

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ ALPINE_VERSION           ?= 0.1
 GIT_VERSION              ?= 0.2
 
 # YYYYmmdd-commitish
-TAG = $(shell date -u +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date -u +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 # HOOK_VERSION is the version of the hook image
 HOOK_VERSION              ?= $(TAG)
 # SINKER_VERSION is the version of the sinker image
@@ -63,7 +63,7 @@ CLUSTER       ?= prow
 REGISTRY ?= gcr.io
 PUSH     ?= docker push
 
-DOCKER_LABELS=--label io.k8s.prow.git-describe="$(shell git describe --tags --always --dirty)"
+DOCKER_LABELS:=--label io.k8s.prow.git-describe="$(shell git describe --tags --always --dirty)"
 
 update-config: get-cluster-credentials
 	kubectl create configmap config --from-file=config=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -

--- a/queue_health/common.mk
+++ b/queue_health/common.mk
@@ -1,5 +1,5 @@
 # Please set IMG
-TAG = $(shell date +v%Y%m%d)
+TAG := $(shell date +v%Y%m%d)
 
 all: push
 

--- a/triage/Makefile
+++ b/triage/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/k8s-testimages/triage
-TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 build:
 	docker build -t $(IMG):$(TAG) .


### PR DESCRIPTION
Change the recursively evaluated variables to simply evaluated
variables.

More details at e.g. http://electric-cloud.com/blog/2009/03/makefile-performance-shell/