### PR TITLE
Increase verbosity for 5k node tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3573,7 +3573,6 @@
       "--env=MASTER_MIN_CPU_ARCHITECTURE=Intel Broadwell",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",
-      "--env-file=jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",
       "--gcp-node-image=gci",

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
@@ -1,4 +1,0 @@
-### cluster-env
-
-# Reduce logs verbosity as the cluster is huge.
-TEST_CLUSTER_LOG_LEVEL=--v=1

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -1,7 +1,4 @@
 ### cluster-env
 
-# Reduce logs verbosity as the cluster is huge.
-TEST_CLUSTER_LOG_LEVEL=--v=1
-
 # Turn off advanced audit logging to simulate production
 ENABLE_APISERVER_ADVANCED_AUDIT=false


### PR DESCRIPTION
With the last runs of 5k-node tests passed:
https://k8s-testgrid.appspot.com/sig-scalability-gce#gce-scale-performance
https://k8s-testgrid.appspot.com/sig-scalability-gce#gce-scale-correctness
I think we should try to towards better unification