### PR TITLE
fix ginkgo focus escapes

### DIFF
--- a/config/jobs/gke/gke-staging-gpu.yaml
+++ b/config/jobs/gke/gke-staging-gpu.yaml
@@ -23,7 +23,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--ginkgo.focus=\\[Feature:GPUDevicePlugin\\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=80m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
@@ -51,6 +51,6 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-v100,count=2
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--ginkgo.focus=\\[Feature:GPUDevicePlugin\\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=80m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master

--- a/config/jobs/gke/gke-staging-upgrade.yaml
+++ b/config/jobs/gke/gke-staging-upgrade.yaml
@@ -22,9 +22,9 @@ periodics:
       - --gcp-zone=us-central1-f
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -52,7 +52,7 @@ periodics:
       - --provider=gke
       - --skew
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -80,7 +80,7 @@ periodics:
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -106,9 +106,9 @@ periodics:
       - --gcp-region=us-central1
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
+      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.9 --upgrade-image=gci"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -134,9 +134,9 @@ periodics:
       - --gcp-zone=us-central1-f
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -164,7 +164,7 @@ periodics:
       - --provider=gke
       - --skew
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -192,7 +192,7 @@ periodics:
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -218,9 +218,9 @@ periodics:
       - --gcp-region=us-central1
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
+      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.10 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -246,9 +246,9 @@ periodics:
       - --gcp-zone=us-central1-f
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -276,7 +276,7 @@ periodics:
       - --provider=gke
       - --skew
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -304,7 +304,7 @@ periodics:
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
 - interval: 2h
@@ -330,7 +330,7 @@ periodics:
       - --gcp-region=us-central1
       - --gke-environment=staging
       - --provider=gke
-      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
+      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master


### PR DESCRIPTION
see https://github.com/kubernetes/test-infra/commit/8797575ea6afeac999c7c421fbe3e5dacc88fa8f#diff-33f1145f7bd7d0749a932c2b4b7f58b2

forgot to do that for upgrade suites, yaml can handle string literals without double escaping.

/assign @msau42 @dashpole @mindprince 

(the gpu job was passing because it didn't run anything, /shrug) 