### PR TITLE
Revert "Rename gce-large job clusters"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3290,7 +3290,7 @@
   },
   "ci-kubernetes-e2e-gce-large-correctness": {
     "args": [
-      "--cluster=gce-large-cluster",
+      "--cluster=gce-scale-cluster",
       "--env=HEAPSTER_MACHINE_TYPE=n1-standard-8",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",
@@ -3353,7 +3353,7 @@
   },
   "ci-kubernetes-e2e-gce-large-performance": {
     "args": [
-      "--cluster=gce-large-cluster",
+      "--cluster=gce-scale-cluster",
       "--env=HEAPSTER_MACHINE_TYPE=n1-standard-8",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-highspeed-common.env",


### PR DESCRIPTION
This reverts commit b535e6553785a121568e13d6e1614106097f5726.

I'm reverting https://github.com/kubernetes/test-infra/pull/8593 as the long-term solution I mentioned under https://github.com/kubernetes/kubernetes/issues/65626 is now made.

fyi - @wojtek-t 