### PR TITLE
Add linux-image-tests tab to google-gce-compute-image-tools in testgrid

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2403,6 +2403,8 @@ test_groups:
 # GCE Guest compute-image-tools
 - name: ci-daisy-e2e
   gcs_prefix: compute-image-tools-test/logs/ci-daisy-e2e
+- name: linux-image-tests
+  gcs_prefix: compute-image-tools-test/logs/linux-image-tests
 # Cluster registry
 - name: pull-cluster-registry-verify-gensrc
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-verify-gensrc
@@ -3254,13 +3256,20 @@ dashboards:
   dashboard_tab:
     - name: ci-daisy-e2e
       test_group_name: ci-daisy-e2e
-      open_test_template:
-        url: https://storage.googleapis.com/<gcs_prefix>/<changelist>/artifacts/log-<test-id>.txt
       file_bug_template:
         url: https://github.com/GoogleCloudPlatform/compute-image-tools/issues/new
         options:
         - key: title
           value: 'ci-daisy-e2e issue: <test-name>'
+        - key: body
+          value: <test-url>
+    - name: linux-image-tests
+      test_group_name: linux-image-tests
+      file_bug_template:
+        url: https://github.com/GoogleCloudPlatform/compute-image-tools/issues/new
+        options:
+        - key: title
+          value: 'linux-image-tests issue: <test-name>'
         - key: body
           value: <test-url>
 


### PR DESCRIPTION
 Also drop open_test_template from ci-daisy-e2e (just use the default gubernator link)