### PR TITLE
Make approve work on controller-{tools,runtime}

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -509,6 +509,12 @@ plugins:
   kubernetes-sigs/kustomize:
   - approve
 
+  kubernetes-sigs/controller-runtime:
+  - approve  
+
+  kubernetes-sigs/controller-tools:
+  - approve  
+
   containerd/cri:
   - assign
   - cla


### PR DESCRIPTION
This makes the approve command work on
kubernetes-sigs/controller-tools and kubernetes-sigs/controller-runtime.