### PR TITLE
approve: Treat author as assignee if ImplicitSelfApprove is disabled

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -300,6 +300,9 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, o
 	// Author implicitly approves their own PR if config allows it
 	if opts.ImplicitSelfApprove {
 		approversHandler.AddAuthorSelfApprover(pr.author, pr.htmlURL+"#", false)
+	} else {
+		// Treat the author as an assignee, and suggest them if possible
+		approversHandler.AddAssignees(pr.author)
 	}
 
 	commentsFromIssueComments := commentsFromIssueComments(issueComments)

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -949,12 +949,12 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 		approvers: map[string]sets.String{
 			"a":   sets.NewString("alice"),
 			"a/b": sets.NewString("alice", "bob"),
-			"c":   sets.NewString("cjwagner"),
+			"c":   sets.NewString("cblecker", "cjwagner"),
 		},
 		leafApprovers: map[string]sets.String{
 			"a":   sets.NewString("alice"),
 			"a/b": sets.NewString("bob"),
-			"c":   sets.NewString("cjwagner"),
+			"c":   sets.NewString("cblecker", "cjwagner"),
 		},
 		approverOwners: map[string]string{
 			"a/a.go":   "a",

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -221,7 +221,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
@@ -542,7 +542,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 
 Approval requirements bypassed by manually added approval.
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 
 The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
 
@@ -585,7 +585,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			comments: []github.IssueComment{
 				newTestComment("k8s-ci-robot", `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **alice**
 
@@ -664,7 +664,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
@@ -735,7 +735,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
@@ -776,7 +776,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
@@ -817,7 +817,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 
@@ -855,7 +855,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by:
 To fully approve this pull request, please assign additional approvers.
 We suggest the following additional approver: **cjwagner**
 

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -581,7 +581,7 @@ func GetMessage(ap Approvers, org, project, branch string) *string {
 Approval requirements bypassed by manually added approval.
 
 {{end -}}
-This pull-request has been approved by: {{range $index, $approval := .ap.ListApprovals}}{{if $index}}, {{end}}{{$approval}}{{end}}
+This pull-request has been approved by:{{range $index, $approval := .ap.ListApprovals}}{{if $index}}, {{else}} {{end}}{{$approval}}{{end}}
 
 {{- if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}
 To fully approve this pull request, please assign additional approvers.
@@ -595,7 +595,7 @@ Assign the PR to them by writing `+"`/assign {{range $index, $cc := .ap.GetCCs}}
 Associated issue: *#{{.ap.AssociatedIssue}}*
 
 {{ else if len .ap.NoIssueApprovers -}}
-Associated issue requirement bypassed by: {{range $index, $approval := .ap.ListNoIssueApprovals}}{{if $index}}, {{end}}{{$approval}}{{end}}
+Associated issue requirement bypassed by:{{range $index, $approval := .ap.ListNoIssueApprovals}}{{if $index}}, {{else}} {{end}}{{$approval}}{{end}}
 
 {{ else if call .ap.ManuallyApproved -}}
 *No associated issue*. Requirement bypassed by manually added approval.


### PR DESCRIPTION
This will allow prow to prefer suggesting the author as an approver
if the author is able to approve their own PR.

/area prow
fixes #7540.