### PR TITLE
prow: add stage plugin

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//prow/plugins/size:go_default_library",
         "//prow/plugins/skip:go_default_library",
         "//prow/plugins/slackevents:go_default_library",
+        "//prow/plugins/stage:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "//prow/plugins/updateconfig:go_default_library",
         "//prow/plugins/wip:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -45,6 +45,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/size"
 	_ "k8s.io/test-infra/prow/plugins/skip"
 	_ "k8s.io/test-infra/prow/plugins/slackevents"
+	_ "k8s.io/test-infra/prow/plugins/stage"
 	_ "k8s.io/test-infra/prow/plugins/trigger"
 	_ "k8s.io/test-infra/prow/plugins/updateconfig"
 	_ "k8s.io/test-infra/prow/plugins/wip"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -74,6 +74,7 @@ filegroup(
         "//prow/plugins/size:all-srcs",
         "//prow/plugins/skip:all-srcs",
         "//prow/plugins/slackevents:all-srcs",
+        "//prow/plugins/stage:all-srcs",
         "//prow/plugins/trigger:all-srcs",
         "//prow/plugins/updateconfig:all-srcs",
         "//prow/plugins/wip:all-srcs",

--- a/prow/plugins/stage/BUILD.bazel
+++ b/prow/plugins/stage/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["stage.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/stage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["stage_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/stage/stage.go
+++ b/prow/plugins/stage/stage.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package stage defines a Prow plugin that defines the stage of
+// the issue in the features process. Eg: alpha, beta, stable.
+package stage
+
+import (
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+var (
+	stageAlpha  = "stage/alpha"
+	stageBeta   = "stage/beta"
+	stageStable = "stage/stable"
+	stageLabels = []string{stageAlpha, stageBeta, stageStable}
+	stageRe     = regexp.MustCompile(`(?mi)^/(remove-)?stage (alpha|beta|stable)\s*$`)
+)
+
+func init() {
+	plugins.RegisterGenericCommentHandler("stage", stageHandleGenericComment, help)
+}
+
+func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The Config field is omitted because this plugin is not configurable.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "Label the stage of an issue as alpha/beta/stable",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/[remove-]stage <alpha|beta|stable>",
+		Description: "Labels the stage of an issue as alpha/beta/stable",
+		Featured:    false,
+		WhoCanUse:   "Anyone can trigger this command.",
+		Examples:    []string{"/stage alpha", "/remove-stage alpha"},
+	})
+	return pluginHelp, nil
+}
+
+type stageClient interface {
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+func stageHandleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, &e)
+}
+
+func handle(gc stageClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+	// Only consider new comments.
+	if e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	for _, mat := range stageRe.FindAllStringSubmatch(e.Body, -1) {
+		if err := handleOne(gc, log, e, mat); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func handleOne(gc stageClient, log *logrus.Entry, e *github.GenericCommentEvent, mat []string) error {
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+
+	remove := mat[1] != ""
+	cmd := mat[2]
+	lbl := "stage/" + cmd
+
+	// Let's start simple and allow anyone to add/remove alpha, beta and stable labels.
+	// Adjust if we find evidence of the community abusing these labels.
+	labels, err := gc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get labels.")
+	}
+
+	// If the label exists and we asked for it to be removed, remove it.
+	if github.HasLabel(lbl, labels) && remove {
+		return gc.RemoveLabel(org, repo, number, lbl)
+	}
+
+	// If the label does not exist and we asked for it to be added,
+	// remove other existing stage labels and add it.
+	if !github.HasLabel(lbl, labels) && !remove {
+		for _, label := range stageLabels {
+			if label != lbl && github.HasLabel(label, labels) {
+				if err := gc.RemoveLabel(org, repo, number, label); err != nil {
+					log.WithError(err).Errorf("Github failed to remove the following label: %s", label)
+				}
+			}
+		}
+
+		if err := gc.AddLabel(org, repo, number, lbl); err != nil {
+			log.WithError(err).Errorf("Github failed to add the following label: %s", lbl)
+		}
+	}
+
+	return nil
+}

--- a/prow/plugins/stage/stage_test.go
+++ b/prow/plugins/stage/stage_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+type fakeClient struct {
+	// current labels
+	labels []string
+	// labels that are added
+	added []string
+	// labels that are removed
+	removed []string
+}
+
+func (c *fakeClient) AddLabel(owner, repo string, number int, label string) error {
+	c.added = append(c.added, label)
+	c.labels = append(c.labels, label)
+	return nil
+}
+
+func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string) error {
+	c.removed = append(c.removed, label)
+
+	// remove from existing labels
+	for k, v := range c.labels {
+		if label == v {
+			c.labels = append(c.labels[:k], c.labels[k+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
+func (c *fakeClient) GetIssueLabels(owner, repo string, number int) ([]github.Label, error) {
+	la := []github.Label{}
+	for _, l := range c.labels {
+		la = append(la, github.Label{Name: l})
+	}
+	return la, nil
+}
+
+func TestStageLabels(t *testing.T) {
+	var testcases = []struct {
+		name    string
+		body    string
+		added   []string
+		removed []string
+		labels  []string
+	}{
+		{
+			name:    "random command -> no-op",
+			body:    "/random-command",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "remove stage but don't specify state -> no-op",
+			body:    "/remove-stage",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add stage but don't specify state -> no-op",
+			body:    "/stage",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add stage random -> no-op",
+			body:    "/stage random",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "remove stage random -> no-op",
+			body:    "/remove-stage random",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add alpha and beta with single command -> no-op",
+			body:    "/stage alpha beta",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add alpha and random with single command -> no-op",
+			body:    "/stage alpha random",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add alpha, don't have it -> alpha added",
+			body:    "/stage alpha",
+			added:   []string{stageAlpha},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add beta, don't have it -> beta added",
+			body:    "/stage beta",
+			added:   []string{stageBeta},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "add stable, don't have it -> stable added",
+			body:    "/stage stable",
+			added:   []string{stageStable},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
+			name:    "remove alpha, have it -> alpha removed",
+			body:    "/remove-stage alpha",
+			added:   []string{},
+			removed: []string{stageAlpha},
+			labels:  []string{stageAlpha},
+		},
+		{
+			name:    "remove beta, have it -> beta removed",
+			body:    "/remove-stage beta",
+			added:   []string{},
+			removed: []string{stageBeta},
+			labels:  []string{stageBeta},
+		},
+		{
+			name:    "remove stable, have it -> stable removed",
+			body:    "/remove-stage stable",
+			added:   []string{},
+			removed: []string{stageStable},
+			labels:  []string{stageStable},
+		},
+		{
+			name:    "add alpha but have it -> no-op",
+			body:    "/stage alpha",
+			added:   []string{},
+			removed: []string{},
+			labels:  []string{stageAlpha},
+		},
+		{
+			name:    "add beta, have alpha -> beta added, alpha removed",
+			body:    "/stage beta",
+			added:   []string{stageBeta},
+			removed: []string{stageAlpha},
+			labels:  []string{stageAlpha},
+		},
+		{
+			name:    "add stable, have beta -> stable added, beta removed",
+			body:    "/stage stable",
+			added:   []string{stageStable},
+			removed: []string{stageBeta},
+			labels:  []string{stageBeta},
+		},
+		{
+			name:    "add stable, have alpha and beta -> stable added, alpha and beta removed",
+			body:    "/stage stable",
+			added:   []string{stageStable},
+			removed: []string{stageAlpha, stageBeta},
+			labels:  []string{stageAlpha, stageBeta},
+		},
+		{
+			name:    "remove alpha, then remove beta and then add stable -> alpha and beta removed, stable added",
+			body:    "/remove-stage alpha\n/remove-stage beta\n/stage stable",
+			added:   []string{stageStable},
+			removed: []string{stageAlpha, stageBeta},
+			labels:  []string{stageAlpha, stageBeta},
+		},
+	}
+	for _, tc := range testcases {
+		fc := &fakeClient{
+			labels:  tc.labels,
+			added:   []string{},
+			removed: []string{},
+		}
+		e := &github.GenericCommentEvent{
+			Body:   tc.body,
+			Action: github.GenericCommentActionCreated,
+		}
+		err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+		switch {
+		case err != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		case !reflect.DeepEqual(tc.added, fc.added):
+			t.Errorf("%s: added %v != actual %v", tc.name, tc.added, fc.added)
+		case !reflect.DeepEqual(tc.removed, fc.removed):
+			t.Errorf("%s: removed %v != actual %v", tc.name, tc.removed, fc.removed)
+		}
+	}
+}


### PR DESCRIPTION
starts work for #8315 

The stage plugin applies the `stage/alpha`, `stage/beta`, `stage/stable` labels to issues in the kubernetes/features repo.

Since all the stage labels are mutually exclusive, only one stage label is allowed to persist at a time. If one stage label is applied, other stage labels are removed (similar to the lifeycle label).

This PR:
- adds the `stage/*` labels in `label_sync/labels.yaml`.
- adds the automation for the stage label and enables it for the k/features repo.
- updates instructions for generation of labels-related docs.

EDIT: see https://github.com/kubernetes/test-infra/pull/8335#issuecomment-396716569 for how the PR is split

/cc fejta BenTheElder cblecker 