### PR TITLE
Use job configmap, and bump prow to v20180622-df01a7f2b

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -17,6 +17,7 @@ spec:
             image: gcr.io/k8s-prow/branchprotector:v20180620-3b98af6f3
             args:
             - --config-path=/etc/config/config
+            - --job-config-path=/etc/job-config
             - --github-token-path=/etc/github/oauth
             - --confirm
             - --github-endpoint=http://ghproxy
@@ -28,6 +29,9 @@ spec:
             - name: config
               mountPath: /etc/config
               readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
+              readOnly: true
           restartPolicy: Never
           volumes:
           - name: oauth
@@ -36,3 +40,6 @@ spec:
           - name: config
             configMap:
               name: config
+          - name: job-config
+            configMap:
+              name: job-config

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20180620-3b98af6f3
+            image: gcr.io/k8s-prow/branchprotector:v20180622-df01a7f2b
             args:
             - --config-path=/etc/config/config
             - --job-config-path=/etc/job-config

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/deck:v20180622-df01a7f2b
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=prow.k8s.io
         - --oauth-url=/github-login
+        - --job-config-path=/etc/job-config
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/github
@@ -56,6 +57,9 @@ spec:
           readOnly: true
         - name: config
           mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
           readOnly: true
       volumes:
       - name: oauth-config
@@ -71,3 +75,6 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - --slack-token-file=/etc/slack/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --job-config-path=/etc/job-config
         ports:
           - name: http
             containerPort: 8888
@@ -54,6 +55,9 @@ spec:
           readOnly: true
         - name: config
           mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
           readOnly: true
         - name: plugins
           mountPath: /etc/plugins
@@ -74,6 +78,9 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config
       - name: plugins
         configMap:
           name: plugins

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/hook:v20180622-df01a7f2b
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -33,7 +33,13 @@ spec:
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
       volumes:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/horologium:v20180622-df01a7f2b
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/needs-rebase:v20180622-df01a7f2b
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/plank:v20180622-df01a7f2b
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
       volumes:
       - name: cluster
         secret:
@@ -55,3 +58,6 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,6 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
+        - --job-config-path=/etc/job-config
         image: gcr.io/k8s-prow/sinker:v20180620-3b98af6f3
         volumeMounts:
         - mountPath: /etc/cluster
@@ -22,6 +23,9 @@ spec:
           readOnly: true
         - name: config
           mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
           readOnly: true
       volumes:
       - name: cluster
@@ -31,3 +35,6 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -16,7 +16,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/sinker:v20180622-df01a7f2b
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -18,7 +18,13 @@ spec:
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
       volumes:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/splice:v20180622-df01a7f2b
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -96,7 +96,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/hook:v20180622-df01a7f2b
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -156,7 +156,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/plank:v20180622-df01a7f2b
         args:
         - --dry-run=false
         volumeMounts:
@@ -189,7 +189,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/sinker:v20180622-df01a7f2b
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -220,7 +220,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/deck:v20180622-df01a7f2b
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -263,7 +263,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/horologium:v20180622-df01a7f2b
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/tide:v20180622-df01a7f2b
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --job-config-path=/etc/job-config
         ports:
           - name: http
             containerPort: 8888
@@ -42,6 +43,9 @@ spec:
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -49,3 +53,6 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,7 +57,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20180620-3b98af6f3
+        image: gcr.io/k8s-prow/tot:v20180622-df01a7f2b
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json


### PR DESCRIPTION
```
senlu@senlu:~/work/src/k8s.io/test-infra$ kubectl create configmap job-config --from-file=test-infra-canaries.yaml=config/jobs/kubernetes/test-infra/test-infra-canaries.yaml --from-file=kubetest-canaries.yaml=config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
configmap "job-config" created
senlu@senlu:~/work/src/k8s.io/test-infra$ kubectl describe cm job-config
Name:         job-config
Namespace:    default
Labels:       <none>
Annotations:  <none>

Data
====
kubetest-canaries.yaml:
----
periodics:
- name: ci-kubernetes-e2e-prow-canary
  interval: 1h
  agent: kubernetes
  labels:
    preset-service-account: "true"
    preset-k8s-ssh: "true"
  spec:
    containers:
    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
      imagePullPolicy: Always
      args:
      - --bare
      - --timeout=85
      - --scenario=kubernetes_e2e
      - --
      - --check-leaked-resources
      - --cluster=canary-e2e-prow
      - --extract=ci/latest
      - --gcp-zone=us-central1-f
      - --ginkgo-parallel=25
      - --provider=gce
      - --test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8
      - --timeout=65m

test-infra-canaries.yaml:
----
presubmits:  
  kubernetes/test-infra:
  - name: pull-test-infra-bazel-canary
    agent: kubernetes
    context: pull-test-infra-bazel-canary
    always_run: false
    rerun_command: "/test pull-test-infra-bazel-canary"
    trigger: "(?m)^/test pull-test-infra-bazel-canary,?(\\s+|$)"
    labels:
      preset-service-account: "true"
      preset-bazel-scratch-dir: "true"
      preset-bazel-remote-cache-enabled: "true"
    spec:
      containers:
      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
        imagePullPolicy: Always
        args:
        - "--job=$(JOB_NAME)"
        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
        - "--service-account=/etc/service-account/service-account.json"
        - "--upload=gs://kubernetes-jenkins/pr-logs"
        - "--scenario=kubernetes_execute_bazel"
        - "--timeout=15"
        - "--" # end bootstrap args, scenario args below
        - "hack/build-then-unit.sh"
        # Bazel needs privileged mode in order to sandbox builds.
        securityContext:
          privileged: true
        volumeMounts:
        resources:
          requests:
            memory: "2Gi"

Events:  <none>

```