### PR TITLE
Handle 404s in tot fallback better.

### DIFF
--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -208,6 +208,8 @@ func (f fallbackHandler) get(jobName string) int {
 				} else {
 					logrus.WithError(err).Error("Failed to read response body.")
 				}
+			} else if resp.StatusCode == http.StatusNotFound {
+				break
 			}
 		} else {
 			logrus.WithError(err).Errorf("Failed to GET %s.", url)


### PR DESCRIPTION
Previously, this would spend over a minute retrying a 404ed job name.