### PR TITLE
prow/owners-label: verify label exists before adding

### DIFF
--- a/prow/plugins/owners-label/BUILD.bazel
+++ b/prow/plugins/owners-label/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],

--- a/prow/plugins/owners-label/owners-label_test.go
+++ b/prow/plugins/owners-label/owners-label_test.go
@@ -17,75 +17,27 @@ limitations under the License.
 package ownerslabel
 
 import (
-	"errors"
+	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 )
 
-type fakeGithubClient struct {
-	changes       []github.PullRequestChange
-	initialLabels []github.Label
-	labelsAdded   sets.String
-}
-
-func newFakeGithubClient(filesChanged []string, initialLabels []string) *fakeGithubClient {
-	changes := make([]github.PullRequestChange, 0, len(filesChanged))
-	for _, name := range filesChanged {
-		changes = append(changes, github.PullRequestChange{Filename: name})
+func formatLabels(labels ...string) []string {
+	r := []string{}
+	for _, l := range labels {
+		r = append(r, fmt.Sprintf("%s/%s#%d:%s", "org", "repo", 1, l))
 	}
-	labels := make([]github.Label, 0, len(initialLabels))
-	for _, label := range initialLabels {
-		labels = append(labels, github.Label{Name: label})
+	if len(r) == 0 {
+		return nil
 	}
-	return &fakeGithubClient{
-		changes:       changes,
-		initialLabels: labels,
-		labelsAdded:   sets.NewString(),
-	}
-}
-
-func (c *fakeGithubClient) AddLabel(org, repo string, number int, label string) error {
-	if org != "org" {
-		return errors.New("org should be 'org'")
-	}
-	if repo != "repo" {
-		return errors.New("repo should be 'repo'")
-	}
-	if number != 5 {
-		return errors.New("number should be 5")
-	}
-	c.labelsAdded.Insert(label)
-	return nil
-}
-
-func (c *fakeGithubClient) GetPullRequestChanges(org, repo string, num int) ([]github.PullRequestChange, error) {
-	if org != "org" {
-		return nil, errors.New("org should be 'org'")
-	}
-	if repo != "repo" {
-		return nil, errors.New("repo should be 'repo'")
-	}
-	if num != 5 {
-		return nil, errors.New("number should be 5")
-	}
-	return c.changes, nil
-}
-
-func (c *fakeGithubClient) GetIssueLabels(org, repo string, num int) ([]github.Label, error) {
-	if org != "org" {
-		return nil, errors.New("org should be 'org'")
-	}
-	if repo != "repo" {
-		return nil, errors.New("repo should be 'repo'")
-	}
-	if num != 5 {
-		return nil, errors.New("number should be 5")
-	}
-	return c.initialLabels, nil
+	return r
 }
 
 type fakeOwnersClient struct {
@@ -108,86 +60,159 @@ func TestHandle(t *testing.T) {
 		},
 	}
 
-	var testcases = []struct {
-		name          string
-		filesChanged  []string
-		initialLabels []string
-		expectedAdded sets.String
-	}{
+	type testCase struct {
+		name              string
+		filesChanged      []string
+		expectedNewLabels []string
+		repoLabels        []string
+		issueLabels       []string
+	}
+	testcases := []testCase{
 		{
-			name:          "no labels",
-			filesChanged:  []string{"other.go", "something.go"},
-			expectedAdded: sets.NewString(),
+			name:              "no labels",
+			filesChanged:      []string{"other.go", "something.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "1 file 1 label",
-			filesChanged:  []string{"b.go"},
-			expectedAdded: sets.NewString("lgtm"),
+			name:              "1 file 1 label",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: formatLabels("lgtm"),
+			repoLabels:        []string{"lgtm"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "1 file 3 labels",
-			filesChanged:  []string{"a.go"},
-			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs"),
+			name:              "1 file 3 labels",
+			filesChanged:      []string{"a.go"},
+			expectedNewLabels: formatLabels("lgtm", "approved", "kind/docs"),
+			repoLabels:        []string{"lgtm", "approved", "kind/docs"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "2 files no overlap",
-			filesChanged:  []string{"c.go", "d.sh"},
-			expectedAdded: sets.NewString("lgtm", "dnm/frozen-docs", "dnm/bash"),
+			name:              "2 files no overlap",
+			filesChanged:      []string{"c.go", "d.sh"},
+			expectedNewLabels: formatLabels("lgtm", "dnm/frozen-docs", "dnm/bash"),
+			repoLabels:        []string{"lgtm", "dnm/frozen-docs", "dnm/bash"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "2 files partial overlap",
-			filesChanged:  []string{"a.go", "b.go"},
-			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs"),
+			name:              "2 files partial overlap",
+			filesChanged:      []string{"a.go", "b.go"},
+			expectedNewLabels: formatLabels("lgtm", "approved", "kind/docs"),
+			repoLabels:        []string{"lgtm", "approved", "kind/docs"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "2 files complete overlap",
-			filesChanged:  []string{"d.sh", "e.sh"},
-			expectedAdded: sets.NewString("dnm/bash"),
+			name:              "2 files complete overlap",
+			filesChanged:      []string{"d.sh", "e.sh"},
+			expectedNewLabels: formatLabels("dnm/bash"),
+			repoLabels:        []string{"dnm/bash"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "3 files partial overlap",
-			filesChanged:  []string{"a.go", "b.go", "c.go"},
-			expectedAdded: sets.NewString("lgtm", "approved", "kind/docs", "dnm/frozen-docs"),
+			name:              "3 files partial overlap",
+			filesChanged:      []string{"a.go", "b.go", "c.go"},
+			expectedNewLabels: formatLabels("lgtm", "approved", "kind/docs", "dnm/frozen-docs"),
+			repoLabels:        []string{"lgtm", "approved", "kind/docs", "dnm/frozen-docs"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "no labels to add, initial unrelated label",
-			filesChanged:  []string{"other.go", "something.go"},
-			initialLabels: []string{"lgtm"},
-			expectedAdded: sets.NewString(),
+			name:              "no labels to add, initial unrelated label",
+			filesChanged:      []string{"other.go", "something.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{"lgtm"},
+			issueLabels:       []string{"lgtm"},
 		},
 		{
-			name:          "1 file 1 label, already present",
-			filesChanged:  []string{"b.go"},
-			initialLabels: []string{"lgtm"},
-			expectedAdded: sets.NewString(),
+			name:              "1 file 1 label, already present",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{"lgtm"},
+			issueLabels:       []string{"lgtm"},
 		},
 		{
-			name:          "2 files no overlap, 1 label already present",
-			filesChanged:  []string{"c.go", "d.sh"},
-			initialLabels: []string{"dnm/bash", "approved"},
-			expectedAdded: sets.NewString("lgtm", "dnm/frozen-docs"),
+			name:              "1 file 1 label, doesn't exist on the repo",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{"approved"},
+			issueLabels:       []string{},
 		},
 		{
-			name:          "2 files complete overlap, label already present",
-			filesChanged:  []string{"d.sh", "e.sh"},
-			initialLabels: []string{"dnm/bash"},
-			expectedAdded: sets.NewString(),
+			name:              "2 files no overlap, 1 label already present",
+			filesChanged:      []string{"c.go", "d.sh"},
+			expectedNewLabels: formatLabels("lgtm", "dnm/frozen-docs"),
+			repoLabels:        []string{"dnm/bash", "approved", "lgtm", "dnm/frozen-docs"},
+			issueLabels:       []string{"dnm/bash", "approved"},
+		},
+		{
+			name:              "2 files complete overlap, label already present",
+			filesChanged:      []string{"d.sh", "e.sh"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{"dnm/bash"},
+			issueLabels:       []string{"dnm/bash"},
 		},
 	}
+
 	for _, tc := range testcases {
-		fghc := newFakeGithubClient(tc.filesChanged, tc.initialLabels)
-		pre := &github.PullRequestEvent{
-			Number:      5,
-			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
-			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+		basicPR := github.PullRequest{
+			Number: 1,
+			Base: github.PullRequestBranch{
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+			},
+			User: github.User{
+				Login: "user",
+			},
 		}
 
-		if err := handle(fghc, foc, logrus.WithField("plugin", pluginName), pre); err != nil {
+		t.Logf("Running scenario %q", tc.name)
+		sort.Strings(tc.expectedNewLabels)
+		changes := make([]github.PullRequestChange, 0, len(tc.filesChanged))
+		for _, name := range tc.filesChanged {
+			changes = append(changes, github.PullRequestChange{Filename: name})
+		}
+		fghc := &fakegithub.FakeClient{
+			PullRequests: map[int]*github.PullRequest{
+				basicPR.Number: &basicPR,
+			},
+			PullRequestChanges: map[int][]github.PullRequestChange{
+				basicPR.Number: changes,
+			},
+			ExistingLabels: tc.repoLabels,
+			LabelsAdded:    []string{},
+		}
+		// Add initial labels
+		for _, label := range tc.issueLabels {
+			fghc.AddLabel(basicPR.Base.Repo.Owner.Login, basicPR.Base.Repo.Name, basicPR.Number, label)
+		}
+		pre := &github.PullRequestEvent{
+			Action:      github.PullRequestActionOpened,
+			Number:      basicPR.Number,
+			PullRequest: basicPR,
+			Repo:        basicPR.Base.Repo,
+		}
+
+		err := handle(fghc, foc, logrus.WithField("plugin", pluginName), pre)
+		if err != nil {
 			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
 			continue
 		}
-		if !fghc.labelsAdded.Equal(tc.expectedAdded) {
-			t.Errorf("[%s] expected the labels %q to be added, but got %q.", tc.name, tc.expectedAdded.List(), fghc.labelsAdded.List())
+
+		// Check that all the correct labels (and only the correct labels) were added.
+		expectLabels := append(formatLabels(tc.issueLabels...), tc.expectedNewLabels...)
+		if expectLabels == nil {
+			expectLabels = []string{}
 		}
+		sort.Strings(expectLabels)
+		sort.Strings(fghc.LabelsAdded)
+		if !reflect.DeepEqual(expectLabels, fghc.LabelsAdded) {
+			t.Errorf("expected the labels %q to be added, but %q were added.", expectLabels, fghc.LabelsAdded)
+		}
+
 	}
 }


### PR DESCRIPTION
The current owners-label plugin doesn't attempt to verify if the label exists first, before adding it. This can result in the label being created automatically. This isn't good if there is possibly a typo in the owners file, etc.

This changes the code to ensure that we verify the label exists first, and only apply if it does. Will log if it doesn't exist.

Also refactored the tests heavily to handle this change.