### PR TITLE
switch pull-test-infra-lint to date-sha tagged image

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3614,8 +3614,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180628-a3a68a1f6-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"


### PR DESCRIPTION
/shrug
this was probably me, not sure why it got left on `:latest-experimental`. that's probably fine but inconsistent with our usual usage of latest tags.