### PR TITLE
Allow job branch restrictions to be regex

### DIFF
--- a/prow/cmd/splice/main_test.go
+++ b/prow/cmd/splice/main_test.go
@@ -394,6 +394,9 @@ func TestNeededPresubmits(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		if err := config.SetPresubmitRegexes(tc.possible); err != nil {
+			t.Fatalf("could not set regexes: %v", err)
+		}
 		var names []string
 		for _, job := range neededPresubmits(tc.possible, tc.current, tc.refs, sets.String{}) {
 			names = append(names, job.Name)

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -429,6 +429,9 @@ func TestJobRequirements(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		if err := SetPresubmitRegexes(tc.config); err != nil {
+			t.Fatalf("could not set regexes: %v", err)
+		}
 		masterActual, masterOptional := jobRequirements(tc.config, "master", false)
 		if !reflect.DeepEqual(masterActual, tc.masterExpected) {
 			t.Errorf("branch: master - %s: actual %v != expected %v", tc.name, masterActual, tc.masterExpected)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -903,7 +903,7 @@ func ValidateController(c *Controller) error {
 	return nil
 }
 
-// SetPresubmitRegexes compiles and validates all the regural expressions for
+// SetPresubmitRegexes compiles and validates all the regular expressions for
 // the provided presubmits.
 func SetPresubmitRegexes(js []Presubmit) error {
 	for i, j := range js {
@@ -934,7 +934,7 @@ func SetPresubmitRegexes(js []Presubmit) error {
 	return nil
 }
 
-// setBrancherRegexes compiles and validates all the regural expressions for
+// setBrancherRegexes compiles and validates all the regular expressions for
 // the provided branch specifiers.
 func setBrancherRegexes(br Brancher) (Brancher, error) {
 	if len(br.Branches) > 0 {
@@ -954,7 +954,7 @@ func setBrancherRegexes(br Brancher) (Brancher, error) {
 	return br, nil
 }
 
-// SetPostsubmitRegexes compiles and validates all the regural expressions for
+// SetPostsubmitRegexes compiles and validates all the regular expressions for
 // the provided postsubmits.
 func SetPostsubmitRegexes(ps []Postsubmit) error {
 	for i, j := range ps {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -386,7 +386,7 @@ func TestConditionalPresubmits(t *testing.T) {
 			RunIfChanged: `(Makefile|\.sh|_(windows|linux|osx|unknown)(_test)?\.go)$`,
 		},
 	}
-	SetRegexes(presubmits)
+	SetPresubmitRegexes(presubmits)
 	ps := presubmits[0]
 	var testcases = []struct {
 		changes  []string
@@ -608,6 +608,10 @@ func TestRunAgainstBranch(t *testing.T) {
 		{
 			Name: "default",
 		},
+	}
+
+	if err := SetPresubmitRegexes(jobs); err != nil {
+		t.Fatalf("could not set regexes: %v", err)
 	}
 
 	for _, job := range jobs {

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -461,7 +461,7 @@ func (c *Controller) getBuildID(name string) (string, error) {
 
 // RunAfterSuccessCanRun returns whether a child job (specified as run_after_success in the
 // prow config) can run once its parent job succeeds. The only case we will not run a child job
-// is when it is a presubmit job and has a run_if_changed regural expression specified which does
+// is when it is a presubmit job and has a run_if_changed regular expression specified which does
 // not match the changed filenames in the pull request the job was meant to run for.
 // TODO: Collapse with plank, impossible to reuse as is due to the interfaces.
 func (c *Controller) RunAfterSuccessCanRun(parent, child *kube.ProwJob, ca configAgent, ghc githubClient) bool {

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -63,7 +63,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, operators []config.Jen
 			Name: "test-bazel-test",
 		},
 	}
-	if err := config.SetRegexes(presubmits); err != nil {
+	if err := config.SetPresubmitRegexes(presubmits); err != nil {
 		t.Fatal(err)
 	}
 	presubmitMap := map[string][]config.Presubmit{

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -521,7 +521,7 @@ func getPodBuildID(pod *kube.Pod) string {
 
 // RunAfterSuccessCanRun returns whether a child job (specified as run_after_success in the
 // prow config) can run once its parent job succeeds. The only case we will not run a child job
-// is when it is a presubmit job and has a run_if_changed regural expression specified which does
+// is when it is a presubmit job and has a run_if_changed regular expression specified which does
 // not match the changed filenames in the pull request the job was meant to run for.
 // TODO: Collapse with Jenkins, impossible to reuse as is due to the interfaces.
 func (c *Controller) RunAfterSuccessCanRun(parent, child *kube.ProwJob, ca configAgent, ghc githubClient) bool {

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -69,7 +69,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 			Name: "test-bazel-test",
 		},
 	}
-	if err := config.SetRegexes(presubmits); err != nil {
+	if err := config.SetPresubmitRegexes(presubmits); err != nil {
 		t.Fatal(err)
 	}
 	presubmitMap := map[string][]config.Presubmit{

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -255,7 +255,7 @@ func TestSkipStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Logf("running scenario %q", test.name)
-		if err := config.SetRegexes(test.presubmits); err != nil {
+		if err := config.SetPresubmitRegexes(test.presubmits); err != nil {
 			t.Fatal(err)
 		}
 

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -178,16 +178,18 @@ func TestHandleIssueComment(t *testing.T) {
 			Presubmits: map[string][]config.Presubmit{
 				"org/repo": {
 					{
-						Name:      "job",
-						AlwaysRun: false,
-						Context:   "pull-job",
-						Trigger:   `/test all`,
+						Name:         "job",
+						AlwaysRun:    false,
+						Context:      "pull-job",
+						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 					{
-						Name:      "jib",
-						AlwaysRun: false,
-						Context:   "pull-jib",
-						Trigger:   `/test jib`,
+						Name:         "jib",
+						AlwaysRun:    false,
+						Context:      "pull-jib",
+						Trigger:      `/test jib`,
+						RerunCommand: `/test jib`,
 					},
 				},
 			},
@@ -203,12 +205,13 @@ func TestHandleIssueComment(t *testing.T) {
 			Presubmits: map[string][]config.Presubmit{
 				"org/repo": {
 					{
-						Name:       "job",
-						AlwaysRun:  true,
-						SkipReport: true,
-						Context:    "pull-job",
-						Trigger:    `/test all`,
-						Brancher:   config.Brancher{Branches: []string{"master"}},
+						Name:         "job",
+						AlwaysRun:    true,
+						SkipReport:   true,
+						Context:      "pull-job",
+						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
+						Brancher:     config.Brancher{Branches: []string{"master"}},
 					},
 				},
 			},
@@ -227,6 +230,7 @@ func TestHandleIssueComment(t *testing.T) {
 						SkipReport:   true,
 						Context:      "pull-jab",
 						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 				},
 			},
@@ -246,6 +250,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED",
 						Context:      "pull-jib",
 						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 				},
 			},
@@ -265,6 +270,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED",
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
+						RerunCommand: `/test jub`,
 					},
 				},
 			},
@@ -284,6 +290,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED2",
 						Context:      "pull-jib",
 						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 				},
 			},
@@ -303,6 +310,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED",
 						Context:      "pull-jab",
 						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 				},
 			},
@@ -319,16 +327,18 @@ func TestHandleIssueComment(t *testing.T) {
 			Presubmits: map[string][]config.Presubmit{
 				"org/repo": {
 					{
-						Name:     "jab",
-						Brancher: config.Brancher{Branches: []string{"master"}},
-						Context:  "pull-jab",
-						Trigger:  `/test jab`,
+						Name:         "jab",
+						Brancher:     config.Brancher{Branches: []string{"master"}},
+						Context:      "pull-jab",
+						Trigger:      `/test jab`,
+						RerunCommand: `/test jab`,
 					},
 					{
-						Name:     "jab",
-						Brancher: config.Brancher{Branches: []string{"release"}},
-						Context:  "pull-jab",
-						Trigger:  `/test jab`,
+						Name:         "jab",
+						Brancher:     config.Brancher{Branches: []string{"release"}},
+						Context:      "pull-jab",
+						Trigger:      `/test jab`,
+						RerunCommand: `/test jab`,
 					},
 				},
 			},
@@ -345,16 +355,18 @@ func TestHandleIssueComment(t *testing.T) {
 			Presubmits: map[string][]config.Presubmit{
 				"org/repo": {
 					{
-						Name:     "jab",
-						Brancher: config.Brancher{Branches: []string{"master"}},
-						Context:  "pull-jab",
-						Trigger:  `/test jab`,
+						Name:         "jab",
+						Brancher:     config.Brancher{Branches: []string{"master"}},
+						Context:      "pull-jab",
+						Trigger:      `/test jab`,
+						RerunCommand: `/test jab`,
 					},
 					{
-						Name:     "jab",
-						Brancher: config.Brancher{Branches: []string{"release"}},
-						Context:  "pull-jab",
-						Trigger:  `/test jab`,
+						Name:         "jab",
+						Brancher:     config.Brancher{Branches: []string{"release"}},
+						Context:      "pull-jab",
+						Trigger:      `/test jab`,
+						RerunCommand: `/test jab`,
 					},
 				},
 			},
@@ -374,6 +386,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED2",
 						Context:      "pull-jeb",
 						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
 					},
 				},
 			},
@@ -393,6 +406,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED2",
 						Context:      "pull-jib",
 						Trigger:      `/test (all|pull-jeb)`,
+						RerunCommand: `/test pull-jeb`,
 					},
 				},
 			},
@@ -411,6 +425,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED",
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
+						RerunCommand: `/test jub`,
 					},
 				},
 			},
@@ -430,6 +445,7 @@ func TestHandleIssueComment(t *testing.T) {
 						RunIfChanged: "CHANGED2",
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
+						RerunCommand: `/test jub`,
 					},
 				},
 			},
@@ -483,22 +499,26 @@ func TestHandleIssueComment(t *testing.T) {
 			presubmits = map[string][]config.Presubmit{
 				"org/repo": {
 					{
-						Name:      "job",
-						AlwaysRun: true,
-						Context:   "pull-job",
-						Trigger:   `/test all`,
-						Brancher:  config.Brancher{Branches: []string{"master"}},
+						Name:         "job",
+						AlwaysRun:    true,
+						Context:      "pull-job",
+						Trigger:      `/test all`,
+						RerunCommand: `/test all`,
+						Brancher:     config.Brancher{Branches: []string{"master"}},
 					},
 					{
-						Name:      "jib",
-						AlwaysRun: false,
-						Context:   "pull-jib",
-						Trigger:   `/test jib`,
+						Name:         "jib",
+						AlwaysRun:    false,
+						Context:      "pull-jib",
+						Trigger:      `/test jib`,
+						RerunCommand: `/test jib`,
 					},
 				},
 			}
 		}
-		c.Config.SetPresubmits(presubmits)
+		if err := c.Config.SetPresubmits(presubmits); err != nil {
+			t.Fatalf("failed to set presubmits: %v", err)
+		}
 
 		var pr *struct{}
 		if tc.IsPR {

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -922,22 +922,26 @@ func TestTakeAction(t *testing.T) {
 	for _, tc := range testcases {
 		ca := &config.Agent{}
 		cfg := &config.Config{}
-		cfg.SetPresubmits(
+		if err := cfg.SetPresubmits(
 			map[string][]config.Presubmit{
 				"o/r": {
 					{
-						Name:      "foo",
-						Trigger:   "/test all",
-						AlwaysRun: true,
+						Name:         "foo",
+						Trigger:      "/test all",
+						RerunCommand: "/test all",
+						AlwaysRun:    true,
 					},
 					{
 						Name:         "if-changed",
 						Trigger:      "/test if-changed",
+						RerunCommand: "/test if-changed",
 						RunIfChanged: "CHANGED",
 					},
 				},
 			},
-		)
+		); err != nil {
+			t.Fatalf("failed to set presubmits: %v", err)
+		}
 		ca.Set(cfg)
 		if len(tc.presubmits) > 0 {
 			for i := 0; i <= 8; i++ {


### PR DESCRIPTION
When we have a branch `release-1.9` and want to quickly and quietly
create a derivative branch `release-1.9-hotfix-cve-1234`, we want the
derivative branch to have all of the same branch jobs as the branch it
is being derived from. In general, it should be cheap and easy to branch
out without having to modify too much of the testing infrastructure. One
step to making this possible is allowing branch restrictions on jobs to
be regular expressions. Git refs already have very stringent validation,
so we should not be concerned with trying to determine if a branch ref
as given is a regular expression or explicit branch name.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind feature
/cc @smarterclayton @bentheelder
/assign @fejta @cjwagner @kargakis

The refactor was very annoying with the way we do config load -.-