### PR TITLE
fix broken test caused by a directory name change

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12077,7 +12077,7 @@
       "--gke-environment=prod",
       "--provider=gke",
       "--test=false",
-      "--test-cmd=../demos/integration_tests.sh",
+      "--test-cmd=../examples/integration_tests.sh",
       "--test-cmd-name=kustomize-integration",
       "--timeout=120m"
     ],


### PR DESCRIPTION
broken test:  https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kustomize-periodic-default-gke/263

PR that broke the test: https://github.com/kubernetes-sigs/kustomize/pull/37