### PR TITLE
tide documentation

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -21,6 +21,9 @@ not make any attempt to preserve backwards compatibility.
 * `cmd/clonerefs`, `cmd/initupload`, `cmd/gcsupload`, `cmd/entrypoint`, and
   `cmd/sidecar` are small utilities used in `ProwJobs` created by `plank` as
   `Pods`. See [their README](./pod-utilities.md) for more information
+* `cmd/tide` manages merging PRs once they pass tests and match other
+  criteria. See [its README](./cmd/tide/README.md) for more
+  information.
 
 See also: [Life of a Prow Job](./architecture.md)
 

--- a/prow/cmd/tide/README.md
+++ b/prow/cmd/tide/README.md
@@ -33,7 +33,7 @@ tide:
     missingLabels:          // List of can't have labels
     excludedBranches:       // Ignore branches
     includedBranches:       // Include-only branches
-    reviewApprovedRequired: // Review approved is must
+    reviewApprovedRequired: // Github Review approval required
   sync_period:            // Sync jobs period
   status_update_period:   // PR status update period
   merge_method:           // Set to squash, rebase or just merge PR
@@ -74,7 +74,10 @@ It can consist of the following dictionary of fields:
 * `missingLabels`: List of labels any given PR must not posses.
 * `excludedBranches`: List of branches that get excluded when querying the `repos`.
 * `includedBranches`: List of branches that get included when querying the `repos`.
-* `reviewApprovedRequired`: If set, each PR in the query must have review approved.
+* `reviewApprovedRequired`: If set, each PR in the query must have at
+  least one [approved github pull request
+  review](https://help.github.com/articles/about-pull-request-reviews/)
+  present for merge. Defaults to `false`.
 
 Under the hood, a query constructed from the fields follows rules described in
 https://help.github.com/articles/searching-issues-and-pull-requests/.


### PR DESCRIPTION
 - link to tide README from prow README
 - clarify reviewApprovedRequired by copying text from k/community

per some discussion in slack, I think this would have avoided some of my questions.