### PR TITLE
prow: add ProwJob information to log entries

### DIFF
--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -393,7 +393,7 @@ func (c *Controller) syncPendingJob(pj kube.ProwJob, reports chan<- kube.ProwJob
 		pj.Status.JenkinsBuildID = strconv.Itoa(jb.Number)
 		var b bytes.Buffer
 		if err := c.config().JobURLTemplate.Execute(&b, &pj); err != nil {
-			c.log.Errorf("error executing URL template: %v", err)
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Errorf("error executing URL template: %v", err)
 		} else {
 			pj.Status.URL = b.String()
 		}

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -407,7 +407,7 @@ func (c *Controller) syncPendingJob(pj kube.ProwJob, pm map[string]kube.Pod, rep
 
 	var b bytes.Buffer
 	if err := c.ca.Config().Plank.JobURLTemplate.Execute(&b, &pj); err != nil {
-		c.log.Errorf("error executing URL template: %v", err)
+		c.log.WithFields(pjutil.ProwJobFields(&pj)).Errorf("error executing URL template: %v", err)
 	} else {
 		pj.Status.URL = b.String()
 	}
@@ -462,7 +462,7 @@ func (c *Controller) syncTriggeredJob(pj kube.ProwJob, pm map[string]kube.Pod, r
 		pj.Status.Description = "Job triggered."
 		var b bytes.Buffer
 		if err := c.ca.Config().Plank.JobURLTemplate.Execute(&b, &pj); err != nil {
-			c.log.Errorf("error executing URL template: %v", err)
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Errorf("error executing URL template: %v", err)
 		} else {
 			pj.Status.URL = b.String()
 		}


### PR DESCRIPTION
All log entries specific to a ProwJob should expose the ProwJobn fields
as entries in the log so that the messages are traceable and useful to
administrators.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @BenTheElder @fejta 
/assign @kargakis @cjwagner 

Example of annoying error logs: https://github.com/openshift/release/issues/908