### PR TITLE
Improve peribolos around child teams, uppercase, invitations

### DIFF
--- a/prow/cmd/peribolos/test-config.yaml
+++ b/prow/cmd/peribolos/test-config.yaml
@@ -1,0 +1,33 @@
+orgs:
+  fejtaverse:
+    description: very-fancy
+    default_repository_permission: read
+    has_organization_projects: false
+    has_repository_projects: true
+    admins:
+    - fejta
+    - k8s-ci-robot
+    members:
+    - fejta-bot
+    - cblecker
+    - bentheelder
+    - krzyzacy
+    - cjwagner
+    teams:
+      bots:
+        members:
+        - fejta-bot
+        maintainers:
+        - k8s-ci-robot
+        teams:
+          robots:
+            members: ["fejta-bot"]
+      humans:
+        maintainers:
+        - fejta
+        members:
+        - bentheelder
+        - cblecker
+        superlative-humans:
+          members:
+          - krzyzacy

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -585,14 +585,21 @@ type Content struct {
 	SHA     string `json:"sha"`
 }
 
+const (
+	// PrivacySecret memberships are only visible to other team members.
+	PrivacySecret = "secret"
+	// PrivacyClosed memberships are visible to org members.
+	PrivacyClosed = "closed"
+)
+
 // Team is a github organizational team
 type Team struct {
 	ID           int    `json:"id,omitempty"`
 	Name         string `json:"name"`
 	Description  string `json:"description,omitempty"`
 	Privacy      string `json:"privacy,omitempty"`
-	Parent       *Team  `json:"parent,omitempty"` // Only present in responses
-	ParentTeamID *int   `json:"parent_team_id"`   // Only valid in creates/edits
+	Parent       *Team  `json:"parent,omitempty"`         // Only present in responses
+	ParentTeamID *int   `json:"parent_team_id,omitempty"` // Only valid in creates/edits
 }
 
 // TeamMember is a member of an organizational team
@@ -647,6 +654,12 @@ type OrgMembership struct {
 // TeamMembership contains Membership fields for user membership on a team.
 type TeamMembership struct {
 	Membership
+}
+
+// OrgInvitation contains Login and other details about the invitation.
+type OrgInvitation struct {
+	TeamMember
+	Inviter TeamMember `json:"login"`
 }
 
 // GenericCommentEventAction coerces multiple actions into its generic equivalent.


### PR DESCRIPTION
Update github client to:
* Support both Create (cannot send null parent) and Edit team (must send null parent)
* Return a response in dry-run mode for a variety of PUT/PATCH calls
* Create/use privacy/accept constants

Update peribolos to:
* Handle `BenTheElder` and other non-lowercase logins correctly
* Wait for someone to accept an invite to update their membership.
* Create child teams
* Set privacy to closed for nested teams (required by github)
* Allow deleting everything if `maxDelta = 1.0`
* Use role constants

/assign @cblecker @cjwagner @stevekuznetsov @BenTheElder 