### PR TITLE
Increase the timeout of ci-kubernetes-e2e-gke-staging-default-serial

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6876,7 +6876,7 @@
       "--gke-environment=prod",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=600m"
+      "--timeout=800m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7592,7 +7592,7 @@
       "--gke-environment=staging",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=600m"
+      "--timeout=800m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13068,7 +13068,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 
@@ -13527,7 +13527,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=620
+      - --timeout=820
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 


### PR DESCRIPTION
It has timed out a lot recently: https://k8s-testgrid.appspot.com/google-gke-staging#gke-staging-default-serial