### PR TITLE
prow: update default config locations to match new keys

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -76,7 +76,7 @@ func (o *options) Validate() error {
 
 func gatherOptions() options {
 	o := options{}
-	flag.StringVar(&o.configPath, "config-path", "/etc/config/config", "Path to config.yaml.")
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	flag.StringVar(&o.buildCluster, "build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	flag.StringVar(&o.tideURL, "tide-url", "", "Path to tide. If empty, do not serve tide data.")
 	flag.StringVar(&o.hookURL, "hook-url", "", "Path to hook plugin help endpoint.")

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -50,7 +50,7 @@ func (o *options) Validate() error {
 
 func gatherOptions() options {
 	o := options{}
-	flag.StringVar(&o.configPath, "config-path", "/etc/config/config", "Path to config.yaml.")
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	flag.StringVar(&o.instance, "gerrit-instance", "", "URL to gerrit instance")
 	flag.StringVar(&o.projects, "gerrit-projects", "", "comma separated gerrit projects to fetch from the gerrit instance")
 	flag.StringVar(&o.storage, "storage", "", "Path to persistent volume to load the last sync time")

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -78,9 +78,9 @@ func gatherOptions() options {
 	}
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 
-	flag.StringVar(&o.configPath, "config-path", "/etc/config/config", "Path to config.yaml.")
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	flag.StringVar(&o.cluster, "cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
-	flag.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
+	flag.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
 
 	flag.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	flag.DurationVar(&o.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration. ")

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -36,7 +36,7 @@ type options struct {
 
 func gatherOptions() options {
 	o := options{}
-	flag.StringVar(&o.configPath, "config-path", "/etc/config/config", "Path to config.yaml.")
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	flag.Parse()
 	return o
 }

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -92,7 +92,7 @@ func gatherOptions() options {
 	o := options{
 		githubEndpoint: flagutil.NewStrings("https://api.github.com"),
 	}
-	flag.StringVar(&o.configPath, "config-path", "/etc/config/config", "Path to config.yaml.")
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	flag.StringVar(&o.selector, "label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 	flag.StringVar(&o.totURL, "tot-url", "", "Tot URL")
 	flag.StringVar(&o.deckURL, "deck-url", "", "Deck URL for read-only access to the cluster.")

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -44,7 +44,7 @@ import (
 var (
 	totURL = flag.String("tot-url", "", "Tot URL")
 
-	configPath   = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	configPath   = flag.String("config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	cluster      = flag.String("cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 	buildCluster = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	selector     = flag.String("label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -43,7 +43,7 @@ type configAgent interface {
 
 var (
 	runOnce      = flag.Bool("run-once", false, "If true, run only once then quit.")
-	configPath   = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	configPath   = flag.String("config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	buildCluster = flag.String("build-cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 )
 

--- a/prow/cmd/splice/main.go
+++ b/prow/cmd/splice/main.go
@@ -42,7 +42,7 @@ var (
 	remoteURL      = flag.String("remote-url", "https://github.com/kubernetes/kubernetes", "Remote Git URL")
 	orgName        = flag.String("org", "kubernetes", "Org name")
 	repoName       = flag.String("repo", "kubernetes", "Repo name")
-	configPath     = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	configPath     = flag.String("config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	maxBatchSize   = flag.Int("batch-size", 5, "Maximum batch size")
 	alwaysRun      = flag.String("always-run", "", "Job names that should be treated as always_run: true in Splice")
 )

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -48,7 +48,7 @@ var (
 	runOnce = flag.Bool("run-once", false, "If true, run only once then quit.")
 	deckURL = flag.String("deck-url", "", "Deck URL for read-only access to the cluster.")
 
-	configPath = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	configPath = flag.String("config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	cluster    = flag.String("cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 
 	githubEndpoint  = flagutil.NewStrings("https://api.github.com")

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -42,7 +42,7 @@ import (
 var (
 	port              = flag.Int("port", 8888, "Port to listen on.")
 	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
-	pluginConfig      = flag.String("plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
+	pluginConfig      = flag.String("plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
 	githubEndpoint    = flagutil.NewStrings("https://api.github.com")
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")


### PR DESCRIPTION
Default ConfigMap keys have been changed to be the basename of the files
that store the information, so we should update the default locations
for the configuration flags to reflect that.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @cjwagner @BenTheElder @krzyzacy 
/assign @fejta 

follow-up to https://github.com/kubernetes/test-infra/pull/8360