### PR TITLE
Adding Netperf and DNS from perf-tests repo  

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4956,7 +4956,7 @@
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jkns-clusterloader",
       "--gcp-zone=us-central1-f",
-      "--perf-tests",
+      "--perf-tests-cluster-loader",
       "--provider=gce",
       "--test=false",
       "--timeout=60m"

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -244,18 +244,18 @@ func run(deploy deployer, o options) error {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "Helm Charts", chartsTest))
 	}
 
-        if o.perfTestsClusterLoader {
-                errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests ClusterLoader", perfTestClusterLoader))
-        }
-        if o.perfTestsNetPerf {
-                 errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Network Performance", perfTestNetPerf))
-        }
-         if o.perfTestsKubeDNS {
-                  errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Kube DNS", perfTestKubeDNS))
-        }
-          if o.perfTestsCoreDNS {
-                  errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Core DNS", perfTestCoreDNS))
-        }
+	if o.perfTestsClusterLoader {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests ClusterLoader", perfTestClusterLoader))
+	}
+	if o.perfTestsNetPerf {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Network Performance", perfTestNetPerf))
+	}
+	if o.perfTestsKubeDNS {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Kube DNS", perfTestKubeDNS))
+	}
+	if o.perfTestsCoreDNS {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Core DNS", perfTestCoreDNS))
+	}
 
 	if dump != "" {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "DumpClusterLogs", func() error {
@@ -542,50 +542,50 @@ func dumpFederationLogs(location string) error {
 }
 
 func perfTestClusterLoader() error {
-        // Run perf tests clusterloader
-        cmdline := []string{
-                 util.K8s("perf-tests","run-e2e.sh"),
-                 "--cluster-loader",
-                }
-                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
-                 return err
-                }
-        return nil
+	// Run perf tests clusterloader
+	cmdline := []string{
+		util.K8s("perf-tests", "run-e2e.sh"),
+		"--cluster-loader",
+	}
+	if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+		return err
+	}
+	return nil
 }
 func perfTestNetPerf() error {
-        // Run perf tests Network Performance
-        cmdline := []string{
-                 util.K8s("perf-tests","run-e2e.sh"),
-                 "--network-performance",
-                }
-                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
-                 return err
-                }
-        return nil
+	// Run perf tests Network Performance
+	cmdline := []string{
+		util.K8s("perf-tests", "run-e2e.sh"),
+		"--network-performance",
+	}
+	if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+		return err
+	}
+	return nil
 
 }
 func perfTestKubeDNS() error {
-        // Run perf tests KubeDNS
-        cmdline := []string{
-                 util.K8s("perf-tests","run-e2e.sh"),
-                 "--kube-dns",
-                }
-                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
-                 return err
-                }
-        return nil
+	// Run perf tests KubeDNS
+	cmdline := []string{
+		util.K8s("perf-tests", "run-e2e.sh"),
+		"--kube-dns",
+	}
+	if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+		return err
+	}
+	return nil
 
 }
 func perfTestCoreDNS() error {
-        // Run perf tests coreDNS
-        cmdline := []string{
-                 util.K8s("perf-tests","run-e2e.sh"),
-                 "--core-dns",
-                }
-                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
-                 return err
-                }
-        return nil
+	// Run perf tests coreDNS
+	cmdline := []string{
+		util.K8s("perf-tests", "run-e2e.sh"),
+		"--core-dns",
+	}
+	if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+		return err
+	}
+	return nil
 
 }
 

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -244,9 +244,18 @@ func run(deploy deployer, o options) error {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "Helm Charts", chartsTest))
 	}
 
-	if o.perfTests {
-		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests", perfTest))
-	}
+        if o.perfTestsClusterLoader {
+                errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests ClusterLoader", perfTestClusterLoader))
+        }
+        if o.perfTestsNetPerf {
+                 errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Network Performance", perfTestNetPerf))
+        }
+         if o.perfTestsKubeDNS {
+                  errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Kube DNS", perfTestKubeDNS))
+        }
+          if o.perfTestsCoreDNS {
+                  errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests Core DNS", perfTestCoreDNS))
+        }
 
 	if dump != "" {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "DumpClusterLogs", func() error {
@@ -532,13 +541,52 @@ func dumpFederationLogs(location string) error {
 	return nil
 }
 
-func perfTest() error {
-	// Run perf tests
-	cmdline := util.K8s("perf-tests", "clusterloader", "run-e2e.sh")
-	if err := control.FinishRunning(exec.Command(cmdline)); err != nil {
-		return err
-	}
-	return nil
+func perfTestClusterLoader() error {
+        // Run perf tests clusterloader
+        cmdline := []string{
+                 util.K8s("perf-tests","run-e2e.sh"),
+                 "--cluster-loader",
+                }
+                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+                 return err
+                }
+        return nil
+}
+func perfTestNetPerf() error {
+        // Run perf tests Network Performance
+        cmdline := []string{
+                 util.K8s("perf-tests","run-e2e.sh"),
+                 "--network-performance",
+                }
+                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+                 return err
+                }
+        return nil
+
+}
+func perfTestKubeDNS() error {
+        // Run perf tests KubeDNS
+        cmdline := []string{
+                 util.K8s("perf-tests","run-e2e.sh"),
+                 "--kube-dns",
+                }
+                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+                 return err
+                }
+        return nil
+
+}
+func perfTestCoreDNS() error {
+        // Run perf tests coreDNS
+        cmdline := []string{
+                 util.K8s("perf-tests","run-e2e.sh"),
+                 "--core-dns",
+                }
+                 if err := control.FinishRunning(exec.Command("bash", cmdline...)); err != nil {
+                 return err
+                }
+        return nil
+
 }
 
 func chartsTest() error {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -56,69 +56,72 @@ var (
 )
 
 type options struct {
-	build               buildStrategy
-	buildFederation     buildFederationStrategy
-	charts              bool
-	checkLeaks          bool
-	checkSkew           bool
-	cluster             string
-	clusterIPRange      string
-	deployment          string
-	dindImage           string
-	down                bool
-	dump                string
-	extract             extractStrategies
-	extractFederation   extractFederationStrategies
-	extractSource       bool
-	federation          bool
-	flushMemAfterBuild  bool
-	focusRegex          string
-	gcpCloudSdk         string
-	gcpMasterImage      string
-	gcpMasterSize       string
-	gcpNetwork          string
-	gcpNodeImage        string
-	gcpImageFamily      string
-	gcpImageProject     string
-	gcpNodes            string
-	gcpNodeSize         string
-	gcpProject          string
-	gcpProjectType      string
-	gcpServiceAccount   string
-	gcpRegion           string
-	gcpZone             string
-	ginkgoParallel      ginkgoParallelValue
-	kubecfg             string
-	kubemark            bool
-	kubemarkMasterSize  string
-	kubemarkNodes       string // TODO(fejta): switch to int after migration
-	logexporterGCSPath  string
-	metadataSources     string
-	multiClusters       multiClusterDeployment
-	multipleFederations bool
-	noAllowDup          bool
-	nodeArgs            string
-	nodeTestArgs        string
-	nodeTests           bool
-	perfTests           bool
-	provider            string
-	publish             string
-	runtimeConfig       string
-	save                string
-	skew                bool
-	skipRegex           string
-	soak                bool
-	soakDuration        time.Duration
-	sshUser             string
-	stage               stageStrategy
-	stageFederation     stageFederationStrategy
-	test                bool
-	testArgs            string
-	testCmd             string
-	testCmdName         string
-	testCmdArgs         []string
-	up                  bool
-	upgradeArgs         string
+	build              	 buildStrategy
+	buildFederation    	 buildFederationStrategy
+	charts             	 bool
+	checkLeaks         	 bool
+	checkSkew          	 bool
+	cluster            	 string
+	clusterIPRange     	 string
+	deployment          	 string
+	dindImage          	 string
+	down              	 bool
+	dump               	 string
+	extract            	 extractStrategies
+	extractFederation  	 extractFederationStrategies
+	extractSource      	 bool
+	federation         	 bool
+	flushMemAfterBuild 	 bool
+	focusRegex         	 string
+	gcpCloudSdk        	 string
+	gcpMasterImage     	 string
+	gcpMasterSize      	 string
+	gcpNetwork         	 string
+	gcpNodeImage       	 string
+	gcpImageFamily     	 string
+	gcpImageProject    	 string
+	gcpNodes           	 string
+	gcpNodeSize        	 string
+	gcpProject         	 string
+	gcpProjectType     	 string
+	gcpServiceAccount  	 string
+	gcpRegion          	 string
+	gcpZone            	 string
+	ginkgoParallel     	 ginkgoParallelValue
+	kubecfg            	 string
+	kubemark           	 bool
+	kubemarkMasterSize 	 string
+	kubemarkNodes      	 string // TODO(fejta): switch to int after migration
+	logexporterGCSPath 	 string
+	metadataSources    	 string
+	multiClusters      	 multiClusterDeployment
+	multipleFederations	 bool
+	noAllowDup         	 bool
+	nodeArgs           	 string
+	nodeTestArgs       	 string
+	nodeTests          	 bool
+        perfTestsClusterLoader   bool
+        perfTestsNetPerf         bool
+        perfTestsKubeDNS         bool
+        perfTestsCoreDNS         bool
+	provider          	 string
+	publish           	 string
+	runtimeConfig       	 string
+	save               	 string
+	skew              	 bool
+	skipRegex          	 string
+	soak               	 bool
+	soakDuration       	 time.Duration
+	sshUser            	 string
+	stage              	 stageStrategy
+	stageFederation     	 stageFederationStrategy
+	test               	 bool
+	testArgs           	 string
+	testCmd            	 string
+	testCmdName        	 string
+	testCmdArgs        	 []string
+	up                 	 bool
+	upgradeArgs        	 string
 }
 
 func defineFlags() *options {
@@ -168,7 +171,10 @@ func defineFlags() *options {
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")
 	flag.BoolVar(&o.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
 	flag.BoolVar(&o.nodeTests, "node-tests", false, "If true, run node-e2e tests.")
-	flag.BoolVar(&o.perfTests, "perf-tests", false, "If true, run tests from perf-tests repo.")
+        flag.BoolVar(&o.perfTestsClusterLoader, "perf-tests-cluster-loader", false, "If true, run  Cluster Loader tests from perf-tests repo.")
+        flag.BoolVar(&o.perfTestsNetPerf, "perf-tests-network-performance", false, "If true, run  Network Performance tests from perf-tests repo.")
+        flag.BoolVar(&o.perfTestsKubeDNS, "perf-tests-kube-dns", false, "If true, run  Kube DNS tests from perf-tests repo.")
+        flag.BoolVar(&o.perfTestsCoreDNS, "perf-tests-core-dns", false, "If true, run  Core DNS tests from perf-tests repo.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -56,72 +56,72 @@ var (
 )
 
 type options struct {
-	build              	 buildStrategy
-	buildFederation    	 buildFederationStrategy
-	charts             	 bool
-	checkLeaks         	 bool
-	checkSkew          	 bool
-	cluster            	 string
-	clusterIPRange     	 string
-	deployment          	 string
-	dindImage          	 string
-	down              	 bool
-	dump               	 string
-	extract            	 extractStrategies
-	extractFederation  	 extractFederationStrategies
-	extractSource      	 bool
-	federation         	 bool
-	flushMemAfterBuild 	 bool
-	focusRegex         	 string
-	gcpCloudSdk        	 string
-	gcpMasterImage     	 string
-	gcpMasterSize      	 string
-	gcpNetwork         	 string
-	gcpNodeImage       	 string
-	gcpImageFamily     	 string
-	gcpImageProject    	 string
-	gcpNodes           	 string
-	gcpNodeSize        	 string
-	gcpProject         	 string
-	gcpProjectType     	 string
-	gcpServiceAccount  	 string
-	gcpRegion          	 string
-	gcpZone            	 string
-	ginkgoParallel     	 ginkgoParallelValue
-	kubecfg            	 string
-	kubemark           	 bool
-	kubemarkMasterSize 	 string
-	kubemarkNodes      	 string // TODO(fejta): switch to int after migration
-	logexporterGCSPath 	 string
-	metadataSources    	 string
-	multiClusters      	 multiClusterDeployment
-	multipleFederations	 bool
-	noAllowDup         	 bool
-	nodeArgs           	 string
-	nodeTestArgs       	 string
-	nodeTests          	 bool
-        perfTestsClusterLoader   bool
-        perfTestsNetPerf         bool
-        perfTestsKubeDNS         bool
-        perfTestsCoreDNS         bool
-	provider          	 string
-	publish           	 string
-	runtimeConfig       	 string
-	save               	 string
-	skew              	 bool
-	skipRegex          	 string
-	soak               	 bool
-	soakDuration       	 time.Duration
-	sshUser            	 string
-	stage              	 stageStrategy
-	stageFederation     	 stageFederationStrategy
-	test               	 bool
-	testArgs           	 string
-	testCmd            	 string
-	testCmdName        	 string
-	testCmdArgs        	 []string
-	up                 	 bool
-	upgradeArgs        	 string
+	build                  buildStrategy
+	buildFederation        buildFederationStrategy
+	charts                 bool
+	checkLeaks             bool
+	checkSkew              bool
+	cluster                string
+	clusterIPRange         string
+	deployment             string
+	dindImage              string
+	down                   bool
+	dump                   string
+	extract                extractStrategies
+	extractFederation      extractFederationStrategies
+	extractSource          bool
+	federation             bool
+	flushMemAfterBuild     bool
+	focusRegex             string
+	gcpCloudSdk            string
+	gcpMasterImage         string
+	gcpMasterSize          string
+	gcpNetwork             string
+	gcpNodeImage           string
+	gcpImageFamily         string
+	gcpImageProject        string
+	gcpNodes               string
+	gcpNodeSize            string
+	gcpProject             string
+	gcpProjectType         string
+	gcpServiceAccount      string
+	gcpRegion              string
+	gcpZone                string
+	ginkgoParallel         ginkgoParallelValue
+	kubecfg                string
+	kubemark               bool
+	kubemarkMasterSize     string
+	kubemarkNodes          string // TODO(fejta): switch to int after migration
+	logexporterGCSPath     string
+	metadataSources        string
+	multiClusters          multiClusterDeployment
+	multipleFederations    bool
+	noAllowDup             bool
+	nodeArgs               string
+	nodeTestArgs           string
+	nodeTests              bool
+	perfTestsClusterLoader bool
+	perfTestsNetPerf       bool
+	perfTestsKubeDNS       bool
+	perfTestsCoreDNS       bool
+	provider               string
+	publish                string
+	runtimeConfig          string
+	save                   string
+	skew                   bool
+	skipRegex              string
+	soak                   bool
+	soakDuration           time.Duration
+	sshUser                string
+	stage                  stageStrategy
+	stageFederation        stageFederationStrategy
+	test                   bool
+	testArgs               string
+	testCmd                string
+	testCmdName            string
+	testCmdArgs            []string
+	up                     bool
+	upgradeArgs            string
 }
 
 func defineFlags() *options {
@@ -171,10 +171,10 @@ func defineFlags() *options {
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")
 	flag.BoolVar(&o.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
 	flag.BoolVar(&o.nodeTests, "node-tests", false, "If true, run node-e2e tests.")
-        flag.BoolVar(&o.perfTestsClusterLoader, "perf-tests-cluster-loader", false, "If true, run  Cluster Loader tests from perf-tests repo.")
-        flag.BoolVar(&o.perfTestsNetPerf, "perf-tests-network-performance", false, "If true, run  Network Performance tests from perf-tests repo.")
-        flag.BoolVar(&o.perfTestsKubeDNS, "perf-tests-kube-dns", false, "If true, run  Kube DNS tests from perf-tests repo.")
-        flag.BoolVar(&o.perfTestsCoreDNS, "perf-tests-core-dns", false, "If true, run  Core DNS tests from perf-tests repo.")
+	flag.BoolVar(&o.perfTestsClusterLoader, "perf-tests-cluster-loader", false, "If true, run  Cluster Loader tests from perf-tests repo.")
+	flag.BoolVar(&o.perfTestsNetPerf, "perf-tests-network-performance", false, "If true, run  Network Performance tests from perf-tests repo.")
+	flag.BoolVar(&o.perfTestsKubeDNS, "perf-tests-kube-dns", false, "If true, run  Kube DNS tests from perf-tests repo.")
+	flag.BoolVar(&o.perfTestsCoreDNS, "perf-tests-core-dns", false, "If true, run  Core DNS tests from perf-tests repo.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -244,7 +244,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
             '--kubemark',
             '--extract=this',
             '--extract=that',
-            '--perf-tests',
+            '--perf-tests-cluster-loader',
             '--save=somewhere',
             '--skew',
             '--publish=location',


### PR DESCRIPTION
Added Network Performance and DNS from perf-tests repo
Modified flags to run clusterloader, Netperf , kube-dns and core-dns
Incorporated using the PR https://github.com/kubernetes/perf-tests/pull/169 