### PR TITLE
Add conformance test results for Openstack and MS Azure

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2707,8 +2707,24 @@ test_groups:
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.10
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-aws-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.11
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-gce-v1.10
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.10
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-gce-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.11
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-os-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-os-v1.11
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-az-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-az-v1.11
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
 
@@ -6336,11 +6352,33 @@ dashboards:
     test_group_name: ci-gardener-e2e-conformance-aws-v1.10
     alert_options:
       alert_mail_to_addresses: 'roland.wilfer@sap.com'
+  - name: "v1.11 AWS"
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
+    test_group_name: ci-gardener-e2e-conformance-aws-v1.11
+    alert_options:
+      alert_mail_to_addresses: 'roland.wilfer@sap.com'
   - name: "v1.10 GCE"
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.10
     alert_options:
       alert_mail_to_addresses: 'roland.wilfer@sap.com'
+  - name: "v1.11 GCE"
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
+    test_group_name: ci-gardener-e2e-conformance-gce-v1.11
+    alert_options:
+      alert_mail_to_addresses: 'roland.wilfer@sap.com'
+  - name: "v1.11 OpenStack"
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
+    test_group_name: ci-gardener-e2e-conformance-os-v1.11
+    alert_options:
+      alert_mail_to_addresses: 'roland.wilfer@sap.com'
+  - name: "v1.11 Azure"
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
+    test_group_name: ci-gardener-e2e-conformance-az-v1.11
+    alert_options:
+      alert_mail_to_addresses: 'roland.wilfer@sap.com'
+
+
 #
 # Start dashboard groups
 #


### PR DESCRIPTION
Currently, the conformance test results of AWS and GCP are published on test grid. 
This pull request adds the Azure and Openstack configuration to the existing configuration for test grid to reflect all currently supported Cloud providers by [Gardener](http://github.com/gardener/gardener).