### PR TITLE
Allow multiple instance of a same job name

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -403,6 +403,7 @@ presubmits:
       containers:
       - image: alpine`,
 			},
+			expectError: true,
 		},
 		{
 			name:       "dup presubmits, two files",
@@ -411,8 +412,7 @@ presubmits:
 				`
 presubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     name: presubmit-bar
     context: bar
     spec:
@@ -421,8 +421,7 @@ presubmits:
 				`
 presubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     context: bar
     name: presubmit-bar
     spec:
@@ -438,8 +437,7 @@ presubmits:
 				`
 presubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     name: presubmit-bar
     context: bar
     branches:
@@ -450,8 +448,7 @@ presubmits:
 				`
 presubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     context: bar
     branches:
     - other
@@ -462,6 +459,49 @@ presubmits:
 			},
 			expectError: false,
 		},
+		{
+			name: "dup presubmits main file",
+			prowConfig: `
+presubmits:
+  foo/bar:
+  - agent: kubernetes
+    name: presubmit-bar
+    context: bar
+    spec:
+      containers:
+      - image: alpine
+  - agent: kubernetes
+    context: bar
+    name: presubmit-bar
+    spec:
+      containers:
+      - image: alpine`,
+			expectError: true,
+		},
+		{
+			name: "dup presubmits main file not on the same branch",
+			prowConfig: `
+presubmits:
+  foo/bar:
+  - agent: kubernetes
+    name: presubmit-bar
+    context: bar
+    branches:
+    - other
+    spec:
+      containers:
+      - image: alpine
+  - agent: kubernetes
+    context: bar
+    branches:
+    - master
+    name: presubmit-bar
+    spec:
+      containers:
+      - image: alpine`,
+			expectError: false,
+		},
+
 		{
 			name:       "one postsubmit, ok",
 			prowConfig: ``,
@@ -520,6 +560,7 @@ postsubmits:
       containers:
       - image: alpine`,
 			},
+			expectError: true,
 		},
 		{
 			name:       "dup postsubmits, two files",
@@ -528,8 +569,7 @@ postsubmits:
 				`
 postsubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     name: postsubmit-bar
     context: bar
     spec:
@@ -538,8 +578,7 @@ postsubmits:
 				`
 postsubmits:
   foo/bar:
-  - interval: 10m
-    agent: kubernetes
+  - agent: kubernetes
     context: bar
     name: postsubmit-bar
     spec:

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -353,27 +353,28 @@ func (c *JobConfig) SetPresubmits(jobs map[string][]Presubmit) error {
 	return nil
 }
 
+// listPresubmits list all the presubmit for a given repo including the run after success jobs.
+func listPresubmits(ps []Presubmit) []Presubmit {
+	var res []Presubmit
+	for _, p := range ps {
+		res = append(res, p)
+		res = append(res, listPresubmits(p.RunAfterSuccess)...)
+	}
+	return res
+}
+
 // AllPresubmits returns all prow presubmit jobs in repos.
 // if repos is empty, return all presubmits.
 func (c *JobConfig) AllPresubmits(repos []string) []Presubmit {
 	var res []Presubmit
-	var listPres func(ps []Presubmit) []Presubmit
-	listPres = func(ps []Presubmit) []Presubmit {
-		var res []Presubmit
-		for _, p := range ps {
-			res = append(res, p)
-			res = append(res, listPres(p.RunAfterSuccess)...)
-		}
-		return res
-	}
 
 	for repo, v := range c.Presubmits {
 		if len(repos) == 0 {
-			res = append(res, listPres(v)...)
+			res = append(res, listPresubmits(v)...)
 		} else {
 			for _, r := range repos {
 				if r == repo {
-					res = append(res, listPres(v)...)
+					res = append(res, listPresubmits(v)...)
 					break
 				}
 			}
@@ -383,27 +384,28 @@ func (c *JobConfig) AllPresubmits(repos []string) []Presubmit {
 	return res
 }
 
+// listPostsubmits list all the postsubmits for a given repo including the run after success jobs.
+func listPostsubmits(ps []Postsubmit) []Postsubmit {
+	var res []Postsubmit
+	for _, p := range ps {
+		res = append(res, p)
+		res = append(res, listPostsubmits(p.RunAfterSuccess)...)
+	}
+	return res
+}
+
 // AllPostsubmits returns all prow postsubmit jobs in repos.
 // if repos is empty, return all postsubmits.
 func (c *JobConfig) AllPostsubmits(repos []string) []Postsubmit {
 	var res []Postsubmit
-	var listPost func(ps []Postsubmit) []Postsubmit
-	listPost = func(ps []Postsubmit) []Postsubmit {
-		var res []Postsubmit
-		for _, p := range ps {
-			res = append(res, p)
-			res = append(res, listPost(p.RunAfterSuccess)...)
-		}
-		return res
-	}
 
 	for repo, v := range c.Postsubmits {
 		if len(repos) == 0 {
-			res = append(res, listPost(v)...)
+			res = append(res, listPostsubmits(v)...)
 		} else {
 			for _, r := range repos {
 				if r == repo {
-					res = append(res, listPost(v)...)
+					res = append(res, listPostsubmits(v)...)
 					break
 				}
 			}

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -204,6 +205,32 @@ func (br Brancher) RunsAgainstBranch(branch string) bool {
 		return true
 	}
 	return false
+}
+
+// Intersects checks if other Brancher would trigger for the same branch.
+func (br Brancher) Intersects(other Brancher) bool {
+	if br.RunsAgainstAllBranch() || other.RunsAgainstAllBranch() {
+		return true
+	}
+	if len(br.Branches) > 0 {
+		baseBranches := sets.NewString(br.Branches...)
+		if len(other.Branches) > 0 {
+			otherBranches := sets.NewString(other.Branches...)
+			if baseBranches.Intersection(otherBranches).Len() > 0 {
+				return true
+			}
+			return false
+		}
+		if !baseBranches.Intersection(sets.NewString(other.SkipBranches...)).Equal(baseBranches) {
+			return true
+		}
+		return false
+	}
+	if len(other.Branches) == 0 {
+		// There can only be one Brancher with skip_branches.
+		return true
+	}
+	return other.Intersects(br)
 }
 
 // RunsAgainstChanges returns true if any of the changed input paths match the run_if_changed regex.

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -172,7 +172,7 @@ func TestPresubmits(t *testing.T) {
 					}
 					// Make sure branches are not overlapping
 					if checkOverlapBrancher(job.Brancher, job2.Brancher) {
-						t.Errorf("Two jobs have the same name: %s, and has conflicted branches", job.Name)
+						t.Errorf("Two jobs have the same name: %s, and have conflicting branches", job.Name)
 					}
 				} else {
 					if job.Context == job2.Context {


### PR DESCRIPTION
As long as there defined on different branches.

As seen, in for pull-kubernetes-bazel-build, we need to allow definition of multiple jobs with the same name, as they could have different spec per branch. Example Bazel version not being compatible from one release to another.

Changed the check to also make sure this is correct for the original one file config.