### PR TITLE
Collect containerd logs for cos_containerd gke test.

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -1,3 +1,10 @@
+presets:
+- labels:
+    preset-cos-containerd-env: "true"
+  env:
+  - name: LOG_DUMP_SYSTEMD_SERVICES
+    value: "containerd containerd-installation"
+
 periodics:
 - interval: 1h
   agent: kubernetes
@@ -5,6 +12,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:
@@ -33,6 +41,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:
@@ -61,6 +70,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:
@@ -89,6 +99,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:
@@ -117,6 +128,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:
@@ -145,6 +157,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-cos-containerd-env: "true"
   spec:
     containers:
     - args:


### PR DESCRIPTION
Collect containerd logs for gke cos_containerd test.

We set the same env for GCE test: https://github.com/kubernetes/test-infra/blob/master/jobs/env/ci-cri-containerd-e2e-gce.env#L3
And the env is used in `log-dump.sh`: https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh#L53

Signed-off-by: Lantao Liu <lantaol@google.com>