### PR TITLE
Remove KUBELET_TEST_LOG_LEVEL from ci-kubernetes-e2e-gci-gce-scalability.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1491,7 +1491,6 @@
   "ci-kubernetes-e2e-gci-gce-scalability": {
     "args": [
       "--cluster=e2e-big",
-      "--env=KUBELET_TEST_LOG_LEVEL=--v=5",
       "--env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env",
       "--extract=ci/latest",


### PR DESCRIPTION
It likely makes latency even worse:  https://github.com/kubernetes/kubernetes/issues/66672#issuecomment-409210208

/assign @shyamjvs 
