### PR TITLE
add blunderbuss and wip plugins to service-catalog repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -361,6 +361,8 @@ plugins:
   - cat
   - dog
   - help
+  - blunderbuss
+  - wip
 
   kubernetes-sigs:
   - assign


### PR DESCRIPTION
blunderbuss seems useful to automatically tag people to review
wip seems useful to automatically tag wip PRs with a label