### PR TITLE
Enable profiling of etcd in scalability tests

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-kubemark-common.env
+++ b/jobs/env/ci-kubernetes-e2e-kubemark-common.env
@@ -5,6 +5,7 @@ KUBE_GCE_ENABLE_IP_ALIASES=true
 CREATE_CUSTOM_NETWORK=true
 ENABLE_HOLLOW_NODE_LOGS=true
 # Turn on profiling for various components.
+ETCD_TEST_ARGS=--enable-pprof
 CONTROLLER_MANAGER_TEST_ARGS=--profiling
 SCHEDULER_TEST_ARGS=--profiling
 # Increase controller-manager's resync period to simulate production.

--- a/jobs/env/ci-kubernetes-e2e-scalability-common.env
+++ b/jobs/env/ci-kubernetes-e2e-scalability-common.env
@@ -9,6 +9,7 @@ LOGROTATE_MAX_SIZE=5G
 # Use IP-aliases for scalability tests.
 KUBE_GCE_ENABLE_IP_ALIASES=true
 # Turn on profiling for various components.
+ETCD_EXTRA_ARGS=--enable-pprof
 CONTROLLER_MANAGER_TEST_ARGS=--profiling
 KUBELET_TEST_ARGS=--enable-debugging-handlers
 KUBEPROXY_TEST_ARGS=--profiling


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/65698

I think this will also be useful (to have etcd profiles under k8s-type usage). cc @jpbetz @xiang90 @hongchaodeng (in case you're interested to examine live perf tests)

/cc @wojtek-t 
