### PR TITLE
Enable milestone plugin for k/test-infra

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -367,6 +367,7 @@ plugins:
   kubernetes/test-infra:
   - approve
   - config-updater
+  - milestone
   - trigger
   - verify-owners
 


### PR DESCRIPTION
I'd like to be able to use the /milestone command
on k/test-infra. As-is, this will check the same
kubernetes-milestone-maintainers team as is used
for kubernetes/kubernetes release management. I'm
open to creating a new team for this repo if I have
to, but I'm defaulting to lazy reuse.