### PR TITLE
Add a metric to Hook for webhook status reports

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -95,7 +95,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -110,7 +110,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -61,7 +61,7 @@ type server struct {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/hook/metrics.go
+++ b/prow/hook/metrics.go
@@ -26,18 +26,25 @@ var (
 		Name: "prow_webhook_counter",
 		Help: "A counter of the webhooks made to prow.",
 	}, []string{"event_type"})
+	responseCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prow_webhook_response_codes",
+		Help: "A counter of the different responses hook has responded to webhooks with.",
+	}, []string{"response_code"})
 )
 
 func init() {
 	prometheus.MustRegister(webhookCounter)
+	prometheus.MustRegister(responseCounter)
 }
 
 type Metrics struct {
-	WebhookCounter *prometheus.CounterVec
+	WebhookCounter  *prometheus.CounterVec
+	ResponseCounter *prometheus.CounterVec
 }
 
 func NewMetrics() *Metrics {
 	return &Metrics{
-		WebhookCounter: webhookCounter,
+		WebhookCounter:  webhookCounter,
+		ResponseCounter: responseCounter,
 	}
 }


### PR DESCRIPTION
On our deployment, we'd like to have some more metrics to keep an eye on Hook's operations, and we would like to notice issues like increased traffic which might need to be looked into.

Thought this may be a change you are interested in integrating as I imagine this may be quiet useful to others too.

cc @petemounce @DoomGerbil @majolo @lottec @efarem