### PR TITLE
Pass node & master distro flag to ginkgo

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -243,6 +243,8 @@ periodics:
       - --
       - --cluster=e2e-kops-gce-canary.k8s.local
       - --deployment=kops
+      - --e2e-master-os-distro=gci
+      - --e2e-node-os-distro=gci
       - --extract=ci/latest
       - --ginkgo-parallel=30
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt

--- a/kubetest/e2e/interfaces.go
+++ b/kubetest/e2e/interfaces.go
@@ -31,7 +31,7 @@ type TestBuilder interface {
 	BuildTester(options *BuildTesterOptions) (Tester, error)
 }
 
-// BuildTesterOptions is the options structt that should be passed to testBuilder::BuildTester
+// BuildTesterOptions is the options struct that should be passed to testBuilder::BuildTester
 type BuildTesterOptions struct {
 	FocusRegex  string
 	SkipRegex   string

--- a/kubetest/e2e/runner.go
+++ b/kubetest/e2e/runner.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -28,6 +29,11 @@ import (
 	"time"
 
 	"k8s.io/test-infra/kubetest/process"
+)
+
+var (
+	e2eMasterOSDistribution = flag.String("e2e-master-os-distro", "", "master-os-distro flag to pass to e2e tests")
+	e2eNodeOSDistribution   = flag.String("e2e-node-os-distro", "", "node-os-distro flag to pass to e2e tests")
 )
 
 // GinkgoTester runs e2e tests directly (by calling ginkgo)
@@ -79,6 +85,9 @@ func NewGinkgoTester(o *BuildTesterOptions) *GinkgoTester {
 	t.GinkgoParallel = o.Parallelism
 	t.FocusRegex = o.FocusRegex
 	t.SkipRegex = o.SkipRegex
+
+	t.MasterOSDistribution = *e2eMasterOSDistribution
+	t.NodeOSDistribution = *e2eNodeOSDistribution
 
 	return t
 }


### PR DESCRIPTION
The e2e tests rely on it being passed in (though they probably should
auto-detect what they need)