### PR TITLE
actual use bazel to build kubemark

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -313,6 +313,8 @@ periodics:
       env:
       - name: DOCKER_IN_DOCKER_ENABLED
         value: "true"
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       volumeMounts:
       - name: docker-graph
         mountPath: /docker-graph


### PR DESCRIPTION
kubemark target is manual, do a k8s bazel build won't build the kubemark image. Do this in the canary instead of --build-bazel

/assign @BenTheElder @shyamjvs 