### PR TITLE
Allow other packages in Prow to utilize JobAgent

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -81,6 +81,7 @@ filegroup(
         "//prow/commentpruner:all-srcs",
         "//prow/config:all-srcs",
         "//prow/cron:all-srcs",
+        "//prow/deck/jobs:all-srcs",
         "//prow/entrypoint:all-srcs",
         "//prow/errorutil:all-srcs",
         "//prow/external-plugins/cherrypicker:all-srcs",

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     name = "go_default_test",
     srcs = [
         "badge_test.go",
-        "jobs_test.go",
         "main_test.go",
         "tide_test.go",
     ],
@@ -63,7 +62,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "badge.go",
-        "jobs.go",
         "main.go",
         "pluginhelp.go",
         "tide.go",
@@ -71,6 +69,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/deck",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/deck/jobs:go_default_library",
         "//prow/githuboauth:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
@@ -84,7 +83,6 @@ go_library(
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/github:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )
 

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["jobs.go"],
+    importpath = "k8s.io/test-infra/prow/deck/jobs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/kube:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["jobs_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//prow/kube:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/deck/jobs/jobs_test.go
+++ b/prow/deck/jobs/jobs_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package jobs
 
 import (
 	"fmt"
@@ -72,7 +72,7 @@ func TestGetLog(t *testing.T) {
 	}
 	ja := &JobAgent{
 		kc:   kc,
-		pkcs: map[string]podLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")},
+		pkcs: map[string]PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")},
 	}
 	if err := ja.update(); err != nil {
 		t.Fatalf("Updating: %v", err)
@@ -109,7 +109,7 @@ func TestProwJobs(t *testing.T) {
 	}
 	ja := &JobAgent{
 		kc:   kc,
-		pkcs: map[string]podLogClient{kube.DefaultClusterAlias: fpkc("")},
+		pkcs: map[string]PodLogClient{kube.DefaultClusterAlias: fpkc("")},
 	}
 	if err := ja.update(); err != nil {
 		t.Fatalf("Updating: %v", err)


### PR DESCRIPTION
Created package deck, deck/jobs, which contains logic for job and config agents and pod logs, moved associated logic out of the main package and refactored deck accordingly. Added a public constructor for JobAgent, made PodLogClient and ConfigAgent public for use by main package.