### PR TITLE
kubeadm-runner: bump the kubernetes-anywhere version

### DIFF
--- a/images/kubeadm/runner
+++ b/images/kubeadm/runner
@@ -26,7 +26,7 @@ if [ ! -e kubernetes-anywhere ]; then
 
   # Explicitly version this dependency so that upstream commits can't
   # immediately break e2e jobs, and we have control over upgrading/downgrading.
-  git -C kubernetes-anywhere checkout 986797c0e17ae718851c7b27e53b632b674004f5
+  git -C kubernetes-anywhere checkout a26f42c716028c4ba967b2d2f3de5ed50acc51da
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332


### PR DESCRIPTION
bump the k-a SHA post a recent k-a fix (again)

i'm sorry, but i had to add some handling of the version format because kubernetes-anywhere can use non-semantic version as input e.g. `ci-cross/latest`.

hope we got it right this time.

refs:
https://github.com/kubernetes/kubernetes-anywhere/pull/549

release team issue:
kubernetes/kubernetes#66338

/assign @BenTheElder
/cc @luxas 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
