### PR TITLE
prow: trigger: re-run tests when a PR's base changes

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package github
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 )
@@ -133,6 +134,10 @@ type PullRequestEvent struct {
 	Repo        Repo                   `json:"repository"`
 	Label       Label                  `json:"label"`
 	Sender      User                   `json:"sender"`
+
+	// Changes holds raw change data, which we must inspect
+	// and deserialize later as this is a polymorphic field
+	Changes json.RawMessage `json:"changes"`
 
 	// GUID is included in the header of the request received by Github.
 	GUID string


### PR DESCRIPTION
When a user changes the base branch that they are targetting with their
pull request we need to re-run tests on it as the previous set of tests
will no longer be valid. However, GitHub does not give us a specific
event for this case so we need to deduce that it happened from an edit
event by trying to unmarshal the changed records.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @BenTheElder @kargakis @fejta 
/assign @cjwagner 
fixes https://github.com/kubernetes/test-infra/issues/8382

/shrug