### PR TITLE
[prow/tide]: add k-sigs/kustomize to tide

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -218,6 +218,7 @@ tide:
     - kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
     - kubernetes-sigs/gcp-filestore-csi-driver
     - kubernetes-sigs/kubebuilder
+    - kubernetes-sigs/kustomize
     - client-go/unofficial-docs
     labels:
     - lgtm


### PR DESCRIPTION
I want to setup automatic merging for the bots on the [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize/) repository