### PR TITLE
Test required_reviewers with prow config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,6 @@ mungegithub/** @cjwagner
 planter/** @bentheelder
 prow/** @cjwagner @stevekuznetsov
 prow/config.yaml @bentheelder @krzyzacy
-prow/plugins.yaml @cblecker
 scenarios/** @bentheelder @krzyzacy
 testgrid/** @krzyzacy @michelle192837
 triage/** @rmmh

--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -1,5 +1,10 @@
-approvers:
-- cjwagner
-- kargakis
-- spxtr
-- stevekuznetsov
+filters:
+  ".*":
+    approvers:
+      - cjwagner
+      - kargakis
+      - spxtr
+      - stevekuznetsov
+  "(plugins|config)\\.yaml$":
+    required_reviewers:
+      - cblecker


### PR DESCRIPTION
I had a CODEOWNERS entry for the prow plugins file to know when there is a change. I want to try and convert that over to a required_reviewers entry.

No clue if this will work :)