### PR TITLE
Typo fix: quering -> querying/receieve -> receive

### DIFF
--- a/prow/cmd/tide/README.md
+++ b/prow/cmd/tide/README.md
@@ -72,8 +72,8 @@ It can consist of the following dictionary of fields:
 * `repos`: List of queried repositories.
 * `labels`: List of labels any given PR must posses.
 * `missingLabels`: List of labels any given PR must not posses.
-* `excludedBranches`: List of branches that get excluded when quering the `repos`.
-* `includedBranches`: List of branches that get included when quering the `repos`.
+* `excludedBranches`: List of branches that get excluded when querying the `repos`.
+* `includedBranches`: List of branches that get included when querying the `repos`.
 * `reviewApprovedRequired`: If set, each PR in the query must have review approved.
 
 Under the hood, a query constructed from the fields follows rules described in

--- a/prow/config/org/org_test.go
+++ b/prow/config/org/org_test.go
@@ -59,7 +59,7 @@ func TestRepoPermissionLevel(t *testing.T) {
 		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
 		switch {
 		case err == nil && tc.expected == nil:
-			t.Errorf("%s: failed to receieve an error", tc.input)
+			t.Errorf("%s: failed to receive an error", tc.input)
 		case err != nil && tc.expected != nil:
 			t.Errorf("%s: unexpected error: %v", tc.input, err)
 		case err == nil && *tc.expected != actual:
@@ -98,7 +98,7 @@ func TestPrivacy(t *testing.T) {
 		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
 		switch {
 		case err == nil && tc.expected == nil:
-			t.Errorf("%s: failed to receieve an error", tc.input)
+			t.Errorf("%s: failed to receive an error", tc.input)
 		case err != nil && tc.expected != nil:
 			t.Errorf("%s: unexpected error: %v", tc.input, err)
 		case err == nil && *tc.expected != actual:


### PR DESCRIPTION
quering -> querying in ./prow/cmd/tide/README.md
receieve -> receive in ../prow/config/org/org_test.go