### PR TITLE
Rename gce-large job clusters

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3211,7 +3211,7 @@
   },
   "ci-kubernetes-e2e-gce-large-correctness": {
     "args": [
-      "--cluster=gce-scale-cluster",
+      "--cluster=gce-large-cluster",
       "--env=HEAPSTER_MACHINE_TYPE=n1-standard-8",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",
@@ -3274,7 +3274,7 @@
   },
   "ci-kubernetes-e2e-gce-large-performance": {
     "args": [
-      "--cluster=gce-scale-cluster",
+      "--cluster=gce-large-cluster",
       "--env=HEAPSTER_MACHINE_TYPE=n1-standard-8",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/65626
So we don't lose more runs because of it.

/cc @wojtek-t 