### PR TITLE
Migrate rest of test-infra jobs and canary jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -340,50 +340,6 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( all| pull-security-kubernetes-bazel-build),?(\s+|$)
   - agent: kubernetes
-    always_run: false
-    cluster: security
-    context: pull-security-kubernetes-bazel-build-canary
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-service-account: "true"
-    max_concurrency: 0
-    name: pull-security-kubernetes-bazel-build-canary
-    rerun_command: /test pull-security-kubernetes-bazel-build-canary
-    run_if_changed: ""
-    skip_report: false
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --job=$(JOB_NAME)
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --scenario=kubernetes_bazel
-        - --timeout=60
-        - --
-        - --build=//... -//vendor/...
-        - --release=//build/release-tars
-        - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build-canary
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            memory: 6Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test pull-security-kubernetes-bazel-build-canary,?(\s+|$)
-  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-bazel-test
@@ -567,89 +523,6 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test( all| pull-security-kubernetes-bazel-test),?(\s+|$)
-  - agent: kubernetes
-    always_run: false
-    cluster: security
-    context: pull-security-kubernetes-bazel-test-canary
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-service-account: "true"
-    max_concurrency: 0
-    name: pull-security-kubernetes-bazel-test-canary
-    rerun_command: /test pull-security-kubernetes-bazel-test-canary
-    run_if_changed: ""
-    skip_report: false
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --job=$(JOB_NAME)
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --scenario=kubernetes_execute_bazel
-        - --timeout=60
-        - --
-        - make
-        - bazel-test
-        image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            memory: 6Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test pull-security-kubernetes-bazel-test-canary,?(\s+|$)
-  - agent: kubernetes
-    always_run: false
-    cluster: security
-    context: pull-security-kubernetes-bazel-test-integration-canary
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-service-account: "true"
-    max_concurrency: 0
-    name: pull-security-kubernetes-bazel-test-integration-canary
-    rerun_command: /test pull-security-kubernetes-bazel-test-integration-canary
-    run_if_changed: ""
-    skip_report: false
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --job=$(JOB_NAME)
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --
-        - --test=//test/integration/...
-        - --test-args=--config=integration
-        - --timeout=60
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            memory: 6Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test pull-security-kubernetes-bazel-test-integration-canary,?(\s+|$)
   - agent: kubernetes
     always_run: false
     cluster: security
@@ -2673,3 +2546,131 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test pull-security-kubernetes-verify-prow,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-bazel-build-canary
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-build-canary
+    rerun_command: /test pull-security-kubernetes-bazel-build-canary
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --scenario=kubernetes_bazel
+        - --timeout=60
+        - --
+        - --build=//... -//vendor/...
+        - --release=//build/release-tars
+        - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build-canary
+        - --gcs-shared=gs://kubernetes-security-prow/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-build-canary,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-bazel-test-canary
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test-canary
+    rerun_command: /test pull-security-kubernetes-bazel-test-canary
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --scenario=kubernetes_execute_bazel
+        - --timeout=60
+        - --
+        - make
+        - bazel-test
+        image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-test-canary,?(\s+|$)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-bazel-test-integration-canary
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-service-account: "true"
+    max_concurrency: 0
+    name: pull-security-kubernetes-bazel-test-integration-canary
+    rerun_command: /test pull-security-kubernetes-bazel-test-integration-canary
+    run_if_changed: ""
+    skip_report: false
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --job=$(JOB_NAME)
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --scenario=kubernetes_execute_bazel
+        - --
+        - --test=//test/integration/...
+        - --test-args=--config=integration
+        - --timeout=60
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test pull-security-kubernetes-bazel-test-integration-canary,?(\s+|$)

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -1,3 +1,98 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-bazel-build-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-build-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-build-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-build-canary,?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
+        imagePullPolicy: Always
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_bazel"
+        - "--timeout=60"
+        - "--" # end bootstrap args, scenario args below
+        - "--build=//... -//vendor/..."
+        - "--release=//build/release-tars"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
+
+  - name: pull-kubernetes-bazel-test-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-test-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-test-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-test-canary,?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
+        imagePullPolicy: Always
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--timeout=60"
+        - "--" # end bootstrap args, scenario args below
+        - "make"
+        - "bazel-test"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
+
+  - name: pull-kubernetes-bazel-test-integration-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-test-integration-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-test-integration-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-test-integration-canary,?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--" # end bootstrap args, scenario args below
+        - "--test=//test/integration/..."
+        - "--test-args=--config=integration"
+        - "--timeout=60"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
+
 periodics:
 - name: ci-kubernetes-e2e-prow-canary
   interval: 1h
@@ -49,3 +144,184 @@ periodics:
       - --timeout=40m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-scalability-canary
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=e2e-big-canary
+      - --env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env
+      - --env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
+      - --extract=ci/latest
+      - --gcp-nodes=100
+      - --gcp-project=google.com:k8s-jenkins-scalability
+      - --gcp-zone=us-central1-f
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --minStartupPods=8
+      - --timeout=120m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-canary
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --deployment=gke
+      - --extract=gke-latest-1.8
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --ginkgo-parallel
+      - --gke-environment=staging
+      - --provider=gke
+      - --test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8
+      - --timeout=50m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-canary
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=e2e-kops-aws-canary.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=ci/latest
+      - --ginkgo-parallel
+      - --kops-etcd-version=3.1.10
+      - --kops-master-count=3
+      - --kops-multiple-zones
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-gce-canary
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=e2e-kops-gce-canary.k8s.local
+      - --deployment=kops
+      - --extract=ci/latest
+      - --ginkgo-parallel=30
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+
+- name: ci-kubernetes-e2e-node-canary
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=110
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --gcp-zone=us-central1-f
+      - --node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud
+      - --node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"
+      - --node-tests=true
+      - --provider=gce
+      - --test_args=--nodes=8 --focus=\"\\[NodeConformance\\]\" --skip=\"\\[Flaky\\]|\\[Serial\\]\"
+      - --timeout=90m
+      env:
+      - name: GOPATH
+        value: /go
+
+- name: ci-kubernetes-kubemark-100-canary
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      args:
+      - --bare
+      - --timeout=260
+      - --scenario=kubernetes_e2e
+      - --
+      - --build=bazel
+      - --cluster=kubemark-100-canary
+      - --env-file=jobs/env/ci-kubernetes-e2e-kubemark-common.env
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-2
+      - --gcp-node-size=n1-standard-4
+      - --gcp-nodes=3
+      - --gcp-project=k8s-jenkins-gci-kubemark
+      - --gcp-zone=us-central1-f
+      - --kubemark
+      - --kubemark-nodes=100
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true
+      - --timeout=240m
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      volumeMounts:
+      - name: docker-graph
+        mountPath: /docker-graph
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+    volumes:
+    - name: docker-graph
+      emptyDir: {}
+
+

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -241,3 +241,72 @@ periodics:
     - name: token
       secret:
         secretName: fejta-bot-token
+
+- name: metrics-bigquery
+  interval: 24h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bigquery:v20180330-f723e8d3f
+      args:
+      - --scenario=execute
+      - --
+      - test-infra/metrics/bigquery.py
+      - --
+      - --bucket=gs://k8s-metrics
+      - --backfill-days=90
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: VELODROME_INFLUXDB_CONFIG
+        value: /etc/velodrome-influxdb/config.json
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: influxdb
+        mountPath: /etc/velodrome-influxdb
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: triage-service-account
+    - name: influxdb
+      secret:
+        secretName: velodrome-influxdb
+
+- name: metrics-kettle
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bigquery:v20180330-f723e8d3f
+      args:
+      - --scenario=execute
+      - --
+      - test-infra/kettle/monitor.py
+      - --
+      - --stale=6
+      - --table
+      - k8s-gubernator:build.all
+      - k8s-gubernator:build.week
+      - k8s-gubernator:build.day
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: VELODROME_INFLUXDB_CONFIG
+        value: /etc/velodrome-influxdb/config.json
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: influxdb
+        mountPath: /etc/velodrome-influxdb
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: triage-service-account
+    - name: influxdb
+      secret:
+        secretName: velodrome-influxdb

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2106,25 +2106,6 @@
       "sig-instrumentation"
     ]
   },
-  "ci-kubernetes-e2e-gce-scalability-canary": {
-    "args": [
-      "--cluster=e2e-big-canary",
-      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
-      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env",
-      "--extract=ci/latest",
-      "--gcp-nodes=100",
-      "--gcp-project=google.com:k8s-jenkins-scalability",
-      "--gcp-zone=us-central1-f",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --minStartupPods=8",
-      "--timeout=120m",
-      "--use-logexporter"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "ci-kubernetes-e2e-gce-scale-correctness": {
     "args": [
       "--cluster=gce-scale-cluster",
@@ -3443,25 +3424,6 @@
       "sig-cli"
     ]
   },
-  "ci-kubernetes-e2e-gke-canary": {
-    "args": [
-      "--check-leaked-resources",
-      "--cluster=",
-      "--deployment=gke",
-      "--extract=gke-latest-1.8",
-      "--gcp-node-image=gci",
-      "--gcp-zone=us-central1-b",
-      "--ginkgo-parallel",
-      "--gke-environment=staging",
-      "--provider=gke",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=50m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-kubernetes-e2e-gke-device-plugin-gpu": {
     "args": [
       "--check-leaked-resources",
@@ -4745,26 +4707,6 @@
       "sig-aws"
     ]
   },
-  "ci-kubernetes-e2e-kops-aws-canary": {
-    "args": [
-      "--cluster=e2e-kops-aws-canary.test-cncf-aws.k8s.io",
-      "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
-      "--extract=ci/latest",
-      "--ginkgo-parallel",
-      "--kops-etcd-version=3.1.10",
-      "--kops-master-count=3",
-      "--kops-multiple-zones",
-      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
-      "--provider=aws",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
-      "--timeout=120m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "ci-kubernetes-e2e-kops-aws-channelalpha": {
     "args": [
       "--cluster=e2e-kops-aws-channelalpha.test-cncf-aws.k8s.io",
@@ -5001,23 +4943,6 @@
       "--cluster=e2e-kops-gce.k8s.local",
       "--deployment=kops",
       "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt",
-      "--extract=ci/latest",
-      "--ginkgo-parallel=30",
-      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
-      "--kops-zones=us-central1-c",
-      "--provider=gce",
-      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
-      "--timeout=120m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-aws"
-    ]
-  },
-  "ci-kubernetes-e2e-kops-gce-canary": {
-    "args": [
-      "--cluster=e2e-kops-gce-canary.k8s.local",
-      "--deployment=kops",
       "--extract=ci/latest",
       "--ginkgo-parallel=30",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -5398,22 +5323,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "ci-kubernetes-e2e-node-canary": {
-    "args": [
-      "--deployment=node",
-      "--gcp-zone=us-central1-f",
-      "--node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud",
-      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
-      "--node-tests=true",
-      "--provider=gce",
-      "--test_args=--nodes=8 --focus=\"\\[NodeConformance\\]\" --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
-      "--timeout=90m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "ci-kubernetes-federation-build-1-8": {
     "args": [
       "--allow-dup",
@@ -5597,29 +5506,6 @@
       "--prow"
     ],
     "scenario": "kubernetes_verify",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
-  "ci-kubernetes-kubemark-100-canary": {
-    "args": [
-      "--build=bazel",
-      "--cluster=kubemark-100-canary",
-      "--env-file=jobs/env/ci-kubernetes-e2e-kubemark-common.env",
-      "--extract=ci/latest",
-      "--gcp-master-size=n1-standard-2",
-      "--gcp-node-size=n1-standard-4",
-      "--gcp-nodes=3",
-      "--gcp-project=k8s-jenkins-gci-kubemark",
-      "--gcp-zone=us-central1-f",
-      "--kubemark",
-      "--kubemark-nodes=100",
-      "--provider=gce",
-      "--test=false",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true",
-      "--timeout=240m"
-    ],
-    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-testing"
     ]
@@ -6084,33 +5970,6 @@
       "sig-gcp"
     ]
   },
-  "metrics-bigquery": {
-    "args": [
-      "test-infra/metrics/bigquery.py",
-      "--",
-      "--bucket=gs://k8s-metrics",
-      "--backfill-days=90"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
-  "metrics-kettle": {
-    "args": [
-      "test-infra/kettle/monitor.py",
-      "--",
-      "--stale=6",
-      "--table",
-      "k8s-gubernator:build.all",
-      "k8s-gubernator:build.week",
-      "k8s-gubernator:build.day"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "periodic-kubernetes-bazel-build-1-10": {
     "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
     "args": [],
@@ -6503,31 +6362,7 @@
       "sig-testing"
     ]
   },
-  "pull-kubernetes-bazel-build-canary": {
-    "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
-    "args": [],
-    "scenario": "kubernetes_bazel",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "pull-kubernetes-bazel-test": {
-    "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
-    "args": [],
-    "scenario": "kubernetes_bazel",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
-  "pull-kubernetes-bazel-test-canary": {
-    "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
-    "args": [],
-    "scenario": "kubernetes_bazel",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
-  "pull-kubernetes-bazel-test-integration-canary": {
     "_comment": "NOTE: args for this are in prow/config.yaml after the `--` !",
     "args": [],
     "scenario": "kubernetes_bazel",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -26,7 +26,6 @@ import re
 import sys
 
 import config_sort
-import env_gc
 import yaml
 
 # pylint: disable=too-many-public-methods, too-many-branches, too-many-locals, too-many-statements
@@ -99,12 +98,14 @@ class JobTest(unittest.TestCase):
                 self.fail('boskos/resources.yaml is not sorted, please run '
                           '`bazel run //jobs:config_sort`')
 
-    def test_orphaned_env(self):
-        orphans = env_gc.find_orphans()
-        if orphans:
-            self.fail('the following .env files are not referenced ' +
-                      'in config.json, please run `bazel run //jobs:env_gc`: ' +
-                      ' '.join(orphans))
+    # TODO(krzyzacy): disabled as we currently have multiple source of truth.
+    # We also should migrate shared env files into presets.
+    #def test_orphaned_env(self):
+    #    orphans = env_gc.find_orphans()
+    #    if orphans:
+    #        self.fail('the following .env files are not referenced ' +
+    #                  'in config.json, please run `bazel run //jobs:env_gc`: ' +
+    #                  ' '.join(orphans))
 
     def check_job_template(self, tmpl):
         builders = tmpl.get('builders')

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1310,37 +1310,6 @@ presubmits:
           - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
             value: "true"
 
-  - name: pull-kubernetes-bazel-build-canary
-    agent: kubernetes
-    context: pull-kubernetes-bazel-build-canary
-    always_run: false
-    rerun_command: "/test pull-kubernetes-bazel-build-canary"
-    trigger: "(?m)^/test pull-kubernetes-bazel-build-canary,?(\\s+|$)"
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
-        imagePullPolicy: Always
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=kubernetes_bazel"
-        - "--timeout=60"
-        - "--" # end bootstrap args, scenario args below
-        - "--build=//... -//vendor/..."
-        - "--release=//build/release-tars"
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "6Gi"
-
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -1468,67 +1437,6 @@ presubmits:
         - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "6Gi"
-
-  - name: pull-kubernetes-bazel-test-canary
-    agent: kubernetes
-    context: pull-kubernetes-bazel-test-canary
-    always_run: false
-    rerun_command: "/test pull-kubernetes-bazel-test-canary"
-    trigger: "(?m)^/test pull-kubernetes-bazel-test-canary,?(\\s+|$)"
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:02fe7ded2e8e477e52f3c82eab5fb6632ad7cd09612e2d7c5944d143974f3685
-        imagePullPolicy: Always
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=kubernetes_execute_bazel"
-        - "--timeout=60"
-        - "--" # end bootstrap args, scenario args below
-        - "make"
-        - "bazel-test"
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "6Gi"
-
-  - name: pull-kubernetes-bazel-test-integration-canary
-    agent: kubernetes
-    context: pull-kubernetes-bazel-test-integration-canary
-    always_run: false
-    rerun_command: "/test pull-kubernetes-bazel-test-integration-canary"
-    trigger: "(?m)^/test pull-kubernetes-bazel-test-integration-canary,?(\\s+|$)"
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
-        imagePullPolicy: Always
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--test=//test/integration/..."
-        - "--test-args=--config=integration"
-        - "--timeout=60"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -5714,20 +5622,6 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
-- interval: 30m
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gce-scalability-canary
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-
 - cron: '1 22 * * 2,4,6' # Run at 14:01PST (22:01 UTC) on even days
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-scale-correctness
@@ -6788,20 +6682,6 @@ periodics:
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
-- interval: 30m
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gke-canary
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu
   interval: 2h
   agent: kubernetes
@@ -7636,21 +7516,6 @@ periodics:
 
 - interval: 1h
   agent: kubernetes
-  name: ci-kubernetes-e2e-kops-aws-canary
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-
-- interval: 1h
-  agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-channelalpha
   labels:
     preset-service-account: "true"
@@ -7850,20 +7715,6 @@ periodics:
       - --timeout=140
       - --bare
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
-
-- interval: 30m
-  agent: kubernetes
-  name: ci-kubernetes-e2e-kops-gce-canary
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --bare
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
 
 - interval: 1h
   agent: kubernetes
@@ -8129,24 +7980,6 @@ periodics:
       - "--timeout=320"
       - "--upload=gs://kubernetes-jenkins/logs"
 
-- name: ci-kubernetes-e2e-node-canary
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-      args:
-      - --repo=k8s.io/kubernetes=master
-      - --timeout=110
-      - --root=/go/src
-      env:
-      - name: GOPATH
-        value: /go
-
 - interval: 2h
   name: ci-kubernetes-federation-build-1-8
   agent: kubernetes
@@ -8405,32 +8238,6 @@ periodics:
       resources:
         requests:
           cpu: 4
-    volumes:
-    - name: docker-graph
-      emptyDir: {}
-
-- name: ci-kubernetes-kubemark-100-canary
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-      args:
-      - --bare
-      - --timeout=260
-      env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: "true"
-      volumeMounts:
-      - name: docker-graph
-        mountPath: /docker-graph
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
     volumes:
     - name: docker-graph
       emptyDir: {}
@@ -8918,58 +8725,6 @@ periodics:
       - --repo=github.com/ostromart/istio=k8s-prow-test
       - --timeout=90
       - --root=/go/src
-
-- name: metrics-bigquery
-  interval: 24h
-  agent: kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20180330-f723e8d3f
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: VELODROME_INFLUXDB_CONFIG
-        value: /etc/velodrome-influxdb/config.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-      - name: influxdb
-        mountPath: /etc/velodrome-influxdb
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: triage-service-account
-    - name: influxdb
-      secret:
-        secretName: velodrome-influxdb
-
-- name: metrics-kettle
-  interval: 1h
-  agent: kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20180330-f723e8d3f
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: VELODROME_INFLUXDB_CONFIG
-        value: /etc/velodrome-influxdb/config.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-      - name: influxdb
-        mountPath: /etc/velodrome-influxdb
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: triage-service-account
-    - name: influxdb
-      secret:
-        secretName: velodrome-influxdb
 
 - name: periodic-kubernetes-bazel-build-1-10
   interval: 6h


### PR DESCRIPTION
I disabled the orphan envfile test, and will refactor envfiles into presets after we sort out all jobs.

/area jobs
/assign @BenTheElder 