### PR TITLE
Add env REGISTRY to ingress-image-push job

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -43,6 +43,7 @@ postsubmits:
         - --scenario=execute
         - --
         - --env=VERSION=$(PULL_BASE_REF)
+        - --env=REGISTRY=gcr.io/k8s-ingress-image-push
         - make
         - push-e2e
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Sorry I missed this in https://github.com/kubernetes/test-infra/pull/8945. Job is failing at the moment: https://k8s-testgrid.appspot.com/sig-network-ingress-gce-e2e#ingress-gce-image-push.
cc @rramkumar1 

Fixes https://github.com/kubernetes/ingress-gce/issues/426.