### PR TITLE
prow: enable stage plugin for k/features and k/sig-release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -240,6 +240,7 @@ plugins:
 
   kubernetes/features:
   - approve
+  - stage
 
   kubernetes/ingress-gce:
   - trigger
@@ -316,6 +317,7 @@ plugins:
 
   kubernetes/sig-release:
   - approve
+  - stage
 
   kubernetes/steering:
   - approve


### PR DESCRIPTION
Fixes #8315 
Follow up to https://github.com/kubernetes/test-infra/pull/8335

This enables the stage plugin for the k/features and k/sig-release repos.

/assign fejta cblecker 