### PR TITLE
fix bazel cache rc script package version resolution and shellcheck lint

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -24,9 +24,9 @@ package_to_version () {
 # look up a binary with which and return the debian package it belongs to
 command_to_package () {
     local binary_path
-    binary_path=$(readlink -f "$(which "$1")")
-    # `dpkg -S $package` spits out lines with the format: "package: file"
-    dpkg -S "$1" | grep "${binary_path}" | cut -d':' -f1
+    binary_path=$(readlink -f "$(command -v "$1")")
+    # `dpkg -S $file` spits out lines with the format: "package: file"
+    dpkg -S "${binary_path}" | cut -d':' -f1
 }
 
 # get the installed package version relating to a binary


### PR DESCRIPTION
this makes more sense and fixes https://github.com/kubernetes/test-infra/issues/8532

also switch from `which` to `command -v` per shellcheck which is a portable builtin. this one isn't totally necessary for our current usage but it's nice to pass shellcheck and it works equally well.

/area greenhouse