### PR TITLE
Make Tide dashboard expose merge blocking issues.

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -116,6 +116,10 @@ th {
     display: none;
 }
 
+.blocked {
+    color: #EF5350;
+}
+
 .icon-cell {
     width: 32px;
 }

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -39,8 +39,8 @@ type githubClient interface {
 
 // Blocker specifies an issue number that should block tide from merging.
 type Blocker struct {
-	Number int
-	URL    string
+	Number     int
+	Title, URL string
 	// TODO: time blocked? (when blocker label was added)
 }
 
@@ -88,8 +88,10 @@ func FindAll(ghc githubClient, log *logrus.Entry, label string, orgs, repos sets
 func fromIssues(issues []Issue) Blockers {
 	res := Blockers{Repo: make(map[orgRepo][]Blocker), Branch: make(map[orgRepoBranch][]Blocker)}
 	for _, issue := range issues {
+		strippedTitle := branchRE.ReplaceAllLiteralString(string(issue.Title), "")
 		block := Blocker{
 			Number: int(issue.Number),
+			Title:  strippedTitle,
 			URL:    string(issue.HTMLURL),
 		}
 		if branches := parseBranches(string(issue.Title)); len(branches) > 0 {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -90,7 +90,7 @@ const (
 	TriggerBatch        = "TRIGGER_BATCH"
 	Merge               = "MERGE"
 	MergeBatch          = "MERGE_BATCH"
-	PoolBlocked         = "POOL_BLOCKED"
+	PoolBlocked         = "BLOCKED"
 )
 
 // Pool represents information about a tide pool. There is one for every


### PR DESCRIPTION
Here is what a blocked pool looks like now (example Tide data is taken from openshift since k8s Tide was idle): 
![screenshot from 2018-07-23 13-05-40](https://user-images.githubusercontent.com/5334145/43100181-6852e6f8-8e79-11e8-9e71-2f0c7788b74c.png)

The issues blocking merge for the pool are linked in the `state` column and have tool tips that show the issue title when hovered over.

follow up to https://github.com/kubernetes/test-infra/pull/8173

/area prow
/cc @stevekuznetsov @amwat @BenTheElder 