### PR TITLE
hack script to generate configmap

### DIFF
--- a/hack/generate_job_configmap.py
+++ b/hack/generate_job_configmap.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script deletes and recreates the job configmap
+
+#
+# USAGE: have KUBECONFIG pointed at your prow cluster then from test-infra root:
+#
+# hack/generate-job-configmap.py [--wet]
+#
+
+from __future__ import print_function
+
+from argparse import ArgumentParser
+import os
+import subprocess
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--job-configmap", default="job-config", help="name of prow jobs configmap")
+    parser.add_argument(
+        "--job-config-dir", default="config/jobs", help="root dir of prow jobs configmap")
+    parser.add_argument("--wet", action="store_true")
+
+    args = parser.parse_args()
+
+    # delete configmap (apply has size limit)
+    cmd = ["kubectl", "delete", "configmap", args.job_configmap]
+    print (cmd)
+    if args.wet:
+        subprocess.check_call(cmd)
+
+    # regenerate
+    cmd = ["kubectl", "create", "configmap", args.job_configmap]
+    for root, _, files in os.walk(args.job_config_dir):
+        for name in files:
+            if name.endswith(".yaml"):
+                cmd.append("--from-file=%s=%s" % (name, os.path.join(root, name)))
+    print (cmd)
+    if args.wet:
+        subprocess.check_call(cmd)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
/assign @BenTheElder 

```
senlu@senlu:~/work/src/k8s.io/test-infra$ ./hack/generate-job-configmap.py --wet
['kubectl', 'delete', 'configmap', 'job-config']
configmap "job-config" deleted
['kubectl', 'create', 'configmap', 'job-config', '--from-file=service-catalog-presubmits.yaml=config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml', '--from-file=rules_k8s_config.yaml=config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml', '--from-file=cadvisor.yaml=config/jobs/cadvisor/cadvisor.yaml', '--from-file=gke-staging-gpu.yaml=config/jobs/gke/gke-staging-gpu.yaml', '--from-file=gke-staging-upgrade.yaml=config/jobs/gke/gke-staging-upgrade.yaml', '--from-file=gke-staging.yaml=config/jobs/gke/gke-staging.yaml', '--from-file=gke-test-containerd.yaml=config/jobs/gke/containerd/gke-test-containerd.yaml', '--from-file=cluster-api-provider-aws-presubmits.yaml=config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml', '--from-file=config.yaml=config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml', '--from-file=cluster-api-ci.yaml=config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml', '--from-file=cluster-api-presubmits.yaml=config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml', '--from-file=gcp-filestore-csi-driver-config.yaml=config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml', '--from-file=cluster-api-provider-gcp-presubmits.yaml=config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml', '--from-file=cluster-api-provider-gcp-ci.yaml=config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml', '--from-file=cluster-api-provider-openstack-presubmits.yaml=config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml', '--from-file=charts.yaml=config/jobs/helm/charts/charts.yaml', '--from-file=minigo.yaml=config/jobs/tensorflow/minigo/minigo.yaml', '--from-file=cloud-provider-gcp-presubmits.yaml=config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml', '--from-file=sig-cli-config.yaml=config/jobs/kubernetes/sig-cli/sig-cli-config.yaml', '--from-file=cloud-provider-vsphere-presubmits.yaml=config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-presubmits.yaml', '--from-file=generated.yaml=config/jobs/kubernetes/generated/generated.yaml', '--from-file=k8s-upgrade-gke.yaml=config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml', '--from-file=k8s-upgrade-gce.yaml=config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml', '--from-file=containerd.yaml=config/jobs/kubernetes/sig-node/containerd.yaml', '--from-file=node-kubelet.yaml=config/jobs/kubernetes/sig-node/node-kubelet.yaml', '--from-file=sig-aws-config.yaml=config/jobs/kubernetes/sig-aws/sig-aws-config.yaml', '--from-file=kubetest-canaries.yaml=config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml', '--from-file=test-infra-canaries.yaml=config/jobs/kubernetes/test-infra/test-infra-canaries.yaml', '--from-file=test-infra-postsubmits.yaml=config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml', '--from-file=janitors.yaml=config/jobs/kubernetes/test-infra/janitors.yaml', '--from-file=test-infra-periodics.yaml=config/jobs/kubernetes/test-infra/test-infra-periodics.yaml', '--from-file=test-infra-presubmits.yaml=config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml', '--from-file=ci-e2e-gce-netd.yaml=config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml', '--from-file=kubeflow-periodics.yaml=config/jobs/kubeflow/kubeflow-periodics.yaml', '--from-file=kubeflow-presubmits.yaml=config/jobs/kubeflow/kubeflow-presubmits.yaml', '--from-file=kubeflow-postsubmits.yaml=config/jobs/kubeflow/kubeflow-postsubmits.yaml', '--from-file=generated-security-jobs.yaml=config/jobs/kubernetes-security/generated-security-jobs.yaml']
configmap "job-config" created
senlu@senlu:~/work/src/k8s.io/test-infra$ kubectl get cm
NAME         DATA      AGE
config       1         87d
job-config   37        5s
plugins      1         87d
```