### PR TITLE
Adding GCB yaml files to build and push k8s images to GCR

### DIFF
--- a/images/image-builder/debian-base.addon.yaml
+++ b/images/image-builder/debian-base.addon.yaml
@@ -1,0 +1,30 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: k8s.gcr.io/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: k8s.gcr.io/addon-builder
+  dir: "/workspace/kubernetes/build/debian-base"
+  env:
+  - 'TMPDIR=/workspace'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    for arch in amd64 arm arm64 ppc64le s390x; do
+      ARCH=$arch make build
+    done
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env:
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  args:
+  - "debian-base"
+timeout: 10800s

--- a/images/image-builder/debian-hyperkube-base.addon.yaml
+++ b/images/image-builder/debian-hyperkube-base.addon.yaml
@@ -1,0 +1,30 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: k8s.gcr.io/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: k8s.gcr.io/addon-builder
+  dir: "/workspace/kubernetes/build/debian-hyperkube-base"
+  env: &env
+  - 'TMPDIR=/workspace'
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    for arch in amd64 arm arm64 ppc64le s390x; do
+      ARCH=$arch make build
+    done
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env: *env
+  args:
+  - "debian-hyperkube-base"
+timeout: 10800s

--- a/images/image-builder/volumes-tester-gluster.addon.yaml
+++ b/images/image-builder/volumes-tester-gluster.addon.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: gcr.io/google-containers/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: gcr.io/google-containers/addon-builder
+  dir: "/workspace/kubernetes/test/images/volumes-tester/gluster"
+  env:
+  - 'TMPDIR=/workspace'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    make image
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env:
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  args:
+  - "volume-gluster"
+timeout: 10800s

--- a/images/image-builder/volumes-tester-iscsi.addon.yaml
+++ b/images/image-builder/volumes-tester-iscsi.addon.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: gcr.io/google-containers/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: gcr.io/google-containers/addon-builder
+  dir: "/workspace/kubernetes/test/images/volumes-tester/iscsi"
+  env:
+  - 'TMPDIR=/workspace'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    make image
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env:
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  args:
+  - "volume-iscsi"
+timeout: 10800s

--- a/images/image-builder/volumes-tester-nfs.addon.yaml
+++ b/images/image-builder/volumes-tester-nfs.addon.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: gcr.io/google-containers/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: gcr.io/google-containers/addon-builder
+  dir: "/workspace/kubernetes/test/images/volumes-tester/nfs"
+  env:
+  - 'TMPDIR=/workspace'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    make image
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env:
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  args:
+  - "volume-nfs"
+timeout: 10800s

--- a/images/image-builder/volumes-tester-rbd.addon.yaml
+++ b/images/image-builder/volumes-tester-rbd.addon.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  _REV: "master"
+  _PUSH_REGISTRY: ""
+steps:
+- name: gcr.io/google-containers/addon-builder
+  entrypoint: checkout
+  args:
+  - "https://github.com/kubernetes/kubernetes"
+  - "--rev"
+  - "${_REV}"
+- name: gcr.io/google-containers/addon-builder
+  dir: "/workspace/kubernetes/test/images/volumes-tester/rbd"
+  env:
+  - 'TMPDIR=/workspace'
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    make image
+- name: k8s.gcr.io/addon-builder
+  entrypoint: label_push
+  env:
+  - "BUILD_ID=$BUILD_ID"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "PUSH_REGISTRY=${_PUSH_REGISTRY}"
+  args:
+  - "volume-rbd"
+timeout: 10800s


### PR DESCRIPTION
This PR adds yaml files to build the following e2e images using Add-on builder and push the updated images to appropriate GCR location.
* [Debian-hyperkube](https://github.com/kubernetes/kubernetes/tree/master/build/debian-hyperkube-base)
* [Debian-base](https://github.com/kubernetes/kubernetes/tree/master/build/debian-base)
* [volumes-tester/gluster](https://github.com/kubernetes/kubernetes/tree/master/test/images/volumes-tester/gluster)
* [volumes-tester/iscsi](https://github.com/kubernetes/kubernetes/tree/master/test/images/volumes-tester/iscsi)
* [volumes-tester/rbd](https://github.com/kubernetes/kubernetes/tree/master/test/images/volumes-tester/rbd)
* [volumes-tester/nfs](https://github.com/kubernetes/kubernetes/tree/master/test/images/volumes-tester/nfs)
