### PR TITLE
Add kind/api-change as org-wide kind/ label, merge in kind/new-api

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -39,6 +39,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="committee/conduct" href="#committee/conduct">`committee/conduct`</a> | Denotes an issue or PR intended to be handled by the code of conduct committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="committee/steering" href="#committee/steering">`committee/steering`</a> | Denotes an issue or PR intended to be handled by the steering committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="kind/api-change" href="#kind/api-change">`kind/api-change`</a> | Categorizes issue or PR as related to adding, removing, or otherwise changing an API <br><br> This was previously `kind/new-api`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | Categorizes issue or PR as related to a bug. <br><br> This was previously `bug`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/cleanup" href="#kind/cleanup">`kind/cleanup`</a> | Categorizes issue or PR as related to cleaning up code, process, or technical debt.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -147,6 +147,14 @@ default:
       prowPlugin: help
       addedBy: anyone
     - color: e11d21
+      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+      name: kind/api-change
+      previously:
+        - name: kind/new-api
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
       description: Categorizes issue or PR as related to a bug.
       name: kind/bug
       previously:


### PR DESCRIPTION
The api review process is being worked on right now, and it sounds like
the folks reviewing that are fine with merging the `kind/new-api` label
into `kind/api-change`

ref: https://github.com/kubernetes/community/pull/2433#discussion_r207361555

Based on discussion in https://github.com/kubernetes/community/issues/2032 I
am assuming we're fine making `kind/api-change` a standard org-wide label

Fixes: https://github.com/kubernetes/community/issues/2013

/hold
for comment, and I need time to see if there is automation that produces these
labels that should also be updated

/sig contributor-experience
/area github-management
/cc @cblecker @jberkus
/sig architecture
/cc @jdumars @thockin