### PR TITLE
fix broken url in commit message when a pr being merged into master

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -105,7 +105,7 @@ gate-approved: true
 gate-cla: true
 
 # extra message when PR is merged to master branch, it must not end in a period.
-merge-to-master-message: "If you want to cherry-pick this change to another branch, please follow the instructions <a href=\"https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md\">here</a>"
+merge-to-master-message: "If you want to cherry-pick this change to another branch, please follow the instructions here: https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md"
 
 protected-branches: "master"
 protected-branches-extra-contexts: "cla/linuxfoundation"


### PR DESCRIPTION
because github cann't resolve "\<a>" tag in commit message,  the commit message commited by @k8s-merge-robot has a broken url. 

should be: https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md
actually: https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md%22%3Ehere%3C/a