### PR TITLE
Enable help plugin for service catalog

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -360,6 +360,7 @@ plugins:
   kubernetes-incubator/service-catalog:
   - cat
   - dog
+  - help
 
   kubernetes-sigs:
   - assign


### PR DESCRIPTION
We want to be able to use /help and /good-first-issue properly. 💖

/area prow