### PR TITLE
allow overwrite gubernator path in unit test

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -45,6 +45,7 @@ type configJSON map[string]map[string]interface{}
 var configPath = flag.String("config", "../../../prow/config.yaml", "Path to prow config")
 var jobConfigPath = flag.String("job-config", "../../jobs", "Path to prow job config")
 var configJSONPath = flag.String("config-json", "../../../jobs/config.json", "Path to prow job config")
+var gubernatorPath = flag.String("gubernator-path", "https://k8s-gubernator.appspot.com", "Path to linked gubernator")
 
 func (c configJSON) ScenarioForJob(jobName string) string {
 	if scenario, ok := c[jobName]["scenario"]; ok {
@@ -145,7 +146,7 @@ func TestReportTemplate(t *testing.T) {
 			t.Errorf("Error executing template: %v", err)
 			continue
 		}
-		expectedPath := "https://k8s-gubernator.appspot.com/pr/" + tc.suffix
+		expectedPath := *gubernatorPath + "/pr/" + tc.suffix
 		if !strings.Contains(b.String(), expectedPath) {
 			t.Errorf("Expected template to contain %s, but it didn't: %s", expectedPath, b.String())
 		}
@@ -169,7 +170,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-pre-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/0/k8s-pre-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/pr-logs/pull/0/k8s-pre-1/1/",
 		},
 		{
 			name:    "k8s/test-infra presubmit",
@@ -178,7 +179,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "test-infra",
 			job:     "ti-pre-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/0/ti-pre-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/pr-logs/pull/test-infra/0/ti-pre-1/1/",
 		},
 		{
 			name:    "foo/k8s presubmit",
@@ -187,7 +188,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-pre-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/foo_kubernetes/0/k8s-pre-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/pr-logs/pull/foo_kubernetes/0/k8s-pre-1/1/",
 		},
 		{
 			name:    "foo-bar presubmit",
@@ -196,7 +197,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "bar",
 			job:     "foo-pre-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/foo_bar/0/foo-pre-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/pr-logs/pull/foo_bar/0/foo-pre-1/1/",
 		},
 		{
 			name:    "k8s postsubmit",
@@ -205,21 +206,21 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-post-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/k8s-post-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/logs/k8s-post-1/1/",
 		},
 		{
 			name:    "k8s periodic",
 			jobType: kube.PeriodicJob,
 			job:     "k8s-peri-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/k8s-peri-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/logs/k8s-peri-1/1/",
 		},
 		{
 			name:    "empty periodic",
 			jobType: kube.PeriodicJob,
 			job:     "nan-peri-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/nan-peri-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/logs/nan-peri-1/1/",
 		},
 		{
 			name:    "k8s batch",
@@ -228,7 +229,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-batch-1",
 			build:   "1",
-			expect:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/batch/k8s-batch-1/1/",
+			expect:  *gubernatorPath + "/build/kubernetes-jenkins/pr-logs/pull/batch/k8s-batch-1/1/",
 		},
 	}
 


### PR DESCRIPTION
We are not always use the k8s gubernator :-)

/area prow
/assign @amwat @cjwagner @BenTheElder 