### PR TITLE
Add NFS client into e2e test image.

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -34,9 +34,14 @@ RUN mkdir -p /go/src/k8s.io/kubernetes \
 # - graphviz package for graphing profiles
 # - bc for shell to junit
 # - rpm for building RPMs with Bazel
+# - nfs for {ci,pull}-kubernetes-local-e2e-containerized - this container image
+#   serves as "the host" for tests with containerized kubelet. Containerized
+#   kubelet uses nfs clients on the host.
 RUN apt-get install -y bc \
     graphviz \
-    rpm
+    rpm \
+    nfs-common
+
 # preinstall this for kops tests xref kubetest prepareAws(...)
 # TODO(bentheelder,krzyzacy,justisb,chrislovecnm): remove this
 RUN pip install awscli


### PR DESCRIPTION
This image is used as "the host" for *-kubernetes-local-e2e-containerized tests and I want to test at least NFS in these test jobs with containerized kubelet.

Tested with:

```
$ make build
$ docker run -ti --entrypoint=/bin/bash --privileged gcr.io/k8s-testimages/kubekins-e2e:v20180608-eb9263c89-dirty-master
root@1cdbcc29c506:/workspace# mount 172.17.0.1:/tmp /mnt

-> NFS share is mounted into /mnt
```

This is related to https://github.com/kubernetes/kubernetes/pull/64687