### PR TITLE
use unique job filename of cloud-provider-vsphere-presubmits and set job root.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     context: pull-cloud-provider-vsphere-test
     branches:
     - master
-    always_run: true
+    always_run: false
     rerun_command: "/test pull-cloud-provider-vsphere-test"
     trigger: "(?m)^/test( all| pull-cloud-provider-vsphere-test),?(\\s+|$)"
     labels:
@@ -16,6 +16,7 @@ presubmits:
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--scenario=execute"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6509,6 +6509,7 @@ dashboard_groups:
 - name: presubmits
   dashboard_names:
   - presubmits-cluster-registry
+  - presubmits-cloud-provider-vsphere-blocking
   - presubmits-federation
   - presubmits-kubernetes-blocking
   - presubmits-kubernetes-nonblocking


### PR DESCRIPTION
fix the cloud-provider-vsphere-presubmits job
  
this patch contains four small changes:
1) report presubmits-cloud-provider-vsphere-blocking under presubmits
2) set the job not always run so that it does not block until it been fully validated at the repo
3) set job root at /go/src
4) use unique job filename: cloud-provider-vsphere-presubmits

@BenTheElder greatly appreciated if you could help to review this PR, thanks very much.

@krzyzacy @frapposelli @akutz @dougm 
