### PR TITLE
Turn on some automation for the new cluster-api-provider-gcp repository.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -227,6 +227,7 @@ tide:
     - kubernetes/website
     - kubernetes-sigs/application
     - kubernetes-sigs/cluster-api
+    - kubernetes-sigs/cluster-api-provider-gcp
     - kubernetes-sigs/cluster-api-provider-openstack
     - kubernetes-sigs/controller-runtime
     - kubernetes-sigs/controller-tools
@@ -293,6 +294,7 @@ tide:
     kubernetes/kube-deploy: squash
     kubernetes/website: squash
     kubernetes-sigs/cluster-api: squash
+    kubernetes-sigs/cluster-api-provider-gcp: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-incubator/service-catalog: squash
   target_url: https://prow.k8s.io/tide.html

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -468,6 +468,9 @@ plugins:
   - approve
   - trigger
 
+  kubernetes-sigs/cluster-api-provider-gcp:
+  - approve
+
   kubernetes-sigs/cluster-api-provider-openstack:
   - approve
   - trigger


### PR DESCRIPTION
Once this merges and squash-merges https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/6 I'll send a follow-up PR to actually run some real tests. 