### PR TITLE
Enable containerized tests in pull-kubernetes-local-e2e-containerized

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12966,7 +12966,7 @@
       "--deployment=local",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]",
+      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --ginkgo.skip=\"\\[Disruptive\\]\"",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
In #8199 I added `[Containerized]` to `ci-kubernetes-local-e2e-containerized` and I forgot there is a separate entry for `pull-kubernetes-local-e2e-containerized`. So let's add it also there.

I'm preparing containerized tests in https://github.com/kubernetes/kubernetes/pull/64687