### PR TITLE
enable approve for service-catalog

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -387,6 +387,7 @@ plugins:
   - blunderbuss
   - wip
   - hold
+  - approve
 
   kubernetes-sigs:
   - assign


### PR DESCRIPTION
We're enjoying the auto assigning of reviews.

We want to start getting used to the standard prow approve flow.