### PR TITLE
fix calico env vars for netd testgrid

### DIFF
--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -158,6 +158,8 @@ presets:
     value: true
   - name: KUBE_ENABLE_NETD
     value: true
+  - name: KUBE_GCE_ENABLE_POLICY_ROUTING
+    value: true
 
 periodics:
 - interval: 2h
@@ -179,7 +181,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=asia-southeast1-a
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
@@ -206,8 +208,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
       env:
-      - name: KUBE_GCE_ENABLE_POLICY_ROUTING
-        value: true
+      - name: NETWORK_POLICY_PROVIDER
+        value: calico
+
 
 - interval: 2h
   agent: kubernetes
@@ -229,7 +232,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud
       - --gcp-zone=asia-southeast1-a
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
 
@@ -257,5 +260,5 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
       env:
-      - name: KUBE_GCE_ENABLE_POLICY_ROUTING
-        value: true
+      - name: NETWORK_POLICY_PROVIDER
+        value: calico

--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -158,8 +158,6 @@ presets:
     value: true
   - name: KUBE_ENABLE_NETD
     value: true
-  - name: KUBE_GCE_ENABLE_POLICY_ROUTING
-    value: true
 
 periodics:
 - interval: 2h
@@ -210,7 +208,6 @@ periodics:
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
-
 
 - interval: 2h
   agent: kubernetes


### PR DESCRIPTION
Skip policy routing tests if NETWORK_POLICY_PROVIDER != calico