### PR TITLE
Turn on master profiling in kubemark jobs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-kubemark-common.env
+++ b/jobs/env/ci-kubernetes-e2e-kubemark-common.env
@@ -4,7 +4,8 @@ KUBE_FASTBUILD=true
 KUBE_GCE_ENABLE_IP_ALIASES=true
 CREATE_CUSTOM_NETWORK=true
 ENABLE_HOLLOW_NODE_LOGS=true
-# Turn on profiling for scheduler
+# Turn on profiling for various components.
+CONTROLLER_MANAGER_TEST_ARGS=--profiling
 SCHEDULER_TEST_ARGS=--profiling
 # Increase controller-manager's resync period to simulate production.
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h


### PR DESCRIPTION
Seems like kubemark was left out for https://github.com/kubernetes/kubernetes/issues/65698.

/cc @wojtek-t 