### PR TITLE
service-catalog cross build test with dind

### DIFF
--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -18,3 +18,37 @@ presubmits:
         env:
         - name: NO_DOCKER
           value: "1"
+  - name: pull-service-catalog-xbuild
+    agent: kubernetes
+    context: pull-service-catalog-xbuild
+    always_run: true
+    skip_report: false
+    rerun_command: "/test pull-service-catalog-xbuild"
+    trigger: "(?m)^/test (all|pull-service-catalog-xbuild)\\s*"
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-1.10
+        args:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src/github.com/kubernetes-incubator/$(REPO_NAME)"
+        - "--timeout=60"
+        - "--scenario=execute"
+        - "--"
+        - "make"
+        - "images-all"
+        - "svcat-all"
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: "true"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+    # docker-in-docker needs a place to store the images
+      volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+    volumes:
+    - name: docker-graph
+      emptyDir: {}


### PR DESCRIPTION

I created this by guessing that I need a docker-in-docker enabled instance.

I found the variable DOCKER_IN_DOCKER_ENABLED, and searched for it.

I picked this to copy from
https://github.com/kubernetes/test-infra/blob/68c68683a066e7b9986113c73a6dcb0f48775ef9/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
because it's in the new location for config, so I figure that means someone has looked at it.

I didn't totally copy it, because I don't know what some of the args are, such as:
```
    labels: 
        preset-service-account: "true"
```
and  ` - "--upload=gs://kubernetes-jenkins/pr-logs"` 

I also don't know how much memory it needs, so I dropped the 6G requirement. I do not know what the default is, but I'm going to hope it's enough for now.