### PR TITLE
repoowners: don't warn when no OWNERS_ALIAS exists

### DIFF
--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -283,7 +283,10 @@ func (a RepoAliases) ExpandAliases(logins sets.String) sets.String {
 func loadAliasesFrom(baseDir string, log *logrus.Entry) RepoAliases {
 	path := filepath.Join(baseDir, aliasesFileName)
 	b, err := ioutil.ReadFile(path)
-	if err != nil {
+	if os.IsNotExist(err) {
+		log.WithError(err).Infof("No alias file exists at %q. Using empty alias map.", path)
+		return nil
+	} else if err != nil {
 		log.WithError(err).Warnf("Failed to read alias file %q. Using empty alias map.", path)
 		return nil
 	}


### PR DESCRIPTION
The lack of an `OWNERS_ALIAS` file is not an error or something to warn
about, so we should emit and informative message but otherwise be
silent. If we found an alias file but could not read it, we should emit
a warning.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @fejta @BenTheElder 
/assign @kargakis @cjwagner 