### PR TITLE
Make verify-codegen required

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -203,9 +203,8 @@ presubmits:
     - master
     rerun_command: "/test pull-test-infra-verify-codegen"
     trigger: "/test pull-test-infra-verify-codegen"
-    run_if_changed: '(prow/(apis|client)|vendor)/.*$'
+    always_run: true
     path_alias: "k8s.io/test-infra"
-    optional: true
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

successful job here: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/5137/pull-test-infra-verify-codegen/30/?log#log
/assign @cjwagner @fejta 