### PR TITLE
prow: tide: ensure correct status contexts are gathered

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -107,6 +107,9 @@ func main() {
 	if o.dryRun {
 		ghcSync = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings()...)
 		ghcStatus = github.NewDryRunClient(oauthSecret, o.githubEndpoint.Strings()...)
+		if o.deckURL == "" {
+			logrus.Fatal("no deck URL was given for read-only ProwJob access")
+		}
 		kc = kube.NewFakeClient(o.deckURL)
 	} else {
 		ghcSync = github.NewClient(oauthSecret, o.githubEndpoint.Strings()...)

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -167,18 +167,16 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 	}
 
 	// fixing label issues takes precedence over status contexts
-	var contexts []string
-	for _, commit := range pr.Commits.Nodes {
-		if commit.Commit.OID == pr.HeadRefOID {
-			for _, ctx := range unsuccessfulContexts(commit.Commit.Status.Contexts, cc) {
-				contexts = append(contexts, string(ctx.Context))
-			}
+	var unsuccessful []string
+	if contexts, ok := headContextsNoCost(pr); ok {
+		for _, ctx := range unsuccessfulContexts(contexts, cc) {
+			unsuccessful = append(unsuccessful, string(ctx.Context))
 		}
 	}
-	diff += len(contexts)
-	if desc == "" && len(contexts) > 0 {
-		sort.Strings(contexts)
-		trunced := truncate(contexts)
+	diff += len(unsuccessful)
+	if desc == "" && len(unsuccessful) > 0 {
+		sort.Strings(unsuccessful)
+		trunced := truncate(unsuccessful)
 		if len(trunced) == 1 {
 			desc = fmt.Sprintf(" Job %s has not succeeded.", trunced[0])
 		} else {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -597,6 +597,22 @@ func prNumbers(prs []PullRequest) []int {
 }
 
 func (c *Controller) pickBatch(sp subpool, cc contextChecker) ([]PullRequest, error) {
+	// we must choose the oldest PRs for the batch
+	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
+
+	var candidates []PullRequest
+	for _, pr := range sp.prs {
+		if isPassingTests(sp.log, c.ghc, pr, cc) {
+			candidates = append(candidates, pr)
+		}
+	}
+
+	if len(candidates) == 0 {
+		sp.log.Debugf("of %d possible PRs, none were passing tests, no batch will be created", len(sp.prs))
+		return nil, nil
+	}
+	sp.log.Debugf("of %d possible PRs, %d are passing tests", len(sp.prs), len(candidates))
+
 	r, err := c.gc.Clone(sp.org + "/" + sp.repo)
 	if err != nil {
 		return nil, err
@@ -615,14 +631,8 @@ func (c *Controller) pickBatch(sp subpool, cc contextChecker) ([]PullRequest, er
 		return nil, err
 	}
 
-	// we must choose the oldest PRs for the batch
-	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
-
 	var res []PullRequest
-	for _, pr := range sp.prs {
-		if !isPassingTests(sp.log, c.ghc, pr, cc) {
-			continue
-		}
+	for _, pr := range candidates {
 		if ok, err := r.Merge(string(pr.HeadRefOID)); err != nil {
 			// we failed to abort the merge and our git client is
 			// in a bad state; it must be cleaned before we try again

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -946,8 +946,13 @@ type PullRequest struct {
 	}
 	HeadRefName githubql.String `graphql:"headRefName"`
 	HeadRefOID  githubql.String `graphql:"headRefOid"`
-	Mergeable   githubql.MergeableState
-	Repository  struct {
+	HeadRef     *struct {
+		Target struct {
+			Commit Commit `graphql:"... on Commit"`
+		}
+	}
+	Mergeable  githubql.MergeableState
+	Repository struct {
 		Name          githubql.String
 		NameWithOwner githubql.String
 		Owner         struct {
@@ -958,12 +963,8 @@ type PullRequest struct {
 		Nodes []struct {
 			Commit Commit
 		}
-		// Request the 'last' 4 commits hoping that one of them is the logically 'last'
-		// commit with OID matching HeadRefOID. If we don't find it we have to use an
-		// additional API token. (see the 'headContexts' func for details)
-		// We can't raise this too much or we could hit the limit of 50,000 nodes
-		// per query: https://developer.github.com/v4/guides/resource-limitations/#node-limit
-	} `graphql:"commits(last: 4)"`
+		// See the 'headContexts' function for details.
+	} `graphql:"commits(last: 1)"`
 	Labels struct {
 		Nodes []struct {
 			Name githubql.String
@@ -1016,26 +1017,40 @@ func (pr *PullRequest) logFields() logrus.Fields {
 
 // headContexts gets the status contexts for the commit with OID == pr.HeadRefOID
 //
-// First, we try to get this value from the commits we got with the PR query.
-// Unfortunately the 'last' commit ordering is determined by author date
-// not commit date so if commits are reordered non-chronologically on the PR
-// branch the 'last' commit isn't necessarily the logically last commit.
-// We list multiple commits with the query to increase our chance of success,
-// but if we don't find the head commit we have to ask Github for it
-// specifically (this costs an API token).
+// There is no single way to use the GitHub Graphql API to get the status contexts
+// for the head commit of PR. There are 2 ways that each only work under certain
+// conditions and sometimes neither of those will work and we must fall back to
+// the REST API. Here is our process:
+//
+// First, we try to get the statuses via the `headRef` field. This works most PRs,
+// only PRs with a deleted head ref will need to continue on.
+//
+// If the head ref has been deleted, we can still get status contexts by looking
+// at the list of commits for the PR. Unfortunately the 'last' commit ordering
+// is determined by author date not commit date so if commits are reordered
+// non-chronologically on the PR branch, the 'last' commit isn't necessarily the
+// logically last commit. Most PRs won't have reorder commits so in most cases
+// we can just use the statuses from this 'last' commit.
+//
+// If the worst case occurs and neither of the above cases is suitable we have
+// to use the REST API to get the head commit statuses. This costs an extra API
+// token every sync loop.
+//
+// Here are some issues on GitHub's support forum that describe why this gross
+// work around is necessary.
+// https://platform.github.community/t/some-prs-are-missing-head-refs/4586
+// https://platform.github.community/t/github-commits-returned-in-the-incorrect-order-how-to-get-the-head-commit-for-statuses/4130
 func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Context, error) {
-	for _, node := range pr.Commits.Nodes {
-		if node.Commit.OID == pr.HeadRefOID {
-			return node.Commit.Status.Contexts, nil
-		}
+	if contexts, ok := headContextsNoCost(pr); ok {
+		return contexts, nil
 	}
-	// We didn't get the head commit from the query (the commits must not be
+
+	// We didn't get the head commit from the query (the PR's commits must not be
 	// logically ordered) so we need to specifically ask Github for the status
 	// and coerce it to a graphql type.
 	org := string(pr.Repository.Owner.Login)
 	repo := string(pr.Repository.Name)
-	// Log this event so we can tune the number of commits we list to minimize this.
-	log.Warnf("'last' %d commits didn't contain logical last commit. Querying Github...", len(pr.Commits.Nodes))
+	log.Warnf("HeadRef was missing and 'last' commit is not the logical last commit. Querying Github...")
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the combined status: %v", err)
@@ -1061,4 +1076,19 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 		},
 	)
 	return contexts, nil
+}
+
+// headContextsNoCost tries to get the head commit contexts from the PullRequest
+// struct without making additional API calls. It returns the contexts if found
+// and a bool indicating success.
+func headContextsNoCost(pr *PullRequest) ([]Context, bool) {
+	if pr.HeadRef != nil {
+		return pr.HeadRef.Target.Commit.Status.Contexts, true
+	}
+	for _, node := range pr.Commits.Nodes {
+		if node.Commit.OID == pr.HeadRefOID {
+			return node.Commit.Status.Contexts, true
+		}
+	}
+	return nil, false
 }

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -992,7 +992,7 @@ type PullRequest struct {
 			Commit Commit
 		}
 		// See the 'headContexts' function for details.
-	} `graphql:"commits(last: 1)"`
+	} `graphql:"commits(last: 4)"`
 	Labels struct {
 		Nodes []struct {
 			Name githubql.String
@@ -1110,11 +1110,11 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 // struct without making additional API calls. It returns the contexts if found
 // and a bool indicating success.
 func headContextsNoCost(pr *PullRequest) ([]Context, bool) {
-	if pr.HeadRef != nil {
+	if pr.HeadRef != nil && len(pr.HeadRef.Target.Commit.Status.Contexts) != 0 {
 		return pr.HeadRef.Target.Commit.Status.Contexts, true
 	}
 	for _, node := range pr.Commits.Nodes {
-		if node.Commit.OID == pr.HeadRefOID {
+		if node.Commit.OID == pr.HeadRefOID && len(node.Commit.Status.Contexts) != 0 {
 			return node.Commit.Status.Contexts, true
 		}
 	}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -199,7 +199,7 @@ func TestAccumulateBatch(t *testing.T) {
 			}
 			pjs = append(pjs, npj)
 		}
-		merges, pending := accumulateBatch(test.presubmits, pulls, pjs)
+		merges, pending := accumulateBatch(test.presubmits, pulls, pjs, logrus.NewEntry(logrus.New()))
 		if (len(pending) > 0) != test.pending {
 			t.Errorf("For case \"%s\", got wrong pending.", test.name)
 		}
@@ -378,7 +378,7 @@ func TestAccumulate(t *testing.T) {
 			})
 		}
 
-		successes, pendings, nones := accumulate(test.presubmits, pulls, pjs)
+		successes, pendings, nones := accumulate(test.presubmits, pulls, pjs, logrus.NewEntry(logrus.New()))
 
 		t.Logf("test run %d", i)
 		testPullsMatchList(t, "successes", successes, test.successes)

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1080,6 +1080,7 @@ func TestHeadContexts(t *testing.T) {
 	headSHA := "head"
 	testCases := []struct {
 		name           string
+		headRef        *commitContext
 		commitContexts []commitContext
 		expectAPICall  bool
 	}{
@@ -1108,6 +1109,21 @@ func TestHeadContexts(t *testing.T) {
 			},
 			expectAPICall: true,
 		},
+		{
+			name:    "headRef is usable",
+			headRef: &commitContext{context: win, sha: headSHA},
+			commitContexts: []commitContext{
+				{context: lose, sha: "shaaa"},
+				{context: lose, sha: "other"},
+				{context: lose, sha: "sha"},
+			},
+			expectAPICall: true,
+		},
+		{
+			name:           "headRef is usable (no other commits in list)",
+			headRef:        &commitContext{context: win, sha: headSHA},
+			commitContexts: []commitContext{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1129,6 +1145,28 @@ func TestHeadContexts(t *testing.T) {
 				OID: githubql.String(ctx.sha),
 			}
 			pr.Commits.Nodes = append(pr.Commits.Nodes, struct{ Commit Commit }{commit})
+		}
+		if tc.headRef != nil {
+			pr.HeadRef = &struct {
+				Target struct {
+					Commit Commit `graphql:"... on Commit"`
+				}
+			}{
+				Target: struct {
+					Commit Commit `graphql:"... on Commit"`
+				}{
+					Commit: Commit{
+						Status: struct{ Contexts []Context }{
+							Contexts: []Context{
+								{
+									Context: githubql.String(tc.headRef.context),
+								},
+							},
+						},
+						OID: githubql.String(tc.headRef.sha),
+					},
+				},
+			}
 		}
 
 		contexts, err := headContexts(logrus.WithField("component", "tide"), fgc, pr)


### PR DESCRIPTION
prow: tide: improve logging to allow for debugging

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

prow: tide: run git operations only when necessary

Git operations are more resource-intensive and less likely to be the
cause of failures while trying to accumulate a batch of PRs to test. We
can run them only if we have sufficient candidate PRs in the first
place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

prow: tide: use head contexts when they are not empty

It is possible for the GitHub API to give us a pull request with a
HeadRef or a commit node that is not fully fleshed out, which leads to
empty status fields. We need to check that we don't short-circuit our
head context search to empty lists.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/area prow
/kind bug
/cc @BenTheElder @krzyzacy 
/assign @cjwagner @fejta 