### PR TITLE
Bump timeout for nosnat job to 40m

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -6028,7 +6028,7 @@ periodics:
     containers:
     - args:
       - --bare
-      - --timeout=40
+      - --timeout=60
       - --scenario=kubernetes_e2e
       - --
       - --cluster=test-eb37105e71
@@ -6039,7 +6039,7 @@ periodics:
       - --image-project=cos-cloud
       - --gcp-node-image=gci
       - --extract=ci/latest
-      - --timeout=20m
+      - --timeout=40m
       - --test_args=--ginkgo.focus=\[Feature:NoSNAT\] --minStartupPods=8
       - --ginkgo-parallel=1
       - --gcp-project=k8s-e2e-170223

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -1131,7 +1131,7 @@ testSuites:
     - --ginkgo-parallel
   nosnat:
     args:
-    - --timeout=20m
+    - --timeout=40m
     - --test_args=--ginkgo.focus=\[Feature:NoSNAT\] --minStartupPods=8
     - --ginkgo-parallel=1
 


### PR DESCRIPTION
From https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat/, seems like this jobs almost always timed out so the TearDown step never finished.
```
TearDown 8m17s
  error during ./hack/e2e-internal/e2e-down.sh (interrupted): signal: aborted (core dumped)
```

This PR bumps its timeout to 40 minutes according to the history.

Ref https://github.com/kubernetes/kubernetes/issues/66141.

/assign @krzyzacy 