### PR TITLE
Remove kube-deploy tests for the cluster api code.

### DIFF
--- a/images/kube-deploy/Makefile
+++ b/images/kube-deploy/Makefile
@@ -14,6 +14,7 @@
 
 VERSION := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
+# TODO(roberthbailey): Rename the image (and this directory) from kube-deploy to cluster-api.
 IMG="gcr.io/k8s-testimages/kube-deploy"
 
 image:

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -861,24 +861,6 @@
       "sig-aws"
     ]
   },
-  "ci-kube-deploy-build": {
-    "args": [
-      "./scripts/ci-build.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "ci-kube-deploy-test": {
-    "args": [
-      "./scripts/ci-test.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-kubemci-image-push": {
     "args": [
       "make",
@@ -11702,24 +11684,6 @@
   "pull-kops-verify-packages": {
     "args": [
       "./hack/verify-packages.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "pull-kube-deploy-build": {
-    "args": [
-      "./scripts/ci-build.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "pull-kube-deploy-test": {
-    "args": [
-      "./scripts/ci-test.sh"
     ],
     "scenario": "execute",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -758,37 +758,6 @@ presubmits:
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
 
-  kubernetes/kube-deploy:
-  - name: pull-kube-deploy-build
-    agent: kubernetes
-    always_run: true
-    context: pull-kube-deploy-build
-    rerun_command: "/test pull-kube-deploy-build"
-    trigger: "/test( all| pull-kube-deploy-build)"
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-  - name: pull-kube-deploy-test
-    agent: kubernetes
-    always_run: true
-    context: pull-kube-deploy-test
-    rerun_command: "/test pull-kube-deploy-test"
-    trigger: "/test( all| pull-kube-deploy-test)"
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kube-deploy:v20180212-214c99406
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
   kubernetes/kops:
   - name: pull-kops-bazel-build
     agent: kubernetes
@@ -4436,31 +4405,6 @@ periodics:
     volumes:
     - name: docker-graph
       emptyDir: {}
-
-- name: ci-kube-deploy-build
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
-      args:
-      - "--repo=k8s.io/kube-deploy"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
-- name: ci-kube-deploy-test
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kube-deploy:v20180212-214c99406
-      args:
-      - "--repo=k8s.io/kube-deploy"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
 
 - interval: 60m
   agent: kubernetes

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -299,7 +299,6 @@ plugins:
   kubernetes/kube-deploy:
   - approve
   - blunderbuss
-  - trigger
 
   kubernetes/kubeadm:
   - approve

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -378,7 +378,6 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes/federation",
 		"kubernetes/heapster",
 		"kubernetes/kops",
-		"kubernetes/kube-deploy",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"tensorflow/minigo",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -226,10 +226,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-upgrade-e2e
 - name: ci-ingress-gce-downgrade-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-downgrade-e2e
-- name: ci-kube-deploy-build
-  gcs_prefix: kubernetes-jenkins/logs/ci-kube-deploy-build
-- name: ci-kube-deploy-test
-  gcs_prefix: kubernetes-jenkins/logs/ci-kube-deploy-test
 - name: ci-cluster-api-build
   gcs_prefix: kubernetes-jenkins/logs/ci-cluster-api-build
 - name: ci-cluster-api-test
@@ -2064,12 +2060,6 @@ test_groups:
 - name: ppc64le-unit
   gcs_prefix: ppc64le-kubernetes/logs/ci-unit-kubernetes
 #presubmits
-- name: pull-kube-deploy-build
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kube-deploy-build
-  num_columns_recent: 20
-- name: pull-kube-deploy-test
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kube-deploy-test
-  num_columns_recent: 20
 - name: pull-cluster-api-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-build
   num_columns_recent: 20
@@ -4850,14 +4840,6 @@ dashboards:
     test_group_name: pull-cluster-api-make
   - name: pr-test
     test_group_name: pull-cluster-api-test
-  - name: kube-deploy build
-    test_group_name: ci-kube-deploy-build
-  - name: kube-deploy unit tests
-    test_group_name: ci-kube-deploy-test
-  - name: kube-deploy pr-build
-    test_group_name: pull-kube-deploy-build
-  - name: kube-deploy pr-test
-    test_group_name: pull-kube-deploy-test
 
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
   dashboard_tab:


### PR DESCRIPTION
Basically undoing https://github.com/kubernetes/test-infra/pull/6761 and https://github.com/kubernetes/test-infra/pull/6792. This will unblock merging https://github.com/kubernetes/kube-deploy/pull/704. 