### PR TITLE
Shorten the name of the test jobs in sig-node-cri

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5341,16 +5341,21 @@ dashboards:
 
 - name: sig-node-cri
   dashboard_tab:
-  - name: sig-node-docker-node-conformance
+  - name: docker-node-conformance
     test_group_name: ci-docker-node-conformance
-  - name: sig-node-docker-node-features
+  - name: docker-node-features
     test_group_name: ci-docker-node-features
-  - name: sig-node-docker-node-legacy
+  - name: docker-node-legacy
     test_group_name: ci-docker-node-legacy
-  - name: sig-node-containerd-node-conformance
+  - name: containerd-node-conformance
     test_group_name: ci-containerd-node-e2e
-  - name: sig-node-containerd-node-features
+  - name: containerd-node-features
     test_group_name: ci-containerd-node-e2e-features
+
+- name: sig-node-cri-1.11
+  dashboard_tab:
+  - name: docker-node-conformance-1.11
+    test_group_name: ci-kubernetes-node-kubelet-beta
 
 - name: sig-node-cadvisor
   dashboard_tab:
@@ -6583,6 +6588,7 @@ dashboard_groups:
   - sig-node-ppc64le
   - sig-node-cri-o
   - sig-node-cri
+  - sig-node-cri-1.11
 
 - name: sig-release
   dashboard_names:


### PR DESCRIPTION
Also add a 1.11 tab for sig-node-cri.