### PR TITLE
Add job to prevent issues in `k/features` from being marked with `lifecycle/frozen`

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13682,8 +13682,8 @@ periodics:
       secret:
         secretName: velodrome-influxdb
 
-- name: periodic-features-no-freeze
-  interval: 1h
+- name: periodic-features-unfreeze
+  interval: 30m
   agent: kubernetes
   spec:
     containers:
@@ -13692,13 +13692,13 @@ periodics:
       - |-
         --query=repo:kubernetes/features
         label:lifecycle/frozen
+      - --updated=5m
       - --token=/etc/token/bot-github-token
       - |-
         --comment=Feature issues opened in `kubernetes/features` should never be marked as frozen.
-        Feature Owners can ensure that features never become rotten by consistently updating their states across release cycles.
+        Feature Owners can ensure that features stay fresh by consistently updating their states across release cycles.
 
         /remove-lifecycle frozen
-      - --template
       - --ceiling=10
       - --confirm
       volumeMounts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13682,6 +13682,33 @@ periodics:
       secret:
         secretName: velodrome-influxdb
 
+- name: periodic-features-no-freeze
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      args:
+      - |-
+        --query=repo:kubernetes/features
+        label:lifecycle/frozen
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Feature issues opened in `kubernetes/features` should never be marked as frozen.
+        Feature Owners can ensure that features never become rotten by consistently updating their states across release cycles.
+
+        /remove-lifecycle frozen
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
 - name: periodic-kubernetes-bazel-build-1-10
   interval: 6h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1483,8 +1483,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/metrics-bigquery
 - name: metrics-kettle
   gcs_prefix: kubernetes-jenkins/logs/metrics-kettle
-- name: periodic-features-no-freeze
-  gcs_prefix: kubernetes-jenkins/logs/periodic-features-no-freeze
+- name: periodic-features-unfreeze
+  gcs_prefix: kubernetes-jenkins/logs/periodic-features-unfreeze
 - name: periodic-kubernetes-bazel-test-1-8
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-8
 - name: periodic-kubernetes-bazel-test-1-9
@@ -5724,9 +5724,9 @@ dashboards:
   - name: close
     description: Closes rotten issues after 30d of inactivity
     test_group_name: periodic-test-infra-close
-  - name: features-no-freeze
+  - name: features-unfreeze
     description: Prevents issues in `k/features` from being marked as `lifecycle/frozen`
-    test_group_name: periodic-features-no-freeze
+    test_group_name: periodic-features-unfreeze
   - name: issue-creator
     description: Creates github issues based on data from various 'IssueSource's.
     test_group_name: issue-creator

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1483,6 +1483,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/metrics-bigquery
 - name: metrics-kettle
   gcs_prefix: kubernetes-jenkins/logs/metrics-kettle
+- name: periodic-features-no-freeze
+  gcs_prefix: kubernetes-jenkins/logs/periodic-features-no-freeze
 - name: periodic-kubernetes-bazel-test-1-8
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-8
 - name: periodic-kubernetes-bazel-test-1-9
@@ -5722,6 +5724,9 @@ dashboards:
   - name: close
     description: Closes rotten issues after 30d of inactivity
     test_group_name: periodic-test-infra-close
+  - name: features-no-freeze
+    description: Prevents issues in `k/features` from being marked as `lifecycle/frozen`
+    test_group_name: periodic-features-no-freeze
   - name: issue-creator
     description: Creates github issues based on data from various 'IssueSource's.
     test_group_name: issue-creator


### PR DESCRIPTION
Based on the current parameters for `fejta-bot` checks, issues will be closed after 90 days, after moving through various `lifecycle/*` phases.

The `lifecycle/frozen` label was introduced to ensure critical issues remain open. However, because Features issues should be reviewed and updated every release cycle (~90 days), I'd like to discourage / disable the use of the `lifecycle/frozen` label via automation.

This PR prevents issues in `k/features` from being marked as `lifecycle/frozen`

Slack convo: https://kubernetes.slack.com/archives/C09QZ4DQB/p1531154081000419

/sig testing
/sig pm
/area prow
/cc @BenTheElder @fejta 

Signed-off-by: Stephen Augustus <foo@agst.us>