### PR TITLE
help: rearrange how labels are applied

### DIFF
--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -128,19 +128,6 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 		return nil
 	}
 
-	// If PR does not have the help label and we're asking it to be added,
-	// add the label
-	if !hasHelp && helpRe.MatchString(e.Body) {
-		if err := gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.IssueHTMLURL, commentAuthor, helpMsg)); err != nil {
-			log.WithError(err).Errorf("Failed to create comment \"%s\".", helpMsg)
-		}
-		if err := gc.AddLabel(org, repo, e.Number, helpLabel); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", helpLabel)
-		}
-
-		return nil
-	}
-
 	// If PR does not have the good-first-issue label and we are asking for it to be added,
 	// add both the good-first-issue and help labels
 	if !hasGoodFirstIssue && helpGoodFirstIssueRe.MatchString(e.Body) {
@@ -156,6 +143,19 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 			if err := gc.AddLabel(org, repo, e.Number, helpLabel); err != nil {
 				log.WithError(err).Errorf("Github failed to add the following label: %s", helpLabel)
 			}
+		}
+
+		return nil
+	}
+
+	// If PR does not have the help label and we're asking it to be added,
+	// add the label
+	if !hasHelp && helpRe.MatchString(e.Body) {
+		if err := gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.IssueHTMLURL, commentAuthor, helpMsg)); err != nil {
+			log.WithError(err).Errorf("Failed to create comment \"%s\".", helpMsg)
+		}
+		if err := gc.AddLabel(org, repo, e.Number, helpLabel); err != nil {
+			log.WithError(err).Errorf("Github failed to add the following label: %s", helpLabel)
 		}
 
 		return nil


### PR DESCRIPTION
Currently, if you do a:

```
/help
/good-first-issue
```
only help gets added. This happens because we check if the comment body matches a regex, add the label and _return_ (due to which the other regexs are never checked against).

This PR arranges the labels so that such combinations give a correct response.

Note: If we don't return here, we would need to check the existing labels on the issue each time we check for a regex.

/cc BenTheElder cblecker fejta 