### PR TITLE
Support managing github teams via config

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -85,7 +85,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	for _, ep := range o.endpoint.Strings() {
 		_, err := url.Parse(ep)
 		if err != nil {
-			return fmt.Errorf("Invalid --endpoint URL %q: %v.", ep, err)
+			return fmt.Errorf("invalid --endpoint URL %q: %v", ep, err)
 		}
 	}
 	if o.minAdmins < 2 {
@@ -134,14 +134,14 @@ func main() {
 	}
 }
 
-type configureOrgMembersClient interface {
+type orgClient interface {
 	BotName() (string, error)
 	ListOrgMembers(org, role string) ([]github.TeamMember, error)
 	RemoveOrgMembership(org, user string) error
 	UpdateOrgMembership(org, user string, admin bool) (*github.OrgMembership, error)
 }
 
-func configureOrgMembers(opt options, client configureOrgMembersClient, orgName string, orgConfig org.Config) error {
+func configureOrgMembers(opt options, client orgClient, orgName string, orgConfig org.Config) error {
 	// Get desired state
 	wantAdmins := sets.NewString(orgConfig.Admins...)
 	wantMembers := sets.NewString(orgConfig.Members...)
@@ -184,57 +184,104 @@ func configureOrgMembers(opt options, client configureOrgMembersClient, orgName 
 		haveMembers.Insert(m.Login)
 	}
 
-	// Ensure desired state is sane
-	both := wantAdmins.Intersection(wantMembers)
-	if n := len(both); n > 0 {
-		return fmt.Errorf("%d users are both a member and admin: %v", n, both)
-	}
-
+	have := memberships{members: haveMembers, super: haveAdmins}
+	want := memberships{members: wantMembers, super: wantAdmins}
 	// Figure out who to remove
-	have := haveMembers.Union(haveAdmins)
-	want := wantMembers.Union(wantAdmins)
-	remove := have.Difference(want)
-
-	// Figure out who to invite and/or reconfigure
-	makeMember := wantMembers.Difference(haveMembers)
-	makeAdmin := wantAdmins.Difference(haveAdmins)
+	remove := have.all().Difference(want.all())
 
 	// Sanity check changes
-	if d := float64(len(remove)) / float64(len(have)); d > opt.maximumDelta {
+	if d := float64(len(remove)) / float64(len(have.all())); d > opt.maximumDelta {
 		return fmt.Errorf("cannot delete %d memberships or %.3f of %s (exceeds limit of %.3f)", len(remove), d, orgName, opt.maximumDelta)
 	}
 
+	teamMembers := sets.String{}
+	teamNames := sets.String{}
+	duplicateTeamNames := sets.String{}
+	for name, team := range orgConfig.Teams {
+		teamMembers.Insert(team.Members...)
+		teamMembers.Insert(team.Maintainers...)
+		if teamNames.Has(name) {
+			duplicateTeamNames.Insert(name)
+		}
+		teamNames.Insert(name)
+		for _, n := range team.Previously {
+			if teamNames.Has(n) {
+				duplicateTeamNames.Insert(n)
+			}
+			teamNames.Insert(n)
+		}
+	}
+
+	if outside := teamMembers.Difference(want.all()); len(outside) > 0 {
+		return fmt.Errorf("all team members/maintainers must also be org members: %s", strings.Join(outside.List(), ", "))
+	}
+
+	if n := len(duplicateTeamNames); n > 0 {
+		return fmt.Errorf("team names must be unique (including previous names), %d duplicated names: %s", n, strings.Join(duplicateTeamNames.List(), ", "))
+	}
+
+	adder := func(user string, super bool) error {
+		role := "member"
+		if super {
+			role = "admin"
+		}
+		om, err := client.UpdateOrgMembership(orgName, user, super)
+		if err != nil {
+			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, %t) failed", orgName, user, super)
+		} else if om.State == github.StatePending {
+			logrus.Infof("Invited %s to %s as a %s", user, orgName, role)
+		} else {
+			logrus.Infof("Set %s as a %s of %s", user, role, orgName)
+		}
+		return err
+	}
+
+	remover := func(user string) error {
+		err := client.RemoveOrgMembership(orgName, user)
+		if err != nil {
+			logrus.WithError(err).Warnf("RemoveOrgMembership(%s, %s) failed", orgName, user)
+		}
+		return err
+	}
+
+	if err = configureMembers(have, want, adder, remover); err != nil {
+		return err
+	}
+	return nil
+}
+
+type memberships struct {
+	members sets.String
+	super   sets.String
+}
+
+func (m memberships) all() sets.String {
+	return m.members.Union(m.super)
+}
+
+func configureMembers(have, want memberships, adder func(user string, super bool) error, remover func(user string) error) error {
+	if both := want.super.Intersection(want.members); len(both) > 0 {
+		return fmt.Errorf("users in both roles: %s", strings.Join(both.List(), ", "))
+	}
+	remove := have.all().Difference(want.all())
+	members := want.members.Difference(have.members)
+	supers := want.super.Difference(have.super)
+
 	var errs []error
+	for u := range members {
+		if err := adder(u, false); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for u := range supers {
+		if err := adder(u, true); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
-	// March towards desired state
 	for u := range remove {
-		if err := client.RemoveOrgMembership(orgName, u); err != nil {
-			logrus.WithError(err).Warnf("RemoveOrgMembership(%s, %s) failed", orgName, u)
+		if err := remover(u); err != nil {
 			errs = append(errs, err)
-		} else {
-			logrus.Infof("Removed %s from %s", u, orgName)
-		}
-	}
-
-	for u := range makeMember {
-		if m, err := client.UpdateOrgMembership(orgName, u, false); err != nil {
-			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, false) failed", orgName, u)
-			errs = append(errs, err)
-		} else if m.State == github.StatePending {
-			logrus.Infof("Invited %s to %s", u, orgName)
-		} else {
-			logrus.Infof("Demoted %s to a %s member", u, orgName)
-		}
-	}
-
-	for u := range makeAdmin {
-		if m, err := client.UpdateOrgMembership(orgName, u, true); err != nil {
-			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, true) failed", orgName, u)
-			errs = append(errs, err)
-		} else if m.State == github.StatePending {
-			logrus.Infof("Invited %s to %s", u, orgName)
-		} else {
-			logrus.Infof("Promoted %s to a %s admin", u, orgName)
 		}
 	}
 
@@ -244,34 +291,267 @@ func configureOrgMembers(opt options, client configureOrgMembersClient, orgName 
 	return nil
 }
 
-func configureOrg(opt options, client *github.Client, orgName string, orgConfig org.Config) error {
-	// get meta
-	// diff meta
-	// patch meta
-
-	if err := configureOrgMembers(opt, client, orgName, orgConfig); err != nil {
-		return fmt.Errorf("failed to configure %s members: %v", orgName, err)
+// findTeam returns teams[n] for the first n in [name, previousNames, ...] that is in teams.
+func findTeam(teams map[string]github.Team, name string, previousNames ...string) *github.Team {
+	if t, ok := teams[name]; ok {
+		return &t
 	}
-
-	// teams = set(all teams)
-	for name, team := range orgConfig.Teams {
-		team.Name = name
-		num := -1
-		// find team name in teams (or previous name)
-		if err := configureTeam(client, num, team); err != nil {
-			return fmt.Errorf("failed to update %s: %v", orgName, err)
+	for _, p := range previousNames {
+		if t, ok := teams[p]; ok {
+			return &t
 		}
 	}
 	return nil
 }
 
-func configureTeam(client *github.Client, num int, team org.Team) error {
-	// create team if num < 0
-	// else diff and patch
+// validateTeamNames returns an error if any current/previous names are used multiple times in the config.
+func validateTeamNames(orgConfig org.Config) error {
+	// Does the config duplicate any team names?
+	used := sets.String{}
+	dups := sets.String{}
+	for name, orgTeam := range orgConfig.Teams {
+		if used.Has(name) {
+			dups.Insert(name)
+		} else {
+			used.Insert(name)
+		}
+		for _, n := range orgTeam.Previously {
+			if used.Has(n) {
+				dups.Insert(n)
+			} else {
+				used.Insert(n)
+			}
+		}
+	}
+	if n := len(dups); n > 0 {
+		return fmt.Errorf("%d duplicated names: %s", n, strings.Join(dups.List(), ", "))
+	}
+	return nil
+}
 
-	// people = set(all org members)
-	// remove = people - orgConfig.members - orgConfig.admins
-	// update = oc.members - [p for p in people if member]
-	// update = oc.admins - [p for p in people if admin]
-	return errors.New("implement")
+type teamClient interface {
+	ListTeams(org string) ([]github.Team, error)
+	CreateTeam(org string, team github.Team) (*github.Team, error)
+	DeleteTeam(id int) error
+}
+
+// configureTeams returns the ids for all expected team names, creating/deleting teams as necessary.
+func configureTeams(client teamClient, orgName string, orgConfig org.Config) (map[string]github.Team, error) {
+	if err := validateTeamNames(orgConfig); err != nil {
+		return nil, err
+	}
+
+	// What teams exist?
+	ids := map[int]github.Team{}
+	ints := sets.Int{}
+	teamList, err := client.ListTeams(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list teams: %v", err)
+	}
+	for _, t := range teamList {
+		ids[t.ID] = t
+		ints.Insert(t.ID)
+	}
+
+	// What is the lowest ID for each team?
+	older := map[string][]github.Team{}
+	names := map[string]github.Team{}
+	for _, t := range ids {
+		n := t.Name
+		switch val, ok := names[n]; {
+		case !ok: // first occurrence of the name
+			names[n] = t
+		case ok && t.ID < val.ID: // t has the lower ID, replace and send current to older set
+			names[n] = t
+			older[n] = append(older[n], val)
+		default: // t does not have smallest id, add it to older set
+			older[n] = append(older[n], val)
+		}
+	}
+
+	// What team are we using for each configured name, and which names are missing?
+	matches := map[string]github.Team{}
+	missing := map[string]org.Team{}
+	used := sets.Int{}
+	for name, orgTeam := range orgConfig.Teams {
+		t := findTeam(names, name, orgTeam.Previously...)
+		if t == nil {
+			missing[name] = orgTeam
+			continue
+		}
+		matches[name] = *t // t.Name != name if we matched on orgTeam.Previously
+		used.Insert(t.ID)
+	}
+
+	// Create any missing team names
+	var failures []string
+	for name, orgTeam := range missing {
+		t := &github.Team{Name: name}
+		if orgTeam.Description != nil {
+			t.Description = *orgTeam.Description
+		}
+		if orgTeam.Privacy != nil {
+			t.Privacy = string(*orgTeam.Privacy)
+		}
+		t, err := client.CreateTeam(orgName, *t)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to create %s in %s", name, orgName)
+			failures = append(failures, name)
+			continue
+		}
+		matches[name] = *t
+		used.Insert(t.ID)
+	}
+	if n := len(failures); n > 0 {
+		return nil, fmt.Errorf("failed to create %d teams: %s", n, strings.Join(failures, ", "))
+	}
+
+	// Delete undeclared teams.
+	// TODO(fejta): consider ensuring we don't delete too many teams at once
+	unused := ints.Difference(used)
+	for id := range unused {
+		if err := client.DeleteTeam(id); err != nil {
+			str := fmt.Sprintf("%d(%s)", id, ids[id].Name)
+			logrus.WithError(err).Warnf("Failed to delete team %s from %s", str, orgName)
+			failures = append(failures, str)
+		}
+	}
+	if n := len(failures); n > 0 {
+		return nil, fmt.Errorf("failed to delete %d teams: %s", n, strings.Join(failures, ", "))
+	}
+
+	// Return matches
+	return matches, nil
+}
+
+func configureOrg(opt options, client *github.Client, orgName string, orgConfig org.Config) error {
+	// get meta
+	// diff meta
+	// patch meta
+
+	// Find the id and current state of each declared team (create/delete as necessary)
+	githubTeams, err := configureTeams(client, orgName, orgConfig)
+	if err != nil {
+		return fmt.Errorf("failed to configure %s teams: %v", orgName, err)
+	}
+
+	// Invite/remove/update members to the org.
+	if err := configureOrgMembers(opt, client, orgName, orgConfig); err != nil {
+		return fmt.Errorf("failed to configure %s members: %v", orgName, err)
+	}
+
+	for name, team := range orgConfig.Teams {
+		gt, ok := githubTeams[name]
+		if !ok { // configureTeams is buggy if this is the case
+			return fmt.Errorf("%s not found in id list", name)
+		}
+
+		// Configure team metadata
+		err := configureTeam(client, orgName, name, team, gt)
+		if err != nil {
+			return fmt.Errorf("failed to update %s: %v", orgName, err)
+		}
+
+		// Add/remove/update members to the team.
+		return configureTeamMembers(client, gt.ID, team)
+	}
+	return nil
+}
+
+type editTeamClient interface {
+	EditTeam(team github.Team) (*github.Team, error)
+}
+
+// configureTeam patches the team name/description/privacy when values differ
+func configureTeam(client editTeamClient, orgName, teamName string, team org.Team, gt github.Team) error {
+	// Do we need to reconfigure any team settings?
+	patch := false
+	if gt.Name != teamName {
+		patch = true
+	}
+	gt.Name = teamName
+	if team.Description != nil && gt.Description != *team.Description {
+		patch = true
+		gt.Description = *team.Description
+	} else {
+		gt.Description = ""
+	}
+	if team.Privacy != nil && gt.Privacy != string(*team.Privacy) {
+		patch = true
+		gt.Privacy = string(*team.Privacy)
+
+	} else {
+		gt.Privacy = ""
+	}
+
+	if patch { // yes we need to patch
+		if _, err := client.EditTeam(gt); err != nil {
+			return fmt.Errorf("failed to edit %s team %d(%s): %v", orgName, gt.ID, gt.Name, err)
+		}
+	}
+	return nil
+}
+
+// teamMembersClient can list/remove/update people to a team.
+type teamMembersClient interface {
+	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	RemoveTeamMembership(id int, user string) error
+	UpdateTeamMembership(id int, user string, maintainer bool) (*github.TeamMembership, error)
+}
+
+// configureTeamMembers will add/update people to the appropriate role on the team, and remove anyone else.
+func configureTeamMembers(client teamMembersClient, id int, team org.Team) error {
+	// Get desired state
+	wantMaintainers := sets.NewString(team.Maintainers...)
+	wantMembers := sets.NewString(team.Members...)
+
+	// Get current state
+	haveMaintainers := sets.String{}
+	haveMembers := sets.String{}
+
+	members, err := client.ListTeamMembers(id, github.RoleMember)
+	if err != nil {
+		return fmt.Errorf("failed to list %d members: %v", id, err)
+	}
+	for _, m := range members {
+		haveMembers.Insert(m.Login)
+	}
+
+	maintainers, err := client.ListTeamMembers(id, github.RoleMaintainer)
+	if err != nil {
+		return fmt.Errorf("failed to list %d maintainers: %v", id, err)
+	}
+	for _, m := range maintainers {
+		haveMaintainers.Insert(m.Login)
+	}
+
+	adder := func(user string, super bool) error {
+		role := github.RoleMember
+		if super {
+			role = github.RoleMaintainer
+		}
+		tm, err := client.UpdateTeamMembership(id, user, super)
+		if err != nil {
+			logrus.WithError(err).Warnf("UpdateTeamMembership(%d, %s, %t) failed", id, user, super)
+		} else if tm.State == github.StatePending {
+			logrus.Infof("Invited %s to %d as a %s", user, id, role)
+		} else {
+			logrus.Infof("Set %s as a %s of %d", user, role, id)
+		}
+		return err
+	}
+
+	remover := func(user string) error {
+		err := client.RemoveTeamMembership(id, user)
+		if err != nil {
+			logrus.WithError(err).Warnf("RemoveTeamMembership(%d, %s) failed", id, user)
+		} else {
+			logrus.Infof("Removed %s from team %d", user, id)
+		}
+		return err
+	}
+
+	want := memberships{members: wantMembers, super: wantMaintainers}
+	have := memberships{members: haveMembers, super: haveMaintainers}
+	return configureMembers(have, want, adder, remover)
 }

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"reflect"
@@ -141,6 +142,7 @@ func TestOptions(t *testing.T) {
 }
 
 type fakeClient struct {
+	orgMembers sets.String
 	admins     sets.String
 	members    sets.String
 	removed    sets.String
@@ -152,19 +154,20 @@ func (c *fakeClient) BotName() (string, error) {
 	return "me", nil
 }
 
-func (c *fakeClient) ListOrgMembers(org, role string) ([]github.TeamMember, error) {
+func (c fakeClient) makeMembers(people sets.String) []github.TeamMember {
 	var ret []github.TeamMember
+	for p := range people {
+		ret = append(ret, github.TeamMember{Login: p})
+	}
+	return ret
+}
+
+func (c *fakeClient) ListOrgMembers(org, role string) ([]github.TeamMember, error) {
 	switch role {
 	case github.RoleMember:
-		for m := range c.members {
-			ret = append(ret, github.TeamMember{Login: m})
-		}
-		return ret, nil
+		return c.makeMembers(c.members), nil
 	case github.RoleAdmin:
-		for m := range c.admins {
-			ret = append(ret, github.TeamMember{Login: m})
-		}
-		return ret, nil
+		return c.makeMembers(c.admins), nil
 	default:
 		// RoleAll: implmenent when/if necessary
 		return nil, fmt.Errorf("bad role: %s", role)
@@ -202,9 +205,192 @@ func (c *fakeClient) UpdateOrgMembership(org, user string, admin bool) (*github.
 		role = github.RoleMember
 	}
 	return &github.OrgMembership{
-		Role:  role,
-		State: state,
+		Membership: github.Membership{
+			Role:  role,
+			State: state,
+		},
 	}, nil
+}
+
+func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+	if id != teamID {
+		return nil, fmt.Errorf("only team 66 supported, not %d", id)
+	}
+	switch role {
+	case github.RoleMember:
+		return c.makeMembers(c.members), nil
+	case github.RoleMaintainer:
+		return c.makeMembers(c.admins), nil
+	default:
+		return nil, fmt.Errorf("fake does not support: %v", role)
+	}
+}
+
+const teamID = 66
+
+func (c *fakeClient) UpdateTeamMembership(id int, user string, maintainer bool) (*github.TeamMembership, error) {
+	if id != teamID {
+		return nil, fmt.Errorf("only team %d supported, not %d", teamID, id)
+	}
+	if user == "fail" {
+		return nil, fmt.Errorf("injected failure for %s", user)
+	}
+	var state string
+	if c.orgMembers.Has(user) || len(c.orgMembers) == 0 {
+		state = github.StateActive
+	} else {
+		state = github.StatePending
+	}
+	var role string
+	if maintainer {
+		c.newAdmins.Insert(user)
+		c.admins.Insert(user)
+		role = github.RoleMaintainer
+	} else {
+		c.newMembers.Insert(user)
+		c.members.Insert(user)
+		role = github.RoleMember
+	}
+	return &github.TeamMembership{
+		Membership: github.Membership{
+			Role:  role,
+			State: state,
+		},
+	}, nil
+}
+
+func (c *fakeClient) RemoveTeamMembership(id int, user string) error {
+	if id != teamID {
+		return fmt.Errorf("only team %d supported, not %d", teamID, id)
+	}
+	if user == "fail" {
+		return fmt.Errorf("injected failure for %s", user)
+	}
+	c.removed.Insert(user)
+	c.admins.Delete(user)
+	c.members.Delete(user)
+	return nil
+}
+
+func TestConfigureMembers(t *testing.T) {
+	cases := []struct {
+		name    string
+		want    memberships
+		have    memberships
+		remove  sets.String
+		members sets.String
+		supers  sets.String
+		err     bool
+	}{
+		{
+			name: "forgot to remove duplicate entry",
+			want: memberships{
+				members: sets.NewString("me"),
+				super:   sets.NewString("me"),
+			},
+			err: true,
+		},
+		{
+			name: "removal fails",
+			have: memberships{
+				members: sets.NewString("fail"),
+			},
+			err: true,
+		},
+		{
+			name: "adding admin fails",
+			want: memberships{
+				super: sets.NewString("fail"),
+			},
+			err: true,
+		},
+		{
+			name: "adding member fails",
+			want: memberships{
+				members: sets.NewString("fail"),
+			},
+			err: true,
+		},
+		{
+			name: "promote to admin",
+			have: memberships{
+				members: sets.NewString("promote"),
+			},
+			want: memberships{
+				super: sets.NewString("promote"),
+			},
+			supers: sets.NewString("promote"),
+		},
+		{
+			name: "downgrade to member",
+			have: memberships{
+				super: sets.NewString("downgrade"),
+			},
+			want: memberships{
+				members: sets.NewString("downgrade"),
+			},
+			members: sets.NewString("downgrade"),
+		},
+		{
+			name: "some of everything",
+			have: memberships{
+				super:   sets.NewString("keep-admin", "drop-admin"),
+				members: sets.NewString("keep-member", "drop-member"),
+			},
+			want: memberships{
+				members: sets.NewString("keep-member", "new-member"),
+				super:   sets.NewString("keep-admin", "new-admin"),
+			},
+			remove:  sets.NewString("drop-admin", "drop-member"),
+			members: sets.NewString("new-member"),
+			supers:  sets.NewString("new-admin"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			removed := sets.String{}
+			members := sets.String{}
+			supers := sets.String{}
+			adder := func(user string, super bool) error {
+				if user == "fail" {
+					return fmt.Errorf("injected adder failure for %s", user)
+				}
+				if super {
+					supers.Insert(user)
+				} else {
+					members.Insert(user)
+				}
+				return nil
+			}
+
+			remover := func(user string) error {
+				if user == "fail" {
+					return fmt.Errorf("injected remover failure for %s", user)
+				}
+				removed.Insert(user)
+				return nil
+			}
+
+			err := configureMembers(tc.have, tc.want, adder, remover)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("Failed to receive error")
+			default:
+				if err := cmpLists(tc.remove.List(), removed.List()); err != nil {
+					t.Errorf("Wrong users removed: %v", err)
+				} else if err := cmpLists(tc.members.List(), members.List()); err != nil {
+					t.Errorf("Wrong members added: %v", err)
+				} else if err := cmpLists(tc.supers.List(), supers.List()); err != nil {
+					t.Errorf("Wrong supers added: %v", err)
+				}
+			}
+		})
+	}
 }
 
 func TestConfigureOrgMembers(t *testing.T) {
@@ -262,12 +448,13 @@ func TestConfigureOrgMembers(t *testing.T) {
 			config: org.Config{},
 			opt: options{
 				maximumDelta: 1,
+				requireSelf:  false,
 			},
 			admins: []string{"me"},
 			remove: []string{"me"},
 		},
 		{
-			name: "forgot to remove duplicate entry",
+			name: "reject same person with both roles",
 			config: org.Config{
 				Admins:  []string{"me"},
 				Members: []string{"me"},
@@ -275,39 +462,64 @@ func TestConfigureOrgMembers(t *testing.T) {
 			err: true,
 		},
 		{
-			name:   "removal fails",
+			name:   "github remove rpc fails",
 			admins: []string{"fail"},
 			err:    true,
 		},
 		{
-			name: "adding admin fails",
+			name: "github add rpc fails",
 			config: org.Config{
 				Admins: []string{"fail"},
 			},
 			err: true,
 		},
 		{
-			name: "adding member fails",
+			name: "require team member to be org member",
 			config: org.Config{
-				Members: []string{"fail"},
+				Teams: map[string]org.Team{
+					"group": {
+						Members: []string{"non-member"},
+					},
+				},
 			},
 			err: true,
 		},
 		{
-			name: "promote to admin",
+			name: "require team maintainer to be org member",
 			config: org.Config{
-				Admins: []string{"promote"},
+				Teams: map[string]org.Team{
+					"group": {
+						Maintainers: []string{"non-member"},
+					},
+				},
 			},
-			members:   []string{"promote"},
-			addAdmins: []string{"promote"},
+			err: true,
 		},
 		{
-			name: "downgrade to member",
+			name: "disallow duplicate names",
 			config: org.Config{
-				Members: []string{"downgrade"},
+				Teams: map[string]org.Team{
+					"duplicate": {},
+					"other": {
+						Previously: []string{"duplicate"},
+					},
+				},
 			},
-			admins:     []string{"downgrade"},
-			addMembers: []string{"downgrade"},
+			err: true,
+		},
+		{
+			name: "disallow duplicate names (single team)",
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"foo": {
+						Previously: []string{"foo"},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "trival case works",
 		},
 		{
 			name: "some of everything",
@@ -335,7 +547,7 @@ func TestConfigureOrgMembers(t *testing.T) {
 				newAdmins:  sets.String{},
 				newMembers: sets.String{},
 			}
-			err := configureOrgMembers(tc.opt, fc, "random-org", tc.config)
+			err := configureOrgMembers(tc.opt, fc, fakeOrg, tc.config)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -352,6 +564,510 @@ func TestConfigureOrgMembers(t *testing.T) {
 					t.Errorf("Wrong admins added: %v", err)
 				}
 			}
+		})
+	}
+}
+
+type fakeTeamClient struct {
+	teams map[int]github.Team
+	max   int
+}
+
+func makeFakeTeamClient(teams ...github.Team) *fakeTeamClient {
+	fc := fakeTeamClient{
+		teams: map[int]github.Team{},
+	}
+	for _, t := range teams {
+		fc.teams[t.ID] = t
+		if t.ID >= fc.max {
+			fc.max = t.ID + 1
+		}
+	}
+	return &fc
+}
+
+const fakeOrg = "random-org"
+
+func (c *fakeTeamClient) CreateTeam(org string, team github.Team) (*github.Team, error) {
+	if org != fakeOrg {
+		return nil, fmt.Errorf("org must be %s, not %s", fakeOrg, org)
+	}
+	if team.Name == "fail" {
+		return nil, errors.New("injected CreateTeam error")
+	}
+	c.max++
+	team.ID = c.max
+	c.teams[team.ID] = team
+	return &team, nil
+
+}
+
+func (c *fakeTeamClient) ListTeams(name string) ([]github.Team, error) {
+	if name == "fail" {
+		return nil, errors.New("injected ListTeams error")
+	}
+	var teams []github.Team
+	for _, t := range c.teams {
+		teams = append(teams, t)
+	}
+	return teams, nil
+}
+
+func (c *fakeTeamClient) DeleteTeam(id int) error {
+	switch _, ok := c.teams[id]; {
+	case !ok:
+		return fmt.Errorf("not found %d", id)
+	case id < 0:
+		return errors.New("injected DeleteTeam error")
+	}
+	delete(c.teams, id)
+	return nil
+}
+
+func (c *fakeTeamClient) EditTeam(team github.Team) (*github.Team, error) {
+	id := team.ID
+	t, ok := c.teams[id]
+	if !ok {
+		return nil, fmt.Errorf("team %d does not exist", id)
+	}
+	switch {
+	case team.Description == "fail":
+		return nil, errors.New("injected description failure")
+	case team.Name == "fail":
+		return nil, errors.New("injected name failure")
+	case team.Privacy == "fail":
+		return nil, errors.New("injected privacy failure")
+	}
+	if team.Description != "" {
+		t.Description = team.Description
+	}
+	if team.Name != "" {
+		t.Name = team.Name
+	}
+	if team.Privacy != "" {
+		t.Privacy = team.Privacy
+	}
+	c.teams[id] = t
+	return &t, nil
+}
+
+func TestFindTeam(t *testing.T) {
+	cases := []struct {
+		name     string
+		teams    map[string]github.Team
+		current  string
+		previous []string
+		expected int
+	}{
+		{
+			name: "will find current team",
+			teams: map[string]github.Team{
+				"hello": {ID: 17},
+			},
+			current:  "hello",
+			expected: 17,
+		},
+		{
+			name: "team does not exist returns nil",
+			teams: map[string]github.Team{
+				"unrelated": {ID: 5},
+			},
+			current: "hypothetical",
+		},
+		{
+			name: "will find previous name",
+			teams: map[string]github.Team{
+				"deprecated name": {ID: 1},
+			},
+			current:  "current name",
+			previous: []string{"archaic name", "deprecated name"},
+			expected: 1,
+		},
+		{
+			name: "prioritize current when previous also exists",
+			teams: map[string]github.Team{
+				"deprecated": {ID: 1},
+				"current":    {ID: 2},
+			},
+			current:  "current",
+			previous: []string{"deprecated"},
+			expected: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := findTeam(tc.teams, tc.current, tc.previous...)
+			switch {
+			case actual == nil:
+				if tc.expected != 0 {
+					t.Errorf("failed to find team %d", tc.expected)
+				}
+			case tc.expected == 0:
+				t.Errorf("unexpected team returned: %v", *actual)
+			case actual.ID != tc.expected:
+				t.Errorf("team %v != expected ID %d", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestConfigureTeams(t *testing.T) {
+	desc := "so interesting"
+	priv := org.Secret
+	cases := []struct {
+		name            string
+		err             bool
+		orgNameOverride string
+		config          org.Config
+		teams           []github.Team
+		expected        map[string]github.Team
+		deleted         []int
+	}{
+		{
+			name: "do nothing without error",
+		},
+		{
+			name: "reject duplicated team names (different teams)",
+			err:  true,
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"hello": {},
+					"there": {Previously: []string{"hello"}},
+				},
+			},
+		},
+		{
+			name: "reject duplicated team names (single team)",
+			err:  true,
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"hello": {Previously: []string{"hello"}},
+				},
+			},
+		},
+		{
+			name:            "fail to list teams",
+			orgNameOverride: "fail",
+			err:             true,
+		},
+		{
+			name: "fail to create team",
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"fail": {},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "fail to delete team",
+			teams: []github.Team{
+				{Name: "fail", ID: -55},
+			},
+			err: true,
+		},
+		{
+			name: "create missing team",
+			teams: []github.Team{
+				{Name: "old", ID: 1},
+			},
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"new": {},
+					"old": {},
+				},
+			},
+			expected: map[string]github.Team{
+				"old": {Name: "old", ID: 1},
+				"new": {Name: "new", ID: 3},
+			},
+		},
+		{
+			name: "reuse existing teams",
+			teams: []github.Team{
+				{Name: "current", ID: 1},
+				{Name: "deprecated", ID: 5},
+			},
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"current": {},
+					"updated": {Previously: []string{"deprecated"}},
+				},
+			},
+			expected: map[string]github.Team{
+				"current": {Name: "current", ID: 1},
+				"updated": {Name: "deprecated", ID: 5},
+			},
+		},
+		{
+			name: "delete unused teams",
+			teams: []github.Team{
+				{
+					Name: "unused",
+					ID:   1,
+				},
+				{
+					Name: "used",
+					ID:   2,
+				},
+			},
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"used": {},
+				},
+			},
+			expected: map[string]github.Team{
+				"used": {ID: 2, Name: "used"},
+			},
+			deleted: []int{1},
+		},
+		{
+			name: "create team with metadata",
+			config: org.Config{
+				Teams: map[string]org.Team{
+					"new": {
+						TeamMetadata: org.TeamMetadata{
+							Description: &desc,
+							Privacy:     &priv,
+						},
+					},
+				},
+			},
+			expected: map[string]github.Team{
+				"new": {ID: 1, Name: "new", Description: desc, Privacy: string(priv)},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := makeFakeTeamClient(tc.teams...)
+			orgName := tc.orgNameOverride
+			if orgName == "" {
+				orgName = fakeOrg
+			}
+			if tc.expected == nil {
+				tc.expected = map[string]github.Team{}
+			}
+			actual, err := configureTeams(fc, orgName, tc.config)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("failed to receive error")
+			case !reflect.DeepEqual(actual, tc.expected):
+				t.Errorf("%#v != actual %#v", tc.expected, actual)
+			}
+			for _, id := range tc.deleted {
+				if team, ok := fc.teams[id]; ok {
+					t.Errorf("%d still present: %#v", id, team)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigureTeam(t *testing.T) {
+	old := "old value"
+	cur := "current value"
+	fail := "fail"
+	pfail := org.Privacy(fail)
+	whatev := "whatever"
+	secret := org.Secret
+	cases := []struct {
+		name     string
+		err      bool
+		teamName string
+		config   org.Team
+		github   github.Team
+		expected github.Team
+	}{
+		{
+			name:     "patch team when name changes",
+			teamName: cur,
+			config: org.Team{
+				Previously: []string{old},
+			},
+			github: github.Team{
+				ID:   1,
+				Name: old,
+			},
+			expected: github.Team{
+				ID:   1,
+				Name: cur,
+			},
+		},
+		{
+			name:     "patch team when description changes",
+			teamName: whatev,
+			config: org.Team{
+				TeamMetadata: org.TeamMetadata{
+					Description: &cur,
+				},
+			},
+			github: github.Team{
+				ID:          2,
+				Name:        whatev,
+				Description: old,
+			},
+			expected: github.Team{
+				ID:          2,
+				Name:        whatev,
+				Description: cur,
+			},
+		},
+		{
+			name:     "patch team when privacy changes",
+			teamName: whatev,
+			config: org.Team{
+				TeamMetadata: org.TeamMetadata{
+					Privacy: &secret,
+				},
+			},
+			github: github.Team{
+				ID:      3,
+				Name:    whatev,
+				Privacy: string(org.Closed),
+			},
+			expected: github.Team{
+				ID:      3,
+				Name:    whatev,
+				Privacy: string(secret),
+			},
+		},
+		{
+			name:     "do not patch team when values are the same",
+			teamName: fail,
+			config: org.Team{
+				TeamMetadata: org.TeamMetadata{
+					Description: &fail,
+					Privacy:     &pfail,
+				},
+			},
+			github: github.Team{
+				ID:          4,
+				Name:        fail,
+				Description: fail,
+				Privacy:     fail,
+			},
+			expected: github.Team{
+				ID:          4,
+				Name:        fail,
+				Description: fail,
+				Privacy:     fail,
+			},
+		},
+		{
+			name:     "fail to patch team",
+			teamName: "team",
+			config: org.Team{
+				TeamMetadata: org.TeamMetadata{
+					Description: &fail,
+				},
+			},
+			github: github.Team{
+				ID:          1,
+				Name:        "team",
+				Description: whatev,
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := makeFakeTeamClient(tc.github)
+			err := configureTeam(fc, fakeOrg, tc.teamName, tc.config, tc.github)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("failed to receive expected error")
+			case !reflect.DeepEqual(fc.teams[tc.expected.ID], tc.expected):
+				t.Errorf("actual %v != expected %v", fc.teams[tc.expected.ID], tc.expected)
+			}
+		})
+	}
+}
+
+func TestConfigureTeamMembers(t *testing.T) {
+	cases := []struct {
+		name           string
+		err            bool
+		members        sets.String
+		maintainers    sets.String
+		remove         sets.String
+		addMembers     sets.String
+		addMaintainers sets.String
+		team           org.Team
+		id             int
+	}{
+		{
+			name: "fail when listing fails",
+			id:   teamID ^ 0xff,
+			err:  true,
+		},
+		{
+			name:    "fail when removal fails",
+			members: sets.NewString("fail"),
+			err:     true,
+		},
+		{
+			name: "fail when add fails",
+			team: org.Team{
+				Maintainers: []string{"fail"},
+			},
+			err: true,
+		},
+		{
+			name: "some of everything",
+			team: org.Team{
+				Maintainers: []string{"keep-maintainer", "new-maintainer"},
+				Members:     []string{"keep-member", "new-member"},
+			},
+			maintainers:    sets.NewString("keep-maintainer", "drop-maintainer"),
+			members:        sets.NewString("keep-member", "drop-member"),
+			remove:         sets.NewString("drop-maintainer", "drop-member"),
+			addMembers:     sets.NewString("new-member"),
+			addMaintainers: sets.NewString("new-maintainer"),
+		},
+	}
+
+	for _, tc := range cases {
+		if tc.id == 0 {
+			tc.id = teamID
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				admins:     sets.StringKeySet(tc.maintainers),
+				members:    sets.StringKeySet(tc.members),
+				removed:    sets.String{},
+				newAdmins:  sets.String{},
+				newMembers: sets.String{},
+			}
+			err := configureTeamMembers(fc, tc.id, tc.team)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("Failed to receive error")
+			default:
+				if err := cmpLists(tc.remove.List(), fc.removed.List()); err != nil {
+					t.Errorf("Wrong users removed: %v", err)
+				} else if err := cmpLists(tc.addMembers.List(), fc.newMembers.List()); err != nil {
+					t.Errorf("Wrong members added: %v", err)
+				} else if err := cmpLists(tc.addMaintainers.List(), fc.newAdmins.List()); err != nil {
+					t.Errorf("Wrong admins added: %v", err)
+				}
+			}
+
 		})
 	}
 }

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -48,7 +48,6 @@ type Config struct {
 //
 // See https://developer.github.com/v3/teams/#edit-team
 type TeamMetadata struct {
-	Name        string   `json:"name,omitempty"`
 	Description *string  `json:"description,omitempty"`
 	Privacy     *Privacy `json:"privacy,omitempty"`
 }

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -274,7 +274,10 @@ func (f *FakeClient) GetFile(org, repo, file, commit string) ([]byte, error) {
 }
 
 // ListTeamMembers return a fake team with a single "sig-lead" Github teammember
-func (f *FakeClient) ListTeamMembers(teamID int) ([]github.TeamMember, error) {
+func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]github.TeamMember, error) {
+	if role != github.RoleAll {
+		return nil, fmt.Errorf("unsupport role %v (only all supported)", role)
+	}
 	return []github.TeamMember{{Login: "sig-lead"}}, nil
 }
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -530,8 +530,10 @@ type Content struct {
 
 // Team is a github organizational team
 type Team struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID          int    `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Privacy     string `json:"privacy,omitempty"`
 }
 
 // TeamMember is a member of an organizational team
@@ -540,24 +542,36 @@ type TeamMember struct {
 }
 
 const (
-	// List members and admins
+	// RoleAll lists both members and admins
 	RoleAll = "all"
-	// User is an admin, or list admins
+	// RoleAdmin specifies the user is an org admin, or lists only admins
 	RoleAdmin = "admin"
-	// User is a regular member, or list members
+	// RoleMaintainer specifies the user is a team maintainer, or lists only maintainers
+	RoleMaintainer = "maintainer"
+	// RoleMember specifies the user is a regular user, or only lists regular users
 	RoleMember = "member"
-	// User has a pending invitation to the org
+	// StatePending specifies the user has an invitation to the org/team.
 	StatePending = "pending"
-	// User accepted the invitation, is in the org
+	// StateActive specifies the user's membership is active.
 	StateActive = "active"
 )
 
-// OrgMembership specifies the org membership details
-type OrgMembership struct {
+// Membership specifies the role and state details for an org and/or team.
+type Membership struct {
 	// admin or member
 	Role string `json:"role"`
 	// pending or active
 	State string `json:"state,omitempty"`
+}
+
+// OrgMembership contains Membership fields for user membership in an org.
+type OrgMembership struct {
+	Membership
+}
+
+// TeamMembership contains Membership fields for user membership on a team.
+type TeamMembership struct {
+	Membership
 }
 
 type GenericCommentEventAction string

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -44,7 +44,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	ClearMilestone(org, repo string, num int) error
 	SetMilestone(org, repo string, issueNum, milestoneNum int) error
-	ListTeamMembers(id int) ([]github.TeamMember, error)
+	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
 	ListMilestones(org, repo string) ([]github.Milestone, error)
 }
 
@@ -90,7 +90,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, m
 	org := e.Repo.Owner.Login
 	repo := e.Repo.Name
 
-	milestoneMaintainers, err := gc.ListTeamMembers(maintainersID)
+	milestoneMaintainers, err := gc.ListTeamMembers(maintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -45,7 +45,7 @@ var (
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	AddLabel(owner, repo string, number int, label string) error
-	ListTeamMembers(id int) ([]github.TeamMember, error)
+	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
 }
 
 func init() {
@@ -86,7 +86,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, m
 	org := e.Repo.Owner.Login
 	repo := e.Repo.Name
 
-	milestoneMaintainers, err := gc.ListTeamMembers(maintainersID)
+	milestoneMaintainers, err := gc.ListTeamMembers(maintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
/assign @BenTheElder @cblecker @stevekuznetsov 
/cc @bgrant0607 

* Update prow's github client to:
  - create/edit teams
  - support a `role` filter on `ListTeamMembers`
  - Update and remove people from a team
* Update peribolos to:
  - Ensure that all team memberships are org members
  - Create teams that do not yet exist, edit existing teams with different metadata
  - Add/remove people from teams and/or update their role.
  - Slightly refactor the member management into a generic library that org and team membership both uses
* Unit tests

Still need to do a bunch of stuff:
* Add a flag (and code) to dump the current org configuration
* Remove the aborts which prevent this code from actually running
* Test things out on a dummy org (and fix whatever doesn't work)

Continuation of https://github.com/kubernetes/test-infra/pull/8187
See also design: https://docs.google.com/document/d/18Kw8InxYk4OF14iTXXfvD2oy3AuoDxfqAmtvf6NbwBI/edit