### PR TITLE
create welcome plugin

### DIFF
--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -79,6 +79,7 @@ filegroup(
         "//prow/plugins/trigger:all-srcs",
         "//prow/plugins/updateconfig:all-srcs",
         "//prow/plugins/verify-owners:all-srcs",
+        "//prow/plugins/welcome:all-srcs",
         "//prow/plugins/wip:all-srcs",
         "//prow/plugins/yuks:all-srcs",
     ],

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -174,6 +174,7 @@ type Configuration struct {
 	Cat           Cat                  `json:"cat,omitempty"`
 	Label         *Label               `json:"label,omitempty"`
 	Lgtm          []Lgtm               `json:"lgtm,omitempty"`
+	Welcome       Welcome              `json:"welcome,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -437,6 +438,13 @@ type MergeWarning struct {
 	WhiteList []string `json:"whitelist,omitempty"`
 	// A slack event is published if the user is not on the branch whitelist
 	BranchWhiteList map[string][]string `json:"branch_whitelist,omitempty"`
+}
+
+// Welcome is config for the welcome plugin
+type Welcome struct {
+	// Message is the welcome message to post on new-contributor PRs
+	// TODO(bentheelder): make this be configurable per-repo?
+	Message string `json:"message,omitempty"`
 }
 
 // TriggerFor finds the Trigger for a repo, if one exists

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -442,9 +442,10 @@ type MergeWarning struct {
 
 // Welcome is config for the welcome plugin
 type Welcome struct {
-	// Message is the welcome message to post on new-contributor PRs
+	// MessageTemplate is the welcome message template to post on new-contributor PRs
+	// For the info struct see prow/plugins/welcome/welcome.go's PRInfo
 	// TODO(bentheelder): make this be configurable per-repo?
-	Message string `json:"message,omitempty"`
+	MessageTemplate string `json:"message_template,omitempty"`
 }
 
 // TriggerFor finds the Trigger for a repo, if one exists

--- a/prow/plugins/welcome/BUILD.bazel
+++ b/prow/plugins/welcome/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["welcome.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/welcome",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["welcome_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package welcome implements a prow plugin to welcome new contributors
+package welcome
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	pluginName = "welcome"
+)
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
+	return &pluginhelp.PluginHelp{
+			Description: "The welcome plugin posts a welcoming message when it detects a user's first contribution to a repo.",
+			Config: map[string]string{
+				"": fmt.Sprintf(
+					"The welcome plugin is configured to post the following welcome message: %s.",
+					config.Welcome.Message,
+				),
+			},
+		},
+		nil
+}
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+}
+
+type client struct {
+	GitHubClient githubClient
+	Logger       *logrus.Entry
+}
+
+func getClient(pc plugins.PluginClient) client {
+	return client{
+		GitHubClient: pc.GitHubClient,
+		Logger:       pc.Logger,
+	}
+}
+
+func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+	return handlePR(getClient(pc), pre, pc.PluginConfig.Welcome.Message)
+}
+
+func handlePR(c client, pre github.PullRequestEvent, welcomeMessage string) error {
+	// Only consider newly opened PRs
+	if pre.Action != github.PullRequestActionOpened {
+		return nil
+	}
+
+	// search for PRs from the author in this repo
+	org := pre.PullRequest.Base.Repo.Owner.Login
+	repo := pre.PullRequest.Base.Repo.Name
+	user := pre.PullRequest.User.Login
+	query := fmt.Sprintf("is:pr repo:%s/%s author:%s", org, repo, user)
+	issues, err := c.GitHubClient.FindIssues(query, "", false)
+	if err != nil {
+		return err
+	}
+
+	// if there is exactly one result, this is the first! post the welcome comment
+	if len(issues) == 1 {
+		c.GitHubClient.CreateComment(org, repo, pre.PullRequest.Number, welcomeMessage)
+	}
+
+	return nil
+}

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -31,7 +31,7 @@ import (
 // There has to be a better way to write tests like this.
 
 const (
-	testWelcomeMessage = "Welcome human! 🤖"
+	testWelcomeTemplate = "Welcome human! 🤖 {{.AuthorName}} {{.AuthorLogin}} {{.Repo}} {{.Org}}}"
 )
 
 type fakeClient struct {
@@ -119,6 +119,7 @@ func makeFakePullRequestEvent(owner, repo, author string, number int, action git
 			},
 			User: github.User{
 				Login: author,
+				Name:  author + "fullname",
 			},
 		},
 	}
@@ -191,7 +192,7 @@ func TestHandlePR(t *testing.T) {
 		fc.AddPR(tc.repoOwner, tc.repoName, tc.author, tc.prNumber)
 
 		// try handling it
-		if err := handlePR(c, event, testWelcomeMessage); err != nil {
+		if err := handlePR(c, event, testWelcomeTemplate); err != nil {
 			t.Fatalf("did not expect error handling PR for case '%s': %v", tc.name, err)
 		}
 

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package welcome
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+)
+
+// TODO(bentheelder): these tests are a bit lame.
+// There has to be a better way to write tests like this.
+
+const (
+	testWelcomeMessage = "Welcome human! 🤖"
+)
+
+type fakeClient struct {
+	commentsAdded map[int][]string
+	prs           map[string]sets.Int
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		commentsAdded: make(map[int][]string),
+		prs:           make(map[string]sets.Int),
+	}
+}
+
+// CreateComment adds and tracks a comment in the client
+func (fc *fakeClient) CreateComment(owner, repo string, number int, comment string) error {
+	fc.commentsAdded[number] = append(fc.commentsAdded[number], comment)
+	return nil
+}
+
+// ClearComments removes all comments in the client
+func (fc *fakeClient) ClearComments() {
+	fc.commentsAdded = map[int][]string{}
+}
+
+// NumComments counts the number of tracked comments
+func (fc *fakeClient) NumComments() int {
+	n := 0
+	for _, comments := range fc.commentsAdded {
+		n += len(comments)
+	}
+	return n
+}
+
+var (
+	expectedQueryRegex = regexp.MustCompile(`is:pr repo:(.+)/(.+) author:(.+)`)
+)
+
+// AddPR records an PR in the client
+func (fc *fakeClient) AddPR(owner, repo, author string, number int) {
+	key := fmt.Sprintf("%s,%s,%s", owner, repo, author)
+	if _, ok := fc.prs[key]; !ok {
+		fc.prs[key] = sets.Int{}
+	}
+	fc.prs[key].Insert(number)
+}
+
+// ClearPRs removes all PRs from the client
+func (fc *fakeClient) ClearPRs() {
+	fc.prs = make(map[string]sets.Int)
+}
+
+// FindIssues fails if the query does not match the expected query regex and
+// looks up issues based on parsing the expected query format
+func (fc *fakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+	fields := expectedQueryRegex.FindStringSubmatch(query)
+	if fields == nil || len(fields) != 4 {
+		return nil, fmt.Errorf("invalid query: `%s` does not match expected regex `%s`", query, expectedQueryRegex.String())
+	}
+	// "find" results
+	owner, repo, author := fields[1], fields[2], fields[3]
+	key := fmt.Sprintf("%s,%s,%s", owner, repo, author)
+
+	issues := []github.Issue{}
+	for _, number := range fc.prs[key].List() {
+		issues = append(issues, github.Issue{
+			Number: number,
+		})
+	}
+	return issues, nil
+}
+
+func makeFakePullRequestEvent(owner, repo, author string, number int, action github.PullRequestEventAction) github.PullRequestEvent {
+	return github.PullRequestEvent{
+		Action: action,
+		Number: number,
+		PullRequest: github.PullRequest{
+			Base: github.PullRequestBranch{
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: owner,
+					},
+					Name: repo,
+				},
+			},
+			User: github.User{
+				Login: author,
+			},
+		},
+	}
+}
+
+func TestHandlePR(t *testing.T) {
+	fc := newFakeClient()
+	// old PRs
+	fc.AddPR("kubernetes", "test-infra", "contributorA", 1)
+	fc.AddPR("kubernetes", "test-infra", "contributorB", 2)
+	fc.AddPR("kubernetes", "test-infra", "contributorB", 3)
+
+	testCases := []struct {
+		name          string
+		repoOwner     string
+		repoName      string
+		author        string
+		prNumber      int
+		prAction      github.PullRequestEventAction
+		expectComment bool
+	}{
+		{
+			name:          "existing contributorA",
+			repoOwner:     "kubernetes",
+			repoName:      "test-infra",
+			author:        "contributorA",
+			prNumber:      20,
+			prAction:      github.PullRequestActionOpened,
+			expectComment: false,
+		},
+		{
+			name:          "existing contributorB",
+			repoOwner:     "kubernetes",
+			repoName:      "test-infra",
+			author:        "contributorB",
+			prNumber:      40,
+			prAction:      github.PullRequestActionOpened,
+			expectComment: false,
+		},
+		{
+			name:          "new contributor",
+			repoOwner:     "kubernetes",
+			repoName:      "test-infra",
+			author:        "newContributor",
+			prAction:      github.PullRequestActionOpened,
+			prNumber:      50,
+			expectComment: true,
+		},
+		{
+			name:          "new contributor, not PR open event",
+			repoOwner:     "kubernetes",
+			repoName:      "test-infra",
+			author:        "newContributor",
+			prAction:      github.PullRequestActionEdited,
+			prNumber:      50,
+			expectComment: false,
+		},
+	}
+
+	c := client{
+		GitHubClient: fc,
+		Logger:       &logrus.Entry{},
+	}
+	for _, tc := range testCases {
+		// clear out comments from the last test case
+		fc.ClearComments()
+
+		event := makeFakePullRequestEvent(tc.repoOwner, tc.repoName, tc.author, tc.prNumber, tc.prAction)
+		// make sure the PR in the event is recorded
+		fc.AddPR(tc.repoOwner, tc.repoName, tc.author, tc.prNumber)
+
+		// try handling it
+		if err := handlePR(c, event, testWelcomeMessage); err != nil {
+			t.Fatalf("did not expect error handling PR for case '%s': %v", tc.name, err)
+		}
+
+		// verify that comments were made
+		numComments := fc.NumComments()
+		if numComments > 1 {
+			t.Fatalf("did not expect multiple comments for any test case and got %d comments", numComments)
+		}
+		if numComments == 0 && tc.expectComment {
+			t.Fatalf("expected a comment for case '%s' and got none", tc.name)
+		} else if numComments > 0 && !tc.expectComment {
+			t.Fatalf("did not expect comments for case '%s' and got %d comments", tc.name, numComments)
+		}
+	}
+}


### PR DESCRIPTION
for https://github.com/kubernetes/test-infra/issues/3083

Adds a `welcome` plugin that will post a configurable comment on PR open events when the PR Author has no previous PRs in the repo.

This should work as long as the GitHub search results are actually consistent enough, and should only cost us one additional token per PR open event per enabled repo (and one more to post the comment when we need to). It looks like we have plenty of room for that.

TODO (followup):
-  currently there is only one configurable message, we may want to have per-repo overrides ..?
- better tests ...?
- configure against test-infra to pilot the plugin, get contribex to help us write a good welcome message 😄 
- eventually roll out to [kubernetes/kubernetes](github.com/kubernetes/kubernetes) and others ...?

/area prow