### PR TITLE
add tests for scenario args

### DIFF
--- a/config/tests/jobs/BUILD.bazel
+++ b/config/tests/jobs/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "//config:prowjobs",
         "//jobs",
         "//prow:configs",
+        "//scenarios",
     ],
     deps = [
         "//prow/config:go_default_library",


### PR DESCRIPTION
also unified a lot of looping logic...

basically converted the logic from https://github.com/kubernetes/test-infra/blob/524735adb3a7f966da00c9232de4cbf551144761/jobs/config_test.py#L251-L286, makes sure the --scenario flag is valid first. Gonna port over rest of the logic in a bit.

/area jobs
/assign @BenTheElder 