### PR TITLE
Enhance Mason concurrency and Fix leased resource leak

### DIFF
--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -24,7 +24,7 @@ import (
 type ResourceNeeds map[string]int
 
 // TypeToResources stores all the leased resources with the same type f
-type TypeToResources map[string][]*Resource
+type TypeToResources map[string][]Resource
 
 // ConfigType gather the type of config to be applied by Mason in order to construct the resource
 type ConfigType struct {
@@ -65,4 +65,12 @@ func ItemToResourcesConfig(i Item) (ResourcesConfig, error) {
 		return ResourcesConfig{}, fmt.Errorf("cannot construct Resource from received object %v", i)
 	}
 	return conf, nil
+}
+
+func (t TypeToResources) Copy() TypeToResources {
+	new := TypeToResources{}
+	for k, v := range t {
+		new[k] = v
+	}
+	return new
 }

--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -67,6 +67,7 @@ func ItemToResourcesConfig(i Item) (ResourcesConfig, error) {
 	return conf, nil
 }
 
+// Copy returns a copy of the TypeToResources
 func (t TypeToResources) Copy() TypeToResources {
 	new := TypeToResources{}
 	for k, v := range t {

--- a/boskos/mason/mason.go
+++ b/boskos/mason/mason.go
@@ -180,7 +180,7 @@ func NewMason(cleanerCount int, client boskosClient, waitPeriod, syncPeriod time
 func checkUserData(res common.Resource) (common.LeasedResources, error) {
 	var leasedResources common.LeasedResources
 	if res.UserData == nil {
-		err := fmt.Errorf("UserData is empty")
+		err := fmt.Errorf("user data is empty")
 		logrus.WithError(err).Errorf("failed to extract %s", LeasedResources)
 		return nil, err
 	}

--- a/boskos/mason/mason.go
+++ b/boskos/mason/mason.go
@@ -26,7 +26,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/storage"
@@ -39,7 +38,7 @@ const (
 
 // Masonable should be implemented by all configurations
 type Masonable interface {
-	Construct(*common.Resource, common.TypeToResources) (*common.UserData, error)
+	Construct(context.Context, *common.Resource, common.TypeToResources) (*common.UserData, error)
 }
 
 // ConfigConverter converts a string into a Masonable
@@ -57,14 +56,14 @@ type boskosClient interface {
 
 // Mason uses config to convert dirty resources to usable one
 type Mason struct {
-	client                      boskosClient
-	cleanerCount                int
-	storage                     Storage
-	pending, fulfilled, cleaned chan requirements
-	sleepTime                   time.Duration
-	wg                          sync.WaitGroup
-	configConverters            map[string]ConfigConverter
-	cancel                      context.CancelFunc
+	client                             boskosClient
+	cleanerCount                       int
+	storage                            Storage
+	pending, fulfilled, cleaned        chan requirements
+	boskosWaitPeriod, boskosSyncPeriod time.Duration
+	wg                                 sync.WaitGroup
+	configConverters                   map[string]ConfigConverter
+	cancel                             context.CancelFunc
 }
 
 // requirements for a given resource
@@ -162,19 +161,35 @@ func ValidateConfig(configs []common.ResourcesConfig, resources []common.Resourc
 //     channelSize  - Size for all the channel
 //     cleanerCount - Number of cleaning threads
 //     client       - boskos client
-//     sleepTime    - time to wait before a retry
+//     boskosWaitPeriod    - time to wait before a retry
 // Out: A Pointer to a Mason Object
-func NewMason(channelSize, cleanerCount int, client boskosClient, sleepTime time.Duration) *Mason {
+func NewMason(cleanerCount int, client boskosClient, waitPeriod, syncPeriod time.Duration) *Mason {
 	return &Mason{
 		client:           client,
 		cleanerCount:     cleanerCount,
 		storage:          *newStorage(storage.NewMemoryStorage()),
-		pending:          make(chan requirements, channelSize),
-		cleaned:          make(chan requirements, channelSize),
-		fulfilled:        make(chan requirements, channelSize),
-		sleepTime:        sleepTime,
+		pending:          make(chan requirements),
+		cleaned:          make(chan requirements, cleanerCount+1),
+		fulfilled:        make(chan requirements, cleanerCount+1),
+		boskosWaitPeriod: waitPeriod,
+		boskosSyncPeriod: syncPeriod,
 		configConverters: map[string]ConfigConverter{},
 	}
+}
+
+func checkUserData(res common.Resource) (common.LeasedResources, error) {
+	var leasedResources common.LeasedResources
+	if res.UserData == nil {
+		err := fmt.Errorf("UserData is empty")
+		logrus.WithError(err).Errorf("failed to extract %s", LeasedResources)
+		return nil, err
+	}
+
+	if err := res.UserData.Extract(LeasedResources, &leasedResources); err != nil {
+		logrus.WithError(err).Errorf("failed to extract %s", LeasedResources)
+		return nil, err
+	}
+	return leasedResources, nil
 }
 
 // RegisterConfigConverter is used to register a new Masonable interface
@@ -228,7 +243,7 @@ func (m *Mason) cleanAll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case req := <-m.fulfilled:
-			if err := m.cleanOne(&req.resource, req.fulfillment); err != nil {
+			if err := m.cleanOne(ctx, &req.resource, req.fulfillment); err != nil {
 				logrus.WithError(err).Errorf("unable to clean resource %s", req.resource.Name)
 				m.garbageCollect(req)
 			} else {
@@ -238,7 +253,7 @@ func (m *Mason) cleanAll(ctx context.Context) {
 	}
 }
 
-func (m *Mason) cleanOne(res *common.Resource, leasedResources common.TypeToResources) error {
+func (m *Mason) cleanOne(ctx context.Context, res *common.Resource, leasedResources common.TypeToResources) error {
 	configEntry, err := m.storage.GetConfig(res.Type)
 	if err != nil {
 		logrus.WithError(err).Errorf("failed to get config for resource %s", res.Type)
@@ -249,7 +264,7 @@ func (m *Mason) cleanOne(res *common.Resource, leasedResources common.TypeToReso
 		logrus.WithError(err).Errorf("failed to convert config type %s - \n%s", configEntry.Config.Type, configEntry.Config.Content)
 		return err
 	}
-	userData, err := config.Construct(res, leasedResources)
+	userData, err := config.Construct(ctx, res, leasedResources)
 	if err != nil {
 		logrus.WithError(err).Errorf("failed to construct resource %s", res.Name)
 		return err
@@ -286,31 +301,22 @@ func (m *Mason) freeAll(ctx context.Context) {
 }
 
 func (m *Mason) freeOne(res *common.Resource) error {
+	leasedResources, err := checkUserData(*res)
+	if err != nil {
+		return err
+	}
+	// TODO: Implement a ReleaseMultiple in a transaction to prevent orphans
 	// Finally return the resource as free
 	if err := m.client.ReleaseOne(res.Name, common.Free); err != nil {
 		logrus.WithError(err).Errorf("failed to release resource %s", res.Name)
 		return err
 	}
-	var leasedResources common.LeasedResources
-	if res.UserData == nil {
-		err := fmt.Errorf("UserData is empty")
-		logrus.WithError(err).Errorf("failed to extract %s", LeasedResources)
-		return err
-	}
-	if err := res.UserData.Extract(LeasedResources, &leasedResources); err != nil {
-		logrus.WithError(err).Errorf("failed to extract %s", LeasedResources)
-		return err
-	}
 	// And release leased resources as res.Name state
-	var allErrors error
 	for _, name := range leasedResources {
 		if err := m.client.ReleaseOne(name, res.Name); err != nil {
 			logrus.WithError(err).Errorf("unable to release %s to state %s", name, res.Name)
-			allErrors = multierror.Append(allErrors, err)
+			return err
 		}
-	}
-	if allErrors != nil {
-		return allErrors
 	}
 	logrus.Infof("Resource %s has been freed", res.Name)
 	return nil
@@ -321,11 +327,12 @@ func (m *Mason) recycleAll(ctx context.Context) {
 		logrus.Info("Exiting recycleAll Thread")
 		m.wg.Done()
 	}()
+	tick := time.NewTicker(m.boskosWaitPeriod).C
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(m.sleepTime):
+		case <-tick:
 			configs, err := m.storage.GetConfigs()
 			if err != nil {
 				logrus.WithError(err).Error("unable to get configuration")
@@ -360,13 +367,8 @@ func (m *Mason) recycleOne(res *common.Resource) (*requirements, error) {
 		logrus.WithError(err).Errorf("could not get config for resource type %s", res.Type)
 		return nil, err
 	}
-	var leasedResources common.LeasedResources
-	if err := res.UserData.Extract(LeasedResources, &leasedResources); err != nil {
-		if _, ok := err.(*common.UserDataNotFound); !ok {
-			logrus.WithError(err).Errorf("cannot parse %s from User Data", LeasedResources)
-			return nil, err
-		}
-	}
+
+	leasedResources, _ := checkUserData(*res)
 	if leasedResources != nil {
 		resources, err := m.client.AcquireByState(res.Name, common.Leased, leasedResources)
 		if err != nil {
@@ -397,11 +399,12 @@ func (m *Mason) syncAll(ctx context.Context) {
 		logrus.Info("Exiting UpdateAll Thread")
 		m.wg.Done()
 	}()
+	tick := time.NewTicker(m.boskosSyncPeriod).C
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(m.sleepTime):
+		case <-tick:
 			if err := m.client.SyncAll(); err != nil {
 				logrus.WithError(err).Errorf("failed to sync resources")
 			}
@@ -420,14 +423,7 @@ func (m *Mason) fulfillAll(ctx context.Context) {
 			return
 		case req := <-m.pending:
 			if err := m.fulfillOne(ctx, &req); err != nil {
-				for _, resources := range req.fulfillment {
-					for _, res := range resources {
-						if err := m.client.ReleaseOne(res.Name, common.Free); err != nil {
-							logrus.WithError(err).Errorf("failed to release resource %s", res.Name)
-						}
-						logrus.Infof("Released resource %s", res.Name)
-					}
-				}
+				m.garbageCollect(req)
 			} else {
 				m.fulfilled <- req
 			}
@@ -441,15 +437,13 @@ func (m *Mason) fulfillOne(ctx context.Context, req *requirements) error {
 	for k, v := range req.needs {
 		needs[k] = v
 	}
+	tick := time.NewTicker(m.boskosWaitPeriod).C
 	for rType := range needs {
 		for needs[rType] > 0 {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(m.sleepTime):
-				// In case we are waiting for a very long time,
-				// we need to make sure that existing resources are being updated
-				// TODO: handle update failures to update fullfillment.
+			case <-tick:
 				m.updateResources(req)
 				if res, err := m.client.Acquire(rType, common.Free, common.Leased); err != nil {
 					logrus.WithError(err).Debug("boskos acquire failed!")

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	fakeConfigType = "fakeConfig"
-	emptyContent   = "empty content"
-	owner          = "mason"
+	fakeConfigType    = "fakeConfig"
+	emptyContent      = "empty content"
+	owner             = "mason"
+	defaultWaitPeriod = 50 * time.Millisecond
 )
 
 type fakeBoskos struct {
@@ -54,7 +55,7 @@ func fakeConfigConverter(in string) (Masonable, error) {
 	return &fakeConfig{}, nil
 }
 
-func (fc *fakeConfig) Construct(res *common.Resource, typeToRes common.TypeToResources) (*common.UserData, error) {
+func (fc *fakeConfig) Construct(ctx context.Context, *res common.Resource, typeToRes common.TypeToResources) (*common.UserData, error) {
 	return common.UserDataFromMap(map[string]string{"fakeConfig": "unused"}), nil
 }
 
@@ -144,7 +145,7 @@ func TestRecycleLeasedResources(t *testing.T) {
 	res2, _ := rStorage.GetResource("type2_0")
 	res2.UserData.Set(LeasedResources, &[]string{"type1_0"})
 	rStorage.UpdateResource(res2)
-	m := NewMason(1, 1, mClient.basic, 50*time.Millisecond)
+	m := NewMason(1, mClient.basic, defaultWaitPeriod, defaultWaitPeriod)
 	m.storage.SyncConfigs(configs)
 	m.RegisterConfigConverter(fakeConfigType, fakeConfigConverter)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -181,7 +182,7 @@ func TestRecycleNoLeasedResources(t *testing.T) {
 	}
 
 	rStorage, mClient, configs := createFakeBoskos(tc)
-	m := NewMason(1, 1, mClient.basic, 50*time.Millisecond)
+	m := NewMason(1, mClient.basic, defaultWaitPeriod, defaultWaitPeriod)
 	m.storage.SyncConfigs(configs)
 	m.RegisterConfigConverter(fakeConfigType, fakeConfigConverter)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -218,7 +219,7 @@ func TestFulfillOne(t *testing.T) {
 	}
 
 	rStorage, mClient, configs := createFakeBoskos(tc)
-	m := NewMason(1, 1, mClient.basic, 50*time.Millisecond)
+	m := NewMason(1, mClient.basic, defaultWaitPeriod, defaultWaitPeriod)
 	m.storage.SyncConfigs(configs)
 	res, _ := mClient.basic.Acquire("type2", common.Dirty, common.Cleaning)
 	conf, err := m.storage.GetConfig("type2")
@@ -275,7 +276,7 @@ func TestMason(t *testing.T) {
 		},
 	}
 	rStorage, mClient, configs := createFakeBoskos(tc)
-	m := NewMason(5, 5, mClient.basic, 50*time.Millisecond)
+	m := NewMason(5, mClient.basic, defaultWaitPeriod, defaultWaitPeriod)
 	m.storage.SyncConfigs(configs)
 	m.RegisterConfigConverter(fakeConfigType, fakeConfigConverter)
 	m.Start()
@@ -353,7 +354,7 @@ func TestMasonStartStop(t *testing.T) {
 		},
 	}
 	_, mClient, configs := createFakeBoskos(tc)
-	m := NewMason(5, 5, mClient.basic, 50*time.Millisecond)
+	m := NewMason(5, mClient.basic, defaultWaitPeriod, defaultWaitPeriod)
 	m.storage.SyncConfigs(configs)
 	m.RegisterConfigConverter(fakeConfigType, fakeConfigConverter)
 	m.Start()


### PR DESCRIPTION
* Using only one goroutine for acquiring and freeing
* Reducing Syncing frequency
* Garbage collect everything after fullfillment fails
* Adds a context to construct to ease cancellation, run this in a goroutine to cancel it faster.
* leased resource were being leaked, because we were passing down struct per ref, and the Construct implementation was changing the content.