### PR TITLE
prow: updateconfig: remove deprecated ConfigMap key updates

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -19,7 +19,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
- - *JUN 1, 2018* all unquoted `boolean` fields in config.yaml that were unmarshall
+ - *June 14, 2018* the `updateconfig` plugin will only add data to your `ConfigMaps`
+   using the basename of the updated file, instead of using that and also duplicating
+   the data using the name of the `ConfigMap` as a key
+ - *June 1, 2018* all unquoted `boolean` fields in config.yaml that were unmarshall
    into type `string` now need to be quoted to avoid unmarshalling error.
  - *May 9, 2018* `deck` logs for jobs run as `Pods` will now return logs for the
    `"test"` container only.

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -87,7 +87,6 @@ func update(gc githubClient, kc kubeClient, org, repo, commit, filename, name, n
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			name:                c,
 			path.Base(filename): c,
 		},
 	}

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -18,6 +18,7 @@ package updateconfig
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"testing"
 
@@ -252,10 +253,16 @@ func TestUpdateConfig(t *testing.T) {
 		}
 
 		for _, configName := range tc.configUpdates {
+			fileName := ""
+			for file, config := range m {
+				if config.Name == configName {
+					fileName = file
+				}
+			}
 			newConfigContent := fmt.Sprintf("new-%s", configName)
 			if config, ok := fkc.maps[configName]; !ok {
 				t.Fatalf("tc %s : Should have updated configmap for '%s'", tc.name, configName)
-			} else if config.Data[configName] != newConfigContent {
+			} else if config.Data[path.Base(fileName)] != newConfigContent {
 				t.Fatalf(
 					"tc %s : Expect get %s '%s', got '%s'",
 					tc.name,


### PR DESCRIPTION
ConfigMaps updated by the `updateconfig` plugin had their data
duplicated in two keys: the basename of the file used to populate the
ConfigMap and the name of the ConfigMap. It's always more clear to use
the latter key and the former was deprecated in February. We can safely
remove it now and add an announcement.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind feature
/cc @cjwagner @BenTheElder 
/assign @fejta 