### PR TITLE
prow: updateconfig: allow for custom keys in ConfigMaps

### DIFF
--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//prow/slack:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/test-infra/prow/commentpruner"
 	"k8s.io/test-infra/prow/config"
@@ -378,6 +380,9 @@ type Slack struct {
 type ConfigMapSpec struct {
 	// Name of ConfigMap
 	Name string `json:"name"`
+	// Key is the key in the ConfigMap to update with the file contents.
+	// If no explicit key is given, the basename of the file will be used.
+	Key string `json:"key,omitempty"`
 	// Namespace in which the configMap needs to be deployed. If no namespace is specified
 	// it will be deployed to the ProwJobNamespace.
 	Namespace string `json:"namespace,omitempty"`
@@ -504,6 +509,9 @@ func (pa *PluginAgent) Load(path string) error {
 	if err := validateBlunderbuss(&np.Blunderbuss); err != nil {
 		return err
 	}
+	if err := validateConfigUpdater(&np.ConfigUpdater); err != nil {
+		return err
+	}
 	// regexp compilation should run after defaulting
 	if err := compileRegexps(np); err != nil {
 		return err
@@ -597,6 +605,32 @@ func validateBlunderbuss(b *Blunderbuss) error {
 	}
 	if b.FileWeightCount != nil && *b.FileWeightCount < 1 {
 		return fmt.Errorf("invalid file_weight_count: %v (needs to be positive)", *b.FileWeightCount)
+	}
+	return nil
+}
+
+func validateConfigUpdater(updater *ConfigUpdater) error {
+	files := sets.NewString()
+	configMapKeys := map[string]sets.String{}
+	for file, config := range updater.Maps {
+		if files.Has(file) {
+			return fmt.Errorf("file %s listed more than once in config updater config", file)
+		}
+		files.Insert(file)
+
+		key := config.Key
+		if key == "" {
+			key = path.Base(file)
+		}
+
+		if _, ok := configMapKeys[config.Name]; ok {
+			if configMapKeys[config.Name].Has(key) {
+				return fmt.Errorf("key %s in configmap %s updated with more than one file", key, config.Name)
+			}
+			configMapKeys[config.Name].Insert(key)
+		} else {
+			configMapKeys[config.Name] = sets.NewString(key)
+		}
 	}
 	return nil
 }

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -16,6 +16,8 @@ go_test(
         "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 

--- a/prow/plugins/updateconfig/README.md
+++ b/prow/plugins/updateconfig/README.md
@@ -12,7 +12,7 @@ plugins:
 
 config_updater:
   maps:
-    # Update the whatever configmap whenever thing changes
+    # Update the thing-config configmap whenever thing changes
     path/to/some/other/thing:
       name: thing-config
       # Using ProwJobNamespace by default.
@@ -25,4 +25,8 @@ config_updater:
     # Update the plugin configmap whenever plugins.yaml changes
     prow/plugins.yaml:
       name: plugin
+    # Update the `other` key in the `data` configmap whenver `data.yaml` changes
+    some/data.yaml:
+      name: data
+      key: other
 ```


### PR DESCRIPTION
prow: updateconfig: allow for custom keys in ConfigMaps

We now support updating specific keys in a `ConfigMap` and will do
incremental updates so as to not clobber data updated from other files.
This allows for one `ConfigMap` on the cluster to have data in its keys
updated from separate files on merge, as well as custom key values for
each file updated.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/area prow
/kind feature
/cc @cjwagner @BenTheElder 
/assign @fejta 


A more direct config would be easier but that would be a breaking change so I decided not to do that.