### PR TITLE
move service-catalog prow config to specific directory

### DIFF
--- a/config/jobs/kubernetes-incubator/service-catalog/OWNERS
+++ b/config/jobs/kubernetes-incubator/service-catalog/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- carolynvs
+- duglin
+- jboyd01
+- jeremyrickard
+- MHBauer

--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  kubernetes-incubator/service-catalog:
+  - name: pull-service-catalog-unit
+    agent: kubernetes
+    context: pull-service-catalog-unit
+    always_run: true
+    skip_report: false
+    rerun_command: "/test pull-service-catalog-unit"
+    trigger: "(?m)^/test (all|pull-service-catalog-unit)\\s*"
+    decorate: true
+    spec:
+      containers:
+      - image: golang:1.10
+        command:
+        - make
+        args:
+        - test-unit
+        env:
+        - name: NO_DOCKER
+          value: "1"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3272,26 +3272,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
 
-  kubernetes-incubator/service-catalog:
-  - name: pull-service-catalog-unit
-    agent: kubernetes
-    context: pull-service-catalog-unit
-    always_run: true
-    skip_report: false
-    rerun_command: "/test pull-service-catalog-unit"
-    trigger: "(?m)^/test (all|pull-service-catalog-unit)\\s*"
-    decorate: true
-    spec:
-      containers:
-      - image: golang:1.10
-        command:
-        - make
-        args:
-        - test-unit
-        env:
-        - name: NO_DOCKER
-          value: "1"
-
 postsubmits:
   kubernetes/ingress-gce:
   - name: ci-ingress-gce-image-push


### PR DESCRIPTION
/cc @BenTheElder @stevekuznetsov 

Should I also move the tide config to a `tide.yaml` ?  No, [see below](https://github.com/kubernetes/test-infra/pull/8718#issuecomment-406032507).

Doing this in preparation to add an e2e test