### PR TITLE
fix version check in create_bazel_cache_rcs.sh

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -84,7 +84,7 @@ make_bazel_rc () {
     # specifically for bazel 0.15.0 we want to set this flag
     # our docker image now sets BAZEL_VERSION with the bazel version as installed
     # https://github.com/bazelbuild/bazel/issues/5047#issuecomment-401295174
-    if [[ -n "${BAZEL_VERSION+}" && "${BAZEL_VERSION}" -eq "0.15.0" ]]; then
+    if [[ -n "${BAZEL_VERSION+}" && "${BAZEL_VERSION}" = "0.15.0" ]]; then
         echo "build --remote_max_connections=200"
     fi
 }


### PR DESCRIPTION
`-eq` is for integers, `=` is for strings 🤦‍♂️ 

xref: https://github.com/kubernetes/test-infra/pull/8516