### PR TITLE
Fix cos_containerd log dump.

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -376,14 +376,15 @@ function log_dump_custom_get_instances() {
     return 0
   fi
 
-  gcloud compute instances list '--project=%[1]s' '--filter=%[3]s' '--format=get(name)'
+  gcloud compute instances list '--project=%[1]s' '--filter=%[4]s' '--format=get(name)'
 }
 export -f log_dump_custom_get_instances
 # Set below vars that log-dump.sh expects in order to use scp with gcloud.
 export PROJECT=%[1]s
 export ZONE='%[2]s'
 export KUBERNETES_PROVIDER=gke
-%[4]s
+export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
+%[5]s
 `
 	// Prevent an obvious injection.
 	if strings.Contains(localPath, "'") || strings.Contains(gcsPath, "'") {
@@ -409,6 +410,7 @@ export KUBERNETES_PROVIDER=gke
 	return control.FinishRunning(exec.Command("bash", "-c", fmt.Sprintf(gkeLogDumpTemplate,
 		g.project,
 		g.zone,
+		os.Getenv("NODE_OS_DISTRIBUTION"),
 		strings.Join(filters, " OR "),
 		dumpCmd)))
 }


### PR DESCRIPTION
`log-dump.sh` [sources `cluster/gce/util.sh`](https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh#L73), which [sources `cluster/gce/config-default.sh`](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/util.sh#L24).

For `cluster/gce/config-default.sh` we need to [specify `KUBE_NODE_OS_DISTRIBUTION` to overwrite the default `NODE_OS_DISTRIBUTION`](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/config-default.sh#L56).

This should fix the log dumping failure in https://k8s-testgrid.appspot.com/google-gke#gke-cos-containerd-alpha-cluster-1.11.

Signed-off-by: Lantao Liu <lantaol@google.com>