### PR TITLE
Bump gcloud version and use latest janitor

### DIFF
--- a/boskos/janitor/Dockerfile
+++ b/boskos/janitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/gcloud-in-go:v20180531-04d09b20c
+FROM gcr.io/k8s-testimages/gcloud-in-go:v20180725-a495f0247
 LABEL maintainer="senlu@google.com"
 
 ADD ["janitor", \

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20180619-83c62c891
+        image: gcr.io/k8s-testimages/janitor:v20180725-c421ed4f9
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gke-project
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-nongke
-        image: gcr.io/k8s-testimages/janitor:v20180619-83c62c891
+        image: gcr.io/k8s-testimages/janitor:v20180725-c421ed4f9
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -47,7 +47,7 @@ periodics:
       - --
       - --mode=ci
       env:
-      image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      image: gcr.io/k8s-testimages/gcloud-in-go:v20180725-a495f0247
       resources:
         requests:
           cpu: 5
@@ -69,7 +69,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      image: gcr.io/k8s-testimages/gcloud-in-go:v20180725-a495f0247
       resources:
         requests:
           cpu: 5
@@ -92,7 +92,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      image: gcr.io/k8s-testimages/gcloud-in-go:v20180725-a495f0247
       resources:
         requests:
           cpu: 5


### PR DESCRIPTION
deployed, looks like the ingress pool http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1 is finally cleaned up

/assign @freehan @crimsonfaith91 @BenTheElder 