### PR TITLE
enable merge automation for k/release

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -204,6 +204,7 @@ tide:
     - kubernetes/org
     - kubernetes/perf-tests
     - kubernetes/publishing-bot
+    - kubernetes/release
     - kubernetes/repo-infra
     - kubernetes/sig-release
     - kubernetes/steering

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -54,6 +54,7 @@ approve:
   - kubernetes/node-problem-detector
   - kubernetes/perf-tests
   - kubernetes/publishing-bot
+  - kubernetes/release
   - kubernetes/repo-infra
   - kubernetes/sig-release
   - kubernetes/steering
@@ -351,6 +352,7 @@ plugins:
   - blunderbuss
 
   kubernetes/release:
+  - approve
   - trigger
 
   kubernetes/repo-infra:


### PR DESCRIPTION
k/release now has OWNERS
- enable `approve` plugin
- enable tide