### PR TITLE
Don't require LGTM1/2 labels for service-catalog

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -284,8 +284,6 @@ tide:
     - lgtm
     - approved
     - "cncf-cla: yes"
-    - LGTM1
-    - LGTM2
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file


### PR DESCRIPTION
We are finally all switched over to using `/lgtm` and `/approve` only, so I am removing the requirement for `LGTM1` and `LGTM2` from the SIG Service Catalog repo.