### PR TITLE
Add Service Account to Verify and Add Sanity Config

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -12536,6 +12536,15 @@
       "sig-cloud-provider-gcp"
     ]
   },
+  "pull-gcp-compute-persistent-disk-csi-driver-sanity": {
+    "args": [
+      "./test/run-sanity.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-cloud-provider-gcp"
+    ]
+  },
   "pull-gcp-compute-persistent-disk-csi-driver-verify": {
     "args": [
       "./hack/verify-all.sh"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6160,6 +6160,23 @@ presubmits:
         env:
         - name: ZONE
           value: us-central1-c
+  - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
+    context: pull-gcp-compute-persistent-disk-csi-driver-sanity
+    always_run: true
+    rerun_command: "/test pull-gcp-compute-persistent-disk-csi-driver-sanity"
+    trigger: "(?m)^/test( all| pull-gcp-compute-persistent-disk-csi-driver-sanity),?(\\s+|$)"
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+        args:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--clean"
+        - "--timeout=10"
   - name: pull-gcp-compute-persistent-disk-csi-driver-verify
     context: pull-gcp-compute-persistent-disk-csi-driver-verify
     always_run: true
@@ -6176,7 +6193,7 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
-        - "--timeout=45"
+        - "--timeout=10"
   kubernetes/release:
   - name: pull-release-cluster-up
     agent: kubernetes

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6166,6 +6166,8 @@ presubmits:
     rerun_command: "/test pull-gcp-compute-persistent-disk-csi-driver-verify"
     trigger: "(?m)^/test( all| pull-gcp-compute-persistent-disk-csi-driver-verify),?(\\s+|$)"
     agent: kubernetes
+    labels:
+      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25


### PR DESCRIPTION
`pull-gcp-compute-persistent-disk-csi-driver-verify` is not uploading test results to gs bucket, maybe its the service account?

Also adding `test-sanity.sh` as a config.

This is the last test config I'm adding in a while I promise! :100: 

/assign @krzyzacy 