### PR TITLE
Add more test configs for GCE GPU upgrade test:

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2961,6 +2961,48 @@
       "sig-cli"
     ]
   },
+  "ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-beta",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/latest",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-gce-gpu-stable1": {
     "args": [
       "--check-leaked-resources",
@@ -2975,6 +3017,48 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-scheduling"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-beta",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/latest",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
     ]
   },
   "ci-kubernetes-e2e-gce-gpu-stable2": {
@@ -2992,6 +3076,27 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-scheduling"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-stable1",
+      "--extract=ci/k8s-stable2",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
     ]
   },
   "ci-kubernetes-e2e-gce-ha-master": {
@@ -3638,27 +3743,6 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-cli"
-    ]
-  },
-  "ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
-      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
-      "--extract=ci/k8s-stable1",
-      "--extract=ci/k8s-stable2",
-      "--gcp-node-image=gci",
-      "--gcp-project-type=gpu-project",
-      "--gcp-zone=us-west1-b",
-      "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
     ]
   },
   "ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10472,6 +10472,32 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
 - name: ci-kubernetes-e2e-gce-gpu-stable1
   interval: 2h
   agent: kubernetes
@@ -10485,6 +10511,32 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
 - name: ci-kubernetes-e2e-gce-gpu-stable2
   interval: 6h
   agent: kubernetes
@@ -10495,6 +10547,19 @@ periodics:
     containers:
     - args:
       - --timeout=300
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 
@@ -10962,19 +11027,6 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
-
-- interval: 12h
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=180
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2364,8 +2364,16 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
 - name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
-- name: ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+- name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
 - name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
 - name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
@@ -4030,7 +4038,15 @@ dashboards:
   - name: gce-1.9-1.10-upgrade-cluster-new
     test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
   - name: gce-1.9-1.10-upgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+  - name: gce-1.10-1.11-upgrade-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+  - name: gce-1.10-master-upgrade-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+  - name: gce-1.11-1.10-downgrade-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+  - name: gce-master-1.10-downgrade-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
   - name: gce-1.10-1.9-downgrade-cluster
     test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster
   - name: gce-1.10-1.9-downgrade-cluster-parallel
@@ -4383,7 +4399,27 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
   - name: gce-1.9-1.10-gpu-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gpu-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.10-1.11-gpu-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.10-master-gpu-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.11-1.10-gpu-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-master-1.10-gpu-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'


### PR DESCRIPTION
- ci-kubernetes-e2e-gce-stable1-beta-gpu-upgrade
- ci-kubernetes-e2e-gce-new-gpu-upgrade
- ci-kubernetes-e2e-gce-beta-stable1-gpu-downgrade
- ci-kubernetes-e2e-gce-new-gpu-downgrade