### PR TITLE
[WIP] Allow Deck to only serve plugin-related help

### DIFF
--- a/prow/cmd/deck/static/extensions/script.js
+++ b/prow/cmd/deck/static/extensions/script.js
@@ -1,1 +1,44 @@
 // This file serves for custom javascript extensions
+function pageFromUri(page) {
+    splitUri = page.split('/');
+    page = splitUri[splitUri.length - 1];
+
+    if (page === '') {
+        page = 'index'
+    }
+
+    return page
+}
+
+function disableIncorrectNavbarLinks(pages) {
+    var links = document.getElementsByClassName("mdl-navigation__link");
+    disabledLinks = [];
+
+    for (var i = 0; i < links.length; i++) {
+        console.log(i + 'testing ' + links[i].href)
+        if (!pages.includes(pageFromUri(links[i].href))) {
+            disabledLinks.push(links[i])
+        }
+    }
+
+    disabledLinks.forEach(function(elem) { elem.remove(); });
+}
+
+window.onload = function() {
+    var req = new XMLHttpRequest();
+    req.open("GET", "/enabled-pages");
+    req.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            let enabledPages = JSON.parse(req.responseText);
+
+            if (!enabledPages.includes(pageFromUri(window.location.href))) {
+                window.location.href = "/" + enabledPages[0];
+            }
+
+            disableIncorrectNavbarLinks(enabledPages);
+        }
+    };
+
+    req.send();
+};
+


### PR DESCRIPTION
### Background

At Improbable, we have deployed Prow for its plugins, and have our own CI solutions, so are not planning to use Prowjobs and Tide. As a result, it would be great if we could deploy Deck without having to set up a service account, and additionally have it only display relevant information.

I assume that as Prow's plugin ecosystem improves that this may become a desire of more people and/or organisations, so thought that this may be appreciated upstream.

### Current work

At the moment, this PR is just a proof of concept bit of patched-on JavaScript to retroactively remove unwanted links - it's a bit gross, so I don't particularly expect to merge this; I'm more curious about whether the general idea is helpful and wanted, in which case I'd be happy to put together a better implementation which e.g. templates the HTML files to generate the correct navbar initially (instead of requiring three round-trip requests).

It also doesn't currently deactivate any of the server-side behavior; it's just a front-end change right now.

---

Questions I'm interested in getting answers to are essentially:

1. Is this helpful?
1. Would a more modular approach be preferred? (e.g. instead of `--plugin-help-only`, perhaps something like `--components tide,plugins,pr`)
1. If there's any particular preference for the format of the solution, or if templating and generating the links would be okay.