### PR TITLE
Update branch managers post-1.11 release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -131,8 +131,6 @@ slack:
     - k8s-merge-robot # submit queue
     - k8s-release-robot # anago
     branch_whitelist:
-        release-1.7:
-            - wojtek-t # 1.7 patch release manager
         release-1.8:
             - jpbetz # 1.8 patch release manager
         release-1.9:
@@ -140,7 +138,7 @@ slack:
         release-1.10:
             - maciekpytel # 1.10 patch release manager
         release-1.11:
-            - calebamiles # 1.11 branch manager
+            - foxish # 1.11 patch release manager
         feature-serverside-apply:
             - lavalamp # feature-serverside-apply "branch manager"
   - repos:


### PR DESCRIPTION
This updates the branch whitelist, post-1.11 release:
- Removes @wojtek-t for release-1.7 as 1.7 is no longer supported
- Swaps @calebamiles (branch manager) for @foxish (patch release manager) on the release-1.11 branch

cc: @kubernetes/sig-release-members 