### PR TITLE
Fix some Python 3 syntax errors

### DIFF
--- a/boskos/janitor/janitor.py
+++ b/boskos/janitor/janitor.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Clean up resources from gcp projects. """
+from __future__ import print_function
 
 import argparse
 import collections
@@ -61,7 +62,7 @@ DEMOLISH_ORDER = [
 def log(message):
     """ print a message if --verbose is set. """
     if ARGS.verbose:
-        print message
+        print(message)
 
 def base_command(resource):
     """ Return the base gcloud command with api_version, group and subgroup.
@@ -227,7 +228,7 @@ def clear_resources(project, cols, resource, rate_limit):
             except subprocess.CalledProcessError as exc:
                 if not resource.tolerate:
                     err = 1
-                print >>sys.stderr, 'Error try to delete resources: %r' % exc
+                print('Error try to delete resources: %r' % exc, file=sys.stderr)
     return err
 
 
@@ -287,7 +288,7 @@ def clean_gke_cluster(project, age, filt):
                     subprocess.check_call(delete)
                 except subprocess.CalledProcessError as exc:
                     err = 1
-                    print >>sys.stderr, 'Error try to delete cluster %s: %r' % (item['name'], exc)
+                    print('Error try to delete cluster %s: %r' % (item['name'], exc), file=sys.stderr)
 
     return err
 
@@ -310,7 +311,7 @@ def main(project, days, hours, filt, rate_limit):
         1 if list or delete command fails
     """
 
-    print '[=== Start Janitor on project %r ===]' % project
+    print('[=== Start Janitor on project %r ===]' % project)
     err = 0
     age = datetime.datetime.utcnow() - datetime.timedelta(days=days, hours=hours)
     clear_all = (days is 0 and hours is 0)
@@ -322,16 +323,16 @@ def main(project, days, hours, filt, rate_limit):
                 err |= clear_resources(project, col, res, rate_limit)
         except (subprocess.CalledProcessError, ValueError):
             err |= 1 # keep clean the other resource
-            print >>sys.stderr, 'Fail to list resource %r from project %r' % (res.name, project)
+            print('Fail to list resource %r from project %r' % (res.name, project), file=sys.stderr)
 
     # try to clean leaking gke cluster
     try:
         err |= clean_gke_cluster(project, age, filt)
     except ValueError:
         err |= 1 # keep clean the other resource
-        print >>sys.stderr, 'Fail to clean up cluster from project %r' % project
+        print('Fail to clean up cluster from project %r' % project, file=sys.stderr)
 
-    print '[=== Finish Janitor on project %r with status %r ===]' % (project, err)
+    print('[=== Finish Janitor on project %r with status %r ===]' % (project, err))
     sys.exit(err)
 
 
@@ -364,7 +365,7 @@ if __name__ == '__main__':
 
     # We want to allow --days=0 and --hours=0, so check against None instead.
     if ARGS.days is None and ARGS.hours is None:
-        print >>sys.stderr, 'must specify --days and/or --hours'
+        print('must specify --days and/or --hours', file=sys.stderr)
         sys.exit(1)
 
     main(ARGS.project, ARGS.days or 0, ARGS.hours or 0, ARGS.filter, ARGS.ratelimit)

--- a/experiment/bilge.py
+++ b/experiment/bilge.py
@@ -19,6 +19,7 @@
 This can happen with repeated '/test all' commands, or
 even something as simple as pushing new code while builds are already queued.
 """
+from __future__ import print_function
 
 import sys
 
@@ -45,11 +46,11 @@ def prune(host):
         if len(val) < 2:
             continue
         val.sort()
-        print '===', key
+        print('===', key)
         for pull in val[:-1]:
-            print pull
+            print(pull)
             _resp = requests.post('http://%s/queue/cancelItem?id=%d' % (host, pull[1]))
-        print 'GOOD:', val[-1]
+        print('GOOD:', val[-1])
 
 
 if __name__ == '__main__':

--- a/experiment/find_developers.py
+++ b/experiment/find_developers.py
@@ -19,6 +19,7 @@
 
 
 """Selects a random sample of kubernetes developers."""
+from __future__ import print_function
 
 import json
 import os
@@ -85,7 +86,7 @@ def main(path=None, num=35, top=0.6, middle=0.2, bottom=0.2):
             data = fp.read()
     users = sorted(load_content(data))
     for user in find_users(users, num, top, middle, bottom):
-        print '%s (%d recent commits, %d total)' % (user.user, user.recent, user.total)
+        print('%s (%d recent commits, %d total)' % (user.user, user.recent, user.total))
 
 
 if __name__ == '__main__':

--- a/experiment/parse_build_log.py
+++ b/experiment/parse_build_log.py
@@ -18,6 +18,7 @@
 
 Useful for finding which tests overlapped with a certain event.
 """
+from __future__ import print_function
 
 import argparse
 import datetime
@@ -113,7 +114,7 @@ def main():
     with open(args.file) as log:
         for test in _get_tests(log):
             if test.overlaps(after, before):
-                print str(test)
+                print(str(test))
 
 
 if __name__ == '__main__':

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+from __future__ import absolute_import
 import re
 import unittest
 import urllib
 
-import filters
+from . import filters
 
 import jinja2
 
@@ -90,7 +92,7 @@ class HelperTest(unittest.TestCase):
             ('//pkg/foo/bar:go_default_test',
             'bazel test //pkg/foo/bar:go_default_test'),
             ('verify typecheck', 'make verify WHAT=typecheck')):
-            print 'test name:', name
+            print('test name:', name)
             self.assertEqual(filters.do_testcmd(name), expected)
 
     def test_classify_size(self):

--- a/gubernator/github/periodic_sync_test.py
+++ b/gubernator/github/periodic_sync_test.py
@@ -16,6 +16,8 @@
 
 # pylint: disable=no-self-use
 
+from __future__ import print_function
+from __future__ import absolute_import
 import cPickle as pickle
 import json
 
@@ -24,10 +26,10 @@ import webtest
 from google.appengine.ext import deferred
 from google.appengine.ext import testbed
 
-import main_test
-import models
-import periodic_sync
-import secrets
+from . import main_test
+from . import models
+from . import periodic_sync
+from . import secrets
 
 app = webtest.TestApp(periodic_sync.app)
 
@@ -106,7 +108,7 @@ class SyncTest(main_test.TestBase):
                 link = '%s&page=%d>; rel="next", %s' % (frag, page + 1, link)
             if page > 1:
                 link = '%s&page=%d>; rel="prev", %s' % (frag, page - 1, link)
-            print link
+            print(link)
             return {'Link': link}
 
         prs = [pr_data(n) for n in range(400)]

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+from __future__ import absolute_import
 import logging
 
 import jinja2
 
-import kubelet_parser
-import regex
+from . import kubelet_parser
+from . import regex
 
 CONTEXT_DEFAULT = 6
 MAX_BUFFER = 5000000  # GAE has RAM limits.
@@ -127,4 +129,4 @@ def digest(data, objref_dict=None, filters=None, error_re=regex.error_re,
 if __name__ == '__main__':
     import sys
     for f in sys.argv[1:]:
-        print digest(open(f).read().decode('utf8'))
+        print(digest(open(f).read().decode('utf8')))

--- a/gubernator/log_parser_test.py
+++ b/gubernator/log_parser_test.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+from __future__ import absolute_import
 import re
 import unittest
 
-import log_parser
-import regex
+from . import log_parser
+from . import regex
 
 def digest(data, strip=True, filters=None,
            error_re=regex.error_re):
@@ -27,7 +29,7 @@ def digest(data, strip=True, filters=None,
 
     digested = log_parser.digest(data.replace(' ', '\n'), error_re=error_re,
                                  skip_fmt=lambda l: 's%d' % l, filters=filters)
-    print digested
+    print(digested)
     if strip:
         digested = re.sub(r'<span class="skipped"[^<]*>([^<]*)</span>', r'(\1)',
             digested, flags=re.MULTILINE)

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -20,6 +20,8 @@ To run these tests:
     $ pip install webtest nosegae
     $ nosetests --with-gae --gae-lib-root ~/google_appengine/
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import unittest
 
@@ -27,9 +29,9 @@ import webtest
 
 import cloudstorage as gcs
 
-import main
-import gcs_async
-import gcs_async_test
+from . import main
+from . import gcs_async
+from . import gcs_async_test
 
 write = gcs_async_test.write
 
@@ -178,7 +180,7 @@ class AppTest(TestBase):
                     '0101 01:01:01.002 pod\n'
                     '01-01T01:01:01.005Z last line')
         response = app.get('/build' + nodelog_url)
-        print response
+        print(response)
         self.assertIn(expected, response)
 
     def test_timestamp_no_apiserver(self):

--- a/gubernator/third_party/cloudstorage/api_utils.py
+++ b/gubernator/third_party/cloudstorage/api_utils.py
@@ -170,7 +170,7 @@ class _RetryWrapper(object):
             'Tasklet has exceeded request deadline after %s seconds total',
             time.time() - start_time)
         raise
-      except self.retriable_exceptions, e:
+      except self.retriable_exceptions as e:
         pass
 
       if n == 1:

--- a/gubernator/third_party/cloudstorage/rest_api.py
+++ b/gubernator/third_party/cloudstorage/rest_api.py
@@ -245,7 +245,7 @@ class _RestApi(object):
     headers.update(self.user_agent)
     try:
       self.token = yield self.get_token_async()
-    except app_identity.InternalError, e:
+    except app_identity.InternalError as e:
       if os.environ.get('DATACENTER', '').endswith('sandman'):
         self.token = None
         logging.warning('Could not fetch an authentication token in sandman '

--- a/gubernator/third_party/cloudstorage/storage_api.py
+++ b/gubernator/third_party/cloudstorage/storage_api.py
@@ -126,7 +126,7 @@ class _StorageApi(rest_api._RestApi):
       resp_tuple = yield super(_StorageApi, self).do_request_async(
           url, method=method, headers=headers, payload=payload,
           deadline=deadline, callback=callback)
-    except urlfetch.DownloadError, e:
+    except urlfetch.DownloadError as e:
       raise errors.TimeoutError(
           'Request to Google Cloud Storage timed out.', e)
 

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,11 +22,11 @@ import defusedxml.ElementTree as ET
 
 from google.appengine.api import urlfetch
 
-import gcs_async
-from github import models
-import log_parser
-import testgrid
-import view_base
+from . import gcs_async
+from .github import models
+from . import log_parser
+from . import testgrid
+from . import view_base
 
 
 class JUnitParser(object):
@@ -65,11 +66,11 @@ class JUnitParser(object):
             return  # can't extract results from nothing!
         try:
             tree = ET.fromstring(xml)
-        except ET.ParseError, e:
+        except ET.ParseError as e:
             logging.exception('parse_junit failed for %s', filename)
             try:
                 tree = ET.fromstring(re.sub(r'[\x00\x80-\xFF]+', '?', xml))
-            except ET.ParseError, e:
+            except ET.ParseError as e:
                 if re.match(r'junit.*\.xml', os.path.basename(filename)):
                     self.failed.append(
                         ('Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename, ''))

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -274,7 +275,7 @@ class BuildTest(main_test.TestBase):
         # Sometimes junit files are actually empty (???)
         write(self.BUILD_DIR + 'artifacts/junit_01.xml', '')
         response = self.get_build_page()
-        print response
+        print(response)
         self.assertIn('No Test Failures', response)
 
     def test_parse_pr_path(self):

--- a/gubernator/view_logs.py
+++ b/gubernator/view_logs.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +16,11 @@
 import os
 import re
 
-import gcs_async
-import log_parser
-import kubelet_parser
-import regex
-import view_base
+from . import gcs_async
+from . import log_parser
+from . import kubelet_parser
+from . import regex
+from . import view_base
 
 
 @view_base.memcache_memoize('log-file-junit://', expires=60*60*4)
@@ -90,8 +91,9 @@ def parse_log_file(log_filename, pod, filters=None, make_dict=False, objref_dict
             error_re=bold_re, filters=filters, objref_dict=objref_dict)
 
 
-def get_logs_junit((log_files, pod_name, filters, objref_dict, apiserver_filename)):
+def get_logs_junit(xxx_todo_changeme):
     # Get the logs in the case where the junit file with the failure is in a specific folder
+    (log_files, pod_name, filters, objref_dict, apiserver_filename) = xxx_todo_changeme
     all_logs = {}
     results = {}
     # default to filtering kube-apiserver log if user unchecks both checkboxes
@@ -202,12 +204,13 @@ def get_woven_logs(log_files, pod, filters, objref_dict):
     return woven_logs
 
 
-def parse_by_timestamp((build_dir, junit, log_files, pod, filters, objref_dict)):
+def parse_by_timestamp(xxx_todo_changeme1):
     """
     Returns:
         woven_logs: HTML code of chosen logs woven together by timestamp
         all_logs: Dictionary of logs relevant for filtering
     """
+    (build_dir, junit, log_files, pod, filters, objref_dict) = xxx_todo_changeme1
     woven_logs = get_woven_logs(log_files, pod, filters, objref_dict)
 
     apiserver_filename = find_log_junit(build_dir, junit, "kube-apiserver.log")

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,12 +19,12 @@ import logging
 import os
 import time
 
-import filters
-import gcs_async
-import github.models as ghm
-import pull_request
-import view_base
-import view_build
+from . import filters
+from . import gcs_async
+from . import github.models as ghm
+from . import pull_request
+from . import view_base
+from . import view_build
 
 
 @view_base.memcache_memoize('pr-details://', expires=60 * 3)
@@ -45,7 +46,7 @@ def pr_builds(path):
                 gcs_async.read('/%sstarted.json' % build),
                 gcs_async.read('/%sfinished.json' % build)])
 
-    futures.sort(key=lambda (job, build, s, f): (job, view_base.pad_numbers(build)), reverse=True)
+    futures.sort(key=lambda job_build_s_f: (job_build_s_f[0], view_base.pad_numbers(job_build_s_f[1])), reverse=True)
 
     jobs = {}
     for job, build, started_fut, finished_fut in futures:
@@ -101,7 +102,7 @@ class PRHandler(view_base.BaseHandler):
         # TODO(fejta): assume all builds are monotonically increasing.
         for bs in builds.itervalues():
             if any(len(b) > 8 for b, _, _ in bs):
-                bs.sort(key=lambda (b, s, f): -(s or {}).get('timestamp', 0))
+                bs.sort(key=lambda b_s_f: -(b_s_f[1] or {}).get('timestamp', 0))
         if pr == 'batch':  # truncate batch results to last day
             cutoff = time.time() - 60 * 60 * 24
             builds = {}

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -918,7 +918,7 @@ def configure_ssh_key(ssh):
         fp.write(
             '#!/bin/sh\nssh -o StrictHostKeyChecking=no -i \'%s\' -F /dev/null "${@}"\n' % ssh)
     try:
-        os.chmod(fp.name, 0500)
+        os.chmod(fp.name, 0o500)
         had = 'GIT_SSH' in os.environ
         old = os.getenv('GIT_SSH')
         os.environ['GIT_SSH'] = fp.name
@@ -1079,7 +1079,7 @@ def bootstrap(args):
                 try:
                     maybe_upload_podspec(
                         call, paths.artifacts, gsutil, os.getenv)
-                except (OSError, subprocess.CalledProcessError), exc:
+                except (OSError, subprocess.CalledProcessError) as exc:
                     logging.error("unable to upload podspecs: %s", exc)
             setup_root(call, args.root, repos, args.ssh,
                        args.git_cache, args.clean)

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Tests for bootstrap."""
+from __future__ import print_function
 
 # pylint: disable=protected-access, attribute-defined-outside-init
 
@@ -1433,7 +1434,7 @@ class IntegrationTest(unittest.TestCase):
             refs.append('%d:%s' % (pr, head_sha()))
         os.chdir('/tmp')
         pull = ','.join(refs)
-        print '--pull', pull
+        print('--pull', pull)
         subprocess.check_call(['ls'])
         test_bootstrap(
             job='fake-pr',

--- a/jobs/env_gc.py
+++ b/jobs/env_gc.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Garbage collect unused .env files."""
+from __future__ import print_function
 
 import argparse
 import os
@@ -63,7 +64,7 @@ def deep_unlink(path):
 def unlink_orphans():
     orphans = find_orphans()
     for path in orphans:
-        print "Deleting unused .env file: {}".format(path)
+        print("Deleting unused .env file: {}".format(path))
         deep_unlink(test_infra(path))
     if orphans:
         print ('\nNote: If this is a git tree, ' +

--- a/jobs/move_extract.py
+++ b/jobs/move_extract.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Migrate --extract flag from an JENKINS_FOO env to a scenario flag."""
+from __future__ import print_function
 
 import json
 import os
@@ -91,8 +92,8 @@ def sort():
         fp.write('\n')
     if not problems:
         sys.exit(0)
-    print >>sys.stderr, '%d problems' % len(problems)
-    print '\n'.join(problems)
+    print('%d problems' % len(problems), file=sys.stderr)
+    print('\n'.join(problems))
 
 if __name__ == '__main__':
     sort()

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -193,14 +193,16 @@ def mp_init_worker(jobs_dir, metadata, client_class, use_signal=True):
     global WORKER_CLIENT  # pylint: disable=global-statement
     WORKER_CLIENT = client_class(jobs_dir, metadata)
 
-def get_started_finished((job, build)):
+def get_started_finished(xxx_todo_changeme):
+    (job, build) = xxx_todo_changeme
     try:
         return WORKER_CLIENT.get_started_finished(job, build)
     except:
         logging.exception('failed to get tests for %s/%s', job, build)
         raise
 
-def get_junits((build_id, gcs_path)):
+def get_junits(xxx_todo_changeme1):
+    (build_id, gcs_path) = xxx_todo_changeme1
     try:
         junits = WORKER_CLIENT.get_junits_from_build(gcs_path)
         return build_id, gcs_path, junits

--- a/kettle/monitor.py
+++ b/kettle/monitor.py
@@ -16,6 +16,7 @@
 """
 A dead-simple Influxdb data pusher to report BigQuery database statistics.
 """
+from __future__ import print_function
 
 
 import argparse
@@ -30,7 +31,7 @@ try:
     from google.cloud import bigquery
     import google.cloud.exceptions
 except ImportError:
-    print 'WARNING: unable to load google cloud (test environment?)'
+    print('WARNING: unable to load google cloud (test environment?)')
     import traceback
     traceback.print_exc()
 
@@ -65,8 +66,8 @@ def collect(tables, stale_hours, influx_client):
 
         hours_old = (time.time() - fields['modified_time'] / 1000) / (3600.0)
         if stale_hours and hours_old > stale_hours:
-            print 'ERROR: table %s is %.1f hours old. Max allowed: %s hours.' % (
-                table.table_id, hours_old, stale_hours)
+            print('ERROR: table %s is %.1f hours old. Max allowed: %s hours.' % (
+                table.table_id, hours_old, stale_hours))
             stale = True
 
         lines.append(influxdb.line_protocol.make_lines({
@@ -74,13 +75,13 @@ def collect(tables, stale_hours, influx_client):
             'points': [{'measurement': 'bigquery', 'fields': fields}]
         }))
 
-    print 'Collected data:'
-    print ''.join(lines)
+    print('Collected data:')
+    print(''.join(lines))
 
     if influx_client:
         influx_client.write_points(lines, time_precision='ms', protocol='line')
     else:
-        print 'Not uploading to influxdb; missing client.'
+        print('Not uploading to influxdb; missing client.')
 
     return int(stale)
 

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -69,7 +69,7 @@ def get_started_finished(gcs_client, db, todo):
     pool = multiprocessing.pool.ThreadPool(16)
     try:
         for ack_id, (build_dir, started, finished) in pool.imap_unordered(
-                lambda (ack_id, job, build): (ack_id, gcs_client.get_started_finished(job, build)),
+                lambda ack_id_job_build: (ack_id_job_build[0], gcs_client.get_started_finished(ack_id_job_build[1], ack_id_job_build[2])),
                 todo):
             if finished:
                 if not db.insert_build(build_dir, started, finished):

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 
+from __future__ import print_function
 import os
 
 
 def call(cmd):
-    print '+', cmd
+    print('+', cmd)
     status = os.system(cmd)
     if status:
         raise OSError('invocation failed')

--- a/queue_health/weekly_commit_stats.py
+++ b/queue_health/weekly_commit_stats.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Lists weekly commits for a github org."""
+from __future__ import print_function
 
 import collections
 import datetime
@@ -26,8 +27,8 @@ import requests  # pip install requests
 SESSION = requests.Session()
 
 if len(sys.argv) != 3:
-    print >>sys.stderr, 'Usage: %s <path/to/token> <org>' % sys.argv[0]
-    print >>sys.stderr, '  Info at https://github.com/settings/tokens'
+    print('Usage: %s <path/to/token> <org>' % sys.argv[0], file=sys.stderr)
+    print('  Info at https://github.com/settings/tokens', file=sys.stderr)
     sys.exit(1)
 
 TOKEN = open(sys.argv[1]).read().strip()
@@ -42,7 +43,7 @@ def get(path):
 
 def github_repos(org):
     """List repos for the org."""
-    print >>sys.stderr, 'Repos', org
+    print('Repos', org, file=sys.stderr)
     resp = get('orgs/%s/repos' % org)
     resp.raise_for_status()
     return json.loads(resp.content)
@@ -50,7 +51,7 @@ def github_repos(org):
 
 def github_commits(owner, repo):
     """List weekly commits for the repo."""
-    print >>sys.stderr, 'Commits', owner, repo
+    print('Commits', owner, repo, file=sys.stderr)
     resp = get('repos/%s/%s/stats/commit_activity' % (owner, repo))
     resp.raise_for_status()
     return json.loads(resp.content)
@@ -64,8 +65,8 @@ def org_commits(org):
         for week in weeks:
             date = datetime.datetime.fromtimestamp(week['week'])
             weekly_commits[date] += week['total']
-    print 'Week,commits'
+    print('Week,commits')
     for week, total in sorted(weekly_commits.items()):
-        print '%s,%d' % (week.strftime('%Y-%m-%d'), total)
+        print('%s,%d' % (week.strftime('%Y-%m-%d'), total))
 
 org_commits(sys.argv[2])

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Runs bazel build/test for current repo."""
+from __future__ import print_function
 
 import argparse
 import os
@@ -29,12 +30,12 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     subprocess.check_call(cmd)
 
 def check_output(*cmd):
     """Log and run the command, raising on errors, return output"""
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     return subprocess.check_output(cmd)
 
 
@@ -94,7 +95,7 @@ class Bazel(object):
 def upload_string(gcs_path, text):
     """Uploads text to gcs_path"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
-    print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
+    print('Run:', cmd, 'stdin=%s'%text, file=sys.stderr)
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
     proc.communicate(input=text)
 
@@ -108,7 +109,7 @@ def echo_result(res):
         4:'Build passed, no tests found',
         5:'Interrupted'
     }
-    print echo_map.get(res, 'Unknown exit code : %s' % res)
+    print(echo_map.get(res, 'Unknown exit code : %s' % res))
 
 def get_version():
     """Return kubernetes version"""
@@ -196,7 +197,7 @@ def main(args):
     if args.release and res == 0:
         version = get_version()
         if not version:
-            print 'Kubernetes version missing; not uploading ci artifacts.'
+            print('Kubernetes version missing; not uploading ci artifacts.')
             res = 1
         else:
             try:

--- a/scenarios/kubernetes_execute_bazel.py
+++ b/scenarios/kubernetes_execute_bazel.py
@@ -17,6 +17,7 @@
 """Executes a command, afterwards executes coalesce.py, preserving the return code.
 
 Also supports configuring bazel remote caching."""
+from __future__ import print_function
 
 import argparse
 import os
@@ -31,12 +32,12 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     subprocess.check_call(cmd)
 
 def call(*cmd):
     """Log and run the command, raising on errors."""
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     return subprocess.call(cmd)
 
 
@@ -46,7 +47,7 @@ def main(cmd):
         raise ValueError(cmd)
     # update bazel caching configuration if enabled
     if os.environ.get('BAZEL_REMOTE_CACHE_ENABLED', 'false') == 'true':
-        print 'Bazel remote cache is enabled, generating .bazelrcs ...'
+        print('Bazel remote cache is enabled, generating .bazelrcs ...')
         # TODO(bentheelder): consider moving this once we've migrated all users
         # of the remote cache to this script
         check(test_infra('images/bootstrap/create_bazel_cache_rcs.sh'))

--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -18,6 +18,7 @@
 # pylint: disable=bad-continuation
 
 """Dig through jobs/FOO.env, and execute a janitor pass for each of the project"""
+from __future__ import print_function
 
 import argparse
 import json
@@ -35,7 +36,7 @@ def test_infra(*paths):
 
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     subprocess.check_call(cmd)
 
 
@@ -124,7 +125,7 @@ def check_ci_jobs():
                 continue
             project = mat.group(1)
             if any(b in project for b in BLACKLIST):
-                print >>sys.stderr, 'Project %r is blacklisted in ci-janitor' % project
+                print('Project %r is blacklisted in ci-janitor' % project, file=sys.stderr)
                 continue
             if project in PR_PROJECTS or project in SCALE_PROJECT:
                 continue # CI janitor skips all PR jobs
@@ -150,9 +151,9 @@ def main(mode, ratelimit, projects, age):
         check_ci_jobs()
 
     # Summary
-    print 'Janitor checked %d project, %d failed to clean up.' % (len(CHECKED), len(FAILED))
+    print('Janitor checked %d project, %d failed to clean up.' % (len(CHECKED), len(FAILED)))
     if FAILED:
-        print >>sys.stderr, 'Failed projects: %r' % FAILED
+        print('Failed projects: %r' % FAILED, file=sys.stderr)
         exit(1)
 
 

--- a/testgrid/conformance/upload_e2e.py
+++ b/testgrid/conformance/upload_e2e.py
@@ -33,6 +33,7 @@
 # Usage: see README.md
 
 
+from __future__ import print_function
 import re
 import sys
 import time
@@ -163,7 +164,7 @@ def testgrid_finished_json_contents(finish_time, passed, metadata):
 def upload_string(gcs_path, text, dry):
     """Uploads text to gcs_path if dry is False, otherwise just prints"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
-    print >>sys.stderr, 'Run:', cmd, 'stdin=%s' % text
+    print('Run:', cmd, 'stdin=%s' % text, file=sys.stderr)
     if dry:
         return
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
@@ -177,7 +178,7 @@ def upload_file(gcs_path, file_path, dry):
     """Uploads file at file_path to gcs_path if dry is False, otherwise just prints"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain',
            'cp', file_path, gcs_path]
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     if dry:
         return
     proc = subprocess.Popen(cmd)
@@ -191,7 +192,7 @@ def get_current_account(dry_run):
     """gets the currently active gcp account by shelling out to gcloud"""
     cmd = ['gcloud', 'auth', 'list',
            '--filter=status:ACTIVE', '--format=value(account)']
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     if dry_run:
         return ""
     return subprocess.check_output(cmd).strip('\n')
@@ -200,7 +201,7 @@ def get_current_account(dry_run):
 def set_current_account(account, dry_run):
     """sets the currently active gcp account by shelling out to gcloud"""
     cmd = ['gcloud', 'config', 'set', 'core/account', account]
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     if dry_run:
         return
     return subprocess.check_call(cmd)
@@ -209,7 +210,7 @@ def set_current_account(account, dry_run):
 def activate_service_account(key_file, dry_run):
     """activates a gcp service account by shelling out to gcloud"""
     cmd = ['gcloud', 'auth', 'activate-service-account', '--key-file='+key_file]
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     if dry_run:
         return
     subprocess.check_call(cmd)
@@ -218,7 +219,7 @@ def activate_service_account(key_file, dry_run):
 def revoke_current_account(dry_run):
     """logs out of the currently active gcp account by shelling out to gcloud"""
     cmd = ['gcloud', 'auth', 'revoke']
-    print >>sys.stderr, 'Run:', cmd
+    print('Run:', cmd, file=sys.stderr)
     if dry_run:
         return
     return subprocess.check_call(cmd)
@@ -293,7 +294,7 @@ def main(cli_args):
     # testgrid entry
     junits = glob.glob(args.junit)
     if not junits:
-        print 'No matching JUnit files found!'
+        print('No matching JUnit files found!')
         sys.exit(-1)
 
     # parse the e2e.log for start time, finish time, and success
@@ -309,14 +310,14 @@ def main(cli_args):
     gcs_dir = args.bucket + '/' + str(datetime_to_unix(started))
 
     # upload metadata, log, junit to testgrid
-    print 'Uploading entry to: %s' % gcs_dir
+    print('Uploading entry to: %s' % gcs_dir)
     upload_string(gcs_dir+'/started.json', started_json, args.dry_run)
     upload_string(gcs_dir+'/finished.json', finished_json, args.dry_run)
     upload_file(gcs_dir+'/build-log.txt', args.log, args.dry_run)
     for junit_file in junits:
         upload_file(gcs_dir+'/artifacts/' +
                     path.basename(junit_file), junit_file, args.dry_run)
-    print 'Done.'
+    print('Done.')
 
 
 if __name__ == '__main__':

--- a/triage/berghelroach_test.py
+++ b/triage/berghelroach_test.py
@@ -128,7 +128,7 @@ class AbstractLevenshteinTestCase(object):
     # @return the number of edits actually performed, the new string
     @staticmethod
     def performSomeEdits(b, alphabet, replaces, inserts):
-        r = random.Random(768614336404564651L)
+        r = random.Random(768614336404564651)
         edits = 0
         b = list(b)
 

--- a/velodrome/config.py
+++ b/velodrome/config.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import os
 import string
 import sys
@@ -38,7 +39,7 @@ DEPLOYMENTS = {
 
 def main():
     if len(sys.argv) != 1:
-        print >> sys.stderr, "Too many arguments."
+        print("Too many arguments.", file=sys.stderr)
         sys.exit(128)
 
     with open(get_absolute_path(CONFIG)) as config_file:
@@ -112,8 +113,8 @@ def print_deployments(components, env):
 
 
 def print_deployment(deployment, env):
-    print string.Template(deployment).safe_substitute(**env),
-    print '---'
+    print(string.Template(deployment).safe_substitute(**env), end=' ')
+    print('---')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Related to #8678 

Changes to be syntax compatible with both Python 2 and Python 3 because [the clock is ticking](http://pythonclock.org)...

There is one remaining syntax error that is [tricky to fix without a third party module like six or future](http://python-future.org/compatible_idioms.html#raising-exceptions).
```
./jenkins/bootstrap.py:1124:23: E999 SyntaxError: invalid syntax
        raise exc_type, exc_value, exc_traceback  # pylint: disable=raising-bad-type
                      ^
```

There will also be many undefined names (#8678) resolve as well.