### PR TITLE
Istio flakiness metrics by week

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -66,7 +66,7 @@ jqmeasurements: |
 * weekly-consistency - compute overall weekly consistency for PRs
     - [Config](configs/weekly-consistency-config.yaml)
     - [weekly-consistency-latest.json](http://storage.googleapis.com/k8s-metrics/weekly-consistency-latest.json)
-* istio-job-flakes - compute overall daily consistency for postsubmits
+* istio-job-flakes - compute overall weekly consistency for postsubmits
     - [Config](configs/istio-flakes.yaml)
     - [istio-job-flakes-latest.json](http://storage.googleapis.com/k8s-metrics/istio-job-flakes-latest.json)
 

--- a/metrics/configs/istio-flakes.yaml
+++ b/metrics/configs/istio-flakes.yaml
@@ -4,7 +4,7 @@
 # istio. This config is used by istio only and generates weekly
 # flakiness summery given the constraints aforementioned.
 metric: istio-job-flakes
-description: Computes daily flakiness for all jobs.
+description: Computes weekly flakiness for all jobs.
 query: |
   SELECT
     job,
@@ -19,10 +19,10 @@ query: |
       date(started) stamp,
       sum(if(result=='SUCCESS',1,0)) passed,
       count(result) runs,
-    FROM [k8s-gubernator:build.day]
+    FROM [k8s-gubernator:build.week]
     WHERE
       path LIKE "gs://istio%" AND
-      started > date_add(current_timestamp(), -1, "DAY")
+      started > date_add(current_timestamp(), -7, "DAY")
     GROUP BY job, stamp, commit
   )
   WHERE commit IS NOT NULL /* i.e. postsumit only */


### PR DESCRIPTION
It is possible for a daily metric to be empty as seen here https://github.com/kubernetes/test-infra/pull/8424#issuecomment-401168724. Getting this data weekly at least gives some data for us to configure the velodrome.