### PR TITLE
Create canary job for e2e on GCE

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10117,6 +10117,23 @@
       "sig-aws"
     ]
   },
+  "ci-kubernetes-e2e-kops-gce-canary": {
+    "args": [
+      "--cluster=e2e-kops-gce-canary.k8s.local",
+      "--deployment=kops",
+      "--extract=ci/latest",
+      "--ginkgo-parallel=30",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
+      "--kops-zones=us-central1-c",
+      "--provider=gce",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-gce-channelalpha": {
     "args": [
       "--cluster=e2e-kops-gce-channelalpha.k8s.local",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15116,6 +15116,20 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-master
 
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-gce-canary
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-gce-channelalpha

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -258,6 +258,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-weave
 - name: ci-kubernetes-e2e-kops-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce
+- name: ci-kubernetes-e2e-kops-gce-canary
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-canary
 - name: ci-kubernetes-e2e-kops-gce-channelalpha
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-channelalpha
 - name: ci-kubernetes-e2e-kops-gce-ha
@@ -3295,6 +3297,8 @@ dashboards:
   dashboard_tab:
   - name: kops-gce
     test_group_name: ci-kubernetes-e2e-kops-gce
+  - name: kops-gce-canary
+    test_group_name: ci-kubernetes-e2e-kops-gce-canary
   - name: kops-gce-channelalpha
     test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
   - name: kops-gce-ha
@@ -6377,6 +6381,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
   - name: kops-gce
     test_group_name: ci-kubernetes-e2e-kops-gce
+  - name: kops-gce-canary
+    test_group_name: ci-kubernetes-e2e-kops-gce-canary
   - name: kops-gce-channelalpha
     test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
   - name: kops-gce-ha


### PR DESCRIPTION
We don't have canary coverage for it yet, and we want to test the upcoming ginkgo change.