### PR TITLE
Fix data race when updating user-data

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -366,7 +366,7 @@ func handleUpdate(r *ranch.Ranch) http.HandlerFunc {
 			}
 		}
 
-		if err := r.Update(name, owner, state, userData); err != nil {
+		if err := r.Update(name, owner, state, &userData); err != nil {
 			logrus.WithError(err).Errorf("Update failed: %v - %v (%v)", name, state, owner)
 			http.Error(res, err.Error(), ErrorToStatus(err))
 			return

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -182,7 +182,7 @@ func (c *Client) SyncAll() error {
 }
 
 // UpdateOne signals update for one of the resources hold by the client.
-func (c *Client) UpdateOne(name, state string, userData common.UserData) error {
+func (c *Client) UpdateOne(name, state string, userData *common.UserData) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -216,7 +216,7 @@ func (c *Client) HasResource() bool {
 
 // private methods
 
-func (c *Client) updateLocalResource(i common.Item, state string, data common.UserData) error {
+func (c *Client) updateLocalResource(i common.Item, state string, data *common.UserData) error {
 	res, err := common.ItemToResource(i)
 	if err != nil {
 		return err
@@ -227,6 +227,7 @@ func (c *Client) updateLocalResource(i common.Item, state string, data common.Us
 	} else {
 		res.UserData.Update(data)
 	}
+
 	return c.storage.Update(res)
 }
 
@@ -297,7 +298,7 @@ func (c *Client) release(name, dest string) error {
 	return nil
 }
 
-func (c *Client) update(name, state string, userData common.UserData) error {
+func (c *Client) update(name, state string, userData *common.UserData) error {
 	var body io.Reader
 	if userData != nil {
 		b := new(bytes.Buffer)

--- a/boskos/common/BUILD.bazel
+++ b/boskos/common/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "mason_config.go",
     ],
     importpath = "k8s.io/test-infra/boskos/common",
-    deps = ["//vendor/gopkg.in/yaml.v2:go_default_library"],
+    deps = ["//vendor/github.com/ghodss/yaml:go_default_library"],
 )
 
 filegroup(

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -19,9 +19,13 @@ package common
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"strings"
 	"time"
+
+	"encoding/json"
+	"sync"
+
+	"github.com/ghodss/yaml"
 )
 
 const (
@@ -38,7 +42,12 @@ const (
 )
 
 // UserData is a map of Name to user defined interface, serialized into a string
-type UserData map[string]string
+type UserData struct {
+	sync.Map
+}
+
+// UserDataMap is the standard Map version of UserMap, it is used to ease UserMap creation.
+type UserDataMap map[string]string
 
 // LeasedResources is a list of resources name that used in order to create another resource by Mason
 type LeasedResources []string
@@ -56,7 +65,7 @@ type Resource struct {
 	Owner      string    `json:"owner"`
 	LastUpdate time.Time `json:"lastupdate"`
 	// Customized UserData
-	UserData UserData `json:"userdata"`
+	UserData *UserData `json:"userdata"`
 }
 
 // ResourceEntry is resource config format defined from config.yaml
@@ -87,7 +96,7 @@ func NewResource(name, rtype, state, owner string, t time.Time) Resource {
 		State:      state,
 		Owner:      owner,
 		LastUpdate: t,
-		UserData:   map[string]string{},
+		UserData:   &UserData{},
 	}
 }
 
@@ -98,6 +107,15 @@ func NewResourcesFromConfig(e ResourceEntry) []Resource {
 		resources = append(resources, NewResource(name, e.Type, e.State, "", time.Time{}))
 	}
 	return resources
+}
+
+// UserDataFromMap returns a UserData from a map
+func UserDataFromMap(m UserDataMap) *UserData {
+	ud := &UserData{}
+	for k, v := range m {
+		ud.Store(k, v)
+	}
+	return ud
 }
 
 // UserDataNotFound will be returned if requested resource does not exist.
@@ -144,13 +162,28 @@ func (r *ResTypes) Set(value string) error {
 // GetName implements the Item interface used for storage
 func (res Resource) GetName() string { return res.Name }
 
+// UnmarshalJSON implements JSON Unmarshaler interface
+func (ud *UserData) UnmarshalJSON(data []byte) error {
+	tmpMap := UserDataMap{}
+	if err := json.Unmarshal(data, &tmpMap); err != nil {
+		return err
+	}
+	ud.FromMap(tmpMap)
+	return nil
+}
+
+// MarshalJSON implents JSON Marshaler interface
+func (ud *UserData) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ud.ToMap())
+}
+
 // Extract unmarshalls a string a given struct if it exists
-func (ud UserData) Extract(id string, out interface{}) error {
-	content, ok := ud[id]
+func (ud *UserData) Extract(id string, out interface{}) error {
+	content, ok := ud.Load(id)
 	if !ok {
 		return &UserDataNotFound{id}
 	}
-	return yaml.Unmarshal([]byte(content), out)
+	return yaml.Unmarshal([]byte(content.(string)), out)
 }
 
 // User Data are used to store custom information mainly by Mason and Masonable implementation.
@@ -158,26 +191,45 @@ func (ud UserData) Extract(id string, out interface{}) error {
 // create the given resource.
 
 // Set marshalls a struct to a string into the UserData
-func (ud UserData) Set(id string, in interface{}) error {
+func (ud *UserData) Set(id string, in interface{}) error {
 	b, err := yaml.Marshal(in)
 	if err != nil {
 		return err
 	}
-	ud[id] = string(b)
+	ud.Store(id, string(b))
 	return nil
 }
 
 // Update updates existing UserData with new UserData.
 // If a key as an empty string, the key will be deleted
-func (ud UserData) Update(new UserData) {
-	if new != nil {
-		for id, content := range new {
-			if content != "" {
-				ud[id] = content
-			} else {
-				delete(ud, id)
-			}
+func (ud *UserData) Update(new *UserData) {
+	if new == nil {
+		return
+	}
+	new.Range(func(key, value interface{}) bool {
+		if value.(string) != "" {
+			ud.Store(key, value)
+		} else {
+			ud.Delete(key)
 		}
+		return true
+	})
+}
+
+// ToMap converts a UserData to UserDataMap
+func (ud *UserData) ToMap() UserDataMap {
+	m := UserDataMap{}
+	ud.Range(func(key, value interface{}) bool {
+		m[key.(string)] = value.(string)
+		return true
+	})
+	return m
+}
+
+// FromMap feels updates user data from a map
+func (ud *UserData) FromMap(m UserDataMap) {
+	for key, value := range m {
+		ud.Store(key, value)
 	}
 }
 

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -69,10 +69,10 @@ type ResourceSpec struct {
 
 // ResourceStatus holds information that are likely to change
 type ResourceStatus struct {
-	State      string          `json:"state,omitempty"`
-	Owner      string          `json:"owner"`
-	LastUpdate time.Time       `json:"lastUpdate,omitempty"`
-	UserData   common.UserData `json:"userData,omitempty"`
+	State      string           `json:"state,omitempty"`
+	Owner      string           `json:"owner"`
+	LastUpdate time.Time        `json:"lastUpdate,omitempty"`
+	UserData   *common.UserData `json:"userData,omitempty"`
 }
 
 // GetName returns a unique identifier for a given resource

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -54,8 +54,8 @@ func fakeConfigConverter(in string) (Masonable, error) {
 	return &fakeConfig{}, nil
 }
 
-func (fc *fakeConfig) Construct(res *common.Resource, typeToRes common.TypeToResources) (common.UserData, error) {
-	return common.UserData{"fakeConfig": "unused"}, nil
+func (fc *fakeConfig) Construct(res *common.Resource, typeToRes common.TypeToResources) (*common.UserData, error) {
+	return common.UserDataFromMap(map[string]string{"fakeConfig": "unused"}), nil
 }
 
 // Create a fake client
@@ -71,7 +71,7 @@ func createFakeBoskos(tc testConfig) (*ranch.Storage, *Client, []common.Resource
 				Type:     rtype,
 				Name:     fmt.Sprintf("%s_%d", rtype, i),
 				State:    common.Free,
-				UserData: common.UserData{},
+				UserData: &common.UserData{},
 			}
 			if c.resourceNeeds != nil {
 				res.State = common.Dirty
@@ -105,7 +105,7 @@ func (fb *fakeBoskos) ReleaseOne(name, dest string) error {
 	return fb.ranch.Release(name, dest, owner)
 }
 
-func (fb *fakeBoskos) UpdateOne(name, state string, userData common.UserData) error {
+func (fb *fakeBoskos) UpdateOne(name, state string, userData *common.UserData) error {
 	return fb.ranch.Update(name, owner, state, userData)
 }
 
@@ -249,10 +249,10 @@ func TestFulfillOne(t *testing.T) {
 	if res.UserData.Extract(LeasedResources, &leasedResources); err != nil {
 		t.Errorf("unable to extract %s", LeasedResources)
 	}
-	if res.UserData[LeasedResources] != req.resource.UserData[LeasedResources] {
+	if res.UserData.ToMap()[LeasedResources] != req.resource.UserData.ToMap()[LeasedResources] {
 		t.Errorf(
 			"resource user data from requirement %v should be the same as the one received %v",
-			req.resource.UserData[LeasedResources], res.UserData[LeasedResources])
+			req.resource.UserData.ToMap()[LeasedResources], res.UserData.ToMap()[LeasedResources])
 	}
 	if len(leasedResources) != 1 {
 		t.Errorf("there should be one leased resource, found %d", len(leasedResources))

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -26,9 +26,9 @@ go_library(
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/storage:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/hashicorp/go-multierror:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -221,7 +221,7 @@ func (r *Ranch) Release(name, dest, owner string) error {
 //      OwnerNotMatch error if owner does not match current owner of the resource, or
 //      ResourceNotFound error if target named resource does not exist, or
 //      StateNotMatch error if state does not match current state of the resource.
-func (r *Ranch) Update(name, owner, state string, ud common.UserData) error {
+func (r *Ranch) Update(name, owner, state string, ud *common.UserData) error {
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
 
@@ -237,7 +237,7 @@ func (r *Ranch) Update(name, owner, state string, ud common.UserData) error {
 		return &StateNotMatch{res.State, state}
 	}
 	if res.UserData == nil {
-		res.UserData = common.UserData{}
+		res.UserData = &common.UserData{}
 	}
 	res.UserData.Update(ud)
 	res.LastUpdate = r.UpdateTime()

--- a/boskos/ranch/storage.go
+++ b/boskos/ranch/storage.go
@@ -23,9 +23,10 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/storage"
 )

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -33,13 +33,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"k8s.io/test-infra/boskos/client"
 	"k8s.io/test-infra/kubetest/conformance"
 	"k8s.io/test-infra/kubetest/dind"
 	"k8s.io/test-infra/kubetest/process"
 	"k8s.io/test-infra/kubetest/util"
-
-	"github.com/spf13/pflag"
 )
 
 // Hardcoded in ginkgo-e2e.sh


### PR DESCRIPTION
I discovered race conditions when debugging part of Mason code, and decided to use a sync.Map to store userdata. It will still be serialized to a normal map as JSON.