### PR TITLE
Add kubernetes-sigs/architecture-tracking to tide

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -228,6 +228,7 @@ tide:
     - kubernetes/test-infra
     - kubernetes/website
     - kubernetes-sigs/application
+    - kubernetes-sigs/architecture-tracking
     - kubernetes-sigs/aws-encryption-provider
     - kubernetes-sigs/cluster-api
     - kubernetes-sigs/cluster-api-provider-aws


### PR DESCRIPTION
default merge method

ref: https://github.com/kubernetes-sigs/architecture-tracking/pull/46#issuecomment-411095516