### PR TITLE
Ensure the interface value is not nil before report

### DIFF
--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/test-infra/prow/plank"
 )
 
+type githubClient interface {}
+
 var (
 	totURL = flag.String("tot-url", "", "Tot URL")
 
@@ -93,7 +95,7 @@ func main() {
 		oauthSecret = string(bytes.TrimSpace(oauthSecretRaw))
 	}
 
-	var ghc *github.Client
+	var ghc githubClient
 	var kc *kube.Client
 	var pkcs map[string]*kube.Client
 	if *dryRun {

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -19,6 +19,7 @@ package plank
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -89,7 +90,7 @@ type Controller struct {
 }
 
 // NewController creates a new Controller from the provided clients.
-func NewController(kc *kube.Client, pkcs map[string]*kube.Client, ghc *github.Client, logger *logrus.Entry, ca *config.Agent, totURL, selector string) (*Controller, error) {
+func NewController(kc *kube.Client, pkcs map[string]*kube.Client, ghc githubClient, logger *logrus.Entry, ca *config.Agent, totURL, selector string) (*Controller, error) {
 	n, err := snowflake.NewNode(1)
 	if err != nil {
 		return nil, err
@@ -217,7 +218,9 @@ func (c *Controller) Sync() error {
 	}
 
 	var reportErrs []error
+	c.log.Warn("*** Before Reporting ***")
 	if c.ghc != nil {
+		c.log.Warn("*** Inside Reporting ***")
 		reportTemplate := c.ca.Config().Plank.ReportTemplate
 		for report := range reportCh {
 			if err := reportlib.Report(c.ghc, reportTemplate, report); err != nil {


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/8505
ghc is an interface rather than a pointer... I think this is the correct way of comparison?

/area prow
/assign @BenTheElder @cjwagner @amwat 