### PR TITLE
Migrate size constant configuration to plugins.yaml

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -73,6 +73,13 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 
+size:
+  sLines: 20
+  mLines: 50
+  lLines: 150
+  xlLines: 400
+  xxlLines: 800
+
 lgtm:
 - repos:
   - bazelbuild

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -73,12 +73,13 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 
+# Lower bounds; XS is assumed to be zero.
 size:
-  sLines: 20
-  mLines: 50
-  lLines: 150
-  xlLines: 400
-  xxlLines: 800
+  s:   10
+  m:   30
+  l:   100
+  xl:  500
+  xxl: 1000
 
 lgtm:
 - repos:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -73,7 +73,7 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 
-# Lower bounds; XS is assumed to be zero.
+# Lower bounds in number of lines changed; XS is assumed to be zero.
 size:
   s:   10
   m:   30

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -173,7 +173,7 @@ type Configuration struct {
 	RequireSIG    RequireSIG           `json:"requiresig,omitempty"`
 	Slack         Slack                `json:"slack,omitempty"`
 	SigMention    SigMention           `json:"sigmention,omitempty"`
-	Size          Sizes                `json:"size,omitempty"`
+	Size          *Sizes               `json:"size,omitempty"`
 	Triggers      []Trigger            `json:"triggers,omitempty"`
 	Welcome       Welcome              `json:"welcome,omitempty"`
 }
@@ -288,11 +288,11 @@ type SigMention struct {
 
 // Size specifies configuration for the size plugin, allowing configurable lower bounds for each size label
 type Sizes struct {
-	SLines   int `json:"omitempty"`
-	MLines   int `json:"omitempty"`
-	LLines   int `json:"omitempty"`
-	XlLines  int `json:"omitempty"`
-	XxlLines int `json:"omitempty"`
+	S   int
+	M   int
+	L   int
+	Xl  int
+	Xxl int
 }
 
 /*

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -161,19 +161,20 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
-	Triggers      []Trigger            `json:"triggers,omitempty"`
-	Heart         Heart                `json:"heart,omitempty"`
-	RepoMilestone map[string]Milestone `json:"repo_milestone,omitempty"`
-	Slack         Slack                `json:"slack,omitempty"`
-	ConfigUpdater ConfigUpdater        `json:"config_updater,omitempty"`
-	Blockades     []Blockade           `json:"blockades,omitempty"`
 	Approve       []Approve            `json:"approve,omitempty"`
+	Blockades     []Blockade           `json:"blockades,omitempty"`
 	Blunderbuss   Blunderbuss          `json:"blunderbuss,omitempty"`
-	RequireSIG    RequireSIG           `json:"requiresig,omitempty"`
-	SigMention    SigMention           `json:"sigmention,omitempty"`
 	Cat           Cat                  `json:"cat,omitempty"`
+	ConfigUpdater ConfigUpdater        `json:"config_updater,omitempty"`
+	Heart         Heart                `json:"heart,omitempty"`
 	Label         *Label               `json:"label,omitempty"`
 	Lgtm          []Lgtm               `json:"lgtm,omitempty"`
+	RepoMilestone map[string]Milestone `json:"repo_milestone,omitempty"`
+	RequireSIG    RequireSIG           `json:"requiresig,omitempty"`
+	Slack         Slack                `json:"slack,omitempty"`
+	SigMention    SigMention           `json:"sigmention,omitempty"`
+	Size          Sizes                `json:"size,omitempty"`
+	Triggers      []Trigger            `json:"triggers,omitempty"`
 	Welcome       Welcome              `json:"welcome,omitempty"`
 }
 
@@ -283,6 +284,15 @@ type SigMention struct {
 	// Compiles into Re during config load.
 	Regexp string         `json:"regexp,omitempty"`
 	Re     *regexp.Regexp `json:"-"`
+}
+
+// Size specifies configuration for the size plugin, allowing configurable lower bounds for each size label
+type Sizes struct {
+	SLines   int `json:"omitempty"`
+	MLines   int `json:"omitempty"`
+	LLines   int `json:"omitempty"`
+	XlLines  int `json:"omitempty"`
+	XxlLines int `json:"omitempty"`
 }
 
 /*

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -286,7 +286,8 @@ type SigMention struct {
 	Re     *regexp.Regexp `json:"-"`
 }
 
-// Size specifies configuration for the size plugin, defining lower bounds (in # lines changed) for each size label
+// Size specifies configuration for the size plugin, defining lower bounds (in # lines changed) for each size label.
+// XS is assumed to be zero.
 type Size struct {
 	S   int `json:"s"`
 	M   int `json:"m"`

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -173,7 +173,7 @@ type Configuration struct {
 	RequireSIG    RequireSIG           `json:"requiresig,omitempty"`
 	Slack         Slack                `json:"slack,omitempty"`
 	SigMention    SigMention           `json:"sigmention,omitempty"`
-	Size          *Sizes               `json:"size,omitempty"`
+	Size          *Size                `json:"size,omitempty"`
 	Triggers      []Trigger            `json:"triggers,omitempty"`
 	Welcome       Welcome              `json:"welcome,omitempty"`
 }
@@ -287,7 +287,7 @@ type SigMention struct {
 }
 
 // Size specifies configuration for the size plugin, allowing configurable lower bounds for each size label
-type Sizes struct {
+type Size struct {
 	S   int
 	M   int
 	L   int

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -286,13 +286,13 @@ type SigMention struct {
 	Re     *regexp.Regexp `json:"-"`
 }
 
-// Size specifies configuration for the size plugin, allowing configurable lower bounds for each size label
+// Size specifies configuration for the size plugin, defining lower bounds (in # lines changed) for each size label
 type Size struct {
-	S   int
-	M   int
-	L   int
-	Xl  int
-	Xxl int
+	S   int `json:"s"`
+	M   int `json:"m"`
+	L   int `json:"l"`
+	Xl  int `json:"xl"`
+	Xxl int `json:"xxl"`
 }
 
 /*

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -552,6 +552,9 @@ func (pa *PluginAgent) Load(path string) error {
 	if err := validateConfigUpdater(&np.ConfigUpdater); err != nil {
 		return err
 	}
+	if err := validateSizes(np.Size); err != nil {
+		return err
+	}
 	// regexp compilation should run after defaulting
 	if err := compileRegexps(np); err != nil {
 		return err
@@ -591,6 +594,16 @@ func validatePlugins(plugins map[string][]string) error {
 		return fmt.Errorf("invalid plugin configuration:\n\t%v", strings.Join(errors, "\n\t"))
 	}
 	return nil
+}
+
+func validateSizes(size *Size) error {
+	if size == nil {
+		return nil
+	}
+
+	if size.S > size.M || size.M > size.L || size.L > size.Xl || size.Xl > size.Xxl {
+		return errors.New("invalid size plugin configuration - one of the smaller sizes is bigger than a larger one")
+	}
 }
 
 func findDuplicatedPluginConfig(repoConfig, orgConfig []string) []string {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -604,6 +604,8 @@ func validateSizes(size *Size) error {
 	if size.S > size.M || size.M > size.L || size.L > size.Xl || size.Xl > size.Xxl {
 		return errors.New("invalid size plugin configuration - one of the smaller sizes is bigger than a larger one")
 	}
+
+	return nil
 }
 
 func findDuplicatedPluginConfig(repoConfig, orgConfig []string) []string {

--- a/prow/plugins/size/BUILD.bazel
+++ b/prow/plugins/size/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -35,7 +35,7 @@ import (
 // in here represent default values used as fallback if none are provided.
 const pluginName = "size"
 
-var defaultSizes = plugins.Sizes{
+var defaultSizes = plugins.Size{
 	S:   10,
 	M:   30,
 	L:   100,
@@ -76,7 +76,7 @@ type githubClient interface {
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 }
 
-func handlePR(gc githubClient, sizes plugins.Sizes, le *logrus.Entry, pe github.PullRequestEvent) error {
+func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe github.PullRequestEvent) error {
 	if !isPRChanged(pe) {
 		return nil
 	}
@@ -188,7 +188,7 @@ func (s size) label() string {
 	return labelUnkown
 }
 
-func bucket(lineCount int, sizes plugins.Sizes) size {
+func bucket(lineCount int, sizes plugins.Size) size {
 	if lineCount < sizes.S {
 		return sizeXS
 	} else if lineCount < sizes.M {
@@ -222,7 +222,7 @@ func isPRChanged(pe github.PullRequestEvent) bool {
 
 // If they don't provide a lower bound for XXL, we assume that no
 // size configuration was passed and hence we fall back to defaults
-func sizesOrDefault(sizes *plugins.Sizes) plugins.Sizes {
+func sizesOrDefault(sizes *plugins.Size) plugins.Size {
 	if sizes == nil {
 		return defaultSizes
 	}

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -220,8 +220,6 @@ func isPRChanged(pe github.PullRequestEvent) bool {
 	}
 }
 
-// If they don't provide a lower bound for XXL, we assume that no
-// size configuration was passed and hence we fall back to defaults
 func sizesOrDefault(sizes *plugins.Size) plugins.Size {
 	if sizes == nil {
 		return defaultSizes

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -36,11 +36,11 @@ import (
 const pluginName = "size"
 
 var defaultSizes = plugins.Sizes{
-	SLines:   10,
-	MLines:   30,
-	LLines:   100,
-	XlLines:  500,
-	XxlLines: 1000,
+	S:   10,
+	M:   30,
+	L:   100,
+	Xl:  500,
+	Xxl: 1000,
 }
 
 func init() {
@@ -58,7 +58,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 <li>size/L    %d-%d</li>
 <li>size/XL:  %d-%d</li>
 <li>size/XXL: %d+</li>
-</ul>`, sizes.SLines-1, sizes.SLines, sizes.MLines-1, sizes.MLines, sizes.LLines-1, sizes.LLines, sizes.XlLines-1, sizes.XlLines, sizes.XxlLines-1, sizes.XxlLines),
+</ul>`, sizes.S-1, sizes.S, sizes.M-1, sizes.M, sizes.L-1, sizes.L, sizes.Xl-1, sizes.Xl, sizes.Xxl-1, sizes.Xxl),
 		},
 		nil
 }
@@ -189,15 +189,15 @@ func (s size) label() string {
 }
 
 func bucket(lineCount int, sizes plugins.Sizes) size {
-	if lineCount < sizes.SLines {
+	if lineCount < sizes.S {
 		return sizeXS
-	} else if lineCount < sizes.MLines {
+	} else if lineCount < sizes.M {
 		return sizeS
-	} else if lineCount < sizes.LLines {
+	} else if lineCount < sizes.L {
 		return sizeM
-	} else if lineCount < sizes.XlLines {
+	} else if lineCount < sizes.Xl {
 		return sizeL
-	} else if lineCount < sizes.XxlLines {
+	} else if lineCount < sizes.Xxl {
 		return sizeXL
 	}
 
@@ -222,10 +222,10 @@ func isPRChanged(pe github.PullRequestEvent) bool {
 
 // If they don't provide a lower bound for XXL, we assume that no
 // size configuration was passed and hence we fall back to defaults
-func sizesOrDefault(sizes plugins.Sizes) plugins.Sizes {
-	if sizes.XxlLines == 0 {
+func sizesOrDefault(sizes *plugins.Sizes) plugins.Sizes {
+	if sizes == nil {
 		return defaultSizes
 	}
 
-	return sizes
+	return *sizes
 }

--- a/prow/plugins/size/size_test.go
+++ b/prow/plugins/size/size_test.go
@@ -496,6 +496,55 @@ func TestHandlePR(t *testing.T) {
 			},
 			sizes: defaultSizes,
 		},
+		{
+			name: "different label constraints",
+			client: &ghc{
+				labels:     map[github.Label]bool{},
+				getFileErr: &github.FileNotFound{},
+				prChanges: []github.PullRequestChange{
+					{
+						SHA:       "abcd",
+						Filename:  "foobar",
+						Additions: 10,
+						Deletions: 10,
+						Changes:   20,
+					},
+					{
+						SHA:       "abcd",
+						Filename:  "barfoo",
+						Additions: 3,
+						Deletions: 4,
+						Changes:   7,
+					},
+				},
+			},
+			event: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				Number: 101,
+				PullRequest: github.PullRequest{
+					Number: 101,
+					Base: github.PullRequestBranch{
+						SHA: "abcd",
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "kubernetes",
+							},
+							Name: "kubernetes",
+						},
+					},
+				},
+			},
+			finalLabels: []github.Label{
+				{Name: "size/XXL"},
+			},
+			sizes: plugins.Size{
+				S:   0,
+				M:   1,
+				L:   2,
+				Xl:  3,
+				Xxl: 4,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/prow/plugins/size/size_test.go
+++ b/prow/plugins/size/size_test.go
@@ -77,22 +77,22 @@ func (c *ghc) GetPullRequestChanges(_, _ string, _ int) ([]github.PullRequestCha
 
 func TestSizesOrDefault(t *testing.T) {
 	for _, c := range []struct {
-		input    *plugins.Sizes
-		expected plugins.Sizes
+		input    *plugins.Size
+		expected plugins.Size
 	}{
 		{
 			input:    &defaultSizes,
 			expected: defaultSizes,
 		},
 		{
-			input: &plugins.Sizes{
+			input: &plugins.Size{
 				S:   12,
 				M:   15,
 				L:   17,
 				Xl:  21,
 				Xxl: 51,
 			},
-			expected: plugins.Sizes{
+			expected: plugins.Size{
 				S:   12,
 				M:   15,
 				L:   17,
@@ -117,7 +117,7 @@ func TestHandlePR(t *testing.T) {
 		client      *ghc
 		event       github.PullRequestEvent
 		err         error
-		sizes       plugins.Sizes
+		sizes       plugins.Size
 		finalLabels []github.Label
 	}{
 		{

--- a/prow/plugins/size/size_test.go
+++ b/prow/plugins/size/size_test.go
@@ -77,31 +77,31 @@ func (c *ghc) GetPullRequestChanges(_, _ string, _ int) ([]github.PullRequestCha
 
 func TestSizesOrDefault(t *testing.T) {
 	for _, c := range []struct {
-		input    plugins.Sizes
+		input    *plugins.Sizes
 		expected plugins.Sizes
 	}{
 		{
-			input:    defaultSizes,
+			input:    &defaultSizes,
 			expected: defaultSizes,
 		},
 		{
-			input: plugins.Sizes{
-				SLines:   12,
-				MLines:   15,
-				LLines:   17,
-				XlLines:  21,
-				XxlLines: 51,
+			input: &plugins.Sizes{
+				S:   12,
+				M:   15,
+				L:   17,
+				Xl:  21,
+				Xxl: 51,
 			},
 			expected: plugins.Sizes{
-				SLines:   12,
-				MLines:   15,
-				LLines:   17,
-				XlLines:  21,
-				XxlLines: 51,
+				S:   12,
+				M:   15,
+				L:   17,
+				Xl:  21,
+				Xxl: 51,
 			},
 		},
 		{
-			input:    plugins.Sizes{},
+			input:    nil,
 			expected: defaultSizes,
 		},
 	} {


### PR DESCRIPTION
This change moves the `size.go` constants into a config file (it keeps them in the `go` file as a fallback, so it can still run happily with an empty config file)