### PR TITLE
Add --dump=ORG option to peribolos

### DIFF
--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
@@ -44,6 +45,7 @@ go_test(
         "//prow/config/org:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )


### PR DESCRIPTION
`bazel run //prow/cmd/peribolos -- --dump=kubernetes` will now output the yaml that can be used to run peribolos in the future.

Also add `--tokens=300` and `--token-burst=100` to configure the throttle at run-time.

/assign @cblecker @stevekuznetsov @BenTheElder 

