### PR TITLE
debug bazelrc contents

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -101,8 +101,13 @@ make_bazel_rc () {
 # - The path specified by the --bazelrc=file startup option. If specified, this option must appear before the command name (e.g. build)
 # - A file named .bazelrc in your base workspace directory
 # - A file named .bazelrc in your home directory
-make_bazel_rc >> "${HOME}/.bazelrc"
+bazel_rc_contents=$(make_bazel_rc)
+echo "create_bazel_cache_rcs.sh: Configuring '${HOME}/.bazelrc' and '/etc/bazel.bazelrc' with"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}" >> "${HOME}/.bazelrc"
 # Aside from the optional configuration file described above, Bazel also looks for a master rc file next to the binary, in the workspace at tools/bazel.rc or system-wide at /etc/bazel.bazelrc.
 # These files are here to support installation-wide options or options shared between users. Reading of this file can be disabled using the --nomaster_bazelrc option.
-make_bazel_rc >> "/etc/bazel.bazelrc"
+echo "${bazel_rc_contents}" >> "/etc/bazel.bazelrc"
 # hopefully no repos create *both* of these ...


### PR DESCRIPTION
/assign @ixdy 

adds output like (actually run inside planter with BAZEL_VERSION=0.15.0 set as an extra env):
```
create_bazel_cache_rcs.sh: Configuring `/usr/local/google/home/bentheelder/.bazelrc` and `/etc/bazel.bazelrc` with
# ------------------------------------------------------------------------------
startup --host_jvm_args=-Dbazel.DigestFunction=sha256
build --experimental_remote_spawn_cache
build --remote_local_fallback
build --remote_http_cache=http://bazel-cache.default:8080/k8s.io/test-infra,d66682966f1853c098fdbb7294330b90
build --remote_max_connections=200
# ------------------------------------------------------------------------------
```

this will let us verify what options we've set via the podlogs