### PR TITLE
Enable bazel build for kubemark-canary

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12954,6 +12954,8 @@ periodics:
       - --bare
       - --timeout=260
       env:
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
       volumeMounts:


### PR DESCRIPTION
To experiment wrt https://github.com/kubernetes/test-infra/issues/8348#issuecomment-403102079

/cc @krzyzacy 