### PR TITLE
Increase pushgateway-proxy worker_connections to 1024 (double the default).

### DIFF
--- a/prow/cluster/pushgateway_deployment.yaml
+++ b/prow/cluster/pushgateway_deployment.yaml
@@ -44,7 +44,7 @@ data:
     pid /run/nginx.pid;
     error_log /dev/stdout;
     events {
-      worker_connections 200;
+      worker_connections 1024;
     }
     http {
       access_log /dev/stdout;


### PR DESCRIPTION
200 seems to have fixed the problem, but the default is 512 and we use 1024 in most places.
This is already deployed.
/shrug

/area prow
/kind bug
/cc @BenTheElder 