### PR TITLE
Spyglass core library

### DIFF
--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -1,13 +1,22 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["placeholder.go"],
-    importpath = "k8s.io/test-infra/prow/spyglass",
-    visibility = ["//visibility:public"],
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "gcsartifact_fetcher_test.go",
+        "gcsartifact_test.go",
+        "podlogartifact_test.go",
+        "spyglass_test.go",
+    ],
+    embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
+        "//prow/deck/jobs:go_default_library",
+        "//prow/kube:go_default_library",
+        "//prow/spyglass/viewers:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/fsouza/fake-gcs-server/fakestorage:go_default_library",
-        "//vendor/github.com/joshdk/go-junit:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 
@@ -20,7 +29,34 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/spyglass/viewers:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "artifactfetchers.go",
+        "gcsartifact.go",
+        "gcsartifact_fetcher.go",
+        "placeholder.go",
+        "podlogartifact.go",
+        "spyglass.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/spyglass",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/deck/jobs:go_default_library",
+        "//prow/spyglass/viewers:go_default_library",
+        "//testgrid/util/gcs:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/fsouza/fake-gcs-server/fakestorage:go_default_library",
+        "//vendor/github.com/joshdk/go-junit:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/google.golang.org/api/iterator:go_default_library",
+    ],
 )

--- a/prow/spyglass/artifactfetchers.go
+++ b/prow/spyglass/artifactfetchers.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"errors"
+
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+var (
+	// ErrCannotParseSource is thrown when an invalid source string is provided to an ArtifactFetcher
+	ErrCannotParseSource = errors.New("could not create job source from provided source")
+)
+
+// jobSource gets information about a location storing the results of a single Prow job
+type jobSource interface {
+	// CanonicalLink returns a link to the storage location of this job's artifacts.
+	canonicalLink() string
+	// JobPath returns the common prefix of all artifacts produced by this job
+	jobPath() string
+}
+
+// ArtifactFetcher gets all information necessary to perform IO operations on artifacts from a storage provider
+type ArtifactFetcher interface {
+	// Lists the names of all artifacts associated with this job source.
+	// If treating the source as a directory structure, names of artifacts should be returned
+	// with the job path prefix removed.
+	// (e.g. return names of the format artifacts/junit_01.xml instead of
+	// logs/ci-example-run/1456/artifacts/junit_01.xml)
+	artifacts(src jobSource) []string
+	// Artifact constructs and returns an artifact object ready for read operations from the
+	// job source and artifact name.
+	artifact(src jobSource, name string, sizeLimit int64) viewers.Artifact
+	// createJobSource tries to create a usable job source from the provided source string for this fetcher
+	createJobSource(src string) (jobSource, error)
+}

--- a/prow/spyglass/gcsartifact.go
+++ b/prow/spyglass/gcsartifact.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+// GCSArtifact represents some output of a prow job stored in GCS
+type GCSArtifact struct {
+	// The handle of the object in GCS
+	handle artifactHandle
+
+	// The link to the Artifact in GCS
+	link string
+
+	// The path of the Artifact within the job
+	path string
+
+	// sizeLimit is the max size to read before failing
+	sizeLimit int64
+
+	// ctx provides context for cancellation and timeout. Embedded in struct to preserve
+	// conformance with io.ReaderAt
+	ctx context.Context
+}
+
+type artifactHandle interface {
+	Attrs(ctx context.Context) (*storage.ObjectAttrs, error)
+	NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error)
+	NewReader(ctx context.Context) (io.ReadCloser, error)
+}
+
+// NewGCSArtifact returns a new GCSArtifact with a given handle, canonical link, and path within the job
+func NewGCSArtifact(ctx context.Context, handle artifactHandle, link string, path string, sizeLimit int64) *GCSArtifact {
+	return &GCSArtifact{
+		handle:    handle,
+		link:      link,
+		path:      path,
+		sizeLimit: sizeLimit,
+		ctx:       ctx,
+	}
+}
+
+func fieldsFor(a *GCSArtifact) logrus.Fields {
+	return logrus.Fields{
+		"artifact": a.path,
+	}
+}
+
+// Size returns the size of the artifact in GCS
+func (a *GCSArtifact) Size() (int64, error) {
+	attrs, err := a.handle.Attrs(a.ctx)
+	if err != nil {
+		return 0, fmt.Errorf("error getting gcs attributes for artifact: %v", err)
+	}
+	return attrs.Size, nil
+}
+
+// JobPath gets the GCS path of the artifact within the current job
+func (a *GCSArtifact) JobPath() string {
+	return a.path
+}
+
+// CanonicalLink gets the GCS web address of the artifact
+func (a *GCSArtifact) CanonicalLink() string {
+	return a.link
+}
+
+// ReadAt reads len(p) bytes from a file in GCS at offset off
+func (a *GCSArtifact) ReadAt(p []byte, off int64) (n int, err error) {
+	gzipped, err := a.gzipped()
+	if err != nil {
+		return 0, fmt.Errorf("error checking artifact for gzip compression: %v", err)
+	}
+	if gzipped {
+		return 0, viewers.ErrGzipOffsetRead
+	}
+	artifactSize, err := a.Size()
+	if err != nil {
+		return 0, fmt.Errorf("error getting artifact size: %v", err)
+	}
+	if off >= artifactSize {
+		return 0, fmt.Errorf("offset must be less than artifact size")
+	}
+	var gotEOF bool
+	toRead := int64(len(p))
+	if toRead+off > artifactSize {
+		return 0, fmt.Errorf("read range exceeds artifact contents")
+	} else if toRead+off == artifactSize {
+		gotEOF = true
+	}
+	reader, err := a.handle.NewRangeReader(a.ctx, off, toRead)
+	defer reader.Close()
+	if err != nil {
+		return 0, fmt.Errorf("error getting artifact reader: %v", err)
+	}
+	n, err = reader.Read(p)
+	if err != nil {
+		return 0, fmt.Errorf("error reading from artifact: %v", err)
+	}
+	if gotEOF {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// ReadAtMost reads at most n bytes from a file in GCS. If the file is compressed (gzip) in GCS, n bytes
+// of gzipped content will be downloaded and decompressed into potentially GREATER than n bytes of content.
+func (a *GCSArtifact) ReadAtMost(n int64) ([]byte, error) {
+	var reader io.ReadCloser
+	var p []byte
+	gzipped, err := a.gzipped()
+	if err != nil {
+		return nil, fmt.Errorf("error checking artifact for gzip compression: %v", err)
+	}
+	if gzipped {
+		reader, err = a.handle.NewReader(a.ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting artifact reader: %v", err)
+		}
+		reader, err = gzip.NewReader(reader)
+		if err != nil {
+			return nil, fmt.Errorf("error getting gzip reader: %v", err)
+		}
+		defer reader.Close()
+		p, err = ioutil.ReadAll(reader) // Must readall for gzipped files
+		if err != nil {
+			return nil, fmt.Errorf("error reading all from artifact: %v", err)
+		}
+		artifactSize := int64(len(p))
+		readRange := n
+		if n > artifactSize {
+			readRange = artifactSize
+			return p[:readRange], io.EOF
+		}
+		return p[:readRange], nil
+
+	}
+	artifactSize, err := a.Size()
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact size: %v", err)
+	}
+	readRange := n
+	var gotEOF bool
+	if n > artifactSize {
+		gotEOF = true
+		readRange = artifactSize
+	}
+	reader, err = a.handle.NewRangeReader(a.ctx, 0, readRange)
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact reader: %v", err)
+	}
+	defer reader.Close()
+	p, err = ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("error reading all from artifact: %v", err)
+	}
+	if gotEOF {
+		return p, io.EOF
+	}
+	return p, nil
+}
+
+// ReadAll will either read the entire file or throw an error if file size is too big
+func (a *GCSArtifact) ReadAll() ([]byte, error) {
+	size, err := a.Size()
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact size: %v", err)
+	}
+	if size > a.sizeLimit {
+		return nil, viewers.ErrFileTooLarge
+	}
+	reader, err := a.handle.NewReader(a.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact reader: %v", err)
+	}
+	defer reader.Close()
+	p, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("error reading all from artifact: %v", err)
+	}
+	return p, nil
+}
+
+// ReadTail reads the last n bytes from a file in GCS
+func (a *GCSArtifact) ReadTail(n int64) ([]byte, error) {
+	gzipped, err := a.gzipped()
+	if err != nil {
+		return nil, fmt.Errorf("error checking artifact for gzip compression: %v", err)
+	}
+	if gzipped {
+		return nil, viewers.ErrGzipOffsetRead
+	}
+	size, err := a.Size()
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact size: %v", err)
+	}
+	var offset int64
+	if n >= size {
+		offset = 0
+	} else {
+		offset = size - n
+	}
+	reader, err := a.handle.NewRangeReader(a.ctx, offset, -1)
+	defer reader.Close()
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("error getting artifact reader: %v", err)
+	}
+	read, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("error reading all from artiact: %v", err)
+	}
+	return read, nil
+}
+
+// gzipped returns whether the file is gzip-encoded in GCS
+func (a *GCSArtifact) gzipped() (bool, error) {
+	attrs, err := a.handle.Attrs(a.ctx)
+	if err != nil {
+		return false, fmt.Errorf("error getting gcs attributes for artifact: %v", err)
+	}
+	return attrs.ContentEncoding == "gzip", nil
+}

--- a/prow/spyglass/gcsartifact_fetcher.go
+++ b/prow/spyglass/gcsartifact_fetcher.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+
+	"k8s.io/test-infra/prow/spyglass/viewers"
+	"k8s.io/test-infra/testgrid/util/gcs"
+)
+
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+)
+
+// GCSArtifactFetcher contains information used for fetching artifacts from GCS
+type GCSArtifactFetcher struct {
+	client *storage.Client
+}
+
+// gcsJobSource is a location in GCS where Prow job-specific artifacts are stored. This implementation assumes
+// Prow's native GCS upload format (treating GCS keys as a directory structure), and is not
+// intended to support arbitrary GCS bucket upload formats.
+type gcsJobSource struct {
+	source     string
+	linkPrefix string
+	bucket     string
+	jobPrefix  string
+	jobName    string
+	buildID    string
+}
+
+// NewGCSArtifactFetcher creates a new ArtifactFetcher with a real GCS Client
+func NewGCSArtifactFetcher(c *storage.Client) *GCSArtifactFetcher {
+	return &GCSArtifactFetcher{
+		client: c,
+	}
+}
+
+func fieldsForJob(src jobSource) logrus.Fields {
+	return logrus.Fields{
+		"jobPrefix": src.jobPath(),
+	}
+}
+
+// newGCSJobSource creates a new gcsJobSource from a given bucket and jobPrefix
+func newGCSJobSource(src string) (*gcsJobSource, error) {
+	gcsURL, err := url.Parse(src)
+	if err != nil {
+		return &gcsJobSource{}, ErrCannotParseSource
+	}
+	gcsPath := &gcs.Path{}
+	err = gcsPath.SetURL(gcsURL)
+	if err != nil {
+		return &gcsJobSource{}, ErrCannotParseSource
+	}
+
+	tokens := strings.FieldsFunc(gcsPath.Object(), func(c rune) bool { return c == '/' })
+	if len(tokens) < 2 {
+		return &gcsJobSource{}, ErrCannotParseSource
+	}
+	buildID := tokens[len(tokens)-1]
+	name := tokens[len(tokens)-2]
+	return &gcsJobSource{
+		source:     src,
+		linkPrefix: "gs://",
+		bucket:     gcsPath.Bucket(),
+		jobPrefix:  gcsPath.Object() + "/",
+		jobName:    name,
+		buildID:    buildID,
+	}, nil
+}
+
+// Artifacts lists all artifacts available for the given job source
+func (af *GCSArtifactFetcher) artifacts(src jobSource) []string {
+	listStart := time.Now()
+	bucketName, prefix := extractBucketPrefixPair(src.jobPath())
+	artifacts := []string{}
+	bkt := af.client.Bucket(bucketName)
+	q := storage.Query{
+		Prefix:   prefix,
+		Versions: false,
+	}
+	objIter := bkt.Objects(context.Background(), &q)
+	for {
+		oAttrs, err := objIter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			logrus.WithFields(fieldsForJob(src)).WithError(err).Error("Error accessing GCS artifact.")
+			continue
+		}
+		artifacts = append(artifacts, strings.TrimPrefix(oAttrs.Name, prefix))
+
+	}
+	listElapsed := time.Since(listStart)
+	logrus.WithField("duration", listElapsed).Infof("Listed %d artifacts.", len(artifacts))
+	return artifacts
+}
+
+type gcsArtifactHandle struct {
+	*storage.ObjectHandle
+}
+
+func (h *gcsArtifactHandle) NewReader(ctx context.Context) (io.ReadCloser, error) {
+	return h.ObjectHandle.NewReader(ctx)
+}
+
+func (h *gcsArtifactHandle) NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error) {
+	return h.ObjectHandle.NewRangeReader(ctx, offset, length)
+}
+
+// Artifact contructs a GCS artifact from the given GCS bucket and key. Uses the golang GCS library
+// to get read handles. If the artifactName is not a valid key in the bucket a handle will still be
+// constructed and returned, but all read operations will fail (dictated by behavior of golang GCS lib).
+func (af *GCSArtifactFetcher) artifact(src jobSource, artifactName string, sizeLimit int64) viewers.Artifact {
+	bucketName, prefix := extractBucketPrefixPair(src.jobPath())
+	bkt := af.client.Bucket(bucketName)
+	obj := &gcsArtifactHandle{bkt.Object(path.Join(prefix, artifactName))}
+	artifactLink := &url.URL{
+		Scheme: httpsScheme,
+		Host:   "storage.googleapis.com",
+		Path:   path.Join(src.jobPath(), artifactName),
+	}
+	return NewGCSArtifact(context.Background(), obj, artifactLink.String(), artifactName, sizeLimit)
+}
+
+func extractBucketPrefixPair(gcsPath string) (string, string) {
+	split := strings.SplitN(gcsPath, "/", 2)
+	return split[0], split[1]
+}
+
+// createJobSource tries to create a GCS job source from the provided string
+func (af *GCSArtifactFetcher) createJobSource(src string) (jobSource, error) {
+	jobSource, err := newGCSJobSource(src)
+	if err != nil {
+		return &gcsJobSource{}, err
+	}
+	return jobSource, nil
+}
+
+// CanonicalLink gets a link to the location of job-specific artifacts in GCS
+func (src *gcsJobSource) canonicalLink() string {
+	return path.Join(src.linkPrefix, src.bucket, src.jobPrefix)
+}
+
+// JobPath gets the prefix to all artifacts in GCS in the job
+func (src *gcsJobSource) jobPath() string {
+	return fmt.Sprintf("%s/%s", src.bucket, src.jobPrefix)
+}

--- a/prow/spyglass/gcsartifact_fetcher_test.go
+++ b/prow/spyglass/gcsartifact_fetcher_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"testing"
+)
+
+func TestNewGCSJobSource(t *testing.T) {
+	testCases := []struct {
+		name        string
+		src         string
+		exJobPrefix string
+		exBucket    string
+		exName      string
+		exBuildID   string
+		expectedErr error
+	}{
+		{
+			name:        "Test standard GCS link",
+			src:         "gs://test-bucket/logs/example-ci-run/403",
+			exBucket:    "test-bucket",
+			exJobPrefix: "logs/example-ci-rin/403",
+			exName:      "example-ci-run",
+			exBuildID:   "403",
+			expectedErr: nil,
+		},
+		{
+			name:        "Test GCS link with trailing /",
+			src:         "gs://test-bucket/logs/example-ci-run/403/",
+			exBucket:    "test-bucket",
+			exJobPrefix: "logs/example-ci-rin/403",
+			exName:      "example-ci-run",
+			exBuildID:   "403",
+			expectedErr: nil,
+		},
+		{
+			name:        "Test GCS link with org name",
+			src:         "gs://test-bucket/logs/sig-flexing/example-ci-run/403",
+			exBucket:    "test-bucket",
+			exJobPrefix: "logs/example-ci-rin/403",
+			exName:      "example-ci-run",
+			exBuildID:   "403",
+			expectedErr: nil,
+		},
+		{
+			name:        "Test invalid GCS link",
+			src:         "garbage/test-bucket/logs/sig-flexing/example-ci-run/403",
+			expectedErr: ErrCannotParseSource,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jobSource, err := newGCSJobSource(tc.src)
+			if err != nil && err != tc.expectedErr {
+				t.Errorf("Expected err: %v, got err: %v", err, tc.expectedErr)
+			}
+			if tc.exBucket != jobSource.bucket {
+				t.Errorf("Expected bucket %s, got %s", tc.exBucket, jobSource.bucket)
+			}
+			if tc.exName != jobSource.jobName {
+				t.Errorf("Expected name %s, got %s", tc.exName, jobSource.jobName)
+			}
+			if tc.exName != jobSource.jobName {
+				t.Errorf("Expected name %s, got %s", tc.exName, jobSource.jobName)
+			}
+		})
+	}
+}
+
+// Tests listing objects associated with the current job in GCS
+func TestArtifacts_ListGCS(t *testing.T) {
+	fakeGCSClient := fakeGCSServer.Client()
+	testAf := NewGCSArtifactFetcher(fakeGCSClient)
+	testCases := []struct {
+		name              string
+		handle            artifactHandle
+		source            string
+		expectedArtifacts []string
+	}{
+		{
+			name:   "Test ArtifactFetcher simple list artifacts",
+			source: "gs://test-bucket/logs/example-ci-run/403",
+			expectedArtifacts: []string{
+				"build-log.txt",
+				"started.json",
+				"finished.json",
+				"junit_01.xml",
+				"long-log.txt",
+			},
+		},
+		{
+			name:              "Test ArtifactFetcher list artifacts on source with no artifacts",
+			source:            "gs://test-bucket/logs/example-ci/404",
+			expectedArtifacts: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		jobSrc, err := testAf.createJobSource(tc.source)
+		if err != nil {
+			t.Fatalf("%s failed to create job source for source: %s", tc.name, tc.source)
+		}
+		actualArtifacts := testAf.artifacts(jobSrc)
+		for _, ea := range tc.expectedArtifacts {
+			found := false
+			for _, aa := range actualArtifacts {
+				if ea == aa {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Case %s failed to retrieve the following artifact: %s\nRetrieved: %s.", tc.name, ea, actualArtifacts)
+			}
+
+		}
+		if len(tc.expectedArtifacts) != len(actualArtifacts) {
+			t.Errorf("Case %s produced more artifacts than expected. Expected: %s\nActual: %s.", tc.name, tc.expectedArtifacts, actualArtifacts)
+		}
+	}
+}
+
+// Tests getting handles to objects associated with the current job in GCS
+func TestFetchArtifacts_GCS(t *testing.T) {
+	fakeGCSClient := fakeGCSServer.Client()
+	testAf := NewGCSArtifactFetcher(fakeGCSClient)
+	maxSize := int64(500e6)
+	testCases := []struct {
+		name         string
+		artifactName string
+		source       string
+		expectedSize int64
+		expectErr    bool
+	}{
+		{
+			name:         "Fetch build-log.txt from valid source",
+			artifactName: "build-log.txt",
+			source:       "gs://test-bucket/logs/example-ci-run/403",
+			expectedSize: 25,
+		},
+		{
+			name:         "Fetch build-log.txt from invalid source",
+			artifactName: "build-log.txt",
+			source:       "gs://test-bucket/logs/example-ci-run/404",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		jobSrc, err := testAf.createJobSource(tc.source)
+		if err != nil {
+			t.Fatalf("%s failed to create job source from source %s", tc.name, tc.source)
+		}
+		artifact := testAf.artifact(jobSrc, tc.artifactName, maxSize)
+		size, err := artifact.Size()
+		if err != nil && !tc.expectErr {
+			t.Fatalf("%s failed getting size for artifact %s, err: %v", tc.name, artifact.JobPath(), err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s expected error, got no error", tc.name)
+		}
+
+		if size != tc.expectedSize {
+			t.Errorf("%s expected artifact with size %d but got %d", tc.name, tc.expectedSize, size)
+		}
+	}
+}

--- a/prow/spyglass/gcsartifact_test.go
+++ b/prow/spyglass/gcsartifact_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"cloud.google.com/go/storage"
+)
+
+type ByteReadCloser struct {
+	io.Reader
+}
+
+func (rc *ByteReadCloser) Close() error {
+	return nil
+}
+
+func (rc *ByteReadCloser) Read(p []byte) (int, error) {
+	read, err := rc.Reader.Read(p)
+	if err != nil {
+		return 0, err
+	}
+	if bytes.Equal(p[:read], []byte("deeper unreadable contents")) {
+		return 0, fmt.Errorf("it's just turtes all the way down")
+	}
+	return read, nil
+}
+
+type fakeArtifactHandle struct {
+	oAttrs   *storage.ObjectAttrs
+	contents []byte
+}
+
+func (h *fakeArtifactHandle) Attrs(ctx context.Context) (*storage.ObjectAttrs, error) {
+	if bytes.Equal(h.contents, []byte("no attrs")) {
+		return nil, fmt.Errorf("error getting attrs")
+	}
+	return h.oAttrs, nil
+}
+
+func (h *fakeArtifactHandle) NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error) {
+	if bytes.Equal(h.contents, []byte("unreadable contents")) {
+		return nil, fmt.Errorf("cannot read unreadable contents")
+	}
+	lenContents := int64(len(h.contents))
+	var err error
+	var toRead int64
+	if length < 0 {
+		toRead = lenContents - offset
+		err = io.EOF
+	} else {
+		toRead = length
+		if offset+length > lenContents {
+			toRead = lenContents - offset
+			err = io.EOF
+		}
+	}
+	return &ByteReadCloser{bytes.NewReader(h.contents[offset : offset+toRead])}, err
+}
+
+func (h *fakeArtifactHandle) NewReader(ctx context.Context) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte("unreadable contents"))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to gzip log text, err: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("Failed to close gzip writer, err: %v", err)
+	}
+	if bytes.Equal(h.contents, buf.Bytes()) {
+		return nil, fmt.Errorf("cannot read unreadable contents, even if theyre gzipped")
+	}
+	if bytes.Equal(h.contents, []byte("unreadable contents")) {
+		return nil, fmt.Errorf("cannot read unreadable contents")
+	}
+	return &ByteReadCloser{bytes.NewReader(h.contents)}, nil
+}
+
+// Tests reading the tail n bytes of data from an artifact
+func TestReadTail(t *testing.T) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte("Oh wow\nlogs\nthis is\ncrazy"))
+	if err != nil {
+		t.Fatalf("Failed to gzip log text, err: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer, err: %v", err)
+	}
+	gzippedLog := buf.Bytes()
+	testCases := []struct {
+		name      string
+		n         int64
+		contents  []byte
+		encoding  string
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:      "ReadTail example build log",
+			n:         4,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("razy"),
+			expectErr: false,
+		},
+		{
+			name:      "ReadTail build log, gzipped",
+			n:         23,
+			contents:  gzippedLog,
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadTail build log, claimed gzipped but not actually gzipped",
+			n:         2333,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadTail N>size of build log",
+			n:         2222,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expectErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		artifact := NewGCSArtifact(context.Background(), &fakeArtifactHandle{
+			contents: tc.contents,
+			oAttrs: &storage.ObjectAttrs{
+				Bucket:          "foo-bucket",
+				Name:            "build-log.txt",
+				Size:            int64(len(tc.contents)),
+				ContentEncoding: tc.encoding,
+			},
+		}, "", "build-log.txt", 500e6)
+		actualBytes, err := artifact.ReadTail(tc.n)
+		if err != nil && !tc.expectErr {
+			t.Fatalf("Test %s failed with err: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("Test %s did not produce error when expected", tc.name)
+		}
+		if !bytes.Equal(actualBytes, tc.expected) {
+			t.Errorf("Test %s failed.\nExpected: %s\nActual: %s", tc.name, tc.expected, actualBytes)
+		}
+	}
+}
+
+// Tests reading at most n bytes of data from files in GCS
+func TestReadAtMost(t *testing.T) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte("Oh wow\nlogs\nthis is\ncrazy"))
+	if err != nil {
+		t.Fatalf("Failed to gzip log text, err: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer, err: %v", err)
+	}
+	gzippedLog := buf.Bytes()
+	var noReadBuf bytes.Buffer
+	zw = gzip.NewWriter(&noReadBuf)
+	_, err = zw.Write([]byte("unreadable contents"))
+	if err != nil {
+		t.Fatalf("Failed to gzip unreadable text, err: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer, err: %v", err)
+	}
+	noReadGzipped := noReadBuf.Bytes()
+	testCases := []struct {
+		name      string
+		n         int64
+		contents  []byte
+		encoding  string
+		expected  []byte
+		expectErr bool
+		expectEOF bool
+	}{
+		{
+			name:      "ReadAtMost example build log",
+			n:         4,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("Oh w"),
+			expectErr: false,
+		},
+		{
+			name:      "ReadAtMost build log, gzipped",
+			n:         23,
+			contents:  gzippedLog,
+			encoding:  "gzip",
+			expected:  []byte("Oh wow\nlogs\nthis is\ncra"),
+			expectErr: false,
+		},
+		{
+			name:      "ReadAtMost build log, claimed gzipped but not actually gzipped",
+			n:         2333,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadAtMost unreadable gzipped contents",
+			n:         2,
+			contents:  noReadGzipped,
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadAtMost unreadable contents",
+			n:         2,
+			contents:  []byte("unreadable contents"),
+			expectErr: true,
+		},
+		{
+			name:      "ReadAtMost unreadable contents",
+			n:         45,
+			contents:  []byte("deeper unreadable contents"),
+			expectErr: true,
+		},
+		{
+			name:      "ReadAtMost N>size of build log",
+			n:         2222,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expectErr: true,
+			expectEOF: true,
+		},
+		{
+			name:      "ReadAtMost N>size of build log, gzipped",
+			n:         2222,
+			contents:  gzippedLog,
+			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			encoding:  "gzip",
+			expectErr: true,
+			expectEOF: true,
+		},
+	}
+	for _, tc := range testCases {
+		artifact := NewGCSArtifact(context.Background(), &fakeArtifactHandle{
+			contents: tc.contents,
+			oAttrs: &storage.ObjectAttrs{
+				Bucket:          "foo-bucket",
+				Name:            "build-log.txt",
+				Size:            int64(len(tc.contents)),
+				ContentEncoding: tc.encoding,
+			},
+		}, "", "build-log.txt", 500e6)
+		actualBytes, err := artifact.ReadAtMost(tc.n)
+		if err != nil && !tc.expectErr {
+			if tc.expectEOF && err != io.EOF {
+				t.Fatalf("Test %s failed with err: %v, expected EOF", tc.name, err)
+			}
+			t.Fatalf("Test %s failed with err: %v", tc.name, err)
+		}
+		if err != nil && tc.expectEOF && err != io.EOF {
+			t.Fatalf("Test %s failed with err: %v, expected EOF", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("Test %s did not produce error when expected", tc.name)
+		}
+		if !bytes.Equal(actualBytes, tc.expected) {
+			t.Errorf("Test %s failed.\nExpected: %s\nActual: %s", tc.name, tc.expected, actualBytes)
+		}
+	}
+}
+
+// Tests reading at offset from files in GCS
+func TestReadAt(t *testing.T) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte("Oh wow\nlogs\nthis is\ncrazy"))
+	if err != nil {
+		t.Fatalf("Failed to gzip log text, err: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer, err: %v", err)
+	}
+	gzippedLog := buf.Bytes()
+	testCases := []struct {
+		name      string
+		n         int64
+		offset    int64
+		contents  []byte
+		encoding  string
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:      "ReadAt example build log",
+			n:         4,
+			offset:    6,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("\nlog"),
+			expectErr: false,
+		},
+		{
+			name:      "ReadAt offest past file size",
+			n:         4,
+			offset:    400,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expectErr: true,
+		},
+		{
+			name:      "ReadAt build log, gzipped",
+			n:         23,
+			contents:  gzippedLog,
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadAt, claimed gzipped but not actually gzipped",
+			n:         2333,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			encoding:  "gzip",
+			expectErr: true,
+		},
+		{
+			name:      "ReadAt offset negative",
+			offset:    -3,
+			n:         32,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		artifact := NewGCSArtifact(context.Background(), &fakeArtifactHandle{
+			contents: tc.contents,
+			oAttrs: &storage.ObjectAttrs{
+				Bucket:          "foo-bucket",
+				Name:            "build-log.txt",
+				Size:            int64(len(tc.contents)),
+				ContentEncoding: tc.encoding,
+			},
+		}, "", "build-log.txt", 500e6)
+		p := make([]byte, tc.n)
+		bytesRead, err := artifact.ReadAt(p, tc.offset)
+		if err != nil && !tc.expectErr {
+			t.Fatalf("Test %s failed with err: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("Test %s did not produce error when expected", tc.name)
+		}
+		readBytes := p[:bytesRead]
+		if !bytes.Equal(readBytes, tc.expected) {
+			t.Errorf("Test %s failed.\nExpected: %s\nActual: %s", tc.name, tc.expected, readBytes)
+		}
+	}
+
+}
+
+// Tests reading all data from files in GCS
+func TestReadAll(t *testing.T) {
+	testCases := []struct {
+		name      string
+		sizeLimit int64
+		contents  []byte
+		expectErr bool
+		expected  []byte
+	}{
+		{
+			name:      "ReadAll example build log",
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			sizeLimit: 500e6,
+			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+		},
+		{
+			name:      "ReadAll example too large build log",
+			sizeLimit: 20,
+			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expectErr: true,
+			expected:  nil,
+		},
+		{
+			name:      "ReadAll unable to get reader",
+			sizeLimit: 500e6,
+			contents:  []byte("unreadable contents"),
+			expectErr: true,
+			expected:  nil,
+		},
+		{
+			name:      "ReadAll unable to read contents",
+			sizeLimit: 500e6,
+			contents:  []byte("deeper unreadable contents"),
+			expectErr: true,
+			expected:  nil,
+		},
+	}
+	for _, tc := range testCases {
+		artifact := NewGCSArtifact(context.Background(), &fakeArtifactHandle{
+			contents: tc.contents,
+			oAttrs: &storage.ObjectAttrs{
+				Bucket: "foo-bucket",
+				Name:   "build-log.txt",
+				Size:   int64(len(tc.contents)),
+			},
+		}, "", "build-log.txt", tc.sizeLimit)
+
+		actualBytes, err := artifact.ReadAll()
+		if err != nil && !tc.expectErr {
+			t.Fatalf("Test %s failed with err: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("Test %s did not produce error when expected", tc.name)
+		}
+		if !bytes.Equal(actualBytes, tc.expected) {
+			t.Errorf("Test %s failed.\nExpected: %s\nActual: %s", tc.name, tc.expected, actualBytes)
+		}
+	}
+}
+
+func TestSize_GCS(t *testing.T) {
+	fakeGCSClient := fakeGCSServer.Client()
+	fakeGCSBucket := fakeGCSClient.Bucket("test-bucket")
+	startedContent := []byte("hi jason, im started")
+	testCases := []struct {
+		name      string
+		handle    artifactHandle
+		expected  int64
+		expectErr bool
+	}{
+		{
+			name: "Test size simple",
+			handle: &fakeArtifactHandle{
+				contents: startedContent,
+				oAttrs: &storage.ObjectAttrs{
+					Bucket: "foo-bucket",
+					Name:   "started.json",
+					Size:   int64(len(startedContent)),
+				},
+			},
+			expected:  int64(len(startedContent)),
+			expectErr: false,
+		},
+		{
+			name: "Test size from attrs error",
+			handle: &fakeArtifactHandle{
+				contents: []byte("no attrs"),
+				oAttrs: &storage.ObjectAttrs{
+					Bucket: "foo-bucket",
+					Name:   "started.json",
+					Size:   8,
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "Size of nonexistentArtifact",
+			handle:    &gcsArtifactHandle{fakeGCSBucket.Object("logs/example-ci-run/404/started.json")},
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		artifact := NewGCSArtifact(context.Background(), tc.handle, "", "started.json", 500e6)
+		actual, err := artifact.Size()
+		if err != nil && !tc.expectErr {
+			t.Fatalf("%s failed getting size for artifact %s, err: %v", tc.name, artifact.JobPath(), err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s did not produce error when error was expected.", tc.name)
+		}
+		if tc.expected != actual {
+			t.Errorf("Test %s failed.\nExpected:\n%d\nActual:\n%d", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/prow/spyglass/podlogartifact.go
+++ b/prow/spyglass/podlogartifact.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+type podLogJobAgent interface {
+	GetJobLog(job string, id string) ([]byte, error)
+	GetJobLogTail(job string, id string, n int64) ([]byte, error)
+}
+
+// PodLogArtifact holds data for reading from a specific pod log
+type PodLogArtifact struct {
+	name      string
+	buildID   string
+	podName   string
+	sizeLimit int64
+	ja        podLogJobAgent
+}
+
+var (
+	errInsufficientJobInfo = errors.New("insufficient job information provided")
+	errInvalidSizeLimit    = errors.New("sizeLimit must be a 64-bit integer greater than 0")
+)
+
+// NewPodLogArtifact creates a new PodLogArtifact
+func NewPodLogArtifact(jobName string, buildID string, podName string, sizeLimit int64, ja podLogJobAgent) (*PodLogArtifact, error) {
+	if jobName == "" {
+		return nil, errInsufficientJobInfo
+	}
+	if buildID == "" {
+		return nil, errInsufficientJobInfo
+	}
+	if sizeLimit < 0 {
+		return nil, errInvalidSizeLimit
+	}
+	return &PodLogArtifact{
+		name:      jobName,
+		buildID:   buildID,
+		podName:   podName,
+		sizeLimit: sizeLimit,
+		ja:        ja,
+	}, nil
+}
+
+// CanonicalLink returns a link to where pod logs are streamed
+func (a *PodLogArtifact) CanonicalLink() string {
+	q := url.Values{
+		"job": []string{a.name},
+		"id":  []string{a.buildID},
+	}
+	u := url.URL{
+		Path:     "/log",
+		RawQuery: q.Encode(),
+	}
+	return u.String()
+}
+
+// JobPath gets the path within the job for the pod log. Always returns build-log.txt.
+// This is because the pod log becomes the build log after the job artifact uploads
+// are complete, which should be used instead of the pod log.
+func (a *PodLogArtifact) JobPath() string {
+	return "build-log.txt"
+}
+
+// ReadAt implements reading a range of bytes from the pod logs endpoint
+func (a *PodLogArtifact) ReadAt(p []byte, off int64) (n int, err error) {
+	logs, err := a.ja.GetJobLog(a.name, a.buildID)
+	if err != nil {
+		return 0, fmt.Errorf("error getting pod log: %v", err)
+	}
+	r := bytes.NewReader(logs)
+	readBytes, err := r.ReadAt(p, off)
+	if err == io.EOF {
+		return readBytes, io.EOF
+	}
+	if err != nil {
+		return 0, fmt.Errorf("error reading pod logs: %v", err)
+	}
+	return readBytes, nil
+}
+
+// ReadAll reads all available pod logs, failing if they are too large
+func (a *PodLogArtifact) ReadAll() ([]byte, error) {
+	size, err := a.Size()
+	if err != nil {
+		return nil, fmt.Errorf("error getting pod log size: %v", err)
+	}
+	if size > a.sizeLimit {
+		return nil, viewers.ErrFileTooLarge
+	}
+	logs, err := a.ja.GetJobLog(a.name, a.buildID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pod log: %v", err)
+	}
+	return logs, nil
+}
+
+// ReadAtMost reads at most n bytes
+func (a *PodLogArtifact) ReadAtMost(n int64) ([]byte, error) {
+	logs, err := a.ja.GetJobLog(a.name, a.buildID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pod log: %v", err)
+	}
+	reader := bytes.NewReader(logs)
+	var byteCount int64
+	var p []byte
+	for byteCount < n {
+		b, err := reader.ReadByte()
+		if err == io.EOF {
+			return p, io.EOF
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error reading pod log: %v", err)
+		}
+		p = append(p, b)
+		byteCount++
+	}
+	return p, nil
+}
+
+// ReadTail reads the last n bytes of the pod log
+func (a *PodLogArtifact) ReadTail(n int64) ([]byte, error) {
+	logs, err := a.ja.GetJobLogTail(a.name, a.buildID, n)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pod log tail: %v", err)
+	}
+	size := int64(len(logs))
+	var off int64
+	if n > size {
+		off = 0
+	} else {
+		off = size - n
+	}
+	p := make([]byte, n)
+	readBytes, err := bytes.NewReader(logs).ReadAt(p, off)
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("error reading pod log tail: %v", err)
+	}
+	return p[:readBytes], nil
+}
+
+// Size gets the size of the pod log. Note: this function makes the same network call as reading the entire file.
+func (a *PodLogArtifact) Size() (int64, error) {
+	logs, err := a.ja.GetJobLog(a.name, a.buildID)
+	if err != nil {
+		return 0, fmt.Errorf("error getting size of pod log: %v", err)
+	}
+	return int64(len(logs)), nil
+
+}
+
+// isProwJobSource returns true if the provided string is a valid Prowjob source and false otherwise
+func isProwJobSource(src string) bool {
+	return strings.HasPrefix(src, "prowjob/")
+}

--- a/prow/spyglass/podlogartifact_test.go
+++ b/prow/spyglass/podlogartifact_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+// fakePodLogJAgent used for pod log artifact dependency injection
+type fakePodLogJAgent struct {
+}
+
+func (j *fakePodLogJAgent) GetJobLog(job, id string) ([]byte, error) {
+	if job == "BFG" && id == "435" {
+		return []byte("frobscottle"), nil
+	} else if job == "Fantastic Mr. Fox" && id == "4" {
+		return []byte("a hundred smoked hams and fifty sides of bacon"), nil
+	}
+	return nil, fmt.Errorf("could not find job %s, id %s", job, id)
+}
+
+func (j *fakePodLogJAgent) GetJobLogTail(job, id string, n int64) ([]byte, error) {
+	log, err := j.GetJobLog(job, id)
+	if err != nil {
+		return nil, fmt.Errorf("error getting log tail: %v", err)
+	}
+	logLen := int64(len(log))
+	if n > logLen {
+		return log, nil
+	}
+	return log[logLen-n:], nil
+
+}
+
+func TestNewPodLogArtifact(t *testing.T) {
+	testCases := []struct {
+		name         string
+		jobName      string
+		buildID      string
+		podName      string
+		sizeLimit    int64
+		expectedErr  error
+		expectedLink string
+	}{
+		{
+			name:         "Create pod log with valid fields",
+			jobName:      "job",
+			buildID:      "123",
+			podName:      "",
+			sizeLimit:    500e6,
+			expectedErr:  nil,
+			expectedLink: "/log?id=123&job=job",
+		},
+		{
+			name:         "Create pod log with no jobName",
+			jobName:      "",
+			buildID:      "123",
+			podName:      "",
+			sizeLimit:    500e6,
+			expectedErr:  errInsufficientJobInfo,
+			expectedLink: "",
+		},
+		{
+			name:         "Create pod log with no buildID",
+			jobName:      "job",
+			buildID:      "",
+			podName:      "",
+			sizeLimit:    500e6,
+			expectedErr:  errInsufficientJobInfo,
+			expectedLink: "",
+		},
+		{
+			name:         "Create pod log with negative sizeLimit",
+			jobName:      "job",
+			buildID:      "123",
+			podName:      "",
+			sizeLimit:    -4,
+			expectedErr:  errInvalidSizeLimit,
+			expectedLink: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := NewPodLogArtifact(tc.jobName, tc.buildID, tc.podName, tc.sizeLimit, &fakePodLogJAgent{})
+			if err != nil {
+				if err != tc.expectedErr {
+					t.Fatalf("failed creating artifact. err: %v", err)
+				}
+				return
+			}
+			link := artifact.CanonicalLink()
+			if link != tc.expectedLink {
+				t.Errorf("Unexpected link, expected %s, got %q", tc.expectedLink, link)
+			}
+		})
+	}
+}
+
+func TestReadTail_PodLog(t *testing.T) {
+	testCases := []struct {
+		name      string
+		jobName   string
+		buildID   string
+		artifact  *PodLogArtifact
+		n         int64
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:     "Podlog ReadTail longer than contents",
+			jobName:  "BFG",
+			buildID:  "435",
+			n:        50,
+			expected: []byte("frobscottle"),
+		},
+		{
+			name:     "Podlog ReadTail shorter than contents",
+			jobName:  "Fantastic Mr. Fox",
+			buildID:  "4",
+			n:        3,
+			expected: []byte("con"),
+		},
+		{
+			name:      "Podlog ReadTail nonexistent pod",
+			jobName:   "Fax",
+			buildID:   "4",
+			n:         3,
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := NewPodLogArtifact(tc.jobName, tc.buildID, "", 500e6, &fakePodLogJAgent{})
+			if err != nil {
+				t.Fatalf("Pod Log Tests failed to create pod log artifact, err %v", err)
+			}
+			res, err := artifact.ReadTail(tc.n)
+			if err != nil && !tc.expectErr {
+				t.Fatalf("failed reading bytes of log. did not expect err, got err: %v", err)
+			}
+			if err == nil && tc.expectErr {
+				t.Errorf("expected an error, got none")
+			}
+			if !bytes.Equal(tc.expected, res) {
+				t.Errorf("Unexpected result of reading pod logs, expected %q, got %q", tc.expected, res)
+			}
+		})
+	}
+
+}
+func TestReadAt_PodLog(t *testing.T) {
+	testCases := []struct {
+		name        string
+		jobName     string
+		buildID     string
+		n           int64
+		offset      int64
+		expectedErr error
+		expected    []byte
+	}{
+		{
+			name:        "Podlog ReadAt range longer than contents",
+			n:           100,
+			jobName:     "BFG",
+			buildID:     "435",
+			offset:      3,
+			expectedErr: io.EOF,
+			expected:    []byte("bscottle"),
+		},
+		{
+			name:        "Podlog ReadAt range within contents",
+			n:           4,
+			jobName:     "Fantastic Mr. Fox",
+			buildID:     "4",
+			offset:      2,
+			expectedErr: nil,
+			expected:    []byte("hund"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := NewPodLogArtifact(tc.jobName, tc.buildID, "", 500e6, &fakePodLogJAgent{})
+			if err != nil {
+				t.Fatalf("Pod Log Tests failed to create pod log artifact, err %v", err)
+			}
+			res := make([]byte, tc.n)
+			readBytes, err := artifact.ReadAt(res, tc.offset)
+			if err != tc.expectedErr {
+				t.Fatalf("failed reading bytes of log. err: %v, expected err: %v", err, tc.expectedErr)
+			}
+			if !bytes.Equal(tc.expected, res[:readBytes]) {
+				t.Errorf("Unexpected result of reading pod logs, expected %q, got %q", tc.expected, res)
+			}
+		})
+	}
+
+}
+func TestReadAtMost_PodLog(t *testing.T) {
+	testCases := []struct {
+		name        string
+		n           int64
+		jobName     string
+		buildID     string
+		expectedErr error
+		expected    []byte
+	}{
+		{
+			name:        "Podlog ReadAtMost longer than contents",
+			jobName:     "BFG",
+			buildID:     "435",
+			n:           100,
+			expectedErr: io.EOF,
+			expected:    []byte("frobscottle"),
+		},
+		{
+			name:        "Podlog ReadAtMost shorter than contents",
+			n:           3,
+			jobName:     "BFG",
+			buildID:     "435",
+			expectedErr: nil,
+			expected:    []byte("fro"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := NewPodLogArtifact(tc.jobName, tc.buildID, "", 500e6, &fakePodLogJAgent{})
+			if err != nil {
+				t.Fatalf("Pod Log Tests failed to create pod log artifact, err %v", err)
+			}
+			res, err := artifact.ReadAtMost(tc.n)
+			if err != tc.expectedErr {
+				t.Fatalf("failed reading bytes of log. err: %v, expected err: %v", err, tc.expectedErr)
+			}
+			if !bytes.Equal(tc.expected, res) {
+				t.Errorf("Unexpected result of reading pod logs, expected %q, got %q", tc.expected, res)
+			}
+		})
+	}
+
+}
+
+func TestReadAll_PodLog(t *testing.T) {
+	fakePodLogAgent := &fakePodLogJAgent{}
+	testCases := []struct {
+		name        string
+		jobName     string
+		buildID     string
+		sizeLimit   int64
+		expectedErr error
+		expected    []byte
+	}{
+		{
+			name:        "Podlog readall not found",
+			jobName:     "job",
+			buildID:     "123",
+			sizeLimit:   500e6,
+			expectedErr: fmt.Errorf("error getting pod log size: error getting size of pod log: could not find job job, id 123"),
+			expected:    nil,
+		},
+		{
+			name:        "Simple \"BFG\" Podlog readall",
+			jobName:     "BFG",
+			buildID:     "435",
+			sizeLimit:   500e6,
+			expectedErr: nil,
+			expected:    []byte("frobscottle"),
+		},
+		{
+			name:        "\"Fantastic Mr. Fox\" Podlog readall",
+			jobName:     "Fantastic Mr. Fox",
+			buildID:     "4",
+			sizeLimit:   500e6,
+			expectedErr: nil,
+			expected:    []byte("a hundred smoked hams and fifty sides of bacon"),
+		},
+		{
+			name:        "Podlog readall over size limit",
+			jobName:     "Fantastic Mr. Fox",
+			buildID:     "4",
+			sizeLimit:   5,
+			expectedErr: viewers.ErrFileTooLarge,
+			expected:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		artifact, err := NewPodLogArtifact(tc.jobName, tc.buildID, "", tc.sizeLimit, fakePodLogAgent)
+		if err != nil {
+			t.Fatalf("Pod Log Tests failed to create pod log artifact, err %v", err)
+		}
+		res, err := artifact.ReadAll()
+		if err != nil && err.Error() != tc.expectedErr.Error() {
+			t.Fatalf("%s failed reading bytes of log. got err: %v, expected err: %v", tc.name, err, tc.expectedErr)
+		}
+		if err != nil {
+			continue
+		}
+		if !bytes.Equal(tc.expected, res) {
+			t.Errorf("Unexpected result of reading pod logs, expected %q, got %q", tc.expected, res)
+		}
+
+	}
+
+}

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package spyglass creates views for Prow job artifacts.
+package spyglass
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/deck/jobs"
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+var (
+	// These are artifacts that we guarantee will be created with every job.
+	// If they are found in a storage location, the stored ones will be used,
+	// otherwise we will try to fetch them from the job runtime. In the future
+	// this might contain job metadata, podspec, etc.
+	guaranteedArtifacts = []string{"build-log.txt"}
+)
+
+// Spyglass records which sets of artifacts need views for a Prow job. The metaphor
+// can be understood as follows: A spyglass receives light from a source through
+// an eyepiece, which has a lens that ultimately presents a view of the light source
+// to the observer. Spyglass receives light (artifacts) via a
+// source (src) through the eyepiece (Eyepiece) and presents the view (what you see
+// in your browser) via a lens (Lens).
+type Spyglass struct {
+
+	// Lenses is a map of names of views to their corresponding lenses
+	Lenses map[string]Lens
+
+	// Eyepieces is a list of ArtifactFetchers used by Spyglass. Whenever spyglass
+	// receives a request to view artifacts from a source, it will check to see if it
+	// can handle that source with one of its registered eyepieces
+	Eyepieces []ArtifactFetcher
+
+	// JobAgent contains information about the current jobs in deck
+	JobAgent *jobs.JobAgent
+}
+
+// Lens is a single view of a set of artifacts
+type Lens struct {
+	// Name of the view, unique within a job
+	Name string
+	// Title of view
+	Title string
+	// Html rendering of the view
+	HTMLView string
+	// Priority is the relative position of the view on the page
+	Priority int
+}
+
+// ViewRequest holds data sent by a view
+type ViewRequest struct {
+	ViewName    string   `json:"name"`
+	ViewMatches []string `json:"viewMatches"`
+	ViewData    string   `json:"viewData"`
+}
+
+// New constructs a Spyglass object from a JobAgent and a list of ArtifactFetchers
+func New(ja *jobs.JobAgent, eyepieces []ArtifactFetcher) *Spyglass {
+	return &Spyglass{
+		Lenses:    make(map[string]Lens),
+		JobAgent:  ja,
+		Eyepieces: eyepieces,
+	}
+}
+
+// Views gets all views of all artifact files matching each regexp with a registered viewer
+func (s *Spyglass) Views(matchCache map[string][]string) []Lens {
+	lenses := []Lens{}
+	for viewer, matches := range matchCache {
+		if len(matches) == 0 {
+			continue
+		}
+		title, err := viewers.Title(viewer)
+		if err != nil {
+			logrus.WithField("viewName", viewer).WithError(err).Error("Could not find artifact viewer")
+			continue
+		}
+		priority, err := viewers.Priority(viewer)
+		if err != nil {
+			logrus.WithField("viewName", viewer).WithError(err).Error("Could not find artifact viewer")
+			continue
+		}
+		lens := Lens{
+			Name:     viewer,
+			Title:    title,
+			HTMLView: "",
+			Priority: priority,
+		}
+		lenses = append(lenses, lens)
+		s.Lenses[viewer] = lens
+	}
+	// Make sure lenses are rendered in order by ascending priority
+	sort.Slice(lenses, func(i, j int) bool {
+		iname := lenses[i].Name
+		jname := lenses[j].Name
+		pi := lenses[i].Priority
+		pj := lenses[j].Priority
+		if pi == pj {
+			return iname < jname
+		}
+		return pi < pj
+	})
+	return lenses
+}
+
+// Refresh reloads the html view for a given view and a set of objects
+func (s *Spyglass) Refresh(src string, podName string, sizeLimit int64, viewReq *ViewRequest) (Lens, error) {
+	lens, ok := s.Lenses[viewReq.ViewName]
+	if !ok {
+		return Lens{}, fmt.Errorf("error finding view with provided name %s", viewReq.ViewName)
+	}
+	artifacts, err := s.FetchArtifacts(src, podName, sizeLimit, viewReq.ViewMatches)
+	if err != nil {
+		return Lens{}, fmt.Errorf("error fetching artifacts: %v", err)
+	}
+
+	view, err := viewers.View(viewReq.ViewName, artifacts, viewReq.ViewData)
+	if err != nil {
+		return Lens{}, fmt.Errorf("error getting view for viewer %s", viewReq.ViewName)
+	}
+	lens.HTMLView = view
+	return lens, nil
+}
+
+// ListArtifacts gets the names of all artifacts available from the given source by checking
+// if any eyepiece in the Spyglass can receive artifacts from that source.
+func (s *Spyglass) ListArtifacts(src string) ([]string, error) {
+	foundArtifacts := []string{}
+	for _, ep := range s.Eyepieces {
+		jobSource, err := ep.createJobSource(src)
+		if err == ErrCannotParseSource {
+			continue
+		} else if err != nil {
+			logrus.WithField("src", src).WithError(err).Error("Error creating job source.")
+			continue
+		}
+		foundArtifacts = append(foundArtifacts, ep.artifacts(jobSource)...)
+	}
+	foundArtifacts = append(foundArtifacts, missingArtifacts(foundArtifacts)...)
+	return foundArtifacts, nil
+}
+
+func missingArtifacts(haveArtifacts []string) []string {
+	var res []string
+	for _, guaranteedArtifact := range guaranteedArtifacts {
+		var found bool
+		for _, haveArtifact := range haveArtifacts {
+			if haveArtifact == guaranteedArtifact {
+				found = true
+			}
+		}
+		if !found {
+			res = append(res, guaranteedArtifact)
+		}
+	}
+	return res
+}
+
+// FetchArtifacts constructs and returns Artifact objects for each artifact name in the list.
+// This includes getting any handles needed for read write operations, direct artifact links, etc.
+func (s *Spyglass) FetchArtifacts(src string, podName string, sizeLimit int64, artifactNames []string) ([]viewers.Artifact, error) {
+	foundArtifacts := []viewers.Artifact{}
+	foundArtifactNames := []string{}
+	for _, ep := range s.Eyepieces {
+		jobSource, err := ep.createJobSource(src)
+		if err == ErrCannotParseSource {
+			continue
+		} else if err != nil {
+			logrus.WithField("src", src).WithError(err).Error("Error creating job source.")
+			continue
+		}
+		artStart := time.Now()
+		for _, name := range artifactNames {
+			artifact := ep.artifact(jobSource, name, sizeLimit)
+			foundArtifacts = append(foundArtifacts, artifact)
+			foundArtifactNames = append(foundArtifactNames, artifact.JobPath())
+		}
+		artElapsed := time.Since(artStart)
+		logrus.WithField("duration", artElapsed).Infof("Retrieved artifacts for %s", src)
+
+	}
+
+	// Special-casing the fetching of in-cluster artifacts that havent been found yet
+	neededArtifactNames := missingArtifacts(foundArtifactNames)
+	for _, artifactName := range neededArtifactNames {
+		switch artifactName {
+		case "build-log.txt":
+			if isProwJobSource(src) {
+				parsed := strings.Split(strings.TrimPrefix(src, "prowjob/"), "/")
+				var jobName string
+				var buildID string
+				if len(parsed) == 2 {
+					jobName = parsed[0]
+					buildID = parsed[1]
+				} else if len(parsed) == 1 {
+					podName = parsed[0]
+				} else {
+					return foundArtifacts, errors.New("invalid Prowjob source provided")
+				}
+				_, err := s.JobAgent.GetProwJob(jobName, buildID)
+				if err != nil {
+					continue
+				}
+				podLog, err := NewPodLogArtifact(jobName, buildID, podName, sizeLimit, s.JobAgent)
+				if err != nil {
+					logrus.WithField("src", src).WithError(err).Error("Error accessing pod log from given source.")
+					continue
+				}
+				foundArtifacts = append(foundArtifacts, podLog)
+
+			}
+		default:
+		}
+	}
+	return foundArtifacts, nil
+
+}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/deck/jobs"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/spyglass/viewers"
+)
+
+var (
+	fakeJa        *jobs.JobAgent
+	fakeGCSServer *fakestorage.Server
+)
+
+const (
+	testSrc = "gs://test-bucket/logs/example-ci-run/403"
+)
+
+type fkc []kube.ProwJob
+
+func (f fkc) GetLog(pod string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f fkc) ListPods(selector string) ([]kube.Pod, error) {
+	return nil, nil
+}
+
+func (f fkc) ListProwJobs(s string) ([]kube.ProwJob, error) {
+	return f, nil
+}
+
+type fpkc string
+
+func (f fpkc) GetLog(pod string) ([]byte, error) {
+	if pod == "wowowow" || pod == "powowow" {
+		return []byte(f), nil
+	}
+	return nil, fmt.Errorf("pod not found: %s", pod)
+}
+
+func (f fpkc) GetContainerLog(pod, container string) ([]byte, error) {
+	if pod == "wowowow" || pod == "powowow" {
+		return []byte(f), nil
+	}
+	return nil, fmt.Errorf("pod not found: %s", pod)
+}
+
+func (f fpkc) GetLogTail(pod, container string, n int64) ([]byte, error) {
+	if pod == "wowowow" || pod == "powowow" {
+		tailBytes := []byte(f)
+		lenTailBytes := int64(len(tailBytes))
+		if lenTailBytes < n {
+			return tailBytes, nil
+		}
+		return tailBytes[lenTailBytes-n-1:], nil
+	}
+	return nil, fmt.Errorf("pod not found: %s", pod)
+}
+
+func TestMain(m *testing.M) {
+	var longLog string
+	for i := 0; i < 300; i++ {
+		longLog += "here a log\nthere a log\neverywhere a log log\n"
+	}
+	fakeGCSServer = fakestorage.NewServer([]fakestorage.Object{
+		{
+			BucketName: "test-bucket",
+			Name:       "logs/example-ci-run/403/build-log.txt",
+			Content:    []byte("Oh wow\nlogs\nthis is\ncrazy"),
+		},
+		{
+			BucketName: "test-bucket",
+			Name:       "logs/example-ci-run/403/long-log.txt",
+			Content:    []byte(longLog),
+		},
+		{
+			BucketName: "test-bucket",
+			Name:       "logs/example-ci-run/403/junit_01.xml",
+			Content: []byte(`<testsuite tests="1017" failures="1017" time="0.016981535">
+<testcase name="BeforeSuite" classname="Kubernetes e2e suite" time="0.006343795">
+<failure type="Failure">
+test/e2e/e2e.go:137 BeforeSuite on Node 1 failed test/e2e/e2e.go:137
+</failure>
+</testcase>
+</testsuite>`),
+		},
+		{
+			BucketName: "test-bucket",
+			Name:       "logs/example-ci-run/403/started.json",
+			Content: []byte(`{
+						  "node": "gke-prow-default-pool-3c8994a8-qfhg", 
+						  "repo-version": "v1.12.0-alpha.0.985+e6f64d0a79243c", 
+						  "timestamp": 1528742858, 
+						  "repos": {
+						    "k8s.io/kubernetes": "master", 
+						    "k8s.io/release": "master"
+						  }, 
+						  "version": "v1.12.0-alpha.0.985+e6f64d0a79243c", 
+						  "metadata": {
+						    "pod": "cbc53d8e-6da7-11e8-a4ff-0a580a6c0269"
+						  }
+						}`),
+		},
+		{
+			BucketName: "test-bucket",
+			Name:       "logs/example-ci-run/403/finished.json",
+			Content: []byte(`{
+						  "timestamp": 1528742943, 
+						  "version": "v1.12.0-alpha.0.985+e6f64d0a79243c", 
+						  "result": "SUCCESS", 
+						  "passed": true, 
+						  "job-version": "v1.12.0-alpha.0.985+e6f64d0a79243c", 
+						  "metadata": {
+						    "repo": "k8s.io/kubernetes", 
+						    "repos": {
+						      "k8s.io/kubernetes": "master", 
+						      "k8s.io/release": "master"
+						    }, 
+						    "infra-commit": "260081852", 
+						    "pod": "cbc53d8e-6da7-11e8-a4ff-0a580a6c0269", 
+						    "repo-commit": "e6f64d0a79243c834babda494151fc5d66582240"
+						  },
+						},`),
+		},
+	})
+	defer fakeGCSServer.Stop()
+	kc := fkc{
+		kube.ProwJob{
+			Spec: kube.ProwJobSpec{
+				Agent: kube.KubernetesAgent,
+				Job:   "job",
+			},
+			Status: kube.ProwJobStatus{
+				PodName: "wowowow",
+				BuildID: "123",
+			},
+		},
+		kube.ProwJob{
+			Spec: kube.ProwJobSpec{
+				Agent:   kube.KubernetesAgent,
+				Job:     "jib",
+				Cluster: "trusted",
+			},
+			Status: kube.ProwJobStatus{
+				PodName: "powowow",
+				BuildID: "123",
+			},
+		},
+	}
+	fakeJa = jobs.NewJobAgent(kc, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, &config.Agent{})
+	fakeJa.Start()
+	os.Exit(m.Run())
+}
+
+func dumpViewHandler(artifacts []viewers.Artifact, raw string) string {
+	var view []byte
+	for _, a := range artifacts {
+		data, err := a.ReadAll()
+		if err != nil {
+			logrus.WithError(err).Error("Error reading artifact")
+			continue
+		}
+		view = append(view, data...)
+	}
+	return string(view)
+}
+
+func TestViews(t *testing.T) {
+	fakeGCSClient := fakeGCSServer.Client()
+	testAf := NewGCSArtifactFetcher(fakeGCSClient)
+	testCases := []struct {
+		name               string
+		registeredViewers  map[string]viewers.ViewMetadata
+		fetchers           []ArtifactFetcher
+		matchCache         map[string][]string
+		expectedLensTitles []string
+	}{
+		{
+			name: "Spyglass basic test",
+			registeredViewers: map[string]viewers.ViewMetadata{
+				"metadata-viewer": {
+					Title:    "MetadataView",
+					Priority: 0,
+				},
+			},
+			fetchers: []ArtifactFetcher{testAf},
+			matchCache: map[string][]string{
+				"metadata-viewer": {"started.json"},
+			},
+			expectedLensTitles: []string{"MetadataView"},
+		},
+		{
+			name:     "Spyglass no matches",
+			fetchers: []ArtifactFetcher{testAf},
+			registeredViewers: map[string]viewers.ViewMetadata{
+				"metadata-viewer": {
+					Title:    "MetadataView",
+					Priority: 0,
+				},
+			},
+			matchCache: map[string][]string{
+				"metadata-viewer": {},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.registeredViewers {
+				viewers.RegisterViewer(k, v, dumpViewHandler)
+			}
+			sg := New(fakeJa, tc.fetchers)
+			lenses := sg.Views(tc.matchCache)
+			for _, l := range lenses {
+				var found bool
+				for _, title := range tc.expectedLensTitles {
+					if title == l.Title {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("lens title %s not found in expected titles.", l.Title)
+				}
+			}
+			for _, title := range tc.expectedLensTitles {
+				var found bool
+				for _, l := range lenses {
+					if title == l.Title {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected title %s not found in produced lenses.", title)
+				}
+			}
+		})
+	}
+}

--- a/prow/spyglass/viewers/BUILD.bazel
+++ b/prow/spyglass/viewers/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["viewers.go"],
+    importpath = "k8s.io/test-infra/prow/spyglass/viewers",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["viewers_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)

--- a/prow/spyglass/viewers/viewers.go
+++ b/prow/spyglass/viewers/viewers.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package viewers provides interfaces and methods necessary for implementing custom artifact viewers
+package viewers
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type viewHandlerRegistry struct {
+	reg map[string]ViewHandler
+	mut sync.Mutex
+}
+
+type viewMetadataRegistry struct {
+	reg map[string]ViewMetadata
+	mut sync.Mutex
+}
+
+var (
+	viewHandlerReg = viewHandlerRegistry{
+		reg: map[string]ViewHandler{},
+		mut: sync.Mutex{},
+	}
+
+	viewMetadataReg = viewMetadataRegistry{
+		reg: map[string]ViewMetadata{},
+		mut: sync.Mutex{},
+	}
+	// ErrGzipOffsetRead will be thrown when an offset read is attempted on a gzip-compressed object
+	ErrGzipOffsetRead = errors.New("offset read on gzipped files unsupported")
+	// ErrInvalidViewName will be thrown when a viewer method is called on a view name that has not
+	// been registered. Ensure your viewer is registered using RegisterViewer and that you are
+	// providing the correct viewer name.
+	ErrInvalidViewName = errors.New("invalid view name")
+	// ErrFileTooLarge will be thrown when a size-limited operation (ex. ReadAll) is called on an
+	// artifact whose size exceeds the configured limit.
+	ErrFileTooLarge = errors.New("file size over specified limit")
+	// ErrContextUnsupported is thrown when attempting to use a context with an artifact that
+	// does not support context operations (cancel, withtimeout, etc.)
+	ErrContextUnsupported = errors.New("artifact does not support context operations")
+)
+
+// ViewMetadata represents some metadata associated with rendering views
+type ViewMetadata struct {
+	// The title of the view
+	Title string
+
+	// Defines the order of views on the page. Lower priority values will be rendered higher up.
+	// Views with identical priorities will be rendered in alphabetical order by title.
+	// Valid: [0-INTMAX].
+	Priority int
+}
+
+// Artifact represents some output of a prow job
+type Artifact interface {
+	// ReadAt reads len(p) bytes of the artifact at offset off. (unsupported on some compressed files)
+	ReadAt(p []byte, off int64) (n int, err error)
+	// ReadAtMost reads at most n bytes from the beginning of the artifact
+	ReadAtMost(n int64) ([]byte, error)
+	// CanonicalLink gets a link to viewing this artifact in storage
+	CanonicalLink() string
+	// JobPath is the path to the artifact within the job (i.e. without the job prefix)
+	JobPath() string
+	// ReadAll reads all bytes from the artifact up to a limit specified by the artifact
+	ReadAll() ([]byte, error)
+	// ReadTail reads the last n bytes from the artifact (unsupported on some compressed files)
+	ReadTail(n int64) ([]byte, error)
+	// Size gets the size of the artifact in bytes, may make a network call
+	Size() (int64, error)
+}
+
+// ViewHandler consumes artifacts and some possible callback json data and returns an html view.
+// Use the javascript function refreshView(viewName, viewData) to allow your viewer to call back to itself
+// (request more data, update the view, etc.). ViewData is a json blob that will be passed back to the
+// handler function for your view as the string
+type ViewHandler func([]Artifact, string) string
+
+// View gets the updated view from an artifact viewer with the provided name
+func View(name string, artifacts []Artifact, raw string) (string, error) {
+	handler, ok := viewHandlerReg.reg[name]
+	if !ok {
+		return "", ErrInvalidViewName
+	}
+	return handler(artifacts, raw), nil
+
+}
+
+// Title gets the title of the view with the given name
+func Title(name string) (string, error) {
+	m, ok := viewMetadataReg.reg[name]
+	if !ok {
+		return "", ErrInvalidViewName
+	}
+	return m.Title, nil
+
+}
+
+// Priority gets the priority of the view with the given name
+func Priority(name string) (int, error) {
+	m, ok := viewMetadataReg.reg[name]
+	if !ok {
+		return -1, ErrInvalidViewName
+	}
+	return m.Priority, nil
+
+}
+
+// RegisterViewer registers new viewers
+func RegisterViewer(viewerName string, metadata ViewMetadata, handler ViewHandler) error {
+	viewHandlerReg.mut.Lock()
+	defer viewHandlerReg.mut.Unlock()
+	viewMetadataReg.mut.Lock()
+	defer viewMetadataReg.mut.Unlock()
+	_, ok := viewHandlerReg.reg[viewerName]
+	if ok {
+		return fmt.Errorf("viewer already registered with name %s", viewerName)
+	}
+
+	if metadata.Title == "" {
+		return errors.New("empty title field in view metadata")
+	}
+	if metadata.Priority < 0 {
+		return errors.New("priority must be >=0")
+	}
+	viewHandlerReg.reg[viewerName] = handler
+	viewMetadataReg.reg[viewerName] = metadata
+	logrus.Infof("Spyglass registered viewer %s with title %s.", viewerName, metadata.Title)
+	return nil
+}
+
+// UnregisterViewer unregisters viewers
+func UnregisterViewer(viewerName string) {
+	viewHandlerReg.mut.Lock()
+	defer viewHandlerReg.mut.Unlock()
+	viewMetadataReg.mut.Lock()
+	defer viewMetadataReg.mut.Unlock()
+	delete(viewHandlerReg.reg, viewerName)
+	delete(viewMetadataReg.reg, viewerName)
+	logrus.Infof("Spyglass unregistered viewer %s.", viewerName)
+}
+
+// LastNLines reads the last n lines from an artifact.
+func LastNLines(a Artifact, n int64) ([]string, error) {
+	// 300B, a reasonable log line length, probably a bit more scalable than a hard-coded value
+	return LastNLinesChunked(a, n, 300*n+1)
+}
+
+// LastNLinesChunked reads the last n lines from an artifact by reading chunks of size chunkSize
+// from the end of the artifact. Best performance is achieved by:
+// argmin 0<chunkSize<INTMAX, f(chunkSize) = chunkSize - n * avgLineLength
+func LastNLinesChunked(a Artifact, n, chunkSize int64) ([]string, error) {
+	toRead := chunkSize + 1 // Add 1 for exclusive upper bound read range
+	chunks := int64(1)
+	var contents []byte
+	var linesInContents int64
+	artifactSize, err := a.Size()
+	if err != nil {
+		return nil, fmt.Errorf("error getting artifact size: %v", err)
+	}
+	offset := artifactSize - chunks*chunkSize
+	lastOffset := offset
+	var lastRead int64
+	for linesInContents < n && offset != 0 {
+		offset = lastOffset - lastRead
+		if offset < 0 {
+			toRead = offset + chunkSize + 1
+			offset = 0
+		}
+		bytesRead := make([]byte, toRead)
+		numBytesRead, err := a.ReadAt(bytesRead, offset)
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("error reading artifact: %v", err)
+		}
+		lastRead = int64(numBytesRead)
+		lastOffset = offset
+		bytesRead = bytes.Trim(bytesRead, "\x00")
+		linesInContents += int64(bytes.Count(bytesRead, []byte("\n")))
+		contents = append(bytesRead, contents...)
+		chunks++
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+		lines = append(lines, line)
+	}
+	l := int64(len(lines))
+	if l < n {
+		return lines, nil
+	}
+	return lines[l-n:], nil
+}

--- a/prow/spyglass/viewers/viewers_test.go
+++ b/prow/spyglass/viewers/viewers_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package viewers
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type FakeArtifact struct {
+	path      string
+	content   []byte
+	sizeLimit int64
+}
+
+func (fa *FakeArtifact) JobPath() string {
+	return fa.path
+}
+
+func (fa *FakeArtifact) Size() (int64, error) {
+	return int64(len(fa.content)), nil
+}
+
+func (fa *FakeArtifact) CanonicalLink() string {
+	return "linknotfound.io/404"
+}
+
+func (fa *FakeArtifact) ReadAt(b []byte, off int64) (int, error) {
+	r := bytes.NewReader(fa.content)
+	return r.ReadAt(b, off)
+}
+
+func (fa *FakeArtifact) ReadAll() ([]byte, error) {
+	size, err := fa.Size()
+	if err != nil {
+		return nil, err
+	}
+	if size > fa.sizeLimit {
+		return nil, ErrFileTooLarge
+	}
+	r := bytes.NewReader(fa.content)
+	return ioutil.ReadAll(r)
+}
+
+func (fa *FakeArtifact) ReadTail(n int64) ([]byte, error) {
+	size, err := fa.Size()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, n)
+	_, err = fa.ReadAt(buf, size-n)
+	return buf, err
+}
+
+func (fa *FakeArtifact) UseContext(ctx context.Context) error {
+	return nil
+}
+
+func (fa *FakeArtifact) ReadAtMost(n int64) ([]byte, error) {
+	buf := make([]byte, n)
+	_, err := fa.ReadAt(buf, 0)
+	return buf, err
+}
+
+func dumpViewHandler(artifacts []Artifact, raw string) string {
+	var view []byte
+	for _, a := range artifacts {
+		data, err := a.ReadAll()
+		if err != nil {
+			logrus.WithError(err).Error("Error reading artifact")
+			continue
+		}
+		view = append(view, data...)
+	}
+	return string(view)
+}
+
+// Tests getting a view from a viewer
+func TestView(t *testing.T) {
+	dumpMetadata := ViewMetadata{
+		Title:    "Dump View",
+		Priority: 1,
+	}
+	err := RegisterViewer("DumpView", dumpMetadata, dumpViewHandler)
+	if err != nil {
+		t.Fatal("Failed to register viewer for testing View")
+	}
+	fakeLog := &FakeArtifact{
+		path:      "log.txt",
+		content:   []byte("Oh wow\nlogs\nthis is\ncrazy"),
+		sizeLimit: 500e6,
+	}
+	testCases := []struct {
+		name       string
+		viewerName string
+		artifacts  []Artifact
+		raw        string
+		expected   string
+		err        error
+	}{
+		{
+			name:       "simple view",
+			viewerName: "DumpView",
+			artifacts: []Artifact{
+				fakeLog, fakeLog,
+			},
+			raw: "",
+			expected: `Oh wow
+logs
+this is
+crazyOh wow
+logs
+this is
+crazy`,
+			err: nil,
+		},
+		{
+			name:       "fail on unregistered view name",
+			viewerName: "MicroverseBattery",
+			artifacts:  []Artifact{},
+			raw:        "",
+			expected:   "",
+			err:        ErrInvalidViewName,
+		},
+	}
+	for _, tc := range testCases {
+		view, err := View(tc.viewerName, tc.artifacts, tc.raw)
+		if tc.err != err {
+			t.Errorf("%s expected error %v but got error %v", tc.name, tc.err, err)
+			continue
+		}
+		if view != tc.expected {
+			t.Errorf("%s expected view to be %s but got %s", tc.name, tc.expected, view)
+		}
+	}
+	UnregisterViewer("DumpView")
+
+}
+
+// Test registering a new viewer
+func TestRegisterViewer(t *testing.T) {
+	testCases := []struct {
+		name           string
+		viewerName     string
+		viewerMetadata ViewMetadata
+		handler        ViewHandler
+		err            error
+	}{
+		{
+			name:       "register dump view",
+			viewerName: "DumpView",
+			viewerMetadata: ViewMetadata{
+				Title:    "Dump View",
+				Priority: 1,
+			},
+			handler: dumpViewHandler,
+			err:     nil,
+		},
+	}
+	for _, tc := range testCases {
+		err := RegisterViewer(tc.viewerName, tc.viewerMetadata, tc.handler)
+		if err != nil {
+			if err != tc.err {
+				t.Errorf("%s expected error %v but got error %v", tc.name, tc.err, err)
+			}
+			continue
+		}
+		title, err := Title(tc.viewerName)
+		if err != nil {
+			t.Errorf("%s got error %v when trying to get title", tc.name, err)
+			continue
+		}
+		if title != tc.viewerMetadata.Title {
+			t.Errorf("%s registered a viewer with title %s but got title %s", tc.name, tc.viewerMetadata.Title, title)
+		}
+		UnregisterViewer(tc.viewerName)
+	}
+}
+
+// Tests reading last N Lines from files in GCS
+func TestLastNLines_GCS(t *testing.T) {
+	fakeGCSServerChunkSize := int64(3500)
+	var longLog string
+	for i := 0; i < 300; i++ {
+		longLog += "here a log\nthere a log\neverywhere a log log\n"
+	}
+	testCases := []struct {
+		name     string
+		path     string
+		contents []byte
+		n        int64
+		a        Artifact
+		expected []string
+	}{
+		{
+			name:     "Read last 2 lines of a 4-line file",
+			n:        2,
+			path:     "log.txt",
+			contents: []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected: []string{"this is", "crazy"},
+		},
+		{
+			name:     "Read last 5 lines of a 4-line file",
+			n:        5,
+			path:     "log.txt",
+			contents: []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected: []string{"Oh wow", "logs", "this is", "crazy"},
+		},
+		{
+			name:     "Read last 2 lines of a long log file",
+			n:        2,
+			path:     "long-log.txt",
+			contents: []byte(longLog),
+			expected: []string{
+				"there a log",
+				"everywhere a log log",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact := &FakeArtifact{
+				path:      tc.path,
+				content:   tc.contents,
+				sizeLimit: 500e6,
+			}
+			actual, err := LastNLinesChunked(artifact, tc.n, fakeGCSServerChunkSize)
+			if err != nil {
+				t.Fatalf("failed with error: %v", err)
+			}
+			if len(actual) != len(tc.expected) {
+				t.Fatalf("Expected length:\n%d\nActual length:\n%d", len(tc.expected), len(actual))
+			}
+			for ix, line := range tc.expected {
+				if line != actual[ix] {
+					t.Errorf("Line %d expected:\n%s\nActual line %d:\n%s", ix, line, ix, actual[ix])
+					break
+				}
+			}
+			for ix, line := range actual {
+				if line != tc.expected[ix] {
+					t.Errorf("Line %d expected:\n%s\nActual line %d:\n%s", ix, tc.expected[ix], ix, line)
+					break
+				}
+			}
+		})
+	}
+}

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/testgrid/util/gcs",
     visibility = [
         "//prow/gcsupload:__subpackages__",
+        "//prow/spyglass:__subpackages__",
         "//testgrid:__subpackages__",
     ],
     deps = [


### PR DESCRIPTION
Core library separated out from #8830. This PR should merge second, and will fail until #8920 merges. The spyglass core contains:

- `Spyglass`
- `ArtifactFetcher` implementation
- `Artifact` implementation
- `viewers` package used by viewer implementers
- Tests

This PR also contains `placeholder.go`, an empty import file used to prevent Bazel from complaining about unused deps. It will be removed when #8922 merges.

This PR does not contain Spyglass' `README.md` because the README contains information and instructions that are dependent on #8922, like config and the default viewers.

/area prow
/assign @fejta @BenTheElder @stevekuznetsov @krzyzacy

Edit: #8920 has merged, barring further review this PR is all set to merge.