### PR TITLE
Use upstream Docker image for Go in codegen test

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -208,7 +208,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/rules-k8s/gcloud-bazel:v20180708-d6e1b65
+      - image: docker.io/library/golang:1.10
         command:
         - ./hack/verify-codegen.sh
         resources:


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/assign @fejta 