### PR TITLE
Only change team memberships for accepted org members

### DIFF
--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 go_binary(
     name = "peribolos",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 
@@ -48,4 +49,80 @@ go_test(
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
+)
+
+# Usage:
+# bazel run :e2e-dump -- --github-token-path ~/whatever # --dump=whatever etc
+go_binary(
+    name = "e2e",
+    args = [
+        "--tokens=0",
+    ],
+    data = [":test-config.yaml"],
+    embed = [":go_default_library"],
+)
+
+go_binary(
+    name = "e2e-dump",
+    args = [
+        "--tokens=0",
+        "--dump=fejtaverse",
+    ],
+    embed = [":go_default_library"],
+)
+
+go_binary(
+    name = "e2e-change",
+    args = [
+        "--tokens=0",
+        "--config-path=prow/cmd/peribolos/test-config.yaml",
+        "--min-admins=2",
+        "--fix-org",
+        "--fix-org-members",
+        "--fix-teams",
+        "--fix-team-members",
+    ],
+    data = [":test-config.yaml"],
+    embed = [":go_default_library"],
+)
+
+# Usage:
+#   bazel run :dev-job.{create,delete,describe}
+load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+load("//def:configmap.bzl", "k8s_configmap")
+
+CLUSTER = "gke_fejta-prod_us-central1-f_erick"  # TODO(fejta): fix
+
+k8s_object(
+    name = "peribolos-job",
+    cluster = CLUSTER,
+    image_chroot = "{STABLE_DOCKER_REPO}",
+    images = {"gcr.io/k8s-testimages/peribolos:latest": ":image"},
+    kind = "Job",
+    template = ":dev.yaml",
+)
+
+k8s_configmap(
+    name = "peribolos-test-config",
+    cluster = CLUSTER,
+    data = {
+        "config.yaml": ":test-config.yaml",
+    },
+)
+
+k8s_objects(
+    name = "dev",
+    objects = [
+        ":peribolos-job",
+        ":peribolos-test-config",
+    ],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "image",
+    binary = ":peribolos",
+    visibility = ["//prow:__subpackages__"],
 )

--- a/prow/cmd/peribolos/dev.yaml
+++ b/prow/cmd/peribolos/dev.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: peribolos
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      name: peribolos
+    spec:
+      containers:
+      - name: peribolos
+        image: gcr.io/k8s-testimages/peribolos:latest  # Note: not gcr.io/k8s-prow for dev
+        imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --github-token-path=/etc/github/oauth
+        - --min-admins=2
+        - --fix-org
+        - --fix-org-members
+        - --fix-teams
+        - --fix-team-members
+        #- --confirm
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: test-config
+          mountPath: /etc/config
+          readOnly: true
+      restartPolicy: Never
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: test-config
+        configMap:
+          name: peribolos-test-config
+

--- a/prow/cmd/peribolos/test-config.yaml
+++ b/prow/cmd/peribolos/test-config.yaml
@@ -10,9 +10,10 @@ orgs:
     members:
     - fejta-bot
     - cblecker
-    - bentheelder
     - krzyzacy
     - cjwagner
+    - spiffxp
+    - paulangton
     teams:
       bots:
         members:
@@ -26,8 +27,8 @@ orgs:
         maintainers:
         - fejta
         members:
-        - bentheelder
-        - cblecker
+        - spiffxp
         superlative-humans:
           members:
           - krzyzacy
+          - cblecker

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -660,7 +660,8 @@ type TeamMembership struct {
 // OrgInvitation contains Login and other details about the invitation.
 type OrgInvitation struct {
 	TeamMember
-	Inviter TeamMember `json:"login"`
+	Email   string     `json:"email"`
+	Inviter TeamMember `json:"inviter"`
 }
 
 // GenericCommentEventAction coerces multiple actions into its generic equivalent.


### PR DESCRIPTION
/assign @cblecker @spiffxp @BenTheElder 

Otherwise, every time the tool runs we wind up attempting to re-add the user to the team, which triggers another invite (and we're "only" allowed O(100) invitations per day).

Also:
* Fix inviter json tag name
* refactor how we handle invitations, so we can pass it to teams
* create bazel rules for testing locally and on (my) kubernetes cluster.