### PR TITLE
kind: breakup subcommands

### DIFF
--- a/kind/cmd/kind/cmd/build/BUILD.bazel
+++ b/kind/cmd/kind/cmd/build/BUILD.bazel
@@ -2,13 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["root.go"],
-    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd",
+    srcs = ["build.go"],
+    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd/build",
     visibility = ["//visibility:public"],
     deps = [
-        "//kind/cmd/kind/cmd/build:go_default_library",
-        "//kind/cmd/kind/cmd/create:go_default_library",
-        "//kind/cmd/kind/cmd/delete:go_default_library",
+        "//kind/cmd/kind/cmd/build/image:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
@@ -24,9 +22,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
-        "//kind/cmd/kind/cmd/build:all-srcs",
-        "//kind/cmd/kind/cmd/create:all-srcs",
-        "//kind/cmd/kind/cmd/delete:all-srcs",
+        "//kind/cmd/kind/cmd/build/image:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/kind/cmd/kind/cmd/build/build.go
+++ b/kind/cmd/kind/cmd/build/build.go
@@ -14,19 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+// Package build implements the `build` command
+package build
 
 import (
 	"github.com/spf13/cobra"
+
+	"k8s.io/test-infra/kind/cmd/kind/cmd/build/image"
 )
 
-func newBuildCommand() *cobra.Command {
+// NewCommand returns a new cobra.Command for building
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "build",
 		Short: "build",
 		Long:  "build",
 	}
-	cmd.AddCommand(newBuildImageCommand())
+	// add subcommands
+	cmd.AddCommand(image.NewCommand())
 	return cmd
 }

--- a/kind/cmd/kind/cmd/build/image/BUILD.bazel
+++ b/kind/cmd/kind/cmd/build/image/BUILD.bazel
@@ -2,13 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["root.go"],
-    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd",
+    srcs = ["image.go"],
+    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd/build/image",
     visibility = ["//visibility:public"],
     deps = [
-        "//kind/cmd/kind/cmd/build:go_default_library",
-        "//kind/cmd/kind/cmd/create:go_default_library",
-        "//kind/cmd/kind/cmd/delete:go_default_library",
+        "//kind/pkg/build:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
@@ -22,12 +20,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//kind/cmd/kind/cmd/build:all-srcs",
-        "//kind/cmd/kind/cmd/create:all-srcs",
-        "//kind/cmd/kind/cmd/delete:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/kind/cmd/kind/cmd/build/image/image.go
+++ b/kind/cmd/kind/cmd/build/image/image.go
@@ -14,34 +14,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package image
 
 import (
 	"os"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"k8s.io/test-infra/kind/pkg/cluster"
+	"k8s.io/test-infra/kind/pkg/build"
 )
 
-func newDeleteCommand() *cobra.Command {
-	return &cobra.Command{
-		// TODO(bentheelder): more detailed usage
-		Use:   "delete",
-		Short: "Deletes a cluster",
-		Long:  "Deletes a Kubernetes cluster",
-		Run:   runDelete,
-	}
+type flags struct {
+	Source string
 }
 
-func runDelete(cmd *cobra.Command, args []string) {
-	// TODO(bentheelder): make this configurable
-	config := cluster.NewConfig("")
-	ctx := cluster.NewContext(config)
-	err := ctx.Delete()
+func NewCommand() *cobra.Command {
+	flags := &flags{}
+	cmd := &cobra.Command{
+		// TODO(bentheelder): more detailed usage
+		Use:   "image",
+		Short: "build the node image",
+		Long:  "build the node image",
+		Run: func(cmd *cobra.Command, args []string) {
+			run(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(&flags.Source, "source", "", "path to the node image sources")
+	return cmd
+}
+
+func run(flags *flags, cmd *cobra.Command, args []string) {
+	// TODO(bentheelder): make this more configurable
+	ctx := build.NewNodeImageBuildContext()
+	ctx.SourceDir = flags.Source
+	err := ctx.Build()
 	if err != nil {
-		glog.Errorf("Failed to delete cluster: %v", err)
 		os.Exit(-1)
 	}
 }

--- a/kind/cmd/kind/cmd/create/BUILD.bazel
+++ b/kind/cmd/kind/cmd/create/BUILD.bazel
@@ -2,13 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["root.go"],
-    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd",
+    srcs = ["create.go"],
+    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd/create",
     visibility = ["//visibility:public"],
     deps = [
-        "//kind/cmd/kind/cmd/build:go_default_library",
-        "//kind/cmd/kind/cmd/create:go_default_library",
-        "//kind/cmd/kind/cmd/delete:go_default_library",
+        "//kind/pkg/cluster:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
@@ -22,12 +21,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//kind/cmd/kind/cmd/build:all-srcs",
-        "//kind/cmd/kind/cmd/create:all-srcs",
-        "//kind/cmd/kind/cmd/delete:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/kind/cmd/kind/cmd/create/create.go
+++ b/kind/cmd/kind/cmd/create/create.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+// Package create implements the `create` command
+package create
 
 import (
 	"os"
@@ -25,19 +26,29 @@ import (
 	"k8s.io/test-infra/kind/pkg/cluster"
 )
 
-func newCreateCommand() *cobra.Command {
-	return &cobra.Command{
+type flags struct {
+	Name string
+}
+
+// NewCommand returns a new cobra.Command for cluster creation
+func NewCommand() *cobra.Command {
+	flags := &flags{}
+	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
 		Use:   "create",
 		Short: "Creates a cluster",
 		Long:  "Creates a Kubernetes cluster",
-		Run:   runCreate,
+		Run: func(cmd *cobra.Command, args []string) {
+			run(flags, cmd, args)
+		},
 	}
+	cmd.Flags().StringVar(&flags.Name, "name", "", "the cluster name")
+	return cmd
 }
 
-func runCreate(cmd *cobra.Command, args []string) {
-	// TODO(bentheelder): make this configurable
-	config := cluster.NewConfig("")
+func run(flags *flags, cmd *cobra.Command, args []string) {
+	// TODO(bentheelder): make this more configurable
+	config := cluster.NewConfig(flags.Name)
 	ctx := cluster.NewContext(config)
 	err := ctx.Create()
 	if err != nil {

--- a/kind/cmd/kind/cmd/delete/BUILD.bazel
+++ b/kind/cmd/kind/cmd/delete/BUILD.bazel
@@ -2,13 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["root.go"],
-    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd",
+    srcs = ["delete.go"],
+    importpath = "k8s.io/test-infra/kind/cmd/kind/cmd/delete",
     visibility = ["//visibility:public"],
     deps = [
-        "//kind/cmd/kind/cmd/build:go_default_library",
-        "//kind/cmd/kind/cmd/create:go_default_library",
-        "//kind/cmd/kind/cmd/delete:go_default_library",
+        "//kind/pkg/cluster:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
@@ -22,12 +21,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//kind/cmd/kind/cmd/build:all-srcs",
-        "//kind/cmd/kind/cmd/create:all-srcs",
-        "//kind/cmd/kind/cmd/delete:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/kind/cmd/kind/cmd/delete/delete.go
+++ b/kind/cmd/kind/cmd/delete/delete.go
@@ -14,41 +14,45 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+// Package delete implements the `delete` command
+package delete
 
 import (
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"k8s.io/test-infra/kind/pkg/build"
+	"k8s.io/test-infra/kind/pkg/cluster"
 )
 
-type buildImageCommandFlags struct {
-	Source string
+type flags struct {
+	Name string
 }
 
-func newBuildImageCommand() *cobra.Command {
-	flags := &buildImageCommandFlags{}
+// NewCommand returns a new cobra.Command for cluster creation
+func NewCommand() *cobra.Command {
+	flags := &flags{}
 	cmd := &cobra.Command{
 		// TODO(bentheelder): more detailed usage
-		Use:   "image",
-		Short: "build the node image",
-		Long:  "build the node image",
+		Use:   "delete",
+		Short: "Deletes a cluster",
+		Long:  "Deletes a Kubernetes cluster",
 		Run: func(cmd *cobra.Command, args []string) {
-			runBuildImage(flags, cmd, args)
+			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Source, "source", "", "path to the node image sources")
+	cmd.Flags().StringVar(&flags.Name, "name", "", "the cluster name")
 	return cmd
 }
 
-func runBuildImage(flags *buildImageCommandFlags, cmd *cobra.Command, args []string) {
+func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
-	ctx := build.NewNodeImageBuildContext()
-	ctx.SourceDir = flags.Source
-	err := ctx.Build()
+	config := cluster.NewConfig(flags.Name)
+	ctx := cluster.NewContext(config)
+	err := ctx.Delete()
 	if err != nil {
+		glog.Errorf("Failed to delete cluster: %v", err)
 		os.Exit(-1)
 	}
 }

--- a/kind/cmd/kind/cmd/root.go
+++ b/kind/cmd/kind/cmd/root.go
@@ -21,18 +21,23 @@ import (
 	"flag"
 
 	"github.com/spf13/cobra"
+
+	"k8s.io/test-infra/kind/cmd/kind/cmd/build"
+	"k8s.io/test-infra/kind/cmd/kind/cmd/create"
+	"k8s.io/test-infra/kind/cmd/kind/cmd/delete"
 )
 
-func newRootCommand() *cobra.Command {
+// NewCommand returns a new cobra.Command implementing the root command for kind
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kind",
 		Short: "kind is a tool for managing local multi-node Kubernetes clusters",
 		Long:  "kind creates and manages local multi-node Kubernetes clusters using Docker containers",
 	}
-	// add all top level commands
-	cmd.AddCommand(newBuildCommand())
-	cmd.AddCommand(newCreateCommand())
-	cmd.AddCommand(newDeleteCommand())
+	// add all top level subcommands
+	cmd.AddCommand(build.NewCommand())
+	cmd.AddCommand(create.NewCommand())
+	cmd.AddCommand(delete.NewCommand())
 	return cmd
 }
 
@@ -43,10 +48,10 @@ func Run() error {
 	// glog logs to files by default, grr
 	flag.Set("logtostderr", "true")
 
-	rootCmd := newRootCommand()
+	cmd := NewCommand()
 	// glog registers global flags on flag.CommandLine...
-	rootCmd.Flags().AddGoFlagSet(flag.CommandLine)
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	// actually execute the cobra commands now...
-	return rootCmd.Execute()
+	return cmd.Execute()
 }


### PR DESCRIPTION
This moves all subcommands into isolated packages, and plumbs through a `--name` flag for `create` and `delete`.

It's a pretty insignificant change, but should help with expanding on these and normalizes the patterns for subcommands.

/assign @amwat @munnerz 