### PR TITLE
prow: tide: use the PR status page for tide context link

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -365,7 +365,7 @@ tide:
     kubernetes/kubernetes-docs-ja: squash
     kubernetes/kubernetes-docs-ko: squash
     kubernetes/website: squash
-  target_url: https://prow.k8s.io/tide.html
+  pr_status_base_url: https://prow.k8s.io/pr
   blocker_label: merge-blocker
 
 push_gateway:


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @cjwagner 
/assign @BenTheElder 