### PR TITLE
upgrade test-infra / kubekins-e2e experimental to bazel 0.14

### DIFF
--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -24,7 +24,7 @@ CFSSL ?= R1.2
 # config for testing prior to rolling out to master / ongoing release
 ifeq ($(K8S), experimental)
 	GO = 1.10.2
-	BAZEL = 0.13.0
+	BAZEL = 0.14.0
 	CFSSL = R1.2
 endif
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -989,7 +989,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -1021,7 +1021,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -1227,7 +1227,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -1272,7 +1272,7 @@ presubmits:
       preset-service-account: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -6820,7 +6820,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -6951,7 +6951,7 @@ presubmits:
       preset-bazel-scratch-dir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -6979,7 +6979,7 @@ presubmits:
       - name: test
         command:
         - ./hack/verify-config.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         env:
         - name: TEST_TMPDIR
           value: /bazel-scratch/.cache/bazel
@@ -7008,7 +7008,7 @@ presubmits:
       preset-bazel-scratch-dir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -7070,7 +7070,7 @@ presubmits:
       preset-bazel-scratch-dir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -7506,7 +7506,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -7559,7 +7559,7 @@ postsubmits:
       preset-bazel-scratch-dir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -7719,7 +7719,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
       args:
       - "--repo=github.com/containerd/containerd=master"
       - "--repo=github.com/containerd/cri=master"
@@ -7812,7 +7812,7 @@ periodics:
     preset-service-account: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
       args:
       - "--repo=github.com/containerd/cri=master"
       - "--root=/go/src"
@@ -16664,7 +16664,7 @@ periodics:
     preset-bazel-remote-cache-enabled: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180511-51cf02e75-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180604-68e777553-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"


### PR DESCRIPTION
This [was released end of last week](https://github.com/bazelbuild/bazel/releases/tag/0.14.0), and importantly includes a fix related to cache misses and cleanup which should end caching flakes for us :crossed_fingers: 

> `35a78c0`: remote: recursively delete incomplete downloaded output
directory.

I've tested Kubernetes on this images as well (`pull-kubernetes-bazel-build-canary` and `pull-kubernetes-bazel-test-canary`) and we can probably upgrade that as well in a follow-up.