### PR TITLE
Make Tide use the 'HeadRefs' field when possible.

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -167,18 +167,16 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 	}
 
 	// fixing label issues takes precedence over status contexts
-	var contexts []string
-	for _, commit := range pr.Commits.Nodes {
-		if commit.Commit.OID == pr.HeadRefOID {
-			for _, ctx := range unsuccessfulContexts(commit.Commit.Status.Contexts, cc) {
-				contexts = append(contexts, string(ctx.Context))
-			}
+	var unsuccessful []string
+	if contexts, ok := headContextsNoCost(pr); ok {
+		for _, ctx := range unsuccessfulContexts(contexts, cc) {
+			unsuccessful = append(unsuccessful, string(ctx.Context))
 		}
 	}
-	diff += len(contexts)
-	if desc == "" && len(contexts) > 0 {
-		sort.Strings(contexts)
-		trunced := truncate(contexts)
+	diff += len(unsuccessful)
+	if desc == "" && len(unsuccessful) > 0 {
+		sort.Strings(unsuccessful)
+		trunced := truncate(unsuccessful)
 		if len(trunced) == 1 {
 			desc = fmt.Sprintf(" Job %s has not succeeded.", trunced[0])
 		} else {


### PR DESCRIPTION
There still is no way to get the current status contexts for any PR using the GitHub graphql API, but we can increase our chances of getting the data we need in the query by trying to fetch the data in two different ways that each sometimes work. If both fail we fallback to the third option of using GitHub's REST API, and we eat the API token cost.
This PR should let us avoid spending extra API tokens for all PRs except for PRs with deleted head refs that also have a misordered commit as the 'last' commit. (It also decreases the number of commits that we list from 4 to 2 which may help with the 502s that GitHub sends us in response to large requests.)

See the documentation for the `headContexts` function for a more detailed explanation of the options we try. 

/cc @rmmh @BenTheElder @stevekuznetsov @kargakis 
/area prow
/shrug