### PR TITLE
Removing required CircleCI check for charts

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -60,10 +60,6 @@ branch-protection:
             users: []
             teams:
             - stage-bots
-        charts:
-          required_status_checks:
-            contexts:
-            - ci/circleci
         client-go:
           restrictions:
             users: []


### PR DESCRIPTION
There are 3 different circleci checks that may be required and its
in an OR. Things are in flux. Removing requirement for now and will
add back when new one is in place.