### PR TITLE
Enable docs-no-retest on cloud-provider-openstack

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -205,6 +205,7 @@ plugins:
   kubernetes/cloud-provider-openstack:
   - approve
   - blunderbuss
+  - docs-no-retest
   - trigger
 
   kubernetes/cloud-provider-vsphere:


### PR DESCRIPTION
As https://github.com/kubernetes/cloud-provider-openstack/pull/196
All PRs which includes docs-changes-only ones also kicks e2e jobs.
That takes unnecessary time and resource on the CI.
This enables docs-no-retest plugin on cloud-provider-openstack CI.