### PR TITLE
Added functionality to request pod logs by pod name

### DIFF
--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -108,6 +108,13 @@ func (f flc) GetJobLog(job, id string) ([]byte, error) {
 	return nil, errors.New("muahaha")
 }
 
+func (f flc) GetJobLogByPodName(podName string) ([]byte, error) {
+	if podName == "powowow" {
+		return []byte("hello"), nil
+	}
+	return nil, errors.New("muahaha")
+}
+
 func TestHandleLog(t *testing.T) {
 	var testcases = []struct {
 		name string
@@ -137,6 +144,16 @@ func TestHandleLog(t *testing.T) {
 		{
 			name: "id and job, not found",
 			path: "?job=ohno&id=123",
+			code: http.StatusNotFound,
+		},
+		{
+			name: "podName, found",
+			path: "?podname=powowow",
+			code: http.StatusOK,
+		},
+		{
+			name: "podName, not found",
+			path: "?podname=notpowowow",
 			code: http.StatusNotFound,
 		},
 	}

--- a/prow/deck/jobs/jobs_test.go
+++ b/prow/deck/jobs/jobs_test.go
@@ -88,6 +88,11 @@ func TestGetLog(t *testing.T) {
 	} else if got, expect := string(res), "clusterB"; got != expect {
 		t.Errorf("Unexpected result getting logs for job 'job'. Expected %q, but got %q.", expect, got)
 	}
+	if res, err := ja.GetJobLogByPodName("powowow"); err != nil {
+		t.Fatalf("Failed to get log: %v", err)
+	} else if got, expect := string(res), "clusterB"; got != expect {
+		t.Errorf("Unexpected result getting logs for job 'job'. Expected %q, but got %q.", expect, got)
+	}
 }
 
 func TestProwJobs(t *testing.T) {


### PR DESCRIPTION
The pod log endpoint should support the ability to fetch pod logs by the pod name, not only the job/build id