### PR TITLE
Tide: Fix racing changed-files cache.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -75,8 +75,9 @@ type Controller struct {
 	m     sync.Mutex
 	pools []Pool
 
-	// Cache from last sync loop. "org/repo#num:sha" -> files changed
-	fileChangesCache map[string][]string
+	// changedFiles caches the names of files changed by PRs.
+	// Cache entries expire if they are not used during a sync loop.
+	changedFiles *changedFilesAgent
 }
 
 // Action represents what actions the controller can take. It will take
@@ -130,13 +131,16 @@ func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, ca *confi
 	}
 	go sc.run()
 	return &Controller{
-		logger:           logger.WithField("controller", "sync"),
-		ghc:              ghcSync,
-		kc:               kc,
-		ca:               ca,
-		gc:               gc,
-		sc:               sc,
-		fileChangesCache: map[string][]string{},
+		logger: logger.WithField("controller", "sync"),
+		ghc:    ghcSync,
+		kc:     kc,
+		ca:     ca,
+		gc:     gc,
+		sc:     sc,
+		changedFiles: &changedFilesAgent{
+			ghc:             ghcSync,
+			nextChangeCache: make(map[changeCacheKey][]string),
+		},
 	}
 }
 
@@ -181,6 +185,8 @@ func contextsToStrings(contexts []Context) []string {
 
 // Sync runs one sync iteration.
 func (c *Controller) Sync() error {
+	defer c.changedFiles.prune()
+
 	ctx := context.Background()
 	c.logger.Debug("Building tide pool.")
 	prs := make(map[string]PullRequest)
@@ -756,6 +762,76 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, n
 	return Wait, nil, nil
 }
 
+// changedFilesAgent queries and caches the names of files changed by PRs.
+// Cache entries expire if they are not used during a sync loop.
+type changedFilesAgent struct {
+	ghc         githubClient
+	changeCache map[changeCacheKey][]string
+	// nextChangeCache caches file change info that is relevant this sync for use next sync.
+	// This becomes the new changeCache when prune() is called at the end of each sync.
+	nextChangeCache map[changeCacheKey][]string
+	sync.RWMutex
+}
+
+type changeCacheKey struct {
+	org, repo string
+	number    int
+	sha       string
+}
+
+// prChanges gets the files changed by the PR, either from the cache or by
+// querying GitHub.
+func (c *changedFilesAgent) prChanges(pr *PullRequest) ([]string, error) {
+	cacheKey := changeCacheKey{
+		org:    string(pr.Repository.Owner.Login),
+		repo:   string(pr.Repository.Name),
+		number: int(pr.Number),
+		sha:    string(pr.HeadRefOID),
+	}
+
+	c.RLock()
+	changedFiles, ok := c.changeCache[cacheKey]
+	if ok {
+		c.RUnlock()
+		c.Lock()
+		c.nextChangeCache[cacheKey] = changedFiles
+		c.Unlock()
+		return changedFiles, nil
+	}
+	if changedFiles, ok = c.nextChangeCache[cacheKey]; ok {
+		c.RUnlock()
+		return changedFiles, nil
+	}
+	c.RUnlock()
+
+	// We need to query the changes from GitHub.
+	changes, err := c.ghc.GetPullRequestChanges(
+		string(pr.Repository.Owner.Login),
+		string(pr.Repository.Name),
+		int(pr.Number),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error getting PR changes for #%d: %v", int(pr.Number), err)
+	}
+	changedFiles = make([]string, 0, len(changes))
+	for _, change := range changes {
+		changedFiles = append(changedFiles, change.Filename)
+	}
+
+	c.Lock()
+	c.nextChangeCache[cacheKey] = changedFiles
+	c.Unlock()
+	return changedFiles, nil
+}
+
+// prune removes any cached file changes that were not used since the last prune.
+func (c *changedFilesAgent) prune() {
+	c.Lock()
+	defer c.Unlock()
+	c.changeCache = c.nextChangeCache
+	c.nextChangeCache = make(map[changeCacheKey][]string)
+}
+
 func (c *Controller) presubmitsByPull(sp *subpool) (map[int]sets.String, error) {
 	presubmits := make(map[int]sets.String, len(sp.prs))
 	record := func(num int, context string) {
@@ -765,11 +841,6 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int]sets.String, error) 
 			presubmits[num] = sets.NewString(context)
 		}
 	}
-	// nextChangeCache caches file change info that is relevant this sync for use next sync.
-	nextChangeCache := map[string][]string{}
-	defer func() {
-		c.fileChangesCache = nextChangeCache
-	}()
 
 	for _, ps := range c.ca.Config().Presubmits[sp.org+"/"+sp.repo] {
 		if !ps.ContextRequired() || !ps.RunsAgainstBranch(sp.branch) {
@@ -784,20 +855,10 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int]sets.String, error) 
 		} else if ps.RunIfChanged != "" {
 			// This is a run if changed job so we need to check if each PR requires it.
 			for _, pr := range sp.prs {
-				cacheKey := fmt.Sprintf("%s/%s#%d:%s", sp.org, sp.repo, int(pr.Number), string(pr.HeadRefOID))
-				changedFiles, ok := c.fileChangesCache[cacheKey]
-				if !ok {
-					changes, err := c.ghc.GetPullRequestChanges(sp.org, sp.repo, int(pr.Number))
-					if err != nil {
-						return nil, fmt.Errorf("error getting PR changes for #%d: %v", int(pr.Number), err)
-					}
-					changedFiles = make([]string, 0, len(changes))
-					for _, change := range changes {
-						changedFiles = append(changedFiles, change.Filename)
-					}
-					c.fileChangesCache[cacheKey] = changedFiles
+				changedFiles, err := c.changedFiles.prChanges(&pr)
+				if err != nil {
+					return nil, err
 				}
-				nextChangeCache[cacheKey] = changedFiles
 				if ps.RunsAgainstChanges(changedFiles) {
 					record(int(pr.Number), ps.Context)
 				}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1280,6 +1280,10 @@ func TestSync(t *testing.T) {
 			kc:     fkc,
 			logger: logrus.WithField("controller", "sync"),
 			sc:     sc,
+			changedFiles: &changedFilesAgent{
+				ghc:             fgc,
+				nextChangeCache: make(map[changeCacheKey][]string),
+			},
 		}
 
 		if err := c.Sync(); err != nil {
@@ -1759,11 +1763,11 @@ func TestPresubmitsByPull(t *testing.T) {
 	testcases := []struct {
 		name string
 
-		initialChangeCache map[string][]string
+		initialChangeCache map[changeCacheKey][]string
 		presubmits         []config.Presubmit
 
 		expectedPresubmits  map[int]sets.String
-		expectedChangeCache map[string][]string
+		expectedChangeCache map[changeCacheKey][]string
 	}{
 		{
 			name: "no matching presubmits",
@@ -1776,7 +1780,7 @@ func TestPresubmitsByPull(t *testing.T) {
 					Context: "never",
 				},
 			},
-			expectedChangeCache: map[string][]string{"org/repo#100:sha": {"CHANGED"}},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"CHANGED"}},
 			expectedPresubmits:  map[int]sets.String{},
 		},
 		{
@@ -1791,7 +1795,7 @@ func TestPresubmitsByPull(t *testing.T) {
 					Context: "never",
 				},
 			},
-			initialChangeCache: map[string][]string{"org/repo#100:sha": {"FILE"}},
+			initialChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits: map[int]sets.String{},
 		},
 		{
@@ -1805,8 +1809,8 @@ func TestPresubmitsByPull(t *testing.T) {
 					Context: "never",
 				},
 			},
-			initialChangeCache:  map[string][]string{"org/repo#100:sha": {"FILE"}},
-			expectedChangeCache: map[string][]string{"org/repo#100:sha": {"FILE"}},
+			initialChangeCache:  map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits:  map[int]sets.String{},
 		},
 		{
@@ -1874,7 +1878,7 @@ func TestPresubmitsByPull(t *testing.T) {
 				},
 			},
 			expectedPresubmits:  map[int]sets.String{100: sets.NewString("presubmit", "always")},
-			expectedChangeCache: map[string][]string{"org/repo#100:sha": {"CHANGED"}},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"CHANGED"}},
 		},
 		{
 			name: "run_if_changed (cached)",
@@ -1891,9 +1895,9 @@ func TestPresubmitsByPull(t *testing.T) {
 					Context: "never",
 				},
 			},
-			initialChangeCache:  map[string][]string{"org/repo#100:sha": {"FILE"}},
+			initialChangeCache:  map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits:  map[int]sets.String{100: sets.NewString("presubmit", "always")},
-			expectedChangeCache: map[string][]string{"org/repo#100:sha": {"FILE"}},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 		},
 		{
 			name: "run_if_changed (cached) (skippable)",
@@ -1910,9 +1914,9 @@ func TestPresubmitsByPull(t *testing.T) {
 					Context: "never",
 				},
 			},
-			initialChangeCache:  map[string][]string{"org/repo#100:sha": {"FILE"}},
+			initialChangeCache:  map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits:  map[int]sets.String{100: sets.NewString("always")},
-			expectedChangeCache: map[string][]string{"org/repo#100:sha": {"FILE"}},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 		},
 	}
 
@@ -1920,39 +1924,42 @@ func TestPresubmitsByPull(t *testing.T) {
 		t.Logf("Starting test case: %q", tc.name)
 
 		if tc.initialChangeCache == nil {
-			tc.initialChangeCache = map[string][]string{}
+			tc.initialChangeCache = map[changeCacheKey][]string{}
 		}
 		if tc.expectedChangeCache == nil {
-			tc.expectedChangeCache = map[string][]string{}
+			tc.expectedChangeCache = map[changeCacheKey][]string{}
 		}
 
 		cfg := &config.Config{}
 		cfg.SetPresubmits(map[string][]config.Presubmit{
-			"org/repo": tc.presubmits,
-			"foo/bar":  {{Context: "wrong-repo", AlwaysRun: true}},
+			"/":       tc.presubmits,
+			"foo/bar": {{Context: "wrong-repo", AlwaysRun: true}},
 		})
 		cfgAgent := &config.Agent{}
 		cfgAgent.Set(cfg)
 		sp := &subpool{
-			org:    "org",
-			repo:   "repo",
 			branch: "master",
 			prs:    []PullRequest{samplePR},
 		}
 		c := &Controller{
-			ca:               cfgAgent,
-			fileChangesCache: tc.initialChangeCache,
-			ghc:              &fgc{},
+			ca:  cfgAgent,
+			ghc: &fgc{},
+			changedFiles: &changedFilesAgent{
+				ghc:             &fgc{},
+				changeCache:     tc.initialChangeCache,
+				nextChangeCache: make(map[changeCacheKey][]string),
+			},
 		}
 		presubmits, err := c.presubmitsByPull(sp)
 		if err != nil {
 			t.Fatalf("unexpected error from presubmitsByPull: %v", err)
 		}
+		c.changedFiles.prune()
 		if !reflect.DeepEqual(presubmits, tc.expectedPresubmits) {
 			t.Errorf("expected presubmit mapping: %v,\nbut got %v\n", tc.expectedPresubmits, presubmits)
 		}
-		if !reflect.DeepEqual(c.fileChangesCache, tc.expectedChangeCache) {
-			t.Errorf("expected file change cache: %v,\nbut got %v\n", tc.expectedChangeCache, c.fileChangesCache)
+		if got := c.changedFiles.changeCache; !reflect.DeepEqual(got, tc.expectedChangeCache) {
+			t.Errorf("expected file change cache: %v,\nbut got %v\n", tc.expectedChangeCache, got)
 		}
 	}
 }


### PR DESCRIPTION
Tide caches the lists of files changed by each PR to save API tokens if ghProxy is not in use, but the cache was not thread safe.
This PR makes the cache thread safe and switches to pruning the cache once per sync loop rather than once per subpool sync.

/kind bug
/area prow
/cc @stevekuznetsov @BenTheElder @fejta 