### PR TITLE
Add --validate to testgrid/cmd/configurator

### DIFF
--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -45,12 +45,12 @@ func (m *multiString) Set(v string) error {
 }
 
 type options struct {
-	creds     string
-	inputs    multiString
-	oneshot   bool
-	output    string
-	printText bool
-	validate  bool
+	creds               string
+	inputs              multiString
+	oneshot             bool
+	output              string
+	printText           bool
+	validateConfigFile  bool
 }
 
 func gatherOptions() (options, error) {
@@ -59,18 +59,18 @@ func gatherOptions() (options, error) {
 	flag.BoolVar(&o.oneshot, "oneshot", false, "Write proto once and exit instead of monitoring --yaml files for changes")
 	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
 	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")
-	flag.BoolVar(&o.validate, "validate", false, "validate the given config files")
+	flag.BoolVar(&o.validateConfigFile, "validate-config-file", false, "validate that the given config files are syntactically correct")
 	flag.Var(&o.inputs, "yaml", "comma-separated list of input YAML files")
 	flag.Parse()
 	if len(o.inputs) == 0 || o.inputs[0] == "" {
 		return o, errors.New("--yaml must include at least one file")
 	}
 
-	if !o.printText && !o.validate && o.output == "" {
+	if !o.printText && !o.validateConfigFile && o.output == "" {
 		return o, errors.New("--print-text or --output=gs://path required")
 	}
-	if o.validate && o.output != "" {
-		return o, errors.New("--validate implies no output")
+	if o.validateConfigFile && o.output != "" {
+		return o, errors.New("--validate-config-file implies no output")
 	}
 	return o, nil
 }
@@ -184,8 +184,8 @@ func main() {
 
 	ctx := context.Background()
 
-	// Validation only
-	if opt.validate {
+	// Config file validation only
+	if opt.validateConfigFile {
 		if err := doOneshot(ctx, nil, opt); err != nil {
 			log.Fatalf("FAIL: %v", err)
 		}

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -59,7 +59,7 @@ func gatherOptions() (options, error) {
 	flag.BoolVar(&o.oneshot, "oneshot", false, "Write proto once and exit instead of monitoring --yaml files for changes")
 	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
 	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")
-	flag.BoolVar(&o.validateConfigFile, "validate-config-file", false, "validate that the given config files are syntactically correct")
+	flag.BoolVar(&o.validateConfigFile, "validate-config-file", false, "validate that the given config files are syntactically correct and exit (proto is not written anywhere)")
 	flag.Var(&o.inputs, "yaml", "comma-separated list of input YAML files")
 	flag.Parse()
 	if len(o.inputs) == 0 || o.inputs[0] == "" {
@@ -70,7 +70,7 @@ func gatherOptions() (options, error) {
 		return o, errors.New("--print-text or --output=gs://path required")
 	}
 	if o.validateConfigFile && o.output != "" {
-		return o, errors.New("--validate-config-file implies no output")
+		return o, errors.New("--validate-config-file doesn't write the proto anywhere")
 	}
 	return o, nil
 }

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -50,28 +50,29 @@ type options struct {
 	oneshot   bool
 	output    string
 	printText bool
+	validate  bool
 }
 
-func gatherOptions() options {
+func gatherOptions() (options, error) {
 	o := options{}
 	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty")
 	flag.BoolVar(&o.oneshot, "oneshot", false, "Write proto once and exit instead of monitoring --yaml files for changes")
 	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
 	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")
+	flag.BoolVar(&o.validate, "validate", false, "validate the given config files")
 	flag.Var(&o.inputs, "yaml", "comma-separated list of input YAML files")
 	flag.Parse()
-	return o
-}
-
-func (o *options) validate() error {
 	if len(o.inputs) == 0 || o.inputs[0] == "" {
-		return errors.New("--yaml must include at least one file")
+		return o, errors.New("--yaml must include at least one file")
 	}
 
-	if !o.printText && o.output == "" {
-		return errors.New("--print-text or --output=gs://path required")
+	if !o.printText && !o.validate && o.output == "" {
+		return o, errors.New("--print-text or --output=gs://path required")
 	}
-	return nil
+	if o.validate && o.output != "" {
+		return o, errors.New("--validate implies no output")
+	}
+	return o, nil
 }
 
 // announceChanges watches for changes to files and writes one of them to the channel
@@ -176,13 +177,23 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options) error {
 
 func main() {
 	// Parse flags
-	opt := gatherOptions()
-	if err := opt.validate(); err != nil {
+	opt, err := gatherOptions()
+	if err != nil {
 		log.Fatalf("Bad flags: %v", err)
 	}
 
-	// Setup stuff
 	ctx := context.Background()
+
+	// Validation only
+	if opt.validate {
+		if err := doOneshot(ctx, nil, opt); err != nil {
+			log.Fatalf("FAIL: %v", err)
+		}
+		log.Println("Config validated successfully")
+		return
+	}
+
+	// Setup GCS client
 	client, err := gcs.ClientWithCreds(ctx, opt.creds)
 	if err != nil {
 		log.Fatalf("Failed to create storage client: %v", err)

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -45,12 +45,12 @@ func (m *multiString) Set(v string) error {
 }
 
 type options struct {
-	creds               string
-	inputs              multiString
-	oneshot             bool
-	output              string
-	printText           bool
-	validateConfigFile  bool
+	creds              string
+	inputs             multiString
+	oneshot            bool
+	output             string
+	printText          bool
+	validateConfigFile bool
 }
 
 func gatherOptions() (options, error) {


### PR DESCRIPTION
The flag `--validate` causes the input files to go through simple validation (file is read and parsed). This is useful for presubmit tests, as no credentials are required for this operation.

To avoid naming conflict, the function `validate()` was merged with `gatherOptions()` (both are used together and in sequence anyway).