### PR TITLE
Add top-level test-grid category "vmware"

### DIFF
--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -43,6 +43,7 @@ var (
 		"kopeio",
 		"tectonic",
 		"redhat",
+		"vmware",
 	}
 	orgs = []string{
 		"conformance",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6136,6 +6136,12 @@ dashboards:
     test_group_name: pull-cloud-provider-vsphere-test
     base_options: 'width=10'
 
+- name: vmware-presubmits-cloud-provider-vsphere
+  dashboard_tab:
+  - name: pull-cloud-provider-vsphere-test
+    test_group_name: pull-cloud-provider-vsphere-test
+    base_options: 'width=10'
+
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance
@@ -6618,3 +6624,7 @@ dashboard_groups:
   - conformance-providerless
   - conformance-cloud-provider-openstack
   - conformance-gardener
+
+- name: vmware
+  dashboard_names:
+  - vmware-presubmits-cloud-provider-vsphere


### PR DESCRIPTION
This patch adds a new top-level category named `vmware` to the test grid in order to organize all VMware-related test results / dashboards in a single location. The same results will still be organized under other, appropriate top-level categories as well, but this will provide a much easier way for visitors concerned specifically with VMware-related results to find said results.

This [document](
https://docs.google.com/document/d/1bW2WxS1tprXwC9VBFDcs8W5yh9MNytj8f73_7TGNNWM/edit?usp=sharing) was the focal point of a discussion of what to name a top-level category. The reasons behind the decision to use `vmware` over a SIG are highlighted in the linked document.