### PR TITLE
tests: run codegen only when necessary, use correct $GOPATH

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -199,30 +199,18 @@ presubmits:
   - name: pull-test-infra-verify-codegen
     agent: kubernetes
     context: pull-test-infra-verify-codegen
-    always_run: false
-    optional: true
     branches:
     - master
     rerun_command: "/test pull-test-infra-verify-codegen"
     trigger: "/test pull-test-infra-verify-codegen"
-    run_if_changed: '^(Gopkg\.|^vendor/).*$'
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
+    run_if_changed: '(prow/(apis|client)|vendor)/.*$'
+    optional: true
+    decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180725-795cceb4c-experimental
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --service-account=/etc/service-account/service-account.json
-        - --scenario=execute
-        - --
+      - image: gcr.io/rules-k8s/gcloud-bazel:v20180708-d6e1b65
+        command:
         - ./hack/verify-codegen.sh
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/test pull-test-infra-verify-codegen
/area prow
/kind bug
/cc @BenTheElder @fejta 
/assign @cjwagner 