### PR TITLE
kubeadm-runner: bump the kubernetes-anywhere version

### DIFF
--- a/images/kubeadm/runner
+++ b/images/kubeadm/runner
@@ -26,7 +26,7 @@ if [ ! -e kubernetes-anywhere ]; then
 
   # Explicitly version this dependency so that upstream commits can't
   # immediately break e2e jobs, and we have control over upgrading/downgrading.
-  git -C kubernetes-anywhere checkout 4ebbb9b0ed38c613e44197195107edaf6b4a7f39
+  git -C kubernetes-anywhere checkout 986797c0e17ae718851c7b27e53b632b674004f5
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332


### PR DESCRIPTION
bump the k-a SHA post a recent k-a fix:

refs:
https://github.com/kubernetes/kubernetes-anywhere/commit/986797c0e17ae718851c7b27e53b632b674004f5
https://github.com/kubernetes/kubernetes-anywhere/pull/545

release team issue:
https://github.com/kubernetes/kubernetes/issues/66338

/cc @BenTheElder 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
