### PR TITLE
Fix bazel build for cloud-provider-gcp

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -15,5 +15,5 @@ presubmits:
         args:
         - -c
         - |
-          bazel --output_base=. build -- //... -//vendor/... \
-          bazel --output_base=. test --test_output=errors -- //... -//vendor/...
+          bazel --output_base=/tmp build -- //... -//vendor/... \
+          bazel --output_base=/tmp test --test_output=errors -- //... -//vendor/...


### PR DESCRIPTION
Turns out you can't mix output_base with actual source directory.
Tested via `docker run` this time, seems to work.