### PR TITLE
Split bazel commands in cloud-provider-gcp

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -15,5 +15,5 @@ presubmits:
         args:
         - -c
         - |
-          bazel --output_base=/tmp build -- //... -//vendor/... \
+          bazel --output_base=/tmp build -- //... -//vendor/... && \
           bazel --output_base=/tmp test --test_output=errors -- //... -//vendor/...


### PR DESCRIPTION
I mis-understood semantics of these multi-line YAML strings.