### PR TITLE
Fix pull-charts-e2e config to include args that were in config.json.

### DIFF
--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -17,6 +17,9 @@ presubmits:
         - "--root=/go/src/"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - --
+        - "./test/e2e.sh"
         env:
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"


### PR DESCRIPTION
We missed some args in https://github.com/kubernetes/test-infra/commit/edc54aadf4954eb529403cbf0632c9c1533f1eba

/kind bug
/area jobs
/cc @mattfarina @krzyzacy @fejta 
/assign @fejta 