### PR TITLE
add kubeflow/chainer-operator to config/jobs/kubeflow/kubeflow-[pre|post]submits.yaml

### DIFF
--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -136,3 +136,14 @@ postsubmits:
       containers:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
+
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-postsubmit
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -162,3 +162,15 @@ presubmits:
       containers:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
+
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -366,6 +366,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/katib",
 		"kubeflow/kubebench",
 		"kubeflow/kubeflow",
+		"kubeflow/chainer-operator",
 		"kubeflow/mpi-operator",
 		"kubeflow/pytorch-operator",
 		"kubeflow/reporting",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2096,6 +2096,11 @@ test_groups:
   num_columns_recent: 30
 - name: kubeflow-mpi-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_mpi-operator/kubeflow-mpi-operator-postsubmit
+- name: kubeflow-chainer-operator-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-chainer-operator-presubmit
+  num_columns_recent: 30
+- name: kubeflow-chainer-operator-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow_chainer-operator/kubeflow-chainer-operator-postsubmit
 - name: tf-minigo-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-minigo-periodic
 - name: tf-minigo-presubmit
@@ -4767,6 +4772,12 @@ dashboards:
   - name: kubeflow-mpi-operator-presubmit
     description: Presubmit tests for kubeflow/mpi-operator.
     test_group_name: kubeflow-mpi-operator-presubmit
+  - name: kubeflow-chainer-operator-postsubmit
+    description: Postsubmit tests for kubeflow/chainer-operator.
+    test_group_name: kubeflow-chainer-operator-postsubmit
+  - name: kubeflow-chainer-operator-presubmit
+    description: Presubmit tests for kubeflow/chainer-operator.
+    test_group_name: kubeflow-chainer-operator-presubmit
   - name: spark-periodic-default-gke
     description: Periodic builds and testing of Apache Spark on default version of GKE.
     test_group_name: spark-periodic-default-gke


### PR DESCRIPTION
I would like to add [kubeflow/chainer-operator](https://github.com/kubeflow/chainer-operator) in prow.

ref: kubeflow/chainer-operator#19

/cc @jlewi would you mind reviewing this? 