### PR TITLE
prow: kube-client: differentiate between GetLog and GetContainerLog

### DIFF
--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -72,7 +72,7 @@ type serviceClusterClient interface {
 }
 
 type PodLogClient interface {
-	GetLog(pod string) ([]byte, error)
+	GetContainerLog(pod, container string) ([]byte, error)
 }
 
 type ConfigAgent interface {
@@ -148,7 +148,7 @@ func (ja *JobAgent) GetJobLog(job, id string) ([]byte, error) {
 		if !ok {
 			return nil, fmt.Errorf("cannot get logs for prowjob %q with agent %q: unknown cluster alias %q", j.ObjectMeta.Name, j.Spec.Agent, j.ClusterAlias())
 		}
-		return client.GetLog(j.Status.PodName)
+		return client.GetContainerLog(j.Status.PodName, kube.TestContainerName)
 	}
 	for _, agentToTmpl := range ja.c.Config().Deck.ExternalAgentLogs {
 		if agentToTmpl.Agent != string(j.Spec.Agent) {

--- a/prow/deck/jobs/jobs_test.go
+++ b/prow/deck/jobs/jobs_test.go
@@ -39,7 +39,10 @@ func (f fkc) ListProwJobs(s string) ([]kube.ProwJob, error) {
 
 type fpkc string
 
-func (f fpkc) GetLog(pod string) ([]byte, error) {
+func (f fpkc) GetContainerLog(pod, container string) ([]byte, error) {
+	if container != kube.TestContainerName {
+		return nil, fmt.Errorf("wrong container: %s", container)
+	}
 	if pod == "wowowow" || pod == "powowow" {
 		return []byte(f), nil
 	}

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -568,14 +568,24 @@ func (c *Client) CreatePod(p v1.Pod) (Pod, error) {
 	return retPod, err
 }
 
-// GetLog returns the log of the test container in the specified pod, in the client's default namespace.
+// GetLog returns the log of the default container in the specified pod, in the client's default namespace.
 //
-// Analogous to kubectl logs POD -c test
+// Analogous to kubectl logs pod
 func (c *Client) GetLog(pod string) ([]byte, error) {
 	c.log("GetLog", pod)
 	return c.requestRetry(&request{
+		path: fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.namespace, pod),
+	})
+}
+
+// GetContainerLog returns the log of a container in the specified pod, in the client's default namespace.
+//
+// Analogous to kubectl logs pod -c container
+func (c *Client) GetContainerLog(pod, container string) ([]byte, error) {
+	c.log("GetContainerLog", pod)
+	return c.requestRetry(&request{
 		path:  fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/log", c.namespace, pod),
-		query: map[string]string{"container": TestContainerName},
+		query: map[string]string{"container": container},
 	})
 }
 


### PR DESCRIPTION
We need to be able to get the logs of the "default" container for
callers like the tracer while also not expecting users of Deck to need
to provide the test container name to get logs from jobs. Splitting out
the functionality in the clients appeases both users.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @kargakis 
/cc @cjwagner 