### PR TITLE
fix id -F does not exist on linux

### DIFF
--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -75,7 +75,12 @@ RUN_OPTS="${RUN_OPTS} --security-opt label:disable"
 _UID="$(id -u "${USER}")"
 _GID="$(id -g "${USER}")"
 RUN_OPTS="${RUN_OPTS} --user ${_UID}:${_GID} -e GID=${_GID} -e UID=${_UID}"
-FULL_NAME="$(id -F "${USER}")"
+# macOS has the convenient `id -F` and no getent, unix has getent
+if command -v getent >/dev/null 2>&1; then
+    FULL_NAME="$(getent passwd "${USER}" | cut -d : -f 5)"
+else
+    FULL_NAME="$(id -F "${USER}")"
+fi
 RUN_OPTS="${RUN_OPTS} -e USER=${USER} -e FULL_NAME='${FULL_NAME}'"
 RUN_OPTS="${RUN_OPTS} -e HOME=${HOME}"
 


### PR DESCRIPTION
The `id` command is a convenient way to get info about posix users, however it turns out when I recently updated planter to pass through the real name using `id -F` I neglected the fact that this flag is only available on mac.....
On other UNIXen we can instead use `getent` to dump the /etc/passwd entry (and `getent` is not available on mac...) and then filter out the full name field.

/assign @ixdy @krzyzacy 
/area planter