### PR TITLE
Updating charts config for move to helm GH org

### DIFF
--- a/config/jobs/helm/charts/OWNERS
+++ b/config/jobs/helm/charts/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- foxish
+- mattfarina
+- prydonius
+- unguiculus
+- viglesiasce

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  kubernetes/charts:
+  helm/charts:
   - name: pull-charts-e2e
     agent: kubernetes
     always_run: true

--- a/config/jobs/kubernetes/charts/OWNERS
+++ b/config/jobs/kubernetes/charts/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- foxish

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -176,13 +176,28 @@ tide:
     - needs-ok-to-test
     - needs-rebase
   - repos:
+    - helm/charts
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+  - repos:
     - kubernetes/client-go
     - kubernetes/cloud-provider-aws
     - kubernetes/cloud-provider-azure
     - kubernetes/cloud-provider-gcp
     - kubernetes/cloud-provider-openstack
     - kubernetes/cloud-provider-vsphere
-    - kubernetes/charts
     - kubernetes/cluster-registry
     - kubernetes/community
     - kubernetes/contrib
@@ -272,8 +287,8 @@ tide:
     - needs-ok-to-test
     - needs-rebase
   merge_method:
+    helm/charts: squash
     kubeflow: squash
-    kubernetes/charts: squash
     kubernetes/dashboard: squash
     kubernetes/kube-deploy: squash
     kubernetes/website: squash

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -113,6 +113,7 @@ func TestMergeMethod(t *testing.T) {
 		MergeType: map[string]github.PullRequestMergeType{
 			"kubernetes/kops":             github.MergeRebase,
 			"kubernetes/charts":           github.MergeSquash,
+			"helm/charts":                 github.MergeSquash,
 			"kubernetes-helm":             github.MergeSquash,
 			"kubernetes-helm/chartmuseum": github.MergeMerge,
 		},

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -33,7 +33,6 @@ owners:
 
 approve:
 - repos:
-  - kubernetes/charts
   - kubernetes/cluster-registry
   - kubernetes/contrib
   - kubernetes/dashboard
@@ -69,6 +68,10 @@ approve:
   - bazelbuild
   implicit_self_approve: true
   review_acts_as_approve: true
+- repos:
+  - helm/charts
+  implicit_self_approve: true
+  lgtm_acts_as_approve: true
 
 lgtm:
 - repos:
@@ -211,9 +214,13 @@ plugins:
     - wip
     - trigger
 
-  kubernetes/charts:
+  helm/charts:
   - approve
+  - assign
   - blunderbuss
+  - cla
+  - hold
+  - lgtm
   - trigger
 
   kubernetes/client-go:

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -356,6 +356,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 	for _, job := range prowConfig.AllPresubmits([]string{
 		"bazelbuild/rules_k8s",
 		"google/cadvisor",
+		"helm/charts",
 		"kubeflow/caffe2-operator",
 		"kubeflow/examples",
 		"kubeflow/experimental-beagle",
@@ -373,7 +374,6 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/cluster-api",
 		"kubernetes-sigs/cluster-api-provider-openstack",
 		"kubernetes-sigs/poseidon",
-		"kubernetes/charts",
 		"kubernetes/cluster-registry",
 		"kubernetes/federation",
 		"kubernetes/heapster",


### PR DESCRIPTION
The charts repo is being set to move to the helm org. This config change is to support that.

Note, I believe the account k8s-ci-robot needs to accept the invite to join that org.