### PR TITLE
A couple changes to gpu upgrade test configs:

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2961,7 +2961,7 @@
       "sig-cli"
     ]
   },
-  "ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade": {
+  "ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
@@ -2973,16 +2973,37 @@
       "--gcp-project-type=gpu-project",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
       "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUClusterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade": {
+  "ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-beta",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUMasterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
@@ -2994,13 +3015,34 @@
       "--gcp-project-type=gpu-project",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
       "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUClusterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/latest",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUMasterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gpu-stable1": {
@@ -3019,7 +3061,7 @@
       "sig-scheduling"
     ]
   },
-  "ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade": {
+  "ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
@@ -3031,16 +3073,37 @@
       "--gcp-project-type=gpu-project",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
       "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUClusterUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade": {
+  "ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-beta",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUMasterUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
@@ -3052,13 +3115,34 @@
       "--gcp-project-type=gpu-project",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
       "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/latest",
+      "--extract=ci/k8s-stable1",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUMasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gpu-stable2": {
@@ -3078,7 +3162,7 @@
       "sig-scheduling"
     ]
   },
-  "ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade": {
+  "ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade": {
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
@@ -3090,13 +3174,34 @@
       "--gcp-project-type=gpu-project",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.focus=\\[Feature:GPUUpgrade\\]",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
       "--timeout=150m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUClusterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-gcp"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env",
+      "--extract=ci/k8s-stable1",
+      "--extract=ci/k8s-stable2",
+      "--gcp-node-image=gci",
+      "--gcp-project-type=gpu-project",
+      "--gcp-zone=us-west1-b",
+      "--provider=gce",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[.+\\]|Initializers|Dashboard",
+      "--timeout=150m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:GPUMasterUpgrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-ha-master": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10502,7 +10502,7 @@ periodics:
 
 - interval: 12h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+  name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -10515,7 +10515,33 @@ periodics:
 
 - interval: 12h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+  name: ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -10541,7 +10567,7 @@ periodics:
 
 - interval: 12h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+  name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -10554,7 +10580,33 @@ periodics:
 
 - interval: 12h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+  name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -10580,7 +10632,20 @@ periodics:
 
 - interval: 12h
   agent: kubernetes
-  name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+  name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=180
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
+
+- interval: 12h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2368,16 +2368,26 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
 - name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
-- name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
-- name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
-- name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
-- name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
-- name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
+- name: ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade
+- name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
+- name: ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade
+- name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
 - name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
 - name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
@@ -4050,16 +4060,26 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
   - name: gce-1.9-1.10-upgrade-cluster-new
     test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
-  - name: gce-1.9-1.10-upgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
-  - name: gce-1.10-1.11-upgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
-  - name: gce-1.10-master-upgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
-  - name: gce-1.11-1.10-downgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
-  - name: gce-master-1.10-downgrade-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+  - name: gce-1.9-1.10-upgrade-master-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
+  - name: gce-1.9-1.10-upgrade-cluster-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
+  - name: gce-1.10-1.11-upgrade-master-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
+  - name: gce-1.10-1.11-upgrade-cluster-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
+  - name: gce-1.10-master-upgrade-master-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
+  - name: gce-1.10-master-upgrade-cluster-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
+  - name: gce-1.11-1.10-downgrade-master-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade
+  - name: gce-1.11-1.10-downgrade-cluster-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
+  - name: gce-master-1.10-downgrade-master-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade
+  - name: gce-master-1.10-downgrade-cluster-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
   - name: gce-1.10-1.9-downgrade-cluster
     test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster
   - name: gce-1.10-1.9-downgrade-cluster-parallel
@@ -4411,28 +4431,53 @@ dashboards:
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-1.9-1.10-gpu-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-upgrade
+  - name: gce-1.9-1.10-gpu-master-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-1.10-1.11-gpu-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-upgrade
+  - name: gce-1.9-1.10-gpu-cluster-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-1.10-master-gpu-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-upgrade
+  - name: gce-1.10-1.11-gpu-master-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-1.11-1.10-gpu-downgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-downgrade
+  - name: gce-1.10-1.11-gpu-cluster-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
-  - name: gce-master-1.10-gpu-downgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-downgrade
+  - name: gce-1.10-master-gpu-master-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.10-master-gpu-cluster-upgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.11-1.10-gpu-master-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-master-downgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-1.11-1.10-gpu-cluster-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-master-1.10-gpu-master-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-master-downgrade
+    base_options: 'exclude-filter-by-regex=^BeforeSuite$'
+    alert_options:
+      alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'
+  - name: gce-master-1.10-gpu-cluster-downgrade
+    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
     base_options: 'exclude-filter-by-regex=^BeforeSuite$'
     alert_options:
       alert_mail_to_addresses: 'gke-kubernetes-accelerators-bugs@google.com'


### PR DESCRIPTION
- Changes --test_args setting to skip all tests because any matching
tests there would be run after upgrade. Instead, the specified tests
in --upgrade_args --ginkgo.focus are the ones run during the upgrade.
- Separates GPUMasterUpgrade and GPUClusterUpgrade in separate test
configs to make sure they will not interfere with each other.