### PR TITLE
milestone issue information moving

### DIFF
--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -91,7 +91,7 @@ const (
 	milestoneDetail = `<details>
 <summary>Help</summary>
 <ul>
- <li><a href="https://git.k8s.io/sig-release/ephemera/issues.md">Additional instructions</a></li>
+ <li><a href="https://git.k8s.io/community/contributors/devel/issues.md">Additional instructions</a></li>
  <li><a href="https://go.k8s.io/bot-commands">Commands for setting labels</a></li>
 </ul>
 </details>

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -127,7 +127,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 <details>
 <summary>Help</summary>
 <ul>
- <li><a href="https://git.k8s.io/sig-release/ephemera/issues.md">Additional instructions</a></li>
+ <li><a href="https://git.k8s.io/community/contributors/devel/issues.md">Additional instructions</a></li>
  <li><a href="https://go.k8s.io/bot-commands">Commands for setting labels</a></li>
 </ul>
 </details>`
@@ -494,7 +494,7 @@ func TestNotificationIsCurrent(t *testing.T) {
 	warningInterval := day
 	createdYesterday := createdNow.Add(-(warningInterval + time.Hour))
 
-	realSample := "@foo @bar @baz\n\n**Action required**: This issue requires label changes. If the required changes are not made within 6 days, the issue will be moved out of the v1.8 milestone.\n\n_**kind**_: Must specify at most one of [`kind/bug`, `kind/cleanup`, `kind/feature`].\n_**priority**_: Must specify at most one of [`priority/critical-urgent`, `priority/important-longterm`, `priority/important-soon`].\n_**sig owner**_: Must specify at least one label prefixed with `sig/`.\n\n<details>\nAdditional instructions available <a href=\"https://git.k8s.io/sig-release/ephemera/issues.md\">here</a>\n</details>"
+	realSample := "@foo @bar @baz\n\n**Action required**: This issue requires label changes. If the required changes are not made within 6 days, the issue will be moved out of the v1.8 milestone.\n\n_**kind**_: Must specify at most one of [`kind/bug`, `kind/cleanup`, `kind/feature`].\n_**priority**_: Must specify at most one of [`priority/critical-urgent`, `priority/important-longterm`, `priority/important-soon`].\n_**sig owner**_: Must specify at least one label prefixed with `sig/`.\n\n<details>\nAdditional instructions available <a href=\"https://git.k8s.io/community/contributors/devel/issues.md\">here</a>\n</details>"
 
 	tests := map[string]struct {
 		message            string


### PR DESCRIPTION
The documentation on how a developer gets code into a milestone release
is proposed to move in https://github.com/kubernetes/community/pull/2430
and would require an associated update of the url the milestone munger
uses as a reference in its information GitHub comments.

Signed-off-by: Tim Pepper <tpepper@vmware.com>