### PR TITLE
Fixed ci-kubernetes-local-e2e-containerized arguments

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11492,7 +11492,7 @@
       "--extract-source",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --skip=\"\\[Disruptive\\]\"",
+      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --ginkgo.skip=\"\\[Disruptive\\]\"",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
It's `--ginkgo.skip`, not `--skip`. All ci-kubernetes-local-e2e-containerized are red now, see https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-local-e2e-containerized/166