### PR TITLE
Increase pushgateway-proxy worker_connections from 20 to 200.

### DIFF
--- a/prow/cluster/pushgateway_deployment.yaml
+++ b/prow/cluster/pushgateway_deployment.yaml
@@ -44,7 +44,7 @@ data:
     pid /run/nginx.pid;
     error_log /dev/stdout;
     events {
-      worker_connections 20;
+      worker_connections 200;
     }
     http {
       access_log /dev/stdout;


### PR DESCRIPTION
Velodrome is missing data from the github cache proxy: http://velodrome.k8s.io/dashboard/db/github-cache?orgId=1&from=1529996400000&to=1530255599999
The pushgateway-proxy is pretty much constantly emitting 'worker_connections are not enough' errors so lets see if a 10x increase fixes the problem.

/area prow
/kind bug
/cc @fejta @rmmh 