### PR TITLE
better handle missing scenario args

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -44,6 +44,8 @@ periodics:
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_janitor
+      - --
+      - --mode=ci
       env:
       image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
       resources:


### PR DESCRIPTION
- podutils has its own presubmit, let's skip here
- we want to enforce all jobs reference bootstrap has a valid scenario arg, either in config.json (legacy), or inline in the job config

/assign @cjwagner 
this should catch missing args like https://github.com/kubernetes/test-infra/pull/8768