### PR TITLE
rewrite testgrid conformance docs

### DIFF
--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -4,12 +4,12 @@ This directory contains tooling for uploading [Kubernetes Conformance test](http
 
 Federated conformance test results are hosted on the TestGrid [conformance dashboards](https://k8s-testgrid.appspot.com/conformance-all), including the "all" dashboard, and specific sub-dashboards, see [the TestGrid README](../README.md#dashboards) for details on dashboards.  
 
-All Kuberentes cluster providers are invited to post results from their conformance test jobs and results from reliable continuous integration against the release branches may even be used as a signal by the Kubernetes release team in the [release-blocking dashboards](https://k8s-testgrid.appspot.com/sig-release-master-blocking).
+All Kubernetes cluster providers are invited to post results from their conformance test jobs and results from reliable continuous integration against the release branches may even be used as a signal by the Kubernetes release team in the [release-blocking dashboards](https://k8s-testgrid.appspot.com/sig-release-master-blocking).
 
 ## Usage Guide
 
 1. First you will need to set up a publicly readable GCS bucket per [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results) to host your jobs' results.  
-If you cannot or do not want to set up a GCS bucket and only wish to post conformance test results, please contact [@BenTheElder](https://github.com/BenTheElder) or more generally [the gke-kubernetes-engprod team](mailto:gke-kubernetes-engprod@google.com) to arrange for a Google [GKE](https://cloud.google.com/kubernetes-engine/) EngProd provided / maintained bucket for hosting your results.
+If you cannot or do not want to set up a GCS bucket and only wish to post conformance test results, please contact [@BenTheElder](https://github.com/BenTheElder) or more generally [the gke-kubernetes-engprod team](mailto:gke-kubernetes-engprod@google.com) to arrange for a Google [GKE](https://cloud.google.com/kubernetes-engine/) EngProd provided / maintained bucket for hosting your results. A bucket will be provided following the [playbook](./creating-a-bucket.md) for this.
 
 2. Make a PR to test-infra adding your bucket to the TestGrid config (again see [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results)).
 

--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -1,19 +1,24 @@
 # Display Conformance Tests with Testgrid
 
-This directory contains tooling for uploading [Kubernetes Conformance test](https://github.com/cncf/k8s-conformance) results for display / monitoring on [TestGrid](../README.md).
+This directory contains tooling for uploading [Kubernetes Conformance test](https://github.com/cncf/k8s-conformance) results for display / monitoring on [TestGrid](../README.md), a tool used heavily by [the core kubernetes project](https://github.com/kubernetes/kubernetes) to monitor test results, particularly as part of the release process.
 
-Federated conformance test results are hosted on the TestGrid [conformance dashboards](https://k8s-testgrid.appspot.com/conformance-all), including the "all" dashboard, and specific sub-dashboards, see [the TestGrid README](../README.md#dashboards) for details on dashboards.  
+Federated conformance test results are hosted on the TestGrid [conformance dashboards](https://k8s-testgrid.appspot.com/conformance-all), including the "all" dashboard, and specific sub-dashboards, see [the TestGrid README](../README.md#dashboards) for details on dashboards. Generally we are aiming to have a dashboard here for each provider E.g. "[conformance-cloud-provider-openstack](https://k8s-testgrid.appspot.com/conformance-cloud-provider-openstack)" as well as [a cross-vendor dashboard](https://k8s-testgrid.appspot.com/conformance-all) to track project wide conformance. 
 
 All Kubernetes cluster providers are invited to post results from their conformance test jobs and results from reliable continuous integration against the release branches may even be used as a signal by the Kubernetes release team in the [release-blocking dashboards](https://k8s-testgrid.appspot.com/sig-release-master-blocking).
+
+The release team has caught actual conformance test regressions using these dashboards just in the first month or so of setting up GCE / OpenStack conformance on TestGrid, and had them fixed before the Kubernetes 1.11 release.
 
 For the original design doc and further details on the motivation please see [design.md](./design.md).
 
 ## Usage Guide
 
 1. First you will need to set up a publicly readable GCS bucket per [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results) to host your jobs' results.  
-If you cannot or do not want to set up a GCS bucket and only wish to post conformance test results, please contact [@BenTheElder](https://github.com/BenTheElder) or more generally [the gke-kubernetes-engprod team](mailto:gke-kubernetes-engprod@google.com) to arrange for a Google [GKE](https://cloud.google.com/kubernetes-engine/) EngProd provided / maintained bucket for hosting your results. A bucket will be provided following the [playbook](./creating-a-bucket.md) for this.
+If you cannot or do not want to set up a GCS bucket and only wish to post conformance test results, please contact [@BenTheElder](https://github.com/BenTheElder) or more generally [the gke-kubernetes-engprod team](mailto:gke-kubernetes-engprod@google.com) to arrange for a Google [GKE](https://cloud.google.com/kubernetes-engine/) EngProd provided / maintained bucket for hosting your results. A bucket will be provided following the [playbook](./creating-a-bucket.md) for this.  
+If you'd like to post other kinds of tests or unrelated content, please consider following the playbook yourself to create your own bucket.
 
 2. Make a PR to test-infra adding your bucket to the TestGrid config (again see [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results)).
+
+- See The following PR from setting up the initial OpenStack bucket: [#7670](https://github.com/kubernetes/test-infra/pull/7670) 
 
 3. Setup a job in your CI system to run the conformance tests. To use [`upload_e2e.py`](./upload_e2e.py) the job environment must have `python` (v2.X) and `gcloud` / `gsutil` commands. For the gcloud CLI see [Installing the Google Cloud SDK](https://cloud.google.com/sdk/downloads).
 

--- a/testgrid/conformance/README.md
+++ b/testgrid/conformance/README.md
@@ -6,6 +6,8 @@ Federated conformance test results are hosted on the TestGrid [conformance dashb
 
 All Kubernetes cluster providers are invited to post results from their conformance test jobs and results from reliable continuous integration against the release branches may even be used as a signal by the Kubernetes release team in the [release-blocking dashboards](https://k8s-testgrid.appspot.com/sig-release-master-blocking).
 
+For the original design doc and further details on the motivation please see [design.md](./design.md).
+
 ## Usage Guide
 
 1. First you will need to set up a publicly readable GCS bucket per [contributing test results](https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md#contributing-test-results) to host your jobs' results.  

--- a/testgrid/conformance/creating-a-bucket.md
+++ b/testgrid/conformance/creating-a-bucket.md
@@ -1,0 +1,21 @@
+# Creating Federated Conformance Test GCS Buckets
+
+This guide is aimed primarily at members of the Google GKE EngProd team for 
+creating Google provided GCS buckets to be used by other providers for hosting
+conformance results on TestGrid, but the general steps should be good practice
+for anyone setting up a GCS bucket for automated uploads.
+
+1) Use a separate dedicated [GCP project](https://cloud.google.com/storage/docs/projects), to further limit access to unrelated resources. We use [k8s-federated-conformance](http://console.cloud.google.com/home/dashboard?project=k8s-federated-conformance).
+
+2) Create a new bucket in the GCP project. See the official [Creating Storage Buckets](https://cloud.google.com/storage/docs/creating-buckets) guide. Buckets should be used one to a provider. We use the naming scheme `k8s-conformance-$PROVIDER` eg `gs://k8s-conformance-openstack`.
+
+3) Follow [Making Data Public](https://cloud.google.com/storage/docs/access-control/making-data-public) (specifically the "Making groups of objects publicly readable" section) to make the bucket readable by TestGrid.
+  - This essentially involves adding `allUsers` to the bucket with `Storage Object Viewer` permission.
+
+4) Create a matching service account, something like `$PROVIDER-logs` which will ultimately create an account like `openstack-logs@k8s-federated-conformance.iam.gserviceaccount.com`. See [Creating and Managing Service Accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts) for more details.
+
+5) Add [`Storage Object Create`](https://cloud.google.com/storage/docs/access-control/iam-roles) permissions (`storage.objects.create`) to the service account created in 4). This allows the service account to create new entries. See also [Identity and Access Management](https://cloud.google.com/storage/docs/access-control/iam).
+
+6) [Generate a service account credential](https://cloud.google.com/storage/docs/authentication#generating-a-private-key) file. Per the [gcloud auth activate-service-account](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account) docs the JSON format is preferred. This file must be provided to the CI uploading the test results. It can be used with the `--key-file` flag in [`upload_e2e.py`](./upload_e2e.py).
+
+

--- a/testgrid/conformance/design.md
+++ b/testgrid/conformance/design.md
@@ -1,0 +1,60 @@
+# Displaying Kubernetes Conformance results with Testgrid
+
+_Note: this document was manually converted to markdown from [the original Google Doc](https://docs.google.com/document/d/1lGvP89_DdeNO84I86BVAU4qY3h2VCRll45tGrpyx90A/)._
+
+_The current state is documented in [README.md](./README.md)_
+
+## Overview
+
+Kubernetes [conformance](https://github.com/cncf/k8s-conformance) testing is required by the CNCF for the “Certified Kubernetes” [program](https://www.cncf.io/certification/software-conformance/). For this, the requirement is to deploy the cncf/k8s-conformance config to a cluster and provide the JUnit artifact and test log. We aim to provide easy support for uploading and displaying conformance test results on Testgrid so that cloud providers can provide publicly discoverable conformance results.
+This tool should be easy to use both manually for development and as part of automated infrastructure / CI, integrating well with the existing conformance tools. We will automate as much as possible while keeping things simple.
+
+### Why Testgrid?
+
+[The Kubernetes Testgrid](http://testgrid.k8s.io/) provides public dashboards well suited to tracking many test runs and individual test results. Testgrid is used heavily to display Kubernetes CI results, many of which are a superset of conformance testing.
+
+## Background
+
+Contributing test results has [an existing workflow](https://github.com/kubernetes/test-infra/blob/1c33865831040aa4fa775b0627abb90389daac9b/docs/contributing-test-results.md#contributing-test-results) covering the GCS storage bucket and Testgrid configuration. This is not easily automated and will be outside the scope of the new tooling. Creating / uploading test results in the right GCS layout however is usually handled by [bootstrap](https://github.com/kubernetes/test-infra/blob/1c33865831040aa4fa775b0627abb90389daac9b/jenkins/bootstrap.py) which is a bit heavy-weight and overly tied to our CI infrastructure, we can automate this with a much lighter and simpler tool focused on conformance results. 
+
+The conformance repo testing config is based on [Sonobuoy](https://github.com/heptio/sonobuoy), both Sonobuoy and the conformance repo provide docs for obtaining results from a running cluster via [snapshot](https://github.com/heptio/sonobuoy/blob/master/docs/snapshot.md) (a tarball of various results) or [kubectl cp](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#running) of the e2e.log and junit.xml directly. Additionally Heptio provides a web based sonobuoy result system [Heptio Scanner](https://scanner.heptio.com/), which provides a downloadable tarball containing e2e.log and junit.xml at:
+
+[https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/download/](https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/download/)
+
+Where "[3f15e956994d70722e8e306b7bd4d13d](https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/download/)" is the UUID of the Scanner run at:  
+
+[https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/](https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/)
+
+We should easily be able to support direct dumping from clusters as well as obtaining or reading the result files from Heptio Scanner.
+
+## Design
+
+We will convert each run’s `junit_01.xml` and `e2e.log` to Testgrid results automatically by parsing timestamps from `e2e.log` to create minimal `started.json` and `finished.json` entries good enough to meet [the required job artifact GCS layout](https://github.com/kubernetes/test-infra/blob/1c33865831040aa4fa775b0627abb90389daac9b/gubernator/README.md#job-artifact-gcs-layout). `junit_01.xml` will be uploaded to the artifacts directory and `e2e.log` will be uploaded as `build-log.txt`.
+
+**TBD**: Testgrid / Gubernator also expect a `"result": "SUCCESS or FAILURE, the result of the build"` field in `finished.json`. For the MVP we can use "zero failures in the junit results == SUCCESS" but we may want something more sophisticated in the future (?)
+
+### Command Line / Example Usage
+
+For each scenario the command line will look something like the following.
+
+- Forwarding to testgrid from e2e.log and junit.xml already obtained by the user (EG dumped from the cluster or downloaded manually from Scanner, etc...):
+
+`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --junit=/path/to/junit_01.xml --log=/path/to/e2e.log`
+
+- Forwarding to testgrid from a running cluster that has just run the tests (assumes kubectl in path and KUBECONFIG pointed at the cluster):
+
+`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --dump-from-cluster`
+
+- Forwarding to testgrid from Heptio Scanner results (automatically downloaded by the tool):
+
+`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --scanner-url=https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/`
+
+`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --scanner-uuid=3f15e956994d70722e8e306b7bd4d13d`
+
+_Note: Scanner integration was dropped in the final design in order to focus on Continuous Integration results, however the tool can still be used to upload scanner results once they've been downloaded._
+
+### Implementation Considerations
+
+Dependencies should be kept minimal to ensure easy adoption. Tentatively these will be limited to the [gcloud command-line / sdk](https://cloud.google.com/sdk/downloads) for GCS upload / auth and optionally kubectl / working KUBECONFIG for automatically dumping results from live clusters. Since gcloud requires Python 2.7.x the tool may be implemented as an otherwise self-contained Python script.
+
+Build IDs in the GCS upload path need to be Incremental for Testgrid; normally in CI we vend the next ID from [tot](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tot), but we don’t want end users to depend on a tot deployment or need to specify the ID manually so we while we will allow setting the buildID from the CLI we will default to the parsed start timestamp as the ID. This should be unique and incremental enough for each conformance job. This will not support Gubernators “recent builds” view, however.


### PR DESCRIPTION
- elaborate a bit more on what this is
- reorganize conformance job requirements into steps
- couple options for running the tests with how to obtain the result files, instead of having two sections for this, xref: https://github.com/kubernetes/test-infra/pull/7460#discussion_r177909510
- drop heptio scanner in favor of just the sonobuoy cli, this doesn't really make sense for CI and the focus of this tool is CI result uploads to TestGrid
- rewrite `upload_e2e.py` usage, document new flags including https://github.com/kubernetes/test-infra/pull/8186
- minor normalization / nits eg. testgrid -> TestGrid
- create bucket creation playbook
- check in markdown version of the original design doc