### PR TITLE
enable cat and dog plugins on service-catalog

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -357,6 +357,10 @@ plugins:
   - lifecycle
   - size
 
+  kubernetes-incubator/service-catalog:
+  - cat
+  - dog
+
   kubernetes-sigs:
   - assign
   - blunderbuss


### PR DESCRIPTION
A first step in specific enablement of Prow features for service-catalog.

Let's see if we can make this happen.

/area so-crazy-it-just-might-work 
/assign @fejta 
