### PR TITLE
Add support for GitHub Nested Teams 🐣

### DIFF
--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -55,8 +55,9 @@ type TeamMetadata struct {
 // Team declares metadata as well as its poeple.
 type Team struct {
 	TeamMetadata
-	Members     []string `json:"members,omitempty"`
-	Maintainers []string `json:"maintainers,omitempty"`
+	Members     []string        `json:"members,omitempty"`
+	Maintainers []string        `json:"maintainers,omitempty"`
+	Children    map[string]Team `json:"teams,omitempty"`
 
 	Previously []string `json:"previously,omitempty"`
 }

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1591,8 +1591,11 @@ func (c *Client) CreateTeam(org string, team Team) (*Team, error) {
 	path := fmt.Sprintf("/orgs/%s/teams", org)
 	var retTeam Team
 	_, err := c.request(&request{
-		method:      http.MethodPost,
-		path:        path,
+		method: http.MethodPost,
+		path:   path,
+		// This accept header enables the nested teams preview.
+		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
+		accept:      "application/vnd.github.hellcat-preview+json",
 		requestBody: &team,
 		exitCodes:   []int{201},
 	}, &retTeam)
@@ -1612,8 +1615,11 @@ func (c *Client) EditTeam(team Team) (*Team, error) {
 	var retTeam Team
 	path := fmt.Sprintf("/teams/%d", id)
 	_, err := c.request(&request{
-		method:      http.MethodPatch,
-		path:        path,
+		method: http.MethodPatch,
+		path:   path,
+		// This accept header enables the nested teams preview.
+		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
+		accept:      "application/vnd.github.hellcat-preview+json",
 		requestBody: &team,
 		exitCodes:   []int{201},
 	}, &retTeam)
@@ -1646,7 +1652,9 @@ func (c *Client) ListTeams(org string) ([]Team, error) {
 	var teams []Team
 	err := c.readPaginatedResults(
 		path,
-		"",
+		// This accept header enables the nested teams preview.
+		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
+		"application/vnd.github.hellcat-preview+json",
 		func() interface{} {
 			return &[]Team{}
 		},

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -575,10 +575,12 @@ type Content struct {
 
 // Team is a github organizational team
 type Team struct {
-	ID          int    `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	Privacy     string `json:"privacy,omitempty"`
+	ID           int    `json:"id,omitempty"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	Privacy      string `json:"privacy,omitempty"`
+	Parent       *Team  `json:"parent,omitempty"` // Only present in responses
+	ParentTeamID *int   `json:"parent_team_id"`   // Only valid in creates/edits
 }
 
 // TeamMember is a member of an organizational team


### PR DESCRIPTION
Add support for Github Nested Teams to peribolos.
https://blog.github.com/2017-06-13-nested-teams-add-depth-to-your-team-structure/

example config:
```
teams:
  sig-foo:
    description: foo enthusiasts
    members:
    - george
    - jane
    privacy: closed
    teams:
      sig-foo-leads:
      members:
      - george
      sig-foo-pr-reviews:
      members:
      - jane
```