### PR TITLE
Fix containerized focus.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11570,7 +11570,7 @@
       "--extract-source",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --ginkgo.skip=\"\\[Disruptive\\]\"",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Containerized\\] --ginkgo.skip=\\[Disruptive\\]",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
@@ -13044,7 +13044,7 @@
       "--deployment=local",
       "--ginkgo-parallel=1",
       "--provider=local",
-      "--test_args=--ginkgo.focus=\"\\[Conformance\\]|\\[Containerized\\]\" --ginkgo.skip=\"\\[Disruptive\\]\"",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Containerized\\] --ginkgo.skip=\\[Disruptive\\]",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Double quotes get propagated to ginkgo and it does not focus anything. See https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-local-e2e-containerized/186 - 13 passed tests, that's various startup checks + teardown.