### PR TITLE
kind: break out and refactor exec helpers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ filegroup(
         "//kind/images/node:all-srcs",
         "//kind/pkg/build:all-srcs",
         "//kind/pkg/cluster:all-srcs",
+        "//kind/pkg/exec:all-srcs",
         "//kubetest:all-srcs",
         "//label_sync:all-srcs",
         "//logexporter/cmd:all-srcs",

--- a/kind/pkg/build/BUILD.bazel
+++ b/kind/pkg/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kind/pkg/build/sources:go_default_library",
+        "//kind/pkg/exec:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )

--- a/kind/pkg/exec/BUILD.bazel
+++ b/kind/pkg/exec/BUILD.bazel
@@ -2,10 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cluster.go"],
-    importpath = "k8s.io/test-infra/kind/pkg/cluster",
+    srcs = ["exec.go"],
+    importpath = "k8s.io/test-infra/kind/pkg/exec",
     visibility = ["//visibility:public"],
-    deps = ["//kind/pkg/exec:go_default_library"],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 
 filegroup(

--- a/kind/pkg/exec/exec.go
+++ b/kind/pkg/exec/exec.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec contains helpers for os/exec
+package exec
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/golang/glog"
+)
+
+// Cmd wraps os/exec.Cmd, with extra options for logging etc. when running
+type Cmd struct {
+	*exec.Cmd
+	CmdOpts
+}
+
+// CmdOpts contains extra options recognized by this package's os/exec.Cmd
+// wrapper (Cmd)
+type CmdOpts struct {
+	// If Debug is true, log the command prior to running
+	Debug bool
+	// If LogOutputOnFail is true, stdout and stderr will be collected, and will
+	// be logged if the command does not exit cleanly
+	LogOutputOnFail bool
+	// If InheritOtuput is true, inheret stdout and stderr from the current process
+	InheritOutput bool
+}
+
+// Command returns a Cmd from os/exec's Command(...)
+func Command(name string, arg ...string) *Cmd {
+	return &Cmd{
+		Cmd: exec.Command(name, arg...),
+	}
+}
+
+// Run wraps cmd.Run(), respecting CmdOpts
+func (cmd *Cmd) Run() error {
+	if cmd.Debug {
+		glog.Infof("Running: %v %v", cmd.Path, cmd.Args)
+	}
+
+	if cmd.LogOutputOnFail {
+		return cmd.runLoggingOutputOnFail()
+	}
+
+	if cmd.InheritOutput {
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+	}
+	return cmd.Cmd.Run()
+}
+
+func (cmd *Cmd) runLoggingOutputOnFail() error {
+	var buff bytes.Buffer
+	cmd.Stdout = &buff
+	cmd.Stderr = &buff
+	err := cmd.Cmd.Run()
+	if cmd.LogOutputOnFail {
+		glog.Error("failed with:")
+		scanner := bufio.NewScanner(&buff)
+		for scanner.Scan() {
+			glog.Error(scanner.Text())
+		}
+	}
+	return err
+}
+
+// CombinedOutputLines is like os/exec's cmd.CombinedOutput(),
+// except instead of returning the byte buffer of stderr + stdout,
+// it scans these for lines and returns a slice of output line strings
+func (cmd *Cmd) CombinedOutputLines() (lines []string, err error) {
+	var buff bytes.Buffer
+	cmd.Stdout = &buff
+	cmd.Stderr = &buff
+	err = cmd.Cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&buff)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, nil
+}


### PR DESCRIPTION
per previous PR feedback, break out os/exec helpers into a common package. I've opted for a light wrapper supporting logging needs and extra methods.

I also broke down the image build steps a bit