### PR TITLE
bump experimental image to bazel 0.15

### DIFF
--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -24,7 +24,7 @@ CFSSL ?= R1.2
 # config for testing prior to rolling out to master / ongoing release
 ifeq ($(K8S), experimental)
 	GO = 1.10.2
-	BAZEL = 0.14.0
+	BAZEL = 0.15.0
 	CFSSL = R1.2
 endif
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1060,7 +1060,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -1092,7 +1092,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -1298,7 +1298,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -1369,7 +1369,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -6207,7 +6207,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -6307,7 +6307,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -6335,7 +6335,7 @@ presubmits:
       - name: test
         command:
         - ./hack/verify-config.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         env:
         - name: TEST_TMPDIR
           value: /bazel-scratch/.cache/bazel
@@ -6364,7 +6364,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -6426,7 +6426,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -6958,7 +6958,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -7011,7 +7011,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -7171,7 +7171,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
       args:
       - "--repo=github.com/containerd/containerd=master"
       - "--repo=github.com/containerd/cri=master"
@@ -7185,7 +7185,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
       args:
       - "--repo=github.com/containerd/containerd=release/1.1"
       - "--repo=github.com/containerd/cri=release/1.0"
@@ -7311,7 +7311,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
       args:
       - "--repo=github.com/containerd/cri=master"
       - "--root=/go/src"
@@ -16436,7 +16436,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180605-65a672b59-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180627-0ed738715-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"


### PR DESCRIPTION
bazel 0.15 is out today, time to start soaking against the canary jobs and test-infra
/hold