### PR TITLE
Increase qps limits for scalability tests

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-scalability-common.env
+++ b/jobs/env/ci-kubernetes-e2e-scalability-common.env
@@ -8,12 +8,13 @@ LOGROTATE_MAX_SIZE=5G
 
 # Use IP-aliases for scalability tests.
 KUBE_GCE_ENABLE_IP_ALIASES=true
-# Turn on profiling for various components.
+# Turn on profiling for various components and
+# increase throughput in master components.
 ETCD_EXTRA_ARGS=--enable-pprof
-CONTROLLER_MANAGER_TEST_ARGS=--profiling
+CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100
 KUBELET_TEST_ARGS=--enable-debugging-handlers
 KUBEPROXY_TEST_ARGS=--profiling
-SCHEDULER_TEST_ARGS=--profiling
+SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100
 # Switch off image puller to workaround #44701
 PREPULL_E2E_IMAGES=false
 # Reduce logs verbosity.

--- a/jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env
+++ b/jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env
@@ -1,6 +1,2 @@
 # Increase size of default subnetworks to enable large clusters.
 ENABLE_BIG_CLUSTER_SUBNETS=true
-
-# Increase throughput in master components.
-SCHEDULER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100
-CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100


### PR DESCRIPTION
This is step towards unification of all our jobs. This PR move the qps limits bump to scalability-common env file, which effectively means adding it to our "100-node scalability jobs" (that's the diff between where those two are used).

This obviously results in a bit worse metrics, but they are still well within SLO, so I think it's worth it (it additionally speeds up a bit those tests).

FTR, metrics from my runs:
load test:
```
Jul  5 10:27:39.616: INFO: Top latency metric: {Resource:pods Subresource: Verb:DELETE Scope:namespace Latency:{Perc50:10.41ms Perc90:39.762ms Perc99:157.179ms Perc100:0s} Count:7514}
Jul  5 10:27:39.616: INFO: Top latency metric: {Resource:nodes Subresource: Verb:LIST Scope:cluster Latency:{Perc50:17.401ms Perc90:44.688ms Perc99:147.274ms Perc100:0s} Count:129}
Jul  5 10:27:39.616: INFO: Top latency metric: {Resource:pods Subresource:binding Verb:POST Scope:namespace Latency:{Perc50:6.536ms Perc90:28.148ms Perc99:104.972ms Perc100:0s} Count:3757}
Jul  5 10:27:39.616: INFO: Top latency metric: {Resource:pods Subresource:status Verb:PATCH Scope:namespace Latency:{Perc50:3.892ms Perc90:20.093ms Perc99:83.217ms Perc100:0s} Count:21203}
Jul  5 10:27:39.616: INFO: Top latency metric: {Resource:pods Subresource: Verb:POST Scope:namespace Latency:{Perc50:8.491ms Perc90:35.087ms Perc99:78.509ms Perc100:0s} Count:37
```
density test:
```
Jul  5 10:32:02.831: INFO: Top latency metric: {Resource:pods Subresource: Verb:POST Scope:namespace Latency:{Perc50:78.741ms Perc90:153.337ms Perc99:302.627ms Perc100:0s} Count:3100}
Jul  5 10:32:02.831: INFO: Top latency metric: {Resource:pods Subresource:binding Verb:POST Scope:namespace Latency:{Perc50:17.684ms Perc90:97.93ms Perc99:284.79ms Perc100:0s} Count:3100}
Jul  5 10:32:02.831: INFO: Top latency metric: {Resource:pods Subresource: Verb:DELETE Scope:namespace Latency:{Perc50:16.3ms Perc90:75.123ms Perc99:184.308ms Perc100:0s} Count:6200}
Jul  5 10:32:02.831: INFO: Top latency metric: {Resource:endpoints Subresource: Verb:GET Scope:namespace Latency:{Perc50:1.607ms Perc90:20.061ms Perc99:166.407ms Perc100:0s} Count:189}
Jul  5 10:32:02.831: INFO: Top latency metric: {Resource:nodes Subresource:status Verb:PATCH Scope:cluster Latency:{Perc50:8.079ms Perc90:43.661ms Perc99:153.534ms Perc100:0s} Count:2228}
```

Thoughts?