### PR TITLE
Uppercase all review states in approve plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat webhook fixtures as generated so they don't clutter PRs
+prow/cmd/phony/examples/*.json linguist-generated=true

--- a/prow/cmd/phony/examples/review_approve_submitted.json
+++ b/prow/cmd/phony/examples/review_approve_submitted.json
@@ -1,0 +1,320 @@
+{
+  "sender": {
+    "avatar_url": "https://avatars1.githubusercontent.com/u/5442475?v=4", 
+    "html_url": "https://github.com/luxas", 
+    "node_id": "MDQ6VXNlcjU0NDI0NzU=", 
+    "gravatar_id": "", 
+    "site_admin": false, 
+    "login": "luxas", 
+    "type": "User", 
+    "id": 5442475
+  }, 
+  "repository": {
+    "stargazers_count": 39280, 
+    "mirror_url": null, 
+    "updated_at": "2018-07-27T16:53:46Z", 
+    "private": false, 
+    "has_wiki": false, 
+    "full_name": "kubernetes/kubernetes", 
+    "owner": {
+      "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+      "html_url": "https://github.com/kubernetes", 
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "kubernetes", 
+      "type": "Organization", 
+      "id": 13629408
+    }, 
+    "id": 20580498, 
+    "description": "Production-Grade Container Scheduling and Management", 
+    "archived": false, 
+    "has_pages": false, 
+    "open_issues_count": 3190, 
+    "has_projects": true, 
+    "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+    "watchers_count": 39280, 
+    "size": 794946, 
+    "homepage": "http://kubernetes.io", 
+    "fork": false, 
+    "watchers": 39280, 
+    "html_url": "https://github.com/kubernetes/kubernetes", 
+    "forks": 13699, 
+    "open_issues": 3190, 
+    "node_id": "MDEwOlJlcG9zaXRvcnkyMDU4MDQ5OA==", 
+    "git_url": "git://github.com/kubernetes/kubernetes.git", 
+    "svn_url": "https://github.com/kubernetes/kubernetes", 
+    "has_issues": true, 
+    "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+    "has_downloads": true, 
+    "license": {
+      "spdx_id": "Apache-2.0", 
+      "node_id": "MDc6TGljZW5zZTI=", 
+      "name": "Apache License 2.0", 
+      "key": "apache-2.0"
+    }, 
+    "name": "kubernetes", 
+    "language": "Go", 
+    "created_at": "2014-06-06T22:56:04Z", 
+    "pushed_at": "2018-07-27T16:56:47Z", 
+    "forks_count": 13699, 
+    "default_branch": "master"
+  }, 
+  "review": {
+    "body": "This LGTM now\r\nWhat I came to think about now is, do we actually support building these images _on the non-amd64 platform_ or do we instead crossbuild and publish?\r\nIf we go with the \"crossbuild and publish\" approach (which I think is in the end is kinda okay), we can just use the `golang:1.9` image as-is for the build.", 
+    "commit_id": "90680e35391e777b5d1e49ad0c9dd7c4946bb459", 
+    "submitted_at": "2018-07-27T17:01:20Z", 
+    "author_association": "MEMBER", 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/66686#pullrequestreview-141192367", 
+    "state": "approved", 
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTQxMTkyMzY3", 
+    "_links": {
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/66686#pullrequestreview-141192367"
+      }, 
+      "pull_request": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66686"
+      }
+    }, 
+    "user": {
+      "avatar_url": "https://avatars1.githubusercontent.com/u/5442475?v=4", 
+      "html_url": "https://github.com/luxas", 
+      "node_id": "MDQ6VXNlcjU0NDI0NzU=", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "luxas", 
+      "type": "User", 
+      "id": 5442475
+    }, 
+    "id": 141192367
+  }, 
+  "pull_request": {
+    "merge_commit_sha": "29375fdfddac11ccf9922d7bd49e246efa74d255", 
+    "labels": [
+      {
+        "default": false, 
+        "name": "cncf-cla: yes", 
+        "color": "bfe5bf", 
+        "node_id": "MDU6TGFiZWw0NzczOTcwODY=", 
+        "id": 477397086
+      }, 
+      {
+        "default": false, 
+        "name": "do-not-merge/hold", 
+        "color": "e11d21", 
+        "node_id": "MDU6TGFiZWw2ODc1NjU4MDQ=", 
+        "id": 687565804
+      }, 
+      {
+        "default": false, 
+        "name": "release-note-none", 
+        "color": "c2e0c6", 
+        "node_id": "MDU6TGFiZWwzNDk1MzAyNDk=", 
+        "id": 349530249
+      }, 
+      {
+        "default": false, 
+        "name": "size/M", 
+        "color": "eebb00", 
+        "node_id": "MDU6TGFiZWwyNTM0NTA5MzQ=", 
+        "id": 253450934
+      }
+    ], 
+    "number": 66686, 
+    "assignee": null, 
+    "closed_at": null, 
+    "requested_reviewers": [], 
+    "id": 204248756, 
+    "title": "test image for a release 1.7 based sample-apiserver", 
+    "merged_at": null, 
+    "state": "open", 
+    "_links": {
+      "review_comment": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/comments{/number}"
+      }, 
+      "commits": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66686/commits"
+      }, 
+      "self": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66686"
+      }, 
+      "review_comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66686/comments"
+      }, 
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/66686"
+      }, 
+      "comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/66686/comments"
+      }, 
+      "issue": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/66686"
+      }, 
+      "statuses": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/statuses/90680e35391e777b5d1e49ad0c9dd7c4946bb459"
+      }
+    }, 
+    "diff_url": "https://github.com/kubernetes/kubernetes/pull/66686.diff", 
+    "body": "<!--  Thanks for sending a pull request!  Here are some tips for you:\r\n1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide\r\n2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews\r\n3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md\r\n4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests\r\n-->\r\n\r\n**What this PR does / why we need it**:\r\nIn our e2e test suite we have use an image \"gcr.io/kubernetes-e2e-test-images:k8s-aggregator-sample-apiserver:1.7v2\". We need a way to build a fresh image that can we can use instead of that one. Especially we need one that has a multi-arch fat manifest so e2e tests can be run across multiple architectures.\r\n\r\nThis is especially important since we are in the process of promoting the test in question to the conformance suite - https://github.com/kubernetes/kubernetes/pull/63947\r\n\r\n**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:\r\nFixes #\r\n\r\n**Special notes for your reviewer**:\r\n/cc @mkumatag \r\n/cc @ixdy \r\n/cc @luxas \r\n\r\n**Release note**:\r\n<!--  Write your release note:\r\n1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string \"action required\".\r\n2. If no release note is required, just write \"NONE\".\r\n-->\r\n```release-note\r\nNONE\r\n```\r\n", 
+    "head": {
+      "repo": {
+        "stargazers_count": 1, 
+        "mirror_url": null, 
+        "updated_at": "2018-07-27T11:33:41Z", 
+        "private": false, 
+        "has_wiki": true, 
+        "full_name": "dims/kubernetes", 
+        "owner": {
+          "avatar_url": "https://avatars2.githubusercontent.com/u/23304?v=4", 
+          "html_url": "https://github.com/dims", 
+          "node_id": "MDQ6VXNlcjIzMzA0", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "dims", 
+          "type": "User", 
+          "id": 23304
+        }, 
+        "id": 58837596, 
+        "description": "Container Cluster Manager from Google", 
+        "archived": false, 
+        "has_pages": false, 
+        "open_issues_count": 0, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/dims/kubernetes.git", 
+        "watchers_count": 1, 
+        "size": 570894, 
+        "homepage": "http://kubernetes.io", 
+        "fork": true, 
+        "watchers": 1, 
+        "html_url": "https://github.com/dims/kubernetes", 
+        "forks": 0, 
+        "open_issues": 0, 
+        "node_id": "MDEwOlJlcG9zaXRvcnk1ODgzNzU5Ng==", 
+        "git_url": "git://github.com/dims/kubernetes.git", 
+        "svn_url": "https://github.com/dims/kubernetes", 
+        "has_issues": false, 
+        "ssh_url": "git@github.com:dims/kubernetes.git", 
+        "has_downloads": true, 
+        "license": {
+          "spdx_id": "Apache-2.0", 
+          "node_id": "MDc6TGljZW5zZTI=", 
+          "name": "Apache License 2.0", 
+          "key": "apache-2.0"
+        }, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2016-05-15T01:04:18Z", 
+        "pushed_at": "2018-07-27T16:37:17Z", 
+        "forks_count": 0, 
+        "default_branch": "master"
+      }, 
+      "sha": "90680e35391e777b5d1e49ad0c9dd7c4946bb459", 
+      "ref": "test-image-for-a-release-1.7-based-sample-apiserver", 
+      "user": {
+        "avatar_url": "https://avatars2.githubusercontent.com/u/23304?v=4", 
+        "html_url": "https://github.com/dims", 
+        "node_id": "MDQ6VXNlcjIzMzA0", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "dims", 
+        "type": "User", 
+        "id": 23304
+      }, 
+      "label": "dims:test-image-for-a-release-1.7-based-sample-apiserver"
+    }, 
+    "author_association": "MEMBER", 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/66686", 
+    "updated_at": "2018-07-27T17:01:20Z", 
+    "node_id": "MDExOlB1bGxSZXF1ZXN0MjA0MjQ4NzU2", 
+    "user": {
+      "avatar_url": "https://avatars2.githubusercontent.com/u/23304?v=4", 
+      "html_url": "https://github.com/dims", 
+      "node_id": "MDQ6VXNlcjIzMzA0", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "dims", 
+      "type": "User", 
+      "id": 23304
+    }, 
+    "milestone": null, 
+    "requested_teams": [], 
+    "locked": false, 
+    "created_at": "2018-07-26T19:51:45Z", 
+    "assignees": [], 
+    "base": {
+      "repo": {
+        "stargazers_count": 39280, 
+        "mirror_url": null, 
+        "updated_at": "2018-07-27T16:53:46Z", 
+        "private": false, 
+        "has_wiki": false, 
+        "full_name": "kubernetes/kubernetes", 
+        "owner": {
+          "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+          "html_url": "https://github.com/kubernetes", 
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "kubernetes", 
+          "type": "Organization", 
+          "id": 13629408
+        }, 
+        "id": 20580498, 
+        "description": "Production-Grade Container Scheduling and Management", 
+        "archived": false, 
+        "has_pages": false, 
+        "open_issues_count": 3190, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+        "watchers_count": 39280, 
+        "size": 794946, 
+        "homepage": "http://kubernetes.io", 
+        "fork": false, 
+        "watchers": 39280, 
+        "html_url": "https://github.com/kubernetes/kubernetes", 
+        "forks": 13699, 
+        "open_issues": 3190, 
+        "node_id": "MDEwOlJlcG9zaXRvcnkyMDU4MDQ5OA==", 
+        "git_url": "git://github.com/kubernetes/kubernetes.git", 
+        "svn_url": "https://github.com/kubernetes/kubernetes", 
+        "has_issues": true, 
+        "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+        "has_downloads": true, 
+        "license": {
+          "spdx_id": "Apache-2.0", 
+          "node_id": "MDc6TGljZW5zZTI=", 
+          "name": "Apache License 2.0", 
+          "key": "apache-2.0"
+        }, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2014-06-06T22:56:04Z", 
+        "pushed_at": "2018-07-27T16:56:47Z", 
+        "forks_count": 13699, 
+        "default_branch": "master"
+      }, 
+      "sha": "4d5d2664c3b038a3da2e16c5285460c32fc0e15c", 
+      "ref": "master", 
+      "user": {
+        "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+        "html_url": "https://github.com/kubernetes", 
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "kubernetes", 
+        "type": "Organization", 
+        "id": 13629408
+      }, 
+      "label": "kubernetes:master"
+    }, 
+    "patch_url": "https://github.com/kubernetes/kubernetes/pull/66686.patch"
+  }, 
+  "action": "submitted", 
+  "organization": {
+    "description": "Kubernetes", 
+    "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+    "login": "kubernetes", 
+    "id": 13629408
+  }
+}

--- a/prow/cmd/phony/examples/review_changes_submitted.json
+++ b/prow/cmd/phony/examples/review_changes_submitted.json
@@ -1,0 +1,375 @@
+{
+  "sender": {
+    "avatar_url": "https://avatars0.githubusercontent.com/u/169553?v=4", 
+    "html_url": "https://github.com/timothysc", 
+    "node_id": "MDQ6VXNlcjE2OTU1Mw==", 
+    "gravatar_id": "", 
+    "site_admin": false, 
+    "login": "timothysc", 
+    "type": "User", 
+    "id": 169553
+  }, 
+  "repository": {
+    "stargazers_count": 39100, 
+    "mirror_url": null, 
+    "updated_at": "2018-07-24T18:02:40Z", 
+    "private": false, 
+    "has_wiki": false, 
+    "full_name": "kubernetes/kubernetes", 
+    "owner": {
+      "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+      "html_url": "https://github.com/kubernetes", 
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "kubernetes", 
+      "type": "Organization", 
+      "id": 13629408
+    }, 
+    "id": 20580498, 
+    "description": "Production-Grade Container Scheduling and Management", 
+    "archived": false, 
+    "has_pages": false, 
+    "open_issues_count": 3153, 
+    "has_projects": true, 
+    "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+    "watchers_count": 39100, 
+    "size": 794612, 
+    "homepage": "http://kubernetes.io", 
+    "fork": false, 
+    "watchers": 39100, 
+    "html_url": "https://github.com/kubernetes/kubernetes", 
+    "forks": 13657, 
+    "open_issues": 3153, 
+    "node_id": "MDEwOlJlcG9zaXRvcnkyMDU4MDQ5OA==", 
+    "git_url": "git://github.com/kubernetes/kubernetes.git", 
+    "svn_url": "https://github.com/kubernetes/kubernetes", 
+    "has_issues": true, 
+    "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+    "has_downloads": true, 
+    "license": {
+      "spdx_id": "Apache-2.0", 
+      "node_id": "MDc6TGljZW5zZTI=", 
+      "name": "Apache License 2.0", 
+      "key": "apache-2.0"
+    }, 
+    "name": "kubernetes", 
+    "language": "Go", 
+    "created_at": "2014-06-06T22:56:04Z", 
+    "pushed_at": "2018-07-24T17:42:36Z", 
+    "forks_count": 13657, 
+    "default_branch": "master"
+  }, 
+  "review": {
+    "body": "", 
+    "commit_id": "6420ae3d9ef16670a4c28848ec7c03311ec2030a", 
+    "submitted_at": "2018-07-24T18:04:22Z", 
+    "author_association": "MEMBER", 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/66534#pullrequestreview-140011842", 
+    "state": "changes_requested", 
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTQwMDExODQy", 
+    "_links": {
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/66534#pullrequestreview-140011842"
+      }, 
+      "pull_request": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66534"
+      }
+    }, 
+    "user": {
+      "avatar_url": "https://avatars0.githubusercontent.com/u/169553?v=4", 
+      "html_url": "https://github.com/timothysc", 
+      "node_id": "MDQ6VXNlcjE2OTU1Mw==", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "timothysc", 
+      "type": "User", 
+      "id": 169553
+    }, 
+    "id": 140011842
+  }, 
+  "pull_request": {
+    "merge_commit_sha": "ffe7c31df513636a23b5472020964e926961b790", 
+    "labels": [
+      {
+        "default": false, 
+        "name": "area/kubeadm", 
+        "color": "0052cc", 
+        "node_id": "MDU6TGFiZWw0NTE0NTk1OTA=", 
+        "id": 451459590
+      }, 
+      {
+        "default": false, 
+        "name": "cncf-cla: yes", 
+        "color": "bfe5bf", 
+        "node_id": "MDU6TGFiZWw0NzczOTcwODY=", 
+        "id": 477397086
+      }, 
+      {
+        "default": false, 
+        "name": "kind/feature", 
+        "color": "c7def8", 
+        "node_id": "MDU6TGFiZWwyNjc3NjEzNjI=", 
+        "id": 267761362
+      }, 
+      {
+        "default": false, 
+        "name": "release-note", 
+        "color": "c2e0c6", 
+        "node_id": "MDU6TGFiZWwyMDAxNDk4MzM=", 
+        "id": 200149833
+      }, 
+      {
+        "default": false, 
+        "name": "sig/cluster-lifecycle", 
+        "color": "d2b48c", 
+        "node_id": "MDU6TGFiZWwxNzM0OTQyMjI=", 
+        "id": 173494222
+      }, 
+      {
+        "default": false, 
+        "name": "size/M", 
+        "color": "eebb00", 
+        "node_id": "MDU6TGFiZWwyNTM0NTA5MzQ=", 
+        "id": 253450934
+      }
+    ], 
+    "number": 66534, 
+    "assignee": {
+      "avatar_url": "https://avatars3.githubusercontent.com/u/331852?v=4", 
+      "html_url": "https://github.com/neolit123", 
+      "node_id": "MDQ6VXNlcjMzMTg1Mg==", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "neolit123", 
+      "type": "User", 
+      "id": 331852
+    }, 
+    "closed_at": null, 
+    "requested_reviewers": [
+      {
+        "avatar_url": "https://avatars3.githubusercontent.com/u/915544?v=4", 
+        "html_url": "https://github.com/detiber", 
+        "node_id": "MDQ6VXNlcjkxNTU0NA==", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "detiber", 
+        "type": "User", 
+        "id": 915544
+      }, 
+      {
+        "avatar_url": "https://avatars0.githubusercontent.com/u/33235082?v=4", 
+        "html_url": "https://github.com/liztio", 
+        "node_id": "MDQ6VXNlcjMzMjM1MDgy", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "liztio", 
+        "type": "User", 
+        "id": 33235082
+      }
+    ], 
+    "id": 203405992, 
+    "title": "Add kubeadm init or join operation record to file", 
+    "merged_at": null, 
+    "state": "open", 
+    "_links": {
+      "review_comment": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/comments{/number}"
+      }, 
+      "commits": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66534/commits"
+      }, 
+      "self": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66534"
+      }, 
+      "review_comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/66534/comments"
+      }, 
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/66534"
+      }, 
+      "comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/66534/comments"
+      }, 
+      "issue": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/66534"
+      }, 
+      "statuses": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/statuses/1343611cc8455e6c9a345be6108cb5b051c41143"
+      }
+    }, 
+    "diff_url": "https://github.com/kubernetes/kubernetes/pull/66534.diff", 
+    "body": "This patch add file record when kubeadm init or kubeadm join\r\noperation, If kubeadm reset the record file will remove.\r\n\r\nIssues record: kubernetes/kubeadm#997\r\n\r\nSigned-off-by: Yuanbin.Chen <cybing4@gmail.com>\r\n\r\n<!--  Thanks for sending a pull request!  Here are some tips for you:\r\n1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide\r\n2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews\r\n3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md\r\n4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests\r\n-->\r\n\r\n**What this PR does / why we need it**:\r\n\r\n**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:\r\nFixes kubernetes/kubeadm#997\r\n\r\n**Special notes for your reviewer**:\r\n\r\n**Release note**:\r\n<!--  Write your release note:\r\n1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string \"action required\".\r\n2. If no release note is required, just write \"NONE\".\r\n-->\r\n```release-note\r\nkubeadm: detect previous kubeadm init and join invocations via a sentinel file\r\n```\r\n", 
+    "head": {
+      "repo": {
+        "stargazers_count": 0, 
+        "mirror_url": null, 
+        "updated_at": "2018-05-17T02:52:49Z", 
+        "private": false, 
+        "has_wiki": false, 
+        "full_name": "chenyb4/kubernetes", 
+        "owner": {
+          "avatar_url": "https://avatars1.githubusercontent.com/u/10691174?v=4", 
+          "html_url": "https://github.com/chenyb4", 
+          "node_id": "MDQ6VXNlcjEwNjkxMTc0", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "chenyb4", 
+          "type": "User", 
+          "id": 10691174
+        }, 
+        "id": 133750108, 
+        "description": "Production-Grade Container Scheduling and Management", 
+        "archived": false, 
+        "has_pages": false, 
+        "open_issues_count": 0, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/chenyb4/kubernetes.git", 
+        "watchers_count": 0, 
+        "size": 573236, 
+        "homepage": "http://kubernetes.io", 
+        "fork": true, 
+        "watchers": 0, 
+        "html_url": "https://github.com/chenyb4/kubernetes", 
+        "forks": 0, 
+        "open_issues": 0, 
+        "node_id": "MDEwOlJlcG9zaXRvcnkxMzM3NTAxMDg=", 
+        "git_url": "git://github.com/chenyb4/kubernetes.git", 
+        "svn_url": "https://github.com/chenyb4/kubernetes", 
+        "has_issues": false, 
+        "ssh_url": "git@github.com:chenyb4/kubernetes.git", 
+        "has_downloads": true, 
+        "license": {
+          "spdx_id": "Apache-2.0", 
+          "node_id": "MDc6TGljZW5zZTI=", 
+          "name": "Apache License 2.0", 
+          "key": "apache-2.0"
+        }, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2018-05-17T02:52:15Z", 
+        "pushed_at": "2018-07-24T15:07:55Z", 
+        "forks_count": 0, 
+        "default_branch": "master"
+      }, 
+      "sha": "1343611cc8455e6c9a345be6108cb5b051c41143", 
+      "ref": "kubeadm_sentinel", 
+      "user": {
+        "avatar_url": "https://avatars1.githubusercontent.com/u/10691174?v=4", 
+        "html_url": "https://github.com/chenyb4", 
+        "node_id": "MDQ6VXNlcjEwNjkxMTc0", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "chenyb4", 
+        "type": "User", 
+        "id": 10691174
+      }, 
+      "label": "chenyb4:kubeadm_sentinel"
+    }, 
+    "author_association": "CONTRIBUTOR", 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/66534", 
+    "updated_at": "2018-07-24T18:04:22Z", 
+    "node_id": "MDExOlB1bGxSZXF1ZXN0MjAzNDA1OTky", 
+    "user": {
+      "avatar_url": "https://avatars1.githubusercontent.com/u/10691174?v=4", 
+      "html_url": "https://github.com/chenyb4", 
+      "node_id": "MDQ6VXNlcjEwNjkxMTc0", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "chenyb4", 
+      "type": "User", 
+      "id": 10691174
+    }, 
+    "milestone": null, 
+    "requested_teams": [], 
+    "locked": false, 
+    "created_at": "2018-07-24T04:20:50Z", 
+    "assignees": [
+      {
+        "avatar_url": "https://avatars3.githubusercontent.com/u/331852?v=4", 
+        "html_url": "https://github.com/neolit123", 
+        "node_id": "MDQ6VXNlcjMzMTg1Mg==", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "neolit123", 
+        "type": "User", 
+        "id": 331852
+      }
+    ], 
+    "base": {
+      "repo": {
+        "stargazers_count": 39100, 
+        "mirror_url": null, 
+        "updated_at": "2018-07-24T18:02:40Z", 
+        "private": false, 
+        "has_wiki": false, 
+        "full_name": "kubernetes/kubernetes", 
+        "owner": {
+          "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+          "html_url": "https://github.com/kubernetes", 
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "kubernetes", 
+          "type": "Organization", 
+          "id": 13629408
+        }, 
+        "id": 20580498, 
+        "description": "Production-Grade Container Scheduling and Management", 
+        "archived": false, 
+        "has_pages": false, 
+        "open_issues_count": 3153, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+        "watchers_count": 39100, 
+        "size": 794612, 
+        "homepage": "http://kubernetes.io", 
+        "fork": false, 
+        "watchers": 39100, 
+        "html_url": "https://github.com/kubernetes/kubernetes", 
+        "forks": 13657, 
+        "open_issues": 3153, 
+        "node_id": "MDEwOlJlcG9zaXRvcnkyMDU4MDQ5OA==", 
+        "git_url": "git://github.com/kubernetes/kubernetes.git", 
+        "svn_url": "https://github.com/kubernetes/kubernetes", 
+        "has_issues": true, 
+        "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+        "has_downloads": true, 
+        "license": {
+          "spdx_id": "Apache-2.0", 
+          "node_id": "MDc6TGljZW5zZTI=", 
+          "name": "Apache License 2.0", 
+          "key": "apache-2.0"
+        }, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2014-06-06T22:56:04Z", 
+        "pushed_at": "2018-07-24T17:42:36Z", 
+        "forks_count": 13657, 
+        "default_branch": "master"
+      }, 
+      "sha": "0ffee495ad173fc75c01031cd3e90798de7fb9c0", 
+      "ref": "master", 
+      "user": {
+        "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+        "html_url": "https://github.com/kubernetes", 
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "kubernetes", 
+        "type": "Organization", 
+        "id": 13629408
+      }, 
+      "label": "kubernetes:master"
+    }, 
+    "patch_url": "https://github.com/kubernetes/kubernetes/pull/66534.patch"
+  }, 
+  "action": "submitted", 
+  "organization": {
+    "description": "Kubernetes", 
+    "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNjI5NDA4", 
+    "login": "kubernetes", 
+    "id": 13629408
+  }
+}

--- a/prow/cmd/phony/examples/review_comment_submitted.json
+++ b/prow/cmd/phony/examples/review_comment_submitted.json
@@ -1,0 +1,279 @@
+{
+  "sender": {
+    "html_url": "https://github.com/brendandburns", 
+    "avatar_url": "https://avatars2.githubusercontent.com/u/5751682?v=4", 
+    "gravatar_id": "", 
+    "site_admin": false, 
+    "login": "brendandburns", 
+    "type": "User", 
+    "id": 5751682
+  }, 
+  "repository": {
+    "stargazers_count": 26148, 
+    "mirror_url": null, 
+    "updated_at": "2017-08-22T03:50:19Z", 
+    "private": false, 
+    "has_wiki": true, 
+    "full_name": "kubernetes/kubernetes", 
+    "owner": {
+      "html_url": "https://github.com/kubernetes", 
+      "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "kubernetes", 
+      "type": "Organization", 
+      "id": 13629408
+    }, 
+    "id": 20580498, 
+    "description": "Production-Grade Container Scheduling and Management", 
+    "has_pages": false, 
+    "open_issues_count": 5327, 
+    "has_projects": true, 
+    "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+    "watchers_count": 26148, 
+    "size": 677615, 
+    "homepage": "http://kubernetes.io", 
+    "fork": false, 
+    "html_url": "https://github.com/kubernetes/kubernetes", 
+    "forks": 9313, 
+    "open_issues": 5327, 
+    "git_url": "git://github.com/kubernetes/kubernetes.git", 
+    "svn_url": "https://github.com/kubernetes/kubernetes", 
+    "has_issues": true, 
+    "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+    "has_downloads": true, 
+    "watchers": 26148, 
+    "name": "kubernetes", 
+    "language": "Go", 
+    "created_at": "2014-06-06T22:56:04Z", 
+    "pushed_at": "2017-08-22T04:27:34Z", 
+    "forks_count": 9313, 
+    "default_branch": "master"
+  }, 
+  "review": {
+    "body": null, 
+    "commit_id": "3257d8d28ba6e4abca8153583869fc9749e809e7", 
+    "submitted_at": "2017-08-22T04:43:19Z", 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/51025#pullrequestreview-57666542", 
+    "state": "commented", 
+    "_links": {
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/51025#pullrequestreview-57666542"
+      }, 
+      "pull_request": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/51025"
+      }
+    }, 
+    "user": {
+      "html_url": "https://github.com/brendandburns", 
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5751682?v=4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "brendandburns", 
+      "type": "User", 
+      "id": 5751682
+    }, 
+    "id": 57666542
+  }, 
+  "pull_request": {
+    "merge_commit_sha": "5267d37fa40fc7905e1eb171563346c71fb16599", 
+    "number": 51025, 
+    "assignee": {
+      "html_url": "https://github.com/brendandburns", 
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5751682?v=4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "brendandburns", 
+      "type": "User", 
+      "id": 5751682
+    }, 
+    "closed_at": null, 
+    "requested_reviewers": [], 
+    "id": 136757895, 
+    "title": "Update defaults.go", 
+    "merged_at": null, 
+    "state": "open", 
+    "_links": {
+      "review_comment": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/comments{/number}"
+      }, 
+      "commits": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/51025/commits"
+      }, 
+      "self": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/51025"
+      }, 
+      "review_comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/pulls/51025/comments"
+      }, 
+      "html": {
+        "href": "https://github.com/kubernetes/kubernetes/pull/51025"
+      }, 
+      "comments": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/51025/comments"
+      }, 
+      "issue": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/issues/51025"
+      }, 
+      "statuses": {
+        "href": "https://api.github.com/repos/kubernetes/kubernetes/statuses/3257d8d28ba6e4abca8153583869fc9749e809e7"
+      }
+    }, 
+    "diff_url": "https://github.com/kubernetes/kubernetes/pull/51025.diff", 
+    "body": "\r\n**What this PR does / why we need it**:\r\nAdd explain about TaintTolerationPriority function.\r\n\r\n\r\n**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #\r\n\r\n**Special notes for your reviewer**:\r\n\r\n**Release note**:\r\n<!--  Steps to write your release note:\r\n1. Use the release-note-* labels to set the release note state (if you have access)\r\n2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.\r\n-->\r\n```release-note\r\nNone.\r\n```\r\n", 
+    "head": {
+      "repo": {
+        "stargazers_count": 0, 
+        "mirror_url": null, 
+        "updated_at": "2017-08-21T12:30:11Z", 
+        "private": false, 
+        "has_wiki": true, 
+        "full_name": "stewart-yu/kubernetes", 
+        "owner": {
+          "html_url": "https://github.com/stewart-yu", 
+          "avatar_url": "https://avatars2.githubusercontent.com/u/30410021?v=4", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "stewart-yu", 
+          "type": "User", 
+          "id": 30410021
+        }, 
+        "id": 100950156, 
+        "description": "Production-Grade Container Scheduling and Management", 
+        "has_pages": false, 
+        "open_issues_count": 0, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/stewart-yu/kubernetes.git", 
+        "watchers_count": 0, 
+        "size": 460704, 
+        "homepage": "http://kubernetes.io", 
+        "fork": true, 
+        "html_url": "https://github.com/stewart-yu/kubernetes", 
+        "forks": 0, 
+        "open_issues": 0, 
+        "git_url": "git://github.com/stewart-yu/kubernetes.git", 
+        "svn_url": "https://github.com/stewart-yu/kubernetes", 
+        "has_issues": false, 
+        "ssh_url": "git@github.com:stewart-yu/kubernetes.git", 
+        "has_downloads": true, 
+        "watchers": 0, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2017-08-21T12:29:29Z", 
+        "pushed_at": "2017-08-21T13:14:51Z", 
+        "forks_count": 0, 
+        "default_branch": "master"
+      }, 
+      "sha": "3257d8d28ba6e4abca8153583869fc9749e809e7", 
+      "ref": "master", 
+      "user": {
+        "html_url": "https://github.com/stewart-yu", 
+        "avatar_url": "https://avatars2.githubusercontent.com/u/30410021?v=4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "stewart-yu", 
+        "type": "User", 
+        "id": 30410021
+      }, 
+      "label": "stewart-yu:master"
+    }, 
+    "html_url": "https://github.com/kubernetes/kubernetes/pull/51025", 
+    "updated_at": "2017-08-22T04:43:19Z", 
+    "base": {
+      "repo": {
+        "stargazers_count": 26148, 
+        "mirror_url": null, 
+        "updated_at": "2017-08-22T03:50:19Z", 
+        "private": false, 
+        "has_wiki": true, 
+        "full_name": "kubernetes/kubernetes", 
+        "owner": {
+          "html_url": "https://github.com/kubernetes", 
+          "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+          "gravatar_id": "", 
+          "site_admin": false, 
+          "login": "kubernetes", 
+          "type": "Organization", 
+          "id": 13629408
+        }, 
+        "id": 20580498, 
+        "description": "Production-Grade Container Scheduling and Management", 
+        "has_pages": false, 
+        "open_issues_count": 5327, 
+        "has_projects": true, 
+        "clone_url": "https://github.com/kubernetes/kubernetes.git", 
+        "watchers_count": 26148, 
+        "size": 677615, 
+        "homepage": "http://kubernetes.io", 
+        "fork": false, 
+        "html_url": "https://github.com/kubernetes/kubernetes", 
+        "forks": 9313, 
+        "open_issues": 5327, 
+        "git_url": "git://github.com/kubernetes/kubernetes.git", 
+        "svn_url": "https://github.com/kubernetes/kubernetes", 
+        "has_issues": true, 
+        "ssh_url": "git@github.com:kubernetes/kubernetes.git", 
+        "has_downloads": true, 
+        "watchers": 26148, 
+        "name": "kubernetes", 
+        "language": "Go", 
+        "created_at": "2014-06-06T22:56:04Z", 
+        "pushed_at": "2017-08-22T04:27:34Z", 
+        "forks_count": 9313, 
+        "default_branch": "master"
+      }, 
+      "sha": "f4afdecef85e83e7b83fc8a6d63a220c9a10acc0", 
+      "ref": "master", 
+      "user": {
+        "html_url": "https://github.com/kubernetes", 
+        "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "kubernetes", 
+        "type": "Organization", 
+        "id": 13629408
+      }, 
+      "label": "kubernetes:master"
+    }, 
+    "user": {
+      "html_url": "https://github.com/stewart-yu", 
+      "avatar_url": "https://avatars2.githubusercontent.com/u/30410021?v=4", 
+      "gravatar_id": "", 
+      "site_admin": false, 
+      "login": "stewart-yu", 
+      "type": "User", 
+      "id": 30410021
+    }, 
+    "milestone": null, 
+    "locked": false, 
+    "created_at": "2017-08-21T13:16:44Z", 
+    "assignees": [
+      {
+        "html_url": "https://github.com/thockin", 
+        "avatar_url": "https://avatars0.githubusercontent.com/u/5595220?v=4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "thockin", 
+        "type": "User", 
+        "id": 5595220
+      }, 
+      {
+        "html_url": "https://github.com/brendandburns", 
+        "avatar_url": "https://avatars2.githubusercontent.com/u/5751682?v=4", 
+        "gravatar_id": "", 
+        "site_admin": false, 
+        "login": "brendandburns", 
+        "type": "User", 
+        "id": 5751682
+      }
+    ], 
+    "patch_url": "https://github.com/kubernetes/kubernetes/pull/51025.patch"
+  }, 
+  "action": "submitted", 
+  "organization": {
+    "description": "Kubernetes", 
+    "avatar_url": "https://avatars2.githubusercontent.com/u/13629408?v=4", 
+    "login": "kubernetes", 
+    "id": 13629408
+  }
+}

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -495,10 +495,15 @@ func isApprovalState(botName string, reviewActsAsApprove bool, c *comment) bool 
 		return false
 	}
 
+	// The review webhook returns state as lowercase, while the review API
+	// returns state as uppercase. Uppercase the value here so it always
+	// matches the constant.
+	reviewState := github.ReviewState(strings.ToUpper(string(c.ReviewState)))
+
 	// consider reviews in either approved OR requested changes states as
 	// approval commands. Reviews in requested changes states will be
 	// interpreted as cancelled approvals.
-	if reviewActsAsApprove && (c.ReviewState == github.ReviewStateApproved || c.ReviewState == github.ReviewStateChangesRequested) {
+	if reviewActsAsApprove && (reviewState == github.ReviewStateApproved || reviewState == github.ReviewStateChangesRequested) {
 		return true
 	}
 	return false

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -729,6 +729,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			reviews: []github.Review{
 				newTestReview("cjwagner", "stuff", "COMMENTED"),
 				newTestReview("cjwagner", "unsubmitted stuff", "PENDING"),
+				newTestReview("cjwagner", "dismissed stuff", "DISMISSED"),
 			},
 			selfApprove:         false,
 			needsIssue:          false,
@@ -1355,7 +1356,7 @@ func TestHandleReviewEvent(t *testing.T) {
 				},
 			},
 			reviewActsAsApprove: true,
-			expectHandle:        false,
+			expectHandle:        true,
 		},
 		{
 			name: "approve command",

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1269,6 +1269,11 @@ func TestHandleGenericComment(t *testing.T) {
 	}
 }
 
+// GitHub webhooks send state as lowercase, so force it to lowercase here.
+func stateToLower(s github.ReviewState) github.ReviewState {
+	return github.ReviewState(strings.ToLower(string(s)))
+}
+
 func TestHandleReviewEvent(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -1286,7 +1291,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateApproved,
+					State: stateToLower(github.ReviewStateApproved),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1301,7 +1306,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateChangesRequested,
+					State: stateToLower(github.ReviewStateChangesRequested),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1316,7 +1321,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStatePending,
+					State: stateToLower(github.ReviewStatePending),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1331,7 +1336,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateApproved,
+					State: stateToLower(github.ReviewStateApproved),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1346,7 +1351,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateDismissed,
+					State: stateToLower(github.ReviewStateDismissed),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1361,7 +1366,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateApproved,
+					State: stateToLower(github.ReviewStateApproved),
 				},
 			},
 			reviewActsAsApprove: true,
@@ -1376,7 +1381,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateApproved,
+					State: stateToLower(github.ReviewStateApproved),
 				},
 			},
 			lgtmActsAsApprove:   true,
@@ -1392,7 +1397,7 @@ func TestHandleReviewEvent(t *testing.T) {
 					User: github.User{
 						Login: "author",
 					},
-					State: github.ReviewStateApproved,
+					State: stateToLower(github.ReviewStateApproved),
 				},
 			},
 			reviewActsAsApprove: false,

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -803,6 +803,43 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 <!-- META={"approvers":["cjwagner"]} -->`,
 		},
 		{
+			name:     "dismissed review doesn't cancel prior approval",
+			hasLabel: true,
+			files:    []string{"a/a.go"},
+			comments: []github.IssueComment{
+				newTestCommentTime(time.Now().Add(time.Hour), "k8s-ci-robot", "[APPROVALNOTIFIER] This PR is **APPROVED**\n\nblah"), // second
+			},
+			reviews: []github.Review{
+				newTestReviewTime(time.Now(), "Alice", "yep", github.ReviewStateApproved),                         // first
+				newTestReviewTime(time.Now().Add(time.Hour*2), "Alice", "dismissed", github.ReviewStateDismissed), // third
+			},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: true,
+
+			expectDelete:  true,
+			expectToggle:  false,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
+
+The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
+
+<details >
+Needs approval from an approver in each of these files:
+
+- ~~[a/OWNERS](https://github.com/org/repo/blob/master/a/OWNERS)~~ [Alice]
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":[]} -->`,
+		},
+		{
 			name:     "approve cancel command supersedes earlier approved review",
 			hasLabel: true,
 			files:    []string{"c/c.go"},


### PR DESCRIPTION
Sadly the `ReviewActsAsApprove` feature added in #8086 and "fixed" in #8140 didn't work. What we didn't realize in #8140 was that the GitHub webhook event for reviews uses lowercase for review state values while the review API uses uppercase values (see https://github.com/kubernetes/test-infra/pull/8140#issuecomment-408559434).

This PR changes `isApprovalState` to always uppercase state values so they match the `github.ReviewState` constants. I've tested this locally with real webhooks logged by gubernator and it does appear to work, for real this time.

I also added handling for review dismissal. I reasoned that dismissing an approved or changes requested review is the same as turning it into a commented review, or perhaps deleting a comment with an approval command, and should update Prow's approval state based on commands or review states that remain.

/cc @guineveresaenger @cjwagner @fejta @stevekuznetsov 