### PR TITLE
Switch pod-utilities documentation to use simpler 'echo' example.

### DIFF
--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -61,12 +61,11 @@ Example ProwJob configuration:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/test-images/bug-finder:1.0
+      - image: alpine
         command:
-        - "/find-bugs"
+        - "echo"
         args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--bug-kind=flake"
+        - "The artifacts dir is $(ARTIFACTS)"
 ```
 
 In addition to normal ProwJob configuration, ProwJobs using the Pod Utilities
@@ -97,12 +96,11 @@ the `exta_refs` field.
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/test-images/bug-finder:1.0
+    - image: alpine
       command:
-      - "/find-bugs"
+      - "echo"
       args:
-      - "--artifacts=$(ARTIFACTS)"
-      - "--bug-kind=flake"
+      - "The artifacts dir is $(ARTIFACTS)"
 
 ```
 


### PR DESCRIPTION
Using `echo` in the example is better than using a fictional example because this can actually be used. Additionally, users are familiar with `echo` so it is more apparent that the command should be replaced with the real test command and not made to match the example (users might otherwise think that `/find-bugs` is actually part of the pod-utilities).

/kind documentation
/area prow
/cc @BenTheElder @stevekuznetsov 