### PR TITLE
First CI job for kubernetes/cloud-provider-vsphere

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- abrarshivani
+- baludontu
+- divyenpatel
+- imkin
+- kerneltime
+- luomiao
+- frapposelli
+- dougm
+- figo
+- akutz

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-presubmits.yaml
@@ -1,0 +1,25 @@
+presubmits:
+  kubernetes/cloud-provider-vsphere:
+  - name: pull-cloud-provider-vsphere-test
+    agent: kubernetes
+    context: pull-cloud-provider-vsphere-test
+    branches:
+    - master
+    always_run: true
+    rerun_command: "/test pull-cloud-provider-vsphere-test"
+    trigger: "(?m)^/test( all| pull-cloud-provider-vsphere-test),?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-master
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--timeout=30"
+        - "--" # end bootstrap args, scenario args below
+        - "make"
+        - "test"

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -377,6 +377,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/cluster-api-provider-openstack",
 		"kubernetes-sigs/poseidon",
 		"kubernetes/cluster-registry",
+		"kubernetes/cloud-provider-vsphere",
 		"kubernetes/federation",
 		"kubernetes/heapster",
 		"kubernetes/kops",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2265,6 +2265,9 @@ test_groups:
 - name: pull-federation-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-federation-verify
   num_columns_recent: 20
+- name: pull-cloud-provider-vsphere-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-vsphere-test
+  num_columns_recent: 20 
 # release-1.8
 - name: ci-kubernetes-e2e-gce-cos-k8sstable1-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable1-default
@@ -6105,6 +6108,11 @@ dashboards:
     test_group_name: pull-kubernetes-e2e-kubeadm-gce
     base_options: 'width=10'
 
+- name: presubmits-cloud-provider-vsphere-blocking
+  dashboard_tab:
+  - name: pull-cloud-provider-vsphere-test
+    test_group_name: pull-cloud-provider-vsphere-test
+    base_options: 'width=10'
 
 - name: presubmits-kubernetes-scalability
   dashboard_tab:


### PR DESCRIPTION
After this, the pull-cloud-provider-vsphere-test will be
run and status will reported to github repo ( https://github.com/kubernetes/cloud-provider-vsphere) by prow when there is pull request.

This is to fix issue at: https://github.com/kubernetes/cloud-provider-vsphere/issues/10

thanks @dims for help,

cc @krzyzacy @BenTheElder @frapposelli