### PR TITLE
Trust repo collaborators unless disabled

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -5,7 +5,7 @@ New features added to each components:
    from a glob match.
  - *June 05, 2018* `blunderbuss` plugin may now suggest approvers in addition
    to reviewers. Use `exclude_approvers: true` to revert to previous behavior.
- - *April 10, 2018* `cla` plugin now supports `/check-cla` command 
+ - *April 10, 2018* `cla` plugin now supports `/check-cla` command
    to force rechecking of the CLA status.
  - *February 1, 2018* `updateconfig` will now update any configmap on merge
  - *November 14, 2017* `jenkins-operator:0.58` exposes prometheus metrics.
@@ -20,6 +20,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *July 2, 2018* the `trigger` plugin will now trust PRs from repo
+   collaborators. Use `only_org_members: true` in the trigger config to
+   temporarily disable this behavior.
  - *June 14, 2018* the `updateconfig` plugin will only add data to your `ConfigMaps`
    using the basename of the updated file, instead of using that and also duplicating
    the data using the name of the `ConfigMap` as a key

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -24,6 +24,7 @@ import (
 )
 
 const botName = "k8s-ci-robot"
+const Bot = botName
 
 // FakeClient is like client, but fake.
 type FakeClient struct {

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -4,12 +4,15 @@
 ---
 triggers:
 - repos:
-  - GoogleCloudPlatform/k8s-multicluster-ingress
-  - google/cadvisor
   - kubernetes
   - kubernetes-incubator
   - kubernetes-security
   - kubernetes-sigs
+  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+  only_org_members: true
+- repos:
+  - google/cadvisor
+  - GoogleCloudPlatform/k8s-multicluster-ingress
   trusted_org: kubernetes
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
 - repos:

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -366,6 +366,9 @@ type Trigger struct {
 	// should be able to read more about joining the organization in order
 	// to become trusted members. Defaults to the Github link of TrustedOrg.
 	JoinOrgURL string `json:"join_org_url,omitempty"`
+	// OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.
+	// By default, trigger also include repo collaborators.
+	OnlyOrgMembers bool `json:"only_org_members,omitempty"`
 }
 
 type Heart struct {

--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -28,7 +28,7 @@ var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 var testAllRe = regexp.MustCompile(`(?m)^/test all\s*$`)
 var retestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 
-func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
+func handleIC(c client, trigger *plugins.Trigger, ic github.IssueCommentEvent) error {
 	org := ic.Repo.Owner.Login
 	repo := ic.Repo.Name
 	number := ic.Issue.Number
@@ -62,12 +62,12 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 		// Check for the presence of the needs-ok-to-test label and remove it
 		// if a trusted member has commented "/ok-to-test".
 		if okToTest && ic.Issue.HasLabel(needsOkToTest) {
-			orgMember, err := isUserTrusted(c.GitHubClient, commentAuthor, trustedOrg, org)
+			trusted, err := trustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
 			if err != nil {
 				return err
 			}
-			if orgMember {
-				return c.GitHubClient.RemoveLabel(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, needsOkToTest)
+			if trusted {
+				return c.GitHubClient.RemoveLabel(org, repo, number, needsOkToTest)
 			}
 		}
 		return nil
@@ -100,25 +100,21 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 
 	var comments []github.IssueComment
 	// Skip untrusted users.
-	orgMember, err := isUserTrusted(c.GitHubClient, commentAuthor, trustedOrg, org)
+	trusted, err := trustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
 	if err != nil {
-		return err
+		return fmt.Errorf("error checking trust of %s: %v", commentAuthor, err)
 	}
-	if !orgMember {
+	if !trusted {
 		comments, err = c.GitHubClient.ListIssueComments(org, repo, number)
 		if err != nil {
-			return err
+			return fmt.Errorf("error listing issue comments: %v", err)
 		}
-		trusted, err := trustedPullRequest(c.GitHubClient, *pr, trustedOrg, comments)
+		trusted, err := trustedPullRequest(c.GitHubClient, trigger, commentAuthor, org, repo, comments)
 		if err != nil {
 			return err
 		}
 		if !trusted {
-			var more string
-			if org != trustedOrg {
-				more = fmt.Sprintf("or [%s](https://github.com/orgs/%s/people) ", org, org)
-			}
-			resp := fmt.Sprintf("you can't request testing unless you are a [%s](https://github.com/orgs/%s/people) %smember.", trustedOrg, trustedOrg, more)
+			resp := fmt.Sprintf("Cannot trigger testing until a trusted user reviews the PR and leaves an `/ok-to-test` message.")
 			c.Logger.Infof("Commenting \"%s\".", resp)
 			return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 		}
@@ -128,7 +124,7 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 		if err := c.GitHubClient.RemoveLabel(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, needsOkToTest); err != nil {
 			c.Logger.WithError(err).Errorf("Failed at removing %s label", needsOkToTest)
 		}
-		err = clearStaleComments(c.GitHubClient, trustedOrg, *pr, comments)
+		err = clearStaleComments(c.GitHubClient, *pr, comments)
 		if err != nil {
 			c.Logger.Warnf("Failed to clear stale comments: %v.", err)
 		}

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -550,7 +550,7 @@ func TestHandleIssueComment(t *testing.T) {
 			event.Issue.Labels = tc.IssueLabels
 		}
 
-		if err := handleIC(c, "kubernetes", event); err != nil {
+		if err := handleIC(c, nil, event); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}
 		if len(kc.started) > 0 && !tc.ShouldBuild {

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -30,43 +30,44 @@ const (
 	needsOkToTest = "needs-ok-to-test"
 )
 
-func handlePR(c client, trustedOrg, joinOrgURL string, pr github.PullRequestEvent) error {
-	author := pr.PullRequest.User.Login
+func handlePR(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
+	org, repo, a := orgRepoAuthor(pr.PullRequest)
+	author := string(a)
+	num := pr.PullRequest.Number
 	switch pr.Action {
 	case github.PullRequestActionOpened:
 		// When a PR is opened, if the author is in the org then build it.
 		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
 		// "/ok-to-test" comments since the PR was just opened!
-		member, err := isUserTrusted(c.GitHubClient, author, trustedOrg, pr.Repo.Owner.Login)
+		member, err := trustedUser(c.GitHubClient, trigger, author, org, repo)
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
 		}
 		if member {
 			c.Logger.Info("Starting all jobs for new PR.")
 			return buildAll(c, &pr.PullRequest, pr.GUID)
-		} else {
-			c.Logger.Infof("Welcome message to PR author %q.", author)
-			if err := welcomeMsg(c.GitHubClient, pr.PullRequest, trustedOrg, joinOrgURL); err != nil {
-				return fmt.Errorf("could not welcome non-org member %q: %v", author, err)
-			}
+		}
+		c.Logger.Infof("Welcome message to PR author %q.", author)
+		if err := welcomeMsg(c.GitHubClient, trigger, pr.PullRequest); err != nil {
+			return fmt.Errorf("could not welcome non-org member %q: %v", author, err)
 		}
 	case github.PullRequestActionReopened:
 		// When a PR is reopened, check that the user is in the org or that an org
 		// member had said "/ok-to-test" before building.
-		comments, err := c.GitHubClient.ListIssueComments(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name, pr.PullRequest.Number)
+		comments, err := c.GitHubClient.ListIssueComments(org, repo, num)
 		if err != nil {
 			return err
 		}
-		trusted, err := trustedPullRequest(c.GitHubClient, pr.PullRequest, trustedOrg, comments)
+		trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, comments)
 		if err != nil {
 			return fmt.Errorf("could not validate PR: %s", err)
 		} else if trusted {
-			err = clearStaleComments(c.GitHubClient, trustedOrg, pr.PullRequest, comments)
+			err = clearStaleComments(c.GitHubClient, pr.PullRequest, comments)
 			if err != nil {
 				c.Logger.Warnf("Failed to clear stale comments: %v.", err)
 			}
 			// Just try to remove "needs-ok-to-test" label if existing, we don't care about the result.
-			c.GitHubClient.RemoveLabel(trustedOrg, pr.PullRequest.Base.Repo.Name, pr.PullRequest.Number, needsOkToTest)
+			c.GitHubClient.RemoveLabel(org, repo, num, needsOkToTest)
 			c.Logger.Info("Starting all jobs for updated PR.")
 			return buildAll(c, &pr.PullRequest, pr.GUID)
 		}
@@ -90,18 +91,18 @@ func handlePR(c client, trustedOrg, joinOrgURL string, pr github.PullRequestEven
 			return nil
 		} else if changes.Base.Ref.From != "" || changes.Base.Sha.From != "" {
 			// the base of the PR changed and we need to re-test it
-			return buildAllIfTrusted(c, trustedOrg, pr)
+			return buildAllIfTrusted(c, trigger, pr)
 		}
 	case github.PullRequestActionSynchronize:
-		return buildAllIfTrusted(c, trustedOrg, pr)
+		return buildAllIfTrusted(c, trigger, pr)
 	case github.PullRequestActionLabeled:
-		comments, err := c.GitHubClient.ListIssueComments(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name, pr.PullRequest.Number)
+		comments, err := c.GitHubClient.ListIssueComments(org, repo, num)
 		if err != nil {
 			return err
 		}
 		// When a PR is LGTMd, if it is untrusted then build it once.
 		if pr.Label.Name == lgtmLabel {
-			trusted, err := trustedPullRequest(c.GitHubClient, pr.PullRequest, trustedOrg, comments)
+			trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, comments)
 			if err != nil {
 				return fmt.Errorf("could not validate PR: %s", err)
 			} else if !trusted {
@@ -113,19 +114,30 @@ func handlePR(c client, trustedOrg, joinOrgURL string, pr github.PullRequestEven
 	return nil
 }
 
-func buildAllIfTrusted(c client, trustedOrg string, pr github.PullRequestEvent) error {
+type login string
+
+func orgRepoAuthor(pr github.PullRequest) (string, string, login) {
+	org := pr.Base.Repo.Owner.Login
+	repo := pr.Base.Repo.Name
+	author := pr.User.Login
+	return org, repo, login(author)
+}
+
+func buildAllIfTrusted(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
 	// When a PR is updated, check that the user is in the org or that an org
 	// member has said "/ok-to-test" before building. There's no need to ask
 	// for "/ok-to-test" because we do that once when the PR is created.
-	comments, err := c.GitHubClient.ListIssueComments(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name, pr.PullRequest.Number)
+	org, repo, a := orgRepoAuthor(pr.PullRequest)
+	author := string(a)
+	comments, err := c.GitHubClient.ListIssueComments(org, repo, pr.PullRequest.Number)
 	if err != nil {
 		return err
 	}
-	trusted, err := trustedPullRequest(c.GitHubClient, pr.PullRequest, trustedOrg, comments)
+	trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, comments)
 	if err != nil {
 		return fmt.Errorf("could not validate PR: %s", err)
 	} else if trusted {
-		err = clearStaleComments(c.GitHubClient, trustedOrg, pr.PullRequest, comments)
+		err = clearStaleComments(c.GitHubClient, pr.PullRequest, comments)
 		if err != nil {
 			c.Logger.Warnf("Failed to clear stale comments: %v.", err)
 		}
@@ -135,7 +147,7 @@ func buildAllIfTrusted(c client, trustedOrg string, pr github.PullRequestEvent) 
 	return nil
 }
 
-func welcomeMsg(ghc githubClient, pr github.PullRequest, trustedOrg, joinOrgURL string) error {
+func welcomeMsg(ghc githubClient, trigger *plugins.Trigger, pr github.PullRequest) error {
 	commentTemplate := `Hi @%s. Thanks for your PR.
 
 I'm waiting for a [%s](https://github.com/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with ` + "`/ok-to-test`" + ` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should [join the org](%s) to skip this step.
@@ -147,16 +159,23 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands)
 %s
 </details>
 `
-	owner := pr.Base.Repo.Owner.Login
-	name := pr.Base.Repo.Name
+	org, repo, a := orgRepoAuthor(pr)
+	author := string(a)
 	var more string
-	if owner != trustedOrg {
-		more = fmt.Sprintf("or [%s](https://github.com/orgs/%s/people) ", owner, owner)
+	if trigger != nil && trigger.TrustedOrg != "" && trigger.TrustedOrg != org {
+		more = fmt.Sprintf("or [%s](https://github.com/orgs/%s/people) ", trigger.TrustedOrg, trigger.TrustedOrg)
 	}
-	comment := fmt.Sprintf(commentTemplate, pr.User.Login, trustedOrg, trustedOrg, more, joinOrgURL, plugins.AboutThisBotWithoutCommands)
 
-	err1 := ghc.AddLabel(owner, name, pr.Number, needsOkToTest)
-	err2 := ghc.CreateComment(owner, name, pr.Number, comment)
+	var joinOrgURL string
+	if trigger != nil && trigger.JoinOrgURL != "" {
+		joinOrgURL = trigger.JoinOrgURL
+	} else {
+		joinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", org)
+	}
+	comment := fmt.Sprintf(commentTemplate, author, org, org, more, joinOrgURL, plugins.AboutThisBotWithoutCommands)
+
+	err1 := ghc.AddLabel(org, repo, pr.Number, needsOkToTest)
+	err2 := ghc.CreateComment(org, repo, pr.Number, comment)
 	if err1 != nil || err2 != nil {
 		return fmt.Errorf("welcomeMsg: error adding label: %v, error creating comment: %v", err1, err2)
 	}
@@ -166,20 +185,16 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands)
 // trustedPullRequest returns whether or not the given PR should be tested.
 // It first checks if the author is in the org, then looks for "/ok-to-test"
 // comments by org members.
-func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg string, comments []github.IssueComment) (bool, error) {
-	author := pr.User.Login
-	org := pr.Base.Repo.Owner.Login
+func trustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org, repo string, comments []github.IssueComment) (bool, error) {
 	// First check if the author is a member of the org.
-	orgMember, err := isUserTrusted(ghc, author, trustedOrg, org)
-	if err != nil {
-		return false, err
-	}
-	if orgMember {
+	if orgMember, err := trustedUser(ghc, trigger, author, org, repo); err != nil {
+		return false, fmt.Errorf("error checking %s for trust: %v", author, err)
+	} else if orgMember {
 		return true, nil
 	}
 	botName, err := ghc.BotName()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("error finding bot name: %v", err)
 	}
 	// Next look for "/ok-to-test" comments on the PR.
 	for _, comment := range comments {
@@ -189,11 +204,9 @@ func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg stri
 			continue
 		}
 		// Ensure that the commenter is in the org.
-		commentAuthorMember, err := isUserTrusted(ghc, commentAuthor, trustedOrg, org)
-		if err != nil {
-			return false, err
-		}
-		if commentAuthorMember {
+		if commentAuthorMember, err := trustedUser(ghc, trigger, commentAuthor, org, repo); err != nil {
+			return false, fmt.Errorf("error checking %s for trust: %v", commentAuthor, err)
+		} else if commentAuthorMember {
 			return true, nil
 		}
 	}
@@ -211,21 +224,18 @@ func buildAll(c client, pr *github.PullRequest, eventGUID string) error {
 }
 
 // clearStaleComments deletes old comments that are no longer applicable.
-func clearStaleComments(gc githubClient, trustedOrg string, pr github.PullRequest, comments []github.IssueComment) error {
+func clearStaleComments(gc githubClient, pr github.PullRequest, comments []github.IssueComment) error {
 	botName, err := gc.BotName()
 	if err != nil {
 		return err
 	}
 
-	var more string
-	if org := pr.Base.Repo.Owner.Login; org != trustedOrg {
-		more = fmt.Sprintf("or [%s](https://github.com/orgs/%s/people) ", org, org)
-	}
-	waitingComment := fmt.Sprintf("I'm waiting for a [%s](https://github.com/orgs/%s/people) %smember to verify that this patch is reasonable to test.", trustedOrg, trustedOrg, more)
+	org, repo, _ := orgRepoAuthor(pr)
+	const waitingComment = "member to verify that this patch is reasonable to test."
 
 	return gc.DeleteStaleComments(
-		trustedOrg,
-		pr.Base.Repo.Name,
+		org,
+		repo,
 		pr.Number,
 		comments,
 		func(c github.IssueComment) bool { // isStale function


### PR DESCRIPTION
* Create `only_org_members: true` option in `triggers:` config.
  - Trust repo collaborators unless this options is set
* Set `only_org_members: true` for kubernetes repos.
* Fix some bugs where we used `trustedOrg` instead of `org`.
* Refactor a bunch of stuff in process

/assign @cblecker @cjwagner @krzyzacy 
/hold