### PR TITLE
(WIP) kops on aws: don't set KUBE_SSH_USER

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3786,7 +3786,6 @@
     "args": [
       "--cluster=e2e-kops-aws-channelalpha.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--channel=alpha",
@@ -3804,7 +3803,6 @@
     "args": [
       "--cluster=e2e-kops-aws-ena-nvme.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha",
@@ -3823,7 +3821,6 @@
     "args": [
       "--cluster=e2e-kops-aws-ha-uswest2.k8s.local",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel=30",
       "--kops-args=--master-count=3",
@@ -3842,7 +3839,6 @@
     "args": [
       "--cluster=e2e-kops-aws-imagecentos7.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=centos",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--image=ami-4bf3d731",
@@ -3862,7 +3858,6 @@
     "args": [
       "--cluster=e2e-kops-aws-imageubuntu1604.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=ubuntu",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180122",
@@ -3881,7 +3876,6 @@
     "args": [
       "--cluster=e2e-kops-aws-kopeio-vxlan.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=kopeio-vxlan",
@@ -3899,7 +3893,6 @@
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -3932,7 +3925,6 @@
     "args": [
       "--cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/k8s-stable1",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -3949,7 +3941,6 @@
     "args": [
       "--cluster=e2e-kops-aws-stable2.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/k8s-stable2",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -3966,7 +3957,6 @@
     "args": [
       "--cluster=e2e-kops-aws-stable3.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/k8s-stable3",
       "--ginkgo-parallel",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt",
@@ -3983,7 +3973,6 @@
     "args": [
       "--cluster=e2e-kops-aws-updown.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-publish=gs://kops-ci/bin/latest-ci-updown-green.txt",
@@ -4001,7 +3990,6 @@
     "args": [
       "--cluster=e2e-kops-aws-weave.test-cncf-aws.k8s.io",
       "--deployment=kops",
-      "--env=KUBE_SSH_USER=admin",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=weave",


### PR DESCRIPTION
We can default KUBE_SSH_USER from --kops-ssh-user.

WIP until #8786 merges