### PR TITLE
make bump_e2e_image.sh handle kubeadm in config/jobs

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -72,4 +72,5 @@ TAG="${DATE}-$(git describe --tags --always --dirty)"
 make -C "${TREE}/images/kubeadm" push TAG="${TAG}"
 
 $SED -i "s/\\/e2e-kubeadm:v.*$/\\/e2e-kubeadm:${TAG}/" "${TREE}/prow/config.yaml"
+find "${TREE}/config/jobs/" -type f -name \*.yaml -exec $SED -i "s/\\/e2e-kubeadm:v.*-\\(.*\)$/\\/e2e-kubeadm:${TAG}-\\1/" {} \;
 git commit -am "Bump to e2e-kubeadm:${TAG}"


### PR DESCRIPTION
/shrug
/assign @krzyzacy 
I think this is right, just copied from the one for kubekins-e2e