### PR TITLE
Increase Tide status controller query overlap to 30s.

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -350,7 +350,10 @@ func (sc *statusController) waitSync() {
 func (sc *statusController) sync(pool map[string]PullRequest) {
 	sc.lastSyncStart = time.Now()
 
-	sinceTime := sc.lastSuccessfulQueryStart.Add(-10 * time.Second)
+	// Query for PRs changed since the last time we successfully queried.
+	// We offset for 30 seconds of overlap because GitHub sometimes doesn't
+	// include recently changed/new PRs in the query results.
+	sinceTime := sc.lastSuccessfulQueryStart.Add(-30 * time.Second)
 	query := sc.ca.Config().Tide.Queries.AllPRsSince(sinceTime)
 	queryStartTime := time.Now()
 	allPRs, err := search(context.Background(), sc.ghc, sc.logger, query)


### PR DESCRIPTION
We increased this overlap in April from 1s to 10s when we saw multiple PRs with missing `tide` statuses: (#7672).  It has been a while without incident, but today @cblecker spotted another PR with a missing `tide` status ([slack thread](https://kubernetes.slack.com/archives/C7J9RP96G/p1533344784000013)). Like the previous occurrences, this was fixed by bumping the PR with a comment which should only change the last updated time of the PR as far as Tide's status controller is concerned.
Increasing the overlap period seems like it might be helping so lets increase this from 10s to 30s and see if it happens again? I'm not sure what else to try.

/kind bug
/area prow
/cc @cblecker @stevekuznetsov @BenTheElder 