### PR TITLE
fix podutils images built by bazel

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -14,11 +14,11 @@ go_library(
     ],
 )
 
-go_image(
+container_image(
     name = "image",
     base = "@git-base//image",
-    binary = ":clonerefs",
     directory = "/",
+    files = [":clonerefs"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -28,11 +28,11 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_image(
+container_image(
     name = "image",
     base = "@git-base//image",
-    binary = ":entrypoint",
     directory = "/",
+    files = [":entrypoint"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_image(
+container_image(
     name = "image",
     base = "@alpine-base//image",
-    binary = ":initupload",
     directory = "/",
+    files = [":initupload"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -14,11 +14,11 @@ go_library(
     ],
 )
 
-go_image(
+container_image(
     name = "image",
     base = "@git-base//image",
-    binary = ":sidecar",
     directory = "/",
+    files = [":sidecar"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
switch to `container_image`, which is less magical, and just place the binaries in root.
fixes: https://github.com/kubernetes/test-infra/issues/7947