### PR TITLE
Make https://prow.k8s.io/pr autologin (like Gubernator's /pr).

### DIFF
--- a/prow/cmd/deck/static/github-login.html
+++ b/prow/cmd/deck/static/github-login.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PR Status</title>
+    <link id="favicon" rel="icon" type="image/png" href="favicon.ico">
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" type="text/css" href="extensions/style.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <script type="text/javascript" src="extensions/script.js"></script>
+    <script type="text/javascript" src="branding.js?var=branding"></script>
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+</head>
+<body>
+<div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+    <header class="mdl-layout__header">
+        <div class="mdl-layout__header-row">
+            <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow"
+               class="logo"><img id="img" src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
+            <span class="mdl-layout-title header-title">GitHub Login</span>
+        </div>
+    </header>
+    <div class="mdl-layout__drawer">
+        <span class="mdl-layout-title">Prow Dashboard</span>
+        <nav class="mdl-navigation">
+            <a class="mdl-navigation__link" href="/">Prow Status</a>
+            <a class="mdl-navigation__link mdl-navigation__link--current" href="/pr">PR Status</a>
+            <a class="mdl-navigation__link" href="/command-help">Command Help</a>
+            <a class="mdl-navigation__link" href="/tide">Tide Status</a>
+            <a class="mdl-navigation__link" href="/plugins">Plugins</a>
+        </nav>
+    </div>
+    <main id="main-container" class="mdl-layout__content">
+        <div class="mdl-card mdl-shadow--2dp">
+          <div class="mdl-card__title">
+            <h2 class="mdl-card__title-text">Error</h2>
+          </div>
+          <div class="mdl-card__supporting-text">
+            This Prow instance is not configured to allow logging in with GitHub.
+          </div>
+          <div class="mdl-card__actions mdl-card--border">
+            <a href="/" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+              Return to main page
+            </a>
+          </div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/prow/cmd/deck/static/pr-script.js
+++ b/prow/cmd/deck/static/pr-script.js
@@ -104,7 +104,7 @@ function redraw(prData) {
     if (prData && prData.Login) {
         loadPrStatus(prData);
     } else {
-        loadGithubLogin();
+        forceGithubLogin();
     }
 }
 
@@ -822,25 +822,10 @@ function createPRCard(pr, builds = [], queries = [], tidePools = []) {
 }
 
 /**
- * Load Github login button if user has not login.
+ * Redirect to initiate github login flow.
  */
-function loadGithubLogin() {
-    const button = document.createElement("BUTTON");
-    button.classList.add("mdl-button", "mdl-js-button", "mdl-button--raised",
-        "mdl-button--primary", "mdl-js-ripple-effect");
-    button.textContent = "Login to Github";
-    button.style.alignSelf = "center";
-    button.style.width = "160px";
-    button.addEventListener("click", () => {
-        const url = window.location;
-        window.location.href = url.origin + "/github-login";
-    });
-    const msg = createMessage(
-        "PR Status needs you to login and grant it OAuth scopes",
-        "sentiment_very_satisfied");
-    const main = document.querySelector("#main-container");
-    main.appendChild(msg);
-    main.appendChild(button);
+function forceGithubLogin() {
+	window.location.href = window.location.origin + "/github-login";
 }
 
 /**


### PR DESCRIPTION
Add a fallback error page if a user tries to login and OAuth isn't configured--
really, the menu should be templatized to *hide* the PR link if it's not
configured, but that's more work.