### PR TITLE
Provide defaults for more presubmit config fields.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1030,6 +1030,9 @@ func DefaultRerunCommandFor(name string) string {
 
 func defaultPresubmitFields(js []Presubmit) {
 	for i, j := range js {
+		if j.Context == "" {
+			js[i].Context = j.Name
+		}
 		// Default the values of Trigger and RerunCommand if both fields are
 		// specified. Otherwise let validation fail as both or neither should have
 		// been specified.

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -330,7 +330,7 @@ periodics:
 			expectError: true,
 		},
 		{
-			name:       "one presubmit, no context",
+			name:       "one presubmit no context will default",
 			prowConfig: ``,
 			jobConfigs: []string{
 				`
@@ -342,7 +342,6 @@ presubmits:
       containers:
       - image: alpine`,
 			},
-			expectError: true,
 		},
 		{
 			name:       "one presubmit, ok",

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -285,6 +285,19 @@ periodics:
 			},
 		},
 		{
+			name:       "one periodic no agent, should default",
+			prowConfig: ``,
+			jobConfigs: []string{
+				`
+periodics:
+- interval: 10m
+  name: foo
+  spec:
+    containers:
+    - image: alpine`,
+			},
+		},
+		{
 			name:       "two periodics",
 			prowConfig: ``,
 			jobConfigs: []string{
@@ -330,13 +343,27 @@ periodics:
 			expectError: true,
 		},
 		{
-			name:       "one presubmit no context will default",
+			name:       "one presubmit no context should default",
 			prowConfig: ``,
 			jobConfigs: []string{
 				`
 presubmits:
   foo/bar:
   - agent: kubernetes
+    name: presubmit-bar
+    spec:
+      containers:
+      - image: alpine`,
+			},
+		},
+		{
+			name:       "one presubmit no agent should default",
+			prowConfig: ``,
+			jobConfigs: []string{
+				`
+presubmits:
+  foo/bar:
+  - context: bar
     name: presubmit-bar
     spec:
       containers:
@@ -510,6 +537,19 @@ postsubmits:
   foo/bar:
   - agent: kubernetes
     name: postsubmit-bar
+    spec:
+      containers:
+      - image: alpine`,
+			},
+		},
+		{
+			name:       "one postsubmit no agent, should default",
+			prowConfig: ``,
+			jobConfigs: []string{
+				`
+postsubmits:
+  foo/bar:
+  - name: postsubmit-bar
     spec:
       containers:
       - image: alpine`,

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -76,36 +76,49 @@ func mergePreset(preset Preset, labels map[string]string, pod *v1.PodSpec) error
 	return nil
 }
 
-// Presubmit is the job-specific trigger info.
+// Presubmit runs on PRs.
 type Presubmit struct {
-	// eg kubernetes-pull-build-test-e2e-gce
+	// The name of the job.
+	// e.g. pull-test-infra-bazel-build
 	Name string `json:"name"`
-	// Labels are added in prowjobs created for this job.
+	// Labels are added to prowjobs and pods created for this job.
 	Labels map[string]string `json:"labels"`
-	// Run for every PR, or only when a comment triggers it.
+
+	// AlwaysRun automatically for every PR, or only when a comment triggers it.
 	AlwaysRun bool `json:"always_run"`
-	// Run if the PR modifies a file that matches this regex.
+	// RunIfChanged automatically run if the PR modifies a file that matches this regex.
 	RunIfChanged string `json:"run_if_changed"`
-	// Context line for GitHub status.
+
+	// Context is the name of the GitHub status context for the job.
 	Context string `json:"context"`
-	// eg @k8s-bot e2e test this
-	Trigger string `json:"trigger"`
-	// Valid rerun command to give users. Must match Trigger.
-	RerunCommand string `json:"rerun_command"`
-	// Whether or not to skip commenting and setting status on GitHub.
+	// Optional indicates that the job's status context should not be required for merge.
+	Optional bool `json:"optional,omitempty"`
+	// SkipReport skips commenting and setting status on GitHub.
 	SkipReport bool `json:"skip_report"`
-	// Maximum number of this job running concurrently, 0 implies no limit.
+
+	// Trigger is the regular expression to trigger the job.
+	// e.g. `@k8s-bot e2e test this`
+	// RerunCommand must also be specified if this field is specified.
+	// (Default: `(?m)^/test (?:.*? )?<job name>(?: .*?)?$`)
+	Trigger string `json:"trigger"`
+	// The RerunCommand to give users. Must match Trigger.
+	// Trigger must also be specified if this field is specified.
+	// (Default: `/test <job name>`)
+	RerunCommand string `json:"rerun_command"`
+
+	// MaximumConcurrency of this job, 0 implies no limit.
 	MaxConcurrency int `json:"max_concurrency"`
 	// Agent that will take care of running this job.
 	Agent string `json:"agent"`
-	// Cluster is the alias of the cluster to run this job in. (Default: kube.DefaultClusterAlias)
+	// Cluster is the alias of the cluster to run this job in.
+	// (Default: kube.DefaultClusterAlias)
 	Cluster string `json:"cluster"`
-	// Kubernetes pod spec.
+
+	// Spec is the Kubernetes pod spec used if Agent is Kubernetes.
 	Spec *v1.PodSpec `json:"spec,omitempty"`
-	// Run these jobs after successfully running this one.
+
+	// RunAfterSuccess is a list of jobs to run after successfully running this one.
 	RunAfterSuccess []Presubmit `json:"run_after_success"`
-	// Consider job optional for branch protection.
-	Optional bool `json:"optional,omitempty"`
 
 	Brancher
 

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"flag"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -37,11 +37,6 @@ var configJSONPath = flag.String("config-json", "../../jobs/config.json", "Path 
 var podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 type configJSON map[string]map[string]interface{}
-
-const (
-	testThis   = "/test all"
-	retestBody = "/test all [submit-queue is verifying that this PR is safe to merge]"
-)
 
 type JSONJob struct {
 	Scenario string   `json:"scenario"`
@@ -143,21 +138,6 @@ func TestPresubmits(t *testing.T) {
 			if job.RerunCommand == "" || job.Trigger == "" {
 				t.Errorf("Job %s needs a trigger and a rerun command.", job.Name)
 				continue
-			}
-			// Check that the merge bot will run AlwaysRun jobs, otherwise it
-			// will attempt to rerun forever.
-			if job.AlwaysRun && !job.re.MatchString(testThis) {
-				t.Errorf("AlwaysRun job %s: \"%s\" does not match regex \"%v\".", job.Name, testThis, job.Trigger)
-			}
-			if job.AlwaysRun && !job.re.MatchString(retestBody) {
-				t.Errorf("AlwaysRun job %s: \"%s\" does not match regex \"%v\".", job.Name, retestBody, job.Trigger)
-			}
-			// Check that the merge bot will not run Non-AlwaysRun jobs
-			if !job.AlwaysRun && job.re.MatchString(testThis) {
-				t.Errorf("Non-AlwaysRun job %s: \"%s\" matches regex \"%v\".", job.Name, testThis, job.Trigger)
-			}
-			if !job.AlwaysRun && job.re.MatchString(retestBody) {
-				t.Errorf("Non-AlwaysRun job %s: \"%s\" matches regex \"%v\".", job.Name, retestBody, job.Trigger)
 			}
 
 			if len(job.Brancher.Branches) > 0 && len(job.Brancher.SkipBranches) > 0 {

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -25,7 +25,7 @@ import (
 )
 
 var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
-var testAllRe = regexp.MustCompile(`(?m)^/test all\s*$`)
+var testAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
 var retestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 
 func handleIC(c client, trigger *plugins.Trigger, ic github.IssueCommentEvent) error {

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -470,6 +470,15 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 			ShouldReport: true,
 		},
+		{
+			name:        "accept /test all from submit-queue",
+			Author:      "t",
+			PRAuthor:    "t",
+			Body:        "/test all [submit-queue is verifying that this PR is safe to merge]",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Logf("running scenario %q", tc.name)


### PR DESCRIPTION
Specifically,
- Default `Trigger` and `RerunCommand` to match `/test <job-name>`.
- Default `Context` to the the job's `Name`.
- Default `Agent` to `kubernetes`.

This should help us passively promote some standards and make it simpler for new Prow users to add new presubmit configurations.

I'll make a separate PR to remove these fields from our config files where the defaults are appropriate (i.e. everywhere). We should wait to merge the other PR until this PR merges and is deployed to avoid config loading failures.

fixes #6655 
/area jobs
/area prow
/cc @krzyzacy @BenTheElder @stevekuznetsov 