### PR TITLE
Update kubetest image and add containerd cri test tabs.

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -109,7 +109,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180725-795cceb4c-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180730-8b7ab3104-master
 
 - interval: 1h
   agent: kubernetes

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5341,6 +5341,10 @@ dashboards:
     test_group_name: ci-docker-node-features
   - name: sig-node-docker-node-legacy
     test_group_name: ci-docker-node-legacy
+  - name: sig-node-containerd-node-conformance
+    test_group_name: ci-containerd-node-e2e
+  - name: sig-node-containerd-node-features
+    test_group_name: ci-containerd-node-e2e-features
 
 - name: sig-node-cadvisor
   dashboard_tab:


### PR DESCRIPTION
This PR:
1) Update kubetest image for ci-kubernetes-e2e-cos-containerd-gke-k8sbeta, which I guess was missed during rebase.
2) Add tabs for containerd in sig-node-cri.

/cc @yujuhong 
Signed-off-by: Lantao Liu <lantaol@google.com>