### PR TITLE
service catalog e2e prowjob

### DIFF
--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -18,3 +18,28 @@ presubmits:
         env:
         - name: NO_DOCKER
           value: "1"
+  - name: pull-service-catalog-e2e
+    agent: kubernetes
+    context: pull-service-catalog-e2e
+    always_run: true
+    skip_report: true
+    rerun_command: "/test pull-service-catalog-e2e"
+    trigger: "(?m)^/test (all|pull-service-catalog-e2e)\\s*"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        command:
+        - make
+        args:
+        - --repo=github.com/kubernetes-incubator/service-catalog
+        - --timeout=90
+        - --scenario=execute
+        - --
+        - make
+        - test-e2e
+        env:
+        - name: KUBECONFIG
+          value: "~/.kube/config"
+        - name: SERVICECATALOGCONFIG
+          value: "~/.kube/config"

--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
         command:
         - make
         args:


### PR DESCRIPTION

first commit https://github.com/kubernetes/test-infra/commit/25a636c1978948a54555cc0f5e52f3472e83b729 should be PR #8718 

I think this might need some back and forth to make sure it's correct.

The only addition should be the new `pull-service-catalog-e2e`.