### PR TITLE
add kubernetes-sigs/contributor-site to prow config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -232,6 +232,7 @@ tide:
     - kubernetes-sigs/cluster-api-provider-aws
     - kubernetes-sigs/cluster-api-provider-gcp
     - kubernetes-sigs/cluster-api-provider-openstack
+    - kubernetes-sigs/contributor-site
     - kubernetes-sigs/controller-runtime
     - kubernetes-sigs/controller-tools
     - kubernetes-sigs/gcp-compute-persistent-disk-csi-driver

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -523,6 +523,10 @@ plugins:
   kubernetes-sigs/controller-tools:
   - approve  
 
+  kubernetes-sigs/contributor-site:
+  - approve
+  - blunderbuss
+
   containerd/cri:
   - assign
   - cla

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -525,7 +525,6 @@ plugins:
 
   kubernetes-sigs/contributor-site:
   - approve
-  - blunderbuss
 
   containerd/cri:
   - assign


### PR DESCRIPTION
This adds support for approve and blunderbuss for the new kubernetes-sigs/contributor-site repo.