### PR TITLE
Enable Prow automation for client-go/unofficial-docs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -206,6 +206,7 @@ tide:
     - kubernetes-sigs/cluster-api
     - kubernetes-sigs/controller-runtime
     - kubernetes-sigs/kubebuilder
+    - client-go/unofficial-docs
     labels:
     - lgtm
     - approved

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -60,6 +60,7 @@ approve:
   lgtm_acts_as_approve: true
 - repos:
   - kubernetes-sigs
+  - client-go/unofficial-docs
   implicit_self_approve: true
 
 blockades:
@@ -433,6 +434,20 @@ plugins:
 
   GoogleCloudPlatform/k8s-multicluster-ingress:
   - trigger
+  
+  client-go/unofficial-docs:
+  - assign
+  - approve
+  - lgtm
+  - approve
+  - label
+  - cla
+  - cat
+  - dog
+  - help
+  - blunderbuss
+  - wip
+  - hold
 
 external_plugins:
   kubernetes/community:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -470,3 +470,7 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  client-go/unofficial-docs:
+  - name: needs-rebase
+    events:
+      - pull_request


### PR DESCRIPTION
Myself, @sttts, @nikhita and @lilic are attempting to create a documentation site for client-go consumers (api extension developers).

In order to focus on getting content written before we propose this become an official kubernetes org project, we have created a separate org and repo to house it.

We are looking at enabling the CNCF CLA bot for the repo, to make a potential move to the kubernetes org in future easier. In the process, it'd be great if we could get Prow automation enabled for the repo so we can handle merges and repo automation in a familiar way 😄 

I'm not sure if it's acceptable/easy to enable Prow for technically external repos, but I've opened this PR to find out 😄. If not, I can use the Jetstack prow deployment for this for the time being.