### PR TITLE
update default configmap key

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -7,14 +7,14 @@ kind: ConfigMap
 metadata:
   name: plugins
 data:
-  plugins: ""
+  plugins.yaml: ""
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config
 data:
-  config: |
+  config.yaml: |
     periodics:
     - interval: 10m
       agent: kubernetes


### PR DESCRIPTION
we changed all the default flags from config -> config.yaml, so starter.yaml is not valid currently :-\

/area prow
cc @paulangton 
/assign @stevekuznetsov @cjwagner 