### PR TITLE
Switch to glob match for updateconfig keys

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -502,6 +502,15 @@
   revision = "38ee283dabf11c9cbdb968eebd79b1fa7acbabe6"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mattn/go-zglob"
+  packages = [
+    ".",
+    "fastwalk",
+  ]
+  revision = "49693fbb3fe3c3a75fc4e4d6fb1d7cedcbdeb385"
+
+[[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
@@ -1009,6 +1018,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5fa60e2b24caebd4fd072543d3c4ecd3af13454a94dab44ad9d8d28ab298ed4"
+  inputs-digest = "dd50696a1aa202a491edf3531915d4b83b1427d6ef1e8418f83c8dfb41dfea96"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,7 +1,8 @@
 # Announcements
 
 New features added to each components:
-
+ - *June 25, 2018* `updateconfig` plugin will now support update/remove keys
+   from a glob match.
  - *June 05, 2018* `blunderbuss` plugin may now suggest approvers in addition
    to reviewers. Use `exclude_approvers: true` to revert to previous behavior.
  - *April 10, 2018* `cla` plugin now supports `/check-cla` command 

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "//vendor/github.com/mattn/go-zglob:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/updateconfig/README.md
+++ b/prow/plugins/updateconfig/README.md
@@ -2,6 +2,8 @@
 
 `updateconfig` allows prow to update configmaps when files in a repo change.
 
+`updateconfig` also supports glob match, or multi-key updates.
+
 ## Usage
 
 Update your `plugins.yaml` file to something along the following lines:
@@ -25,8 +27,14 @@ config_updater:
     # Update the plugin configmap whenever plugins.yaml changes
     prow/plugins.yaml:
       name: plugin
-    # Update the `other` key in the `data` configmap whenver `data.yaml` changes
+    # Update the `this` or/and `that` key in the `data` configmap whenever `data.yaml` or/and `other-data.yaml` changes
     some/data.yaml:
       name: data
-      key: other
+      key: this
+    some/other-data.yaml
+      name: data
+      key: that
+    # Update the fejtaverse configmap whenever any `.yaml` file under `fejtaverse` changes
+    fejtaverse/**/*.yaml
+      name: fejtaverse
 ```

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -21,6 +21,7 @@ import (
 	"path"
 
 	"github.com/sirupsen/logrus"
+	"github.com/mattn/go-zglob"
 
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
@@ -157,8 +158,24 @@ func handle(gc githubClient, kc kubeClient, log *logrus.Entry, pre github.PullRe
 	}
 	toUpdate := map[configMapID]map[string]string{}
 	for _, change := range changes {
-		cm, ok := configMaps[change.Filename]
-		if !ok {
+		var cm plugins.ConfigMapSpec
+		found := false
+
+		for key, configMap := range configMaps {
+			found, err = zglob.Match(key, change.Filename)
+			if err != nil {
+				// Should not happen, log err and continue
+				log.WithError(err).Info("key matching error")
+				continue
+			}
+
+			if found {
+				cm = configMap
+				break
+			}
+		}
+
+		if !found {
 			continue // This file does not define a configmap
 		}
 

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/sirupsen/logrus"
 	"github.com/mattn/go-zglob"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -431,7 +431,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
-						"fejta.yaml": "old-fejta-config",
+						"fejta.yaml":    "old-fejta-config",
 						"krzyzacy.yaml": "old-krzyzacy-config",
 					},
 				},
@@ -443,7 +443,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
-						"fejta.yaml": "old-fejta-config",
+						"fejta.yaml":    "old-fejta-config",
 						"krzyzacy.yaml": "new-krzyzacy-config",
 					},
 				},
@@ -466,8 +466,8 @@ func TestUpdateConfig(t *testing.T) {
 					Additions: 1,
 				},
 				{
-					Filename:  "dir/subdir/fejtaverse/sig-bar/removed.yaml",
-					Status:    "removed",
+					Filename: "dir/subdir/fejtaverse/sig-bar/removed.yaml",
+					Status:   "removed",
 				},
 			},
 			existConfigMaps: map[string]kube.ConfigMap{
@@ -477,9 +477,9 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
-						"fejta.yaml": "old-fejta-config",
+						"fejta.yaml":    "old-fejta-config",
 						"krzyzacy.yaml": "old-krzyzacy-config",
-						"removed.yaml": "old-removed-config",
+						"removed.yaml":  "old-removed-config",
 					},
 				},
 			},
@@ -490,9 +490,9 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
-						"fejta.yaml": "new-fejta-config",
+						"fejta.yaml":    "new-fejta-config",
 						"krzyzacy.yaml": "old-krzyzacy-config",
-						"added.yaml": "new-added-config",
+						"added.yaml":    "new-added-config",
 					},
 				},
 			},
@@ -549,7 +549,7 @@ func TestUpdateConfig(t *testing.T) {
 					"12345":  "new-krzyzacy-config",
 				},
 				"dir/subdir/fejtaverse/sig-foo/added.yaml": {
-					"12345":  "new-added-config",
+					"12345": "new-added-config",
 				},
 				"dir/subdir/fejtaverse/sig-bar/removed.yaml": {
 					"master": "old-removed-config",

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -412,6 +412,91 @@ func TestUpdateConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "edited dir/subdir/fejtaverse/krzyzacy.yaml, 1 update",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "dir/subdir/fejtaverse/krzyzacy.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: map[string]kube.ConfigMap{
+				"glob-config": {
+					ObjectMeta: kube.ObjectMeta{
+						Name:      "glob-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"fejta.yaml": "old-fejta-config",
+						"krzyzacy.yaml": "old-krzyzacy-config",
+					},
+				},
+			},
+			expectedConfigMaps: map[string]kube.ConfigMap{
+				"glob-config": {
+					ObjectMeta: kube.ObjectMeta{
+						Name:      "glob-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"fejta.yaml": "old-fejta-config",
+						"krzyzacy.yaml": "new-krzyzacy-config",
+					},
+				},
+			},
+		},
+		{
+			name:        "add delete edit glob config, 3 update",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "dir/subdir/fejta.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+				{
+					Filename:  "dir/subdir/fejtaverse/sig-foo/added.yaml",
+					Status:    "added",
+					Additions: 1,
+				},
+				{
+					Filename:  "dir/subdir/fejtaverse/sig-bar/removed.yaml",
+					Status:    "removed",
+				},
+			},
+			existConfigMaps: map[string]kube.ConfigMap{
+				"glob-config": {
+					ObjectMeta: kube.ObjectMeta{
+						Name:      "glob-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"fejta.yaml": "old-fejta-config",
+						"krzyzacy.yaml": "old-krzyzacy-config",
+						"removed.yaml": "old-removed-config",
+					},
+				},
+			},
+			expectedConfigMaps: map[string]kube.ConfigMap{
+				"glob-config": {
+					ObjectMeta: kube.ObjectMeta{
+						Name:      "glob-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"fejta.yaml": "new-fejta-config",
+						"krzyzacy.yaml": "old-krzyzacy-config",
+						"added.yaml": "new-added-config",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -455,6 +540,20 @@ func TestUpdateConfig(t *testing.T) {
 					"master": "old-bar-config",
 					"12345":  "new-bar-config",
 				},
+				"dir/subdir/fejta.yaml": {
+					"master": "old-fejta-config",
+					"12345":  "new-fejta-config",
+				},
+				"dir/subdir/fejtaverse/krzyzacy.yaml": {
+					"master": "old-krzyzacy-config",
+					"12345":  "new-krzyzacy-config",
+				},
+				"dir/subdir/fejtaverse/sig-foo/added.yaml": {
+					"12345":  "new-added-config",
+				},
+				"dir/subdir/fejtaverse/sig-bar/removed.yaml": {
+					"master": "old-removed-config",
+				},
 			},
 		}
 		fkc := &fakeKubeClient{
@@ -479,10 +578,13 @@ func TestUpdateConfig(t *testing.T) {
 			"config/bar.yaml": {
 				Name: "multikey-config",
 			},
+			"dir/subdir/**/*.yaml": {
+				Name: "glob-config",
+			},
 		}
 
 		if err := handle(fgc, fkc, log, event, m); err != nil {
-			t.Fatal(err)
+			t.Fatalf("tc: %s, err: %s", tc.name, err)
 		}
 
 		if tc.expectedConfigMaps != nil {

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -108,6 +108,7 @@ filegroup(
         "//vendor/github.com/mailru/easyjson/jlexer:all-srcs",
         "//vendor/github.com/mailru/easyjson/jwriter:all-srcs",
         "//vendor/github.com/mattn/go-sqlite3:all-srcs",
+        "//vendor/github.com/mattn/go-zglob:all-srcs",
         "//vendor/github.com/matttproud/golang_protobuf_extensions/pbutil:all-srcs",
         "//vendor/github.com/modern-go/concurrent:all-srcs",
         "//vendor/github.com/modern-go/reflect2:all-srcs",

--- a/vendor/github.com/mattn/go-zglob/BUILD.bazel
+++ b/vendor/github.com/mattn/go-zglob/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["zglob.go"],
+    importmap = "vendor/github.com/mattn/go-zglob",
+    importpath = "github.com/mattn/go-zglob",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/mattn/go-zglob/fastwalk:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//vendor/github.com/mattn/go-zglob/fastwalk:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/mattn/go-zglob/LICENSE
+++ b/vendor/github.com/mattn/go-zglob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-zglob/fastwalk/BUILD.bazel
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fastwalk.go",
+        "fastwalk_dirent_fileno.go",
+        "fastwalk_dirent_ino.go",
+        "fastwalk_portable.go",
+        "fastwalk_unix.go",
+    ],
+    importmap = "vendor/github.com/mattn/go-zglob/fastwalk",
+    importpath = "github.com/mattn/go-zglob/fastwalk",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk.go
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk.go
@@ -1,0 +1,182 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// A faster implementation of filepath.Walk.
+//
+// filepath.Walk's design necessarily calls os.Lstat on each file,
+// even if the caller needs less info. And goimports only need to know
+// the type of each file. The kernel interface provides the type in
+// the Readdir call but the standard library ignored it.
+// fastwalk_unix.go contains a fork of the syscall routines.
+//
+// See golang.org/issue/16399
+
+package fastwalk
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// TraverseLink is a sentinel error for fastWalk, similar to filepath.SkipDir.
+var TraverseLink = errors.New("traverse symlink, assuming target is a directory")
+
+// FastWalk walks the file tree rooted at root, calling walkFn for
+// each file or directory in the tree, including root.
+//
+// If fastWalk returns filepath.SkipDir, the directory is skipped.
+//
+// Unlike filepath.Walk:
+//   * file stat calls must be done by the user.
+//     The only provided metadata is the file type, which does not include
+//     any permission bits.
+//   * multiple goroutines stat the filesystem concurrently. The provided
+//     walkFn must be safe for concurrent use.
+//   * fastWalk can follow symlinks if walkFn returns the TraverseLink
+//     sentinel error. It is the walkFn's responsibility to prevent
+//     fastWalk from going into symlink cycles.
+func FastWalk(root string, walkFn func(path string, typ os.FileMode) error) error {
+	// Check if "root" is actually a file, not a directory.
+	stat, err := os.Stat(root)
+	if err != nil {
+		return err
+	}
+	if !stat.IsDir() {
+		// If it is, just directly pass it to walkFn and return.
+		return walkFn(root, stat.Mode())
+	}
+
+	// TODO(bradfitz): make numWorkers configurable? We used a
+	// minimum of 4 to give the kernel more info about multiple
+	// things we want, in hopes its I/O scheduling can take
+	// advantage of that. Hopefully most are in cache. Maybe 4 is
+	// even too low of a minimum. Profile more.
+	numWorkers := 4
+	if n := runtime.NumCPU(); n > numWorkers {
+		numWorkers = n
+	}
+	w := &walker{
+		fn:       walkFn,
+		enqueuec: make(chan walkItem, numWorkers), // buffered for performance
+		workc:    make(chan walkItem, numWorkers), // buffered for performance
+		donec:    make(chan struct{}),
+
+		// buffered for correctness & not leaking goroutines:
+		resc: make(chan error, numWorkers),
+	}
+	defer close(w.donec)
+	// TODO(bradfitz): start the workers as needed? maybe not worth it.
+	for i := 0; i < numWorkers; i++ {
+		go w.doWork()
+	}
+	todo := []walkItem{{dir: root}}
+	out := 0
+	for {
+		workc := w.workc
+		var workItem walkItem
+		if len(todo) == 0 {
+			workc = nil
+		} else {
+			workItem = todo[len(todo)-1]
+		}
+		select {
+		case workc <- workItem:
+			todo = todo[:len(todo)-1]
+			out++
+		case it := <-w.enqueuec:
+			todo = append(todo, it)
+		case err := <-w.resc:
+			out--
+			if err != nil {
+				return err
+			}
+			if out == 0 && len(todo) == 0 {
+				// It's safe to quit here, as long as the buffered
+				// enqueue channel isn't also readable, which might
+				// happen if the worker sends both another unit of
+				// work and its result before the other select was
+				// scheduled and both w.resc and w.enqueuec were
+				// readable.
+				select {
+				case it := <-w.enqueuec:
+					todo = append(todo, it)
+				default:
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// doWork reads directories as instructed (via workc) and runs the
+// user's callback function.
+func (w *walker) doWork() {
+	for {
+		select {
+		case <-w.donec:
+			return
+		case it := <-w.workc:
+			w.resc <- w.walk(it.dir, !it.callbackDone)
+		}
+	}
+}
+
+type walker struct {
+	fn func(path string, typ os.FileMode) error
+
+	donec    chan struct{} // closed on fastWalk's return
+	workc    chan walkItem // to workers
+	enqueuec chan walkItem // from workers
+	resc     chan error    // from workers
+}
+
+type walkItem struct {
+	dir          string
+	callbackDone bool // callback already called; don't do it again
+}
+
+func (w *walker) enqueue(it walkItem) {
+	select {
+	case w.enqueuec <- it:
+	case <-w.donec:
+	}
+}
+
+func (w *walker) onDirEnt(dirName, baseName string, typ os.FileMode) error {
+	joined := dirName + string(os.PathSeparator) + baseName
+	if typ == os.ModeDir {
+		w.enqueue(walkItem{dir: joined})
+		return nil
+	}
+
+	err := w.fn(joined, typ)
+	if typ == os.ModeSymlink {
+		if err == TraverseLink {
+			// Set callbackDone so we don't call it twice for both the
+			// symlink-as-symlink and the symlink-as-directory later:
+			w.enqueue(walkItem{dir: joined, callbackDone: true})
+			return nil
+		}
+		if err == filepath.SkipDir {
+			// Permit SkipDir on symlinks too.
+			return nil
+		}
+	}
+	return err
+}
+func (w *walker) walk(root string, runUserCallback bool) error {
+	if runUserCallback {
+		err := w.fn(root, os.ModeDir)
+		if err == filepath.SkipDir {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return readDir(root, w.onDirEnt)
+}

--- a/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_dirent_fileno.go
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_dirent_fileno.go
@@ -1,0 +1,13 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd openbsd netbsd
+
+package fastwalk
+
+import "syscall"
+
+func direntInode(dirent *syscall.Dirent) uint64 {
+	return uint64(dirent.Fileno)
+}

--- a/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_dirent_ino.go
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_dirent_ino.go
@@ -1,0 +1,13 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,!appengine darwin
+
+package fastwalk
+
+import "syscall"
+
+func direntInode(dirent *syscall.Dirent) uint64 {
+	return uint64(dirent.Ino)
+}

--- a/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_portable.go
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_portable.go
@@ -1,0 +1,29 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd
+
+package fastwalk
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// readDir calls fn for each directory entry in dirName.
+// It does not descend into directories or follow symlinks.
+// If fn returns a non-nil error, readDir returns with that error
+// immediately.
+func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
+	fis, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		return err
+	}
+	for _, fi := range fis {
+		if err := fn(dirName, fi.Name(), fi.Mode()&os.ModeType); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_unix.go
+++ b/vendor/github.com/mattn/go-zglob/fastwalk/fastwalk_unix.go
@@ -1,0 +1,122 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,!appengine darwin freebsd openbsd netbsd
+
+package fastwalk
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const blockSize = 8 << 10
+
+// unknownFileMode is a sentinel (and bogus) os.FileMode
+// value used to represent a syscall.DT_UNKNOWN Dirent.Type.
+const unknownFileMode os.FileMode = os.ModeNamedPipe | os.ModeSocket | os.ModeDevice
+
+func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
+	fd, err := syscall.Open(dirName, 0, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(fd)
+
+	// The buffer must be at least a block long.
+	buf := make([]byte, blockSize) // stack-allocated; doesn't escape
+	bufp := 0                      // starting read position in buf
+	nbuf := 0                      // end valid data in buf
+	for {
+		if bufp >= nbuf {
+			bufp = 0
+			nbuf, err = syscall.ReadDirent(fd, buf)
+			if err != nil {
+				return os.NewSyscallError("readdirent", err)
+			}
+			if nbuf <= 0 {
+				return nil
+			}
+		}
+		consumed, name, typ := parseDirEnt(buf[bufp:nbuf])
+		bufp += consumed
+		if name == "" || name == "." || name == ".." {
+			continue
+		}
+		// Fallback for filesystems (like old XFS) that don't
+		// support Dirent.Type and have DT_UNKNOWN (0) there
+		// instead.
+		if typ == unknownFileMode {
+			fi, err := os.Lstat(dirName + "/" + name)
+			if err != nil {
+				// It got deleted in the meantime.
+				if os.IsNotExist(err) {
+					continue
+				}
+				return err
+			}
+			typ = fi.Mode() & os.ModeType
+		}
+		if err := fn(dirName, name, typ); err != nil {
+			return err
+		}
+	}
+}
+
+func parseDirEnt(buf []byte) (consumed int, name string, typ os.FileMode) {
+	// golang.org/issue/15653
+	dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[0]))
+	if v := unsafe.Offsetof(dirent.Reclen) + unsafe.Sizeof(dirent.Reclen); uintptr(len(buf)) < v {
+		panic(fmt.Sprintf("buf size of %d smaller than dirent header size %d", len(buf), v))
+	}
+	if len(buf) < int(dirent.Reclen) {
+		panic(fmt.Sprintf("buf size %d < record length %d", len(buf), dirent.Reclen))
+	}
+	consumed = int(dirent.Reclen)
+	if direntInode(dirent) == 0 { // File absent in directory.
+		return
+	}
+	switch dirent.Type {
+	case syscall.DT_REG:
+		typ = 0
+	case syscall.DT_DIR:
+		typ = os.ModeDir
+	case syscall.DT_LNK:
+		typ = os.ModeSymlink
+	case syscall.DT_BLK:
+		typ = os.ModeDevice
+	case syscall.DT_FIFO:
+		typ = os.ModeNamedPipe
+	case syscall.DT_SOCK:
+		typ = os.ModeSocket
+	case syscall.DT_UNKNOWN:
+		typ = unknownFileMode
+	default:
+		// Skip weird things.
+		// It's probably a DT_WHT (http://lwn.net/Articles/325369/)
+		// or something. Revisit if/when this package is moved outside
+		// of goimports. goimports only cares about regular files,
+		// symlinks, and directories.
+		return
+	}
+
+	nameBuf := (*[unsafe.Sizeof(dirent.Name)]byte)(unsafe.Pointer(&dirent.Name[0]))
+	nameLen := bytes.IndexByte(nameBuf[:], 0)
+	if nameLen < 0 {
+		panic("failed to find terminating 0 byte in dirent")
+	}
+
+	// Special cases for common things:
+	if nameLen == 1 && nameBuf[0] == '.' {
+		name = "."
+	} else if nameLen == 2 && nameBuf[0] == '.' && nameBuf[1] == '.' {
+		name = ".."
+	} else {
+		name = string(nameBuf[:nameLen])
+	}
+	return
+}

--- a/vendor/github.com/mattn/go-zglob/zglob.go
+++ b/vendor/github.com/mattn/go-zglob/zglob.go
@@ -1,0 +1,208 @@
+package zglob
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/mattn/go-zglob/fastwalk"
+)
+
+var (
+	envre = regexp.MustCompile(`^(\$[a-zA-Z][a-zA-Z0-9_]+|\$\([a-zA-Z][a-zA-Z0-9_]+\))$`)
+	mu    sync.Mutex
+)
+
+type zenv struct {
+	dre     *regexp.Regexp
+	fre     *regexp.Regexp
+	pattern string
+	root    string
+}
+
+func New(pattern string) (*zenv, error) {
+	globmask := ""
+	root := ""
+	for n, i := range strings.Split(filepath.ToSlash(pattern), "/") {
+		if root == "" && strings.Index(i, "*") != -1 {
+			if globmask == "" {
+				root = "."
+			} else {
+				root = filepath.ToSlash(globmask)
+			}
+		}
+		if n == 0 && i == "~" {
+			if runtime.GOOS == "windows" {
+				i = os.Getenv("USERPROFILE")
+			} else {
+				i = os.Getenv("HOME")
+			}
+		}
+		if envre.MatchString(i) {
+			i = strings.Trim(strings.Trim(os.Getenv(i[1:]), "()"), `"`)
+		}
+
+		globmask = filepath.Join(globmask, i)
+		if n == 0 {
+			if runtime.GOOS == "windows" && filepath.VolumeName(i) != "" {
+				globmask = i + "/"
+			} else if len(globmask) == 0 {
+				globmask = "/"
+			}
+		}
+	}
+	if root == "" {
+		return &zenv{
+			dre:     nil,
+			fre:     nil,
+			pattern: pattern,
+			root:    "",
+		}, nil
+	}
+	if globmask == "" {
+		globmask = "."
+	}
+	globmask = filepath.ToSlash(filepath.Clean(globmask))
+
+	cc := []rune(globmask)
+	dirmask := ""
+	filemask := ""
+	for i := 0; i < len(cc); i++ {
+		if cc[i] == '*' {
+			if i < len(cc)-2 && cc[i+1] == '*' && cc[i+2] == '/' {
+				filemask += "(.*/)?"
+				if dirmask == "" {
+					dirmask = filemask
+				}
+				i += 2
+			} else {
+				filemask += "[^/]*"
+			}
+		} else {
+			c := cc[i]
+			if c == '/' || ('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || 255 < c {
+				filemask += string(c)
+			} else {
+				filemask += fmt.Sprintf("[\\x%02X]", c)
+			}
+			if c == '/' && dirmask == "" && strings.Index(filemask, "*") != -1 {
+				dirmask = filemask
+			}
+		}
+	}
+	if dirmask == "" {
+		dirmask = filemask
+	}
+	if len(filemask) > 0 && filemask[len(filemask)-1] == '/' {
+		if root == "" {
+			root = filemask
+		}
+		filemask += "[^/]*"
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		dirmask = "(?i:" + dirmask + ")"
+		filemask = "(?i:" + filemask + ")"
+	}
+	return &zenv{
+		dre:     regexp.MustCompile("^" + dirmask),
+		fre:     regexp.MustCompile("^" + filemask + "$"),
+		pattern: pattern,
+		root:    filepath.Clean(root),
+	}, nil
+}
+
+func Glob(pattern string) ([]string, error) {
+	return glob(pattern, false)
+}
+
+func GlobFollowSymlinks(pattern string) ([]string, error) {
+	return glob(pattern, true)
+}
+
+func glob(pattern string, followSymlinks bool) ([]string, error) {
+	zenv, err := New(pattern)
+	if err != nil {
+		return nil, err
+	}
+	if zenv.root == "" {
+		_, err := os.Stat(pattern)
+		if err != nil {
+			return nil, os.ErrNotExist
+		}
+		return []string{pattern}, nil
+	}
+	relative := !filepath.IsAbs(pattern)
+	matches := []string{}
+
+	fastwalk.FastWalk(zenv.root, func(path string, info os.FileMode) error {
+		if zenv.root == "." && len(zenv.root) < len(path) {
+			path = path[len(zenv.root)+1:]
+		}
+		path = filepath.ToSlash(path)
+
+		if followSymlinks && info == os.ModeSymlink {
+			followedPath, err := filepath.EvalSymlinks(path)
+			if err == nil {
+				fi, err := os.Lstat(followedPath)
+				if err == nil && fi.IsDir() {
+					return fastwalk.TraverseLink
+				}
+			}
+		}
+
+		if info.IsDir() {
+			if path == "." || len(path) <= len(zenv.root) {
+				return nil
+			}
+			if zenv.fre.MatchString(path) {
+				mu.Lock()
+				matches = append(matches, path)
+				mu.Unlock()
+				return nil
+			}
+			if !zenv.dre.MatchString(path + "/") {
+				return filepath.SkipDir
+			}
+		}
+
+		if zenv.fre.MatchString(path) {
+			if relative && filepath.IsAbs(path) {
+				path = path[len(zenv.root)+1:]
+			}
+			mu.Lock()
+			matches = append(matches, path)
+			mu.Unlock()
+		}
+		return nil
+	})
+	return matches, nil
+}
+
+func Match(pattern, name string) (matched bool, err error) {
+	zenv, err := New(pattern)
+	if err != nil {
+		return false, err
+	}
+	return zenv.Match(name), nil
+}
+
+func (z *zenv) Match(name string) bool {
+	if z.root == "" {
+		return z.pattern == name
+	}
+
+	name = filepath.ToSlash(name)
+
+	if name == "." || len(name) <= len(z.root) {
+		return false
+	}
+
+	if z.fre.MatchString(name) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
vendor go-zglob because golang filepath does not support double ** match https://github.com/golang/go/issues/11862

My original code was do an exact key lookup, if no key, then do a glob match, but I feel like if there's conflict, user is sorta asking for trouble and I cannot think of a use case for that. Let me know if I'm wrong.

(I can also try to update all affected configmaps)

xref https://github.com/kubernetes/test-infra/issues/8296

/area prow
/meow
/assign @stevekuznetsov @cjwagner @BenTheElder @fejta  