### PR TITLE
Refactor the cluster-api jobs into a new directory

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- jessicaochen
+- k4leung4
+- karan
+- kris-nova
+- krousey
+- mkjelland
+- roberthbailey

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -1,0 +1,31 @@
+periodics:
+- name: ci-cluster-api-build
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      args:
+      - "--repo=sigs.k8s.io/cluster-api"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./scripts/ci-build.sh"
+- name: ci-cluster-api-test
+  interval: 1h
+  agent: kubernetes
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
+      args:
+      - "--repo=sigs.k8s.io/cluster-api"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./scripts/ci-test.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -1,0 +1,66 @@
+presubmits:
+  kubernetes-sigs/cluster-api:
+  - name: pull-cluster-api-build
+    agent: kubernetes
+    always_run: true
+    context: pull-cluster-api-build
+    rerun_command: "/test pull-cluster-api-build"
+    trigger: "/test( all| pull-cluster-api-build)"
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+        args:	
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
+        - "./scripts/ci-build.sh"
+  - name: pull-cluster-api-make
+    agent: kubernetes
+    always_run: true
+    context: pull-cluster-api-make
+    rerun_command: "/test pull-cluster-api-make"
+    trigger: "/test( all| pull-cluster-api-make)"
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - args:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--scenario=execute"
+        - "--"
+        - "./scripts/ci-make.sh"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-1.10
+        resources:
+          requests:
+            memory: "6Gi"
+  - name: pull-cluster-api-test
+    agent: kubernetes
+    always_run: true
+    context: pull-cluster-api-test
+    rerun_command: "/test pull-cluster-api-test"
+    trigger: "/test( all| pull-cluster-api-test)"
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
+        args:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
+        - "./scripts/ci-test.sh"

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -29,24 +29,6 @@
       "sig-scheduling"
     ]
   },
-  "ci-cluster-api-build": {
-    "args": [
-      "./scripts/ci-build.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "ci-cluster-api-test": {
-    "args": [
-      "./scripts/ci-test.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-containerd-build": {
     "args": [
       "/go/src/github.com/containerd/cri/test/containerd/build.sh"
@@ -5190,33 +5172,6 @@
     "scenario": "execute",
     "sigOwners": [
       "sig-openstack"
-    ]
-  },
-  "pull-cluster-api-build": {
-    "args": [
-      "./scripts/ci-build.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "pull-cluster-api-make": {
-    "args": [
-      "./scripts/ci-make.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "pull-cluster-api-test": {
-    "args": [
-      "./scripts/ci-test.sh"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
     ]
   },
   "pull-cluster-registry-verify-gensrc": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2944,63 +2944,6 @@ presubmits:
       - name: docker-graph
         emptyDir: {}
 
-  kubernetes-sigs/cluster-api:
-  - name: pull-cluster-api-build
-    agent: kubernetes
-    always_run: true
-    context: pull-cluster-api-build
-    rerun_command: "/test pull-cluster-api-build"
-    trigger: "/test( all| pull-cluster-api-build)"
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
-        args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-  - name: pull-cluster-api-make
-    agent: kubernetes
-    always_run: true
-    context: pull-cluster-api-make
-    rerun_command: "/test pull-cluster-api-make"
-    trigger: "/test( all| pull-cluster-api-make)"
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=90"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180716-9145034c9-1.10
-        resources:
-          requests:
-            memory: "6Gi"
-  - name: pull-cluster-api-test
-    agent: kubernetes
-    always_run: true
-    context: pull-cluster-api-test
-    rerun_command: "/test pull-cluster-api-test"
-    trigger: "/test( all| pull-cluster-api-test)"
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
-        args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-
   kubernetes-sigs/testing_frameworks:
   - name: pull-frameworks-test
     context: pull-frameworks-test
@@ -3546,31 +3489,6 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
-- name: ci-cluster-api-build
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
-      args:
-      - "--repo=sigs.k8s.io/cluster-api"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
-- name: ci-cluster-api-test
-  interval: 1h
-  agent: kubernetes
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
-      args:
-      - "--repo=sigs.k8s.io/cluster-api"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
 
 - name: ci-containerd-build
   interval: 30m


### PR DESCRIPTION
As requested in https://github.com/kubernetes/test-infra/pull/8757, this PR breaks the cluster-api test config out of the monolithic file. 

/assign @krzyzacy 

/cc @jessicaochen @k4leung4 @karan @kris-nova @krousey @mkjelland