### PR TITLE
keep codegen verification go version in sync with other jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -207,7 +207,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: docker.io/library/golang:1.10
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180730-8b7ab3104-experimental
         command:
         - ./hack/verify-codegen.sh
         resources:


### PR DESCRIPTION
we control which go version we run our jobs in by the kubekins image and are consolidating on this.
I also intend to validate some bazel support against go/shell support https://github.com/kubernetes/test-infra/pull/8955

/assign @krzyzacy 
/area jobs