### PR TITLE
Use default qps limits in gce-1.9, gce-1.10 and gce-1.11.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2329,6 +2329,7 @@
     "args": [
       "--cluster=e2e-big-beta",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-old-common.env",
       "--extract=ci/k8s-beta",
       "--gcp-node-image=gci",
       "--gcp-nodes=100",
@@ -2348,6 +2349,7 @@
     "args": [
       "--cluster=e2e-big-stable1",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-old-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability-stable.env",
       "--extract=ci/k8s-stable1",
       "--gcp-node-image=gci",
@@ -2368,6 +2370,7 @@
     "args": [
       "--cluster=e2e-big-stable2",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-scalability-old-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability-stable.env",
       "--extract=ci/k8s-stable2",
       "--gcp-node-image=gci",

--- a/jobs/env/ci-kubernetes-e2e-scalability-old-common.env
+++ b/jobs/env/ci-kubernetes-e2e-scalability-old-common.env
@@ -1,0 +1,6 @@
+### Common env variables for scalability-related suites using 1.9, 1.10 and 1.11 versions.
+
+
+# Use default kube-qps and kube-api-burst flag values.
+CONTROLLER_MANAGER_TEST_ARGS=--profiling
+SCHEDULER_TEST_ARGS=--profiling


### PR DESCRIPTION
Decrease qps limits in kube-apiserver and kube-controller-manager.

After this change, the increased qps will be used only in:
* ci-kubernetes-e2e-gci-gce-scalability
* pull-kubernetes-e2e-gce-100-performance