### PR TITLE
add BAZEL_VERSION env to kubekins, check it in caching config

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -73,6 +73,12 @@ make_bazel_rc () {
     local cache_id="$(get_workspace),$(hash_toolchains)"
     local cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
     echo "build --remote_http_cache=${cache_url}"
+    # specifically for bazel 0.15.0 we want to set this flag
+    # our docker image now sets BAZEL_VERSION with the bazel version as installed
+    # https://github.com/bazelbuild/bazel/issues/5047#issuecomment-401295174
+    if [[ -n "${BAZEL_VERSION+}" && "${BAZEL_VERSION}" -eq "0.15.0" ]]; then
+        echo "build --remote_max_connections=200"
+    fi
 }
 
 # https://docs.bazel.build/versions/master/user-manual.html#bazelrc

--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -18,19 +18,21 @@ CACHE_PORT="8080"
 
 # get the installed version of a debian package
 package_to_version () {
-    dpkg-query --showformat='${Version}' --show $1
+    dpkg-query --showformat='${Version}' --show "$1"
 }
 
 # look up a binary with which and return the debian package it belongs to
 command_to_package () {
-    local binary_path=$(readlink -f $(which $1))
+    local binary_path
+    binary_path=$(readlink -f "$(which "$1")")
     # `dpkg -S $package` spits out lines with the format: "package: file"
-    dpkg -S $1 | grep "${binary_path}" | cut -d':' -f1
+    dpkg -S "$1" | grep "${binary_path}" | cut -d':' -f1
 }
 
 # get the installed package version relating to a binary
 command_to_version () {
-    local package=$(command_to_package $1)
+    local package
+    package=$(command_to_package "$1")
     package_to_version "${package}"
 }
 
@@ -38,15 +40,19 @@ hash_toolchains () {
     # if $CC is set bazel will use this to detect c/c++ toolchains, otherwise gcc
     # https://blog.bazel.build/2016/03/31/autoconfiguration.html
     local cc="${CC:-gcc}"
-    local cc_version=$(command_to_version $cc)
+    local cc_version
+    cc_version=$(command_to_version "$cc")
     # NOTE: IIRC some rules call python internally, this can't hurt
-    local python_version=$(command_to_version python)
+    local python_version
+    python_version=$(command_to_version python)
     # the rpm packaging rules use rpmbuild
-    local rpmbuild_version=$(command_to_version rpmbuild)
+    local rpmbuild_version
+    rpmbuild_version=$(command_to_version rpmbuild)
     # combine all tool versions into a hash
     # NOTE(bentheelder): if we change the set of tools considered we should
     # consider prepending the hash with a """schema version""" for completeness
-    local tool_versions="CC:${cc_version},PY:${python_version},RPM:${rpmbuild_version}"
+    local tool_versions
+    tool_versions="CC:${cc_version},PY:${python_version},RPM:${rpmbuild_version}"
     echo "${tool_versions}" | md5sum | cut -d" " -f1
 }
 
@@ -55,7 +61,7 @@ get_workspace () {
     if [[ -n "${REPO_NAME}" ]] && [[ -n "${REPO_OWNER}" ]]; then
         echo "${REPO_OWNER}/${REPO_NAME}"
     else
-        echo "$(basename $(dirname $PWD))/$(basename $PWD)"
+        echo "$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
     fi
 }
 
@@ -70,8 +76,10 @@ make_bazel_rc () {
     # point bazel at our http cache ...
     # NOTE our caches are versioned by all path segments up until the last two
     # IE PUT /foo/bar/baz/cas/asdf -> is in cache "/foo/bar/baz"
-    local cache_id="$(get_workspace),$(hash_toolchains)"
-    local cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
+    local cache_id
+    cache_id="$(get_workspace),$(hash_toolchains)"
+    local cache_url
+    cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
     echo "build --remote_http_cache=${cache_url}"
     # specifically for bazel 0.15.0 we want to set this flag
     # our docker image now sets BAZEL_VERSION with the bazel version as installed

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -59,7 +59,8 @@ RUN wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
     rm "${GO_TARBALL}"
 
 # install bazel
-ARG BAZEL_VERSION
+ARG BAZEL_VERSION_ARG
+ENV BAZEL_VERSION=${BAZEL_VERSION_ARG}
 RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
     wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
     chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -62,7 +62,7 @@ kubetest:
 
 build: kubetest
 	@echo Building with go:$(GO) and bazel:$(BAZEL)
-	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) --build-arg IMAGE_ARG=$(IMG):$(TAG)-$(K8S) -t $(IMG):$(TAG)-$(K8S) .
+	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION_ARG=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) --build-arg IMAGE_ARG=$(IMG):$(TAG)-$(K8S) -t $(IMG):$(TAG)-$(K8S) .
 	docker tag $(IMG):$(TAG)-$(K8S) $(IMG):latest-$(K8S)
 	rm kubetest
 	@echo Built $(IMG):$(TAG)-$(K8S) and tagged with latest-$(K8S)


### PR DESCRIPTION
- add `$BAZEL_VERSION` with the version we're installing as an env instead of just an arg
- check for it in `create_bazel_cache_rcs.sh` so we can configure bazel 0.15.0 with a max concurrent connections for the remote cache (if this goes well the next patch release will have it as the default and we won't need to detect other versions)
- fix shellcheck lints in `create_bazel_cache_rcs.sh`

xref: https://github.com/bazelbuild/bazel/issues/5047