### PR TITLE
fix --skew run tests twice

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -190,21 +190,20 @@ func run(deploy deployer, o options) error {
 			errs = util.AppendError(errs, control.XMLWrap(&suite, "Node Tests", func() error {
 				return nodeTest(nodeArgs, o.testArgs, o.nodeTestArgs, o.gcpProject, o.gcpZone)
 			}))
+		} else if err := control.XMLWrap(&suite, "IsUp", deploy.IsUp); err != nil {
+			errs = util.AppendError(errs, err)
+		} else if o.federation {
+			errs = util.AppendError(errs, control.XMLWrap(&suite, "FederationTest", func() error {
+				return federationTest(testArgs)
+			}))
 		} else {
 			if o.deployment != "dind" && o.deployment != "conformance" {
 				errs = util.AppendError(errs, control.XMLWrap(&suite, "kubectl version", getKubectlVersion))
-				if o.skew {
-					errs = util.AppendError(errs, control.XMLWrap(&suite, "SkewTest", func() error {
-						return skewTest(testArgs, "skew", o.checkSkew)
-					}))
-				}
 			}
 
-			if err := control.XMLWrap(&suite, "IsUp", deploy.IsUp); err != nil {
-				errs = util.AppendError(errs, err)
-			} else if o.federation {
-				errs = util.AppendError(errs, control.XMLWrap(&suite, "FederationTest", func() error {
-					return federationTest(testArgs)
+			if o.skew {
+				errs = util.AppendError(errs, control.XMLWrap(&suite, "SkewTest", func() error {
+					return skewTest(testArgs, "skew", o.checkSkew)
 				}))
 			} else {
 				var tester e2e.Tester


### PR DESCRIPTION
xref #8375 

Everything beside nodes need to check cluster up
Nothing prevents dind and conformance run skewed tests

Otherwise should be the same logic as https://sourcegraph.com/github.com/kubernetes/test-infra@03aa625b8d57429cf307bfc222e11d97b01c53f2/-/blob/kubetest/e2e.go?diff=03aa625b8d57429cf307bfc222e11d97b01c53f2&utm_source=chrome-extension

/assign @BenTheElder @justinsb @dims 
