### PR TITLE
Tide front end touch ups.

### DIFF
--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -55,7 +55,7 @@
                             <th>Batch</th>
                             <th>Passing</th>
                             <th>Pending</th>
-                            <th>Failing or Untested</th>
+                            <th>Queued for Retest</th>
                             </thead>
                             <tbody>
                             </tbody>

--- a/prow/cmd/deck/static/tidescript.js
+++ b/prow/cmd/deck/static/tidescript.js
@@ -168,7 +168,6 @@ function redrawPools() {
     while (pools.firstChild)
         pools.removeChild(pools.firstChild);
 
-    // TODO(spxtr): Sort these.
     if (!tideData.Pools) {
         return;
     }


### PR DESCRIPTION
This PR:
- Changes the 'Failing or Untested' column to 'Queued for Retest' since the category no longer contains failing PRs.
- Makes Tide sort the slice of `Pool`s and their contained `PullRequest` slices before serving them to deck.

/area prow
/kind bug
/cc @fejta @amwat @stevekuznetsov  