### PR TITLE
remove Q-lee from top-level test-infra owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - krzyzacy
 - michelle192837
 - mithra
-- Q-Lee
 - rmmh
 - shyamjvs
 - spiffxp


### PR DESCRIPTION
aka https://github.com/kubernetes/test-infra/pull/8924 probably should not request a review from @Q-Lee anymore.

/assign @mithrav @spiffxp 