### PR TITLE
Revamp Planter

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -42,14 +42,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 SHELL ["/bin/bash", "-c"]
 
-RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
-    if [[ "${BAZEL_VERSION}" =~ ([0-9\.]+)(rc[0-9]+) ]]; then \
-      DOWNLOAD_URL="https://storage.googleapis.com/bazel/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${INSTALLER}"; \
-    else \
-      DOWNLOAD_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}"; \
-    fi; \
-    wget -q "${DOWNLOAD_URL}" && \
-    chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
+# install bazel as some non-root user
+RUN useradd -ms /bin/bash install-user
+COPY ./install-bazel.sh /
+RUN chmod +rx /install-bazel.sh && \
+    cd /home/install-user && \
+    su install-user /install-bazel.sh
+# make sure bazel is in $PATH
+ENV PATH="/home/install-user/bin:${PATH}"
 
 # It turns out git and bazel pkg_tar and a bunch of other things fail if we
 # don't have a /etc/passwd with the user in it, so let's solve that.
@@ -58,6 +58,7 @@ RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
 # this means we don't need to run the container as root! :-)
 # We care about not running as root because it means build files are owned by
 # the host users, not root (and logs, etc).
+# More about this in entrypoint.sh
 RUN touch /etc/passwd && chmod a+rw /etc/passwd
 
 COPY ./entrypoint.sh /

--- a/planter/OWNERS
+++ b/planter/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - BenTheElder

--- a/planter/README.md
+++ b/planter/README.md
@@ -36,8 +36,8 @@ Planter respects the following environment variables:
 
 Currently, SELinux is disabled for the container that runs the bazel
 environment, which allows for the rest of the host system to leave SELinux
-enabled. Automatic relabeling is not done to avoid inadvertently causing issues
-with the host system.
+enabled. We could relabel the volumes and enable SELinux but this could cause
+major issues on the host if planter was used from say $HOME.
 
 
 Further details can be found in `planter.sh` itself, which is somewhat

--- a/planter/README.md
+++ b/planter/README.md
@@ -42,3 +42,20 @@ with the host system.
 
 Further details can be found in `planter.sh` itself, which is somewhat
 self-documenting.
+
+## Docker for Mac
+
+Performance with docker for mac can be quite bad compared to installing bazel 
+natively (which is an option!). If you are going to use planter though, 
+consider tuning the following Docker options:
+
+- Increase CPU reservation, 4+ cores reccomended
+- Increase Memory reservation, 8+ GB reccomended
+
+You can find these under [preferences > advanced](https://docs.docker.com/docker-for-mac/#advanced)
+
+Check [this unnoficial guide](https://medium.com/@TomKeur/how-get-better-disk-performance-in-docker-for-mac-2ba1244b5b70)
+and make sure that you are using `.raw` formatted VM disk for the daemon. 
+
+We also use [delegated volume mounts](https://docs.docker.com/docker-for-mac/osxfs-caching/) to improve osxfs performance.
+

--- a/planter/README.md
+++ b/planter/README.md
@@ -49,8 +49,8 @@ Performance with docker for mac can be quite bad compared to installing bazel
 natively (which is an option!). If you are going to use planter though, 
 consider tuning the following Docker options:
 
-- Increase CPU reservation, 4+ cores reccomended
-- Increase Memory reservation, 8+ GB reccomended
+- Increase CPU reservation, 4+ cores recommended
+- Increase Memory reservation, 8+ GB recommended
 
 You can find these under [preferences > advanced](https://docs.docker.com/docker-for-mac/#advanced)
 

--- a/planter/README.md
+++ b/planter/README.md
@@ -57,5 +57,9 @@ You can find these under [preferences > advanced](https://docs.docker.com/docker
 Check [this unnoficial guide](https://medium.com/@TomKeur/how-get-better-disk-performance-in-docker-for-mac-2ba1244b5b70)
 and make sure that you are using `.raw` formatted VM disk for the daemon. 
 
+Periodically restarting the daemon (docker for mac tray icon > restart) can
+also help. In particular if you see the Bazel analysis phase taking a long time
+consider restarting the docker daemon before trying again.
+
 We also use [delegated volume mounts](https://docs.docker.com/docker-for-mac/osxfs-caching/) to improve osxfs performance.
 

--- a/planter/entrypoint.sh
+++ b/planter/entrypoint.sh
@@ -22,7 +22,7 @@ set -o nounset
 # so that the file permissions, log paths etc are the same, and we will
 # run the container as this $UID:$GID so tools like python will expect
 # a matching entry here to lookup $HOME, etc.
-echo "${USER}:!:${UID}:${GID}:${FULL_NAME}:${HOME}:/bin/bash" >> /etc/passwd
+echo "${USER}:!:${UID}:${GID}:${FULL_NAME:-}:${HOME}:/bin/bash" >> /etc/passwd
 
 # actually run the user's command
 exec "$@"

--- a/planter/entrypoint.sh
+++ b/planter/entrypoint.sh
@@ -15,6 +15,14 @@
 
 set -o errexit
 set -o nounset
-# write a fake user entry with settings matching the host user possible
-echo "${USER}:!:${UID}:${GID}:${HOME}:/bin/bash" >> /etc/passwd
+
+# write a fake user entry with settings matching the host user
+# note that this is different from the user we installed bazel as, we want
+# it to look just like the user calling planter outside the container
+# so that the file permissions, log paths etc are the same, and we will
+# run the container as this $UID:$GID so tools like python will expect
+# a matching entry here to lookup $HOME, etc.
+echo "${USER}:!:${UID}:${GID}:${FULL_NAME}:${HOME}:/bin/bash" >> /etc/passwd
+
+# actually run the user's command
 exec "$@"

--- a/planter/install-bazel.sh
+++ b/planter/install-bazel.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script fetches and runs the upstream installer based on BAZEL_VERSION
+# like 0.14.0 or 0.14.0rc1 etc.
+set -o errexit
+set -o nounset
+
+# match BAZEL_VERSION to installer URL
+INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+if [[ "${BAZEL_VERSION}" =~ ([0-9\.]+)(rc[0-9]+) ]]; then
+    DOWNLOAD_URL="https://storage.googleapis.com/bazel/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${INSTALLER}"
+else
+    DOWNLOAD_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}"
+fi
+# get the installer
+wget -q "${DOWNLOAD_URL}" && chmod +x "${INSTALLER}"
+# install to user dir
+"./${INSTALLER}" --user
+# remove the installer, we no longer need it
+rm "${INSTALLER}"

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -50,7 +50,9 @@ BAZEL_CACHE="${HOME}/.cache/bazel"
 # - ${HOME}/.cache/bazel to share bazel cache across builds
 # - /tmp also needs to be a suitable tmpfs mounted with exec so that bazel
 # can use it when executing various things
-VOLUMES="-v ${REPO}:${REPO} -v ${BAZEL_CACHE}:${BAZEL_CACHE} --tmpfs /tmp:exec,mode=777"
+# We also use the delegated option on the mounts to improve performance on macOS.
+# https://docs.docker.com/docker-for-mac/osxfs-caching/
+VOLUMES="-v ${REPO}:${REPO}:delegated -v ${BAZEL_CACHE}:${BAZEL_CACHE}:delegated --tmpfs /tmp:exec,mode=777"
 
 # We want to run as the host user so they own the build outputs etc.
 # Part of this is handled in planter/entrypoint.sh

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -63,6 +63,9 @@ RUN_OPTS="--rm"
 # - run interactively, which gives a better user experience
 RUN_OPTS="${RUN_OPTS} -it"
 
+# we want a fixed hostname because this leaks into the env when building
+RUN_OPTS="${RUN_OPTS} --hostname=planter"
+
 # - NOTE: SELinux disabled for this container to prevent relabeling $HOME (!)
 RUN_OPTS="${RUN_OPTS} --security-opt label:disable"
 

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -18,7 +18,7 @@
 #
 # Environment variable options:
 # - $TAG can be overridden to choose a bazel version eg `TAG=0.8.0 planter.sh ...`
-# - Alternatively $IMAGE or $IMAGE_NAME can be overriden to set the exact image
+# - Alternatively $IMAGE or $IMAGE_NAME can be overridden to set the exact image
 # - $NO_PULL will disable pulling the image before running if set
 # - $DOCKER_EXTRA can be set to supply extra args in the docker call
 # - $DRY_RUN will trigger echoing the docker call instead of running it
@@ -39,7 +39,7 @@
 set -o errexit
 set -o nounset
 
-# these can be overriden but otherwise default to the current stable image
+# these can be overridden but otherwise default to the current stable image
 # used to build kubernetes from the master branch
 IMAGE_NAME="${IMAGE_NAME:-gcr.io/k8s-testimages/planter}"
 TAG="${TAG:-0.14.0}"

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -60,6 +60,8 @@ fi
 # Construct the set of docker run options (RUN_OPTS)
 # - Don't keep the container after it exits
 RUN_OPTS="--rm"
+# - run interactively, which gives a better user experience
+RUN_OPTS="${RUN_OPTS} -it"
 
 # - NOTE: SELinux disabled for this container to prevent relabeling $HOME (!)
 RUN_OPTS="${RUN_OPTS} --security-opt label:disable"

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -16,52 +16,99 @@
 #
 # Use like: ./planter/planter.sh bazel build //cmd/...
 #
+# Environment variable options:
 # - $TAG can be overridden to choose a bazel version eg `TAG=0.8.0 planter.sh ...`
+# - Alternatively $IMAGE or $IMAGE_NAME can be overriden to set the exact image
+# - $NO_PULL will disable pulling the image before running if set
 # - $DOCKER_EXTRA can be set to supply extra args in the docker call
 # - $DRY_RUN will trigger echoing the docker call instead of running it
-# - planter will always `docker pull $IMAGE` before running it, see below
 #
 # To build kubernetes, first you checkout github.com/kubernetes/kubernetes
 # to $GOPATH/src/k8s.io/kubernetes and github.com/kubernetes/test-infra
 # to $GOPATH/src/k8s.io/test-infra.
 #
 # Then you can build with:
-# $ cd $GOPATH/src/k8s.io/kubernetes`
-# $ $GOPATH/src/k8s.io/test-infra/planter/planter.sh make bazel-build`
+# $ cd $GOPATH/src/k8s.io/kubernetes
+# $ $GOPATH/src/k8s.io/test-infra/planter/planter.sh make bazel-release
+# 
+# or build a specific binary like:
+# $ cd $GOPATH/src/k8s.io/kubernetes
+# $ $GOPATH/src/k8s.io/test-infra/planter/planter.sh bazel build //cmd/kubectl
 #
 
 set -o errexit
 set -o nounset
-IMAGE_NAME="gcr.io/k8s-testimages/planter"
+
+# these can be overriden but otherwise default to the current stable image
+# used to build kubernetes from the master branch
+IMAGE_NAME="${IMAGE_NAME:-gcr.io/k8s-testimages/planter}"
 TAG="${TAG:-0.14.0}"
-IMAGE="${IMAGE_NAME}:${TAG}"
+IMAGE=${IMAGE:-${IMAGE_NAME}:${TAG}}
+
 # We want to mount our bazel workspace and the bazel cache
 # - WORKSPACE is assumed to be in your current git repo, or alternatively $PWD
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 REPO=${REPO:-${PWD}}
 
 # Ensure the bazel cache directory exists, as otherwise docker will create it,
-# owned by root.
+# possibly with the wrong owner.
 BAZEL_CACHE="${HOME}/.cache/bazel"
-[[ -d "${BAZEL_CACHE}" ]] || mkdir -p "${BAZEL_CACHE}"
+if [ -d "${BAZEL_CACHE}" ] ; then
+    mkdir -p "${BAZEL_CACHE}"
+fi
 
-# Instead of mounting the full user ${HOME} which previously causes many issues like #5607 & #5736
-# We mount only the following folders:
-# - ${HOME}/.cache/bazel to share bazel cache across builds
-# - /tmp also needs to be a suitable tmpfs mounted with exec so that bazel
-# can use it when executing various things
-# We also use the delegated option on the mounts to improve performance on macOS.
-# https://docs.docker.com/docker-for-mac/osxfs-caching/
-VOLUMES="-v ${REPO}:${REPO}:delegated -v ${BAZEL_CACHE}:${BAZEL_CACHE}:delegated --tmpfs /tmp:exec,mode=777"
+# Construct the set of docker run options (RUN_OPTS)
+# - Don't keep the container after it exits
+RUN_OPTS="--rm"
 
-# We want to run as the host user so they own the build outputs etc.
-# Part of this is handled in planter/entrypoint.sh
-GID="$(id -g ${USER})"
-ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
-# construct the final docker command, with SELinux disabled for this container
-CMD="docker pull ${IMAGE} && docker run --security-opt label:disable --rm ${VOLUMES} --user ${UID}:${GID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
+# - NOTE: SELinux disabled for this container to prevent relabeling $HOME (!)
+RUN_OPTS="${RUN_OPTS} --security-opt label:disable"
+
+# - supply the host user's `id` info so we can run as the host user and create
+#   a matching environment for the purposes of building, see the Dockerfile and
+#   entrypoint.sh for more details.
+_UID="$(id -u "${USER}")"
+_GID="$(id -g "${USER}")"
+RUN_OPTS="${RUN_OPTS} --user ${_UID}:${_GID} -e GID=${_GID} -e UID=${_UID}"
+FULL_NAME="$(id -F "${USER}")"
+RUN_OPTS="${RUN_OPTS} -e USER=${USER} -e FULL_NAME='${FULL_NAME}'"
+RUN_OPTS="${RUN_OPTS} -e HOME=${HOME}"
+
+# - We mount the following folders:
+# + `/tmp` which needs to be a suitable tmpfs mounted with exec so that bazel
+#   can use it when executing various things
+RUN_OPTS="${RUN_OPTS} --tmpfs /tmp:exec,mode=777"
+
+# + `${HOME}/.cache/bazel` to share bazel cache across builds
+RUN_OPTS="${RUN_OPTS} -v ${BAZEL_CACHE}:${BAZEL_CACHE}:delegated"
+
+# + `${REPO}` so we can build the code in REPO
+RUN_OPTS="${RUN_OPTS} -v ${REPO}:${REPO}:delegated"
+
+# NOTE: We use the delegated option on both persistent mounts to improve
+# performance on macOS. https://docs.docker.com/docker-for-mac/osxfs-caching/
+
+# - we set the working directory to $PWD, which already must have been in $REPO
+#   This needs to be set at runtime because $REPO isn't known when we build the
+#   planter image.
+#   $PWD specifically can also make commands other than bazel more consistent
+RUN_OPTS="${RUN_OPTS} -w ${PWD}"
+
+# - pass through any extra user-supplied options
+if [ -z "${DOCKER_EXTRA:-set}" ]; then
+    RUN_OPTS="${RUN_OPTS} ${DOCKER_EXTRA:-}"
+fi
+
+# this is the command we will actually run
+CMD="docker run ${RUN_OPTS} ${IMAGE} ${1+"$@"}"
+# if not NO_PULL then including pulling the image before running
+if [ -z "${NO_PULL+set}" ]; then
+    CMD="docker pull ${IMAGE} && ${CMD}"
+fi
+
+# run the command or echo it if dry run
 if [ -n "${DRY_RUN+set}" ]; then
     echo "${CMD}"
 else
-    eval ${CMD}
+    eval "${CMD}"
 fi

--- a/planter/remove-cache.sh
+++ b/planter/remove-cache.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a utility to remove the Bazel cache after using Planter
+#
+# After using planter the cache contents are correctly owned by the host user,
+# but some files are not writable so we make them writable and then delete
+# the cache dir rather than the normal `bazel clean`.
+# NOTE: this is a rough approximation of `bazel clean --expunge`
+set -o errexit
+set -o nounset
+
+BAZEL_CACHE="${HOME}/.cache/bazel"
+chmod -R +w "${BAZEL_CACHE}" && rm -rf "${BAZEL_CACHE}"


### PR DESCRIPTION
- performance improvements and documentation regarding docker for mac
- fix shellcheck lints, make planter actually posix shell compliant
- reorganize the source to better self document why we do various things
- include the host user's full name (`id -F $USER`) in the container's `/etc/passwd` entry (and don't miss having a field for this which broke some tools while experimenting [!] (gosu))
- move bazel installation logic out of `Dockerfile` into a script, install bazel as a non-root user
- other documentation cleanup
- allow overriding the image name, full image+tag with `$IMAGE_NAME`, `$IMAGE`
- allow disabling image pull before running with `$NO_PULL`
- add an `OWNERS` file
- run planter interactively (`-it`)
- add utility to clean the bazel cache (`planter/remove-cache.sh`, necessary because some files may be owned by the user but not writable)
- use fixed hostname to avoid unnecessary env changes

/area planter