### PR TITLE
prow: plank: make report error logging more verbose

### DIFF
--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -224,6 +224,7 @@ func (c *Controller) Sync() error {
 	for report := range reportCh {
 		if err := reportlib.Report(c.ghc, reportTemplate, report); err != nil {
 			reportErrs = append(reportErrs, err)
+			c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 		}
 	}
 

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -222,6 +222,7 @@ func (c *Controller) Sync() error {
 		for report := range reportCh {
 			if err := reportlib.Report(c.ghc, reportTemplate, report); err != nil {
 				reportErrs = append(reportErrs, err)
+				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 			}
 		}
 	}


### PR DESCRIPTION
The current approach to logging report errors does not expose any of the
information that is needed to debug and fix the errors, so we should log
at the error collection location as well as propagating the aggregate
up.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @BenTheElder @fejta 
/assign @cjwagner @kargakis 

This is another example of where aggregating the errors and passing them up may make some sense code-wise but is annoying for an admin. Current error is basically useless:

```
{"component":"plank","error":"errors syncing: [], errors reporting: [error setting status: status code 422 not one of [201], body: {\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"Status\",\"code\":\"custom\",\"field\":\"sha\",\"message\":\"sha must be a 40 character SHA1\"}],\"documentation_url\":\"https://developer.github.com/v3/repos/statuses/#create-a-status\"}]","level":"error","msg":"Error syncing.","time":"2018-06-04T16:50:19Z"}
```