### PR TITLE
Revert "Deactivate fejta-bot until kubernetes/test-infra#9001 is fixed"

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -65,7 +65,7 @@ periodics:
         /close
       - --template
       - --ceiling=10
-      # - --confirm  // TODO(cblecker): Restore when https://github.com/kubernetes/test-infra/issues/9001 is resolved
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/token
@@ -107,7 +107,7 @@ periodics:
 
       - --template
       - --ceiling=1
-      # - --confirm  // TODO(cblecker): Restore when https://github.com/kubernetes/test-infra/issues/9001 is resolved
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/token
@@ -140,7 +140,7 @@ periodics:
         /lifecycle rotten
       - --template
       - --ceiling=10
-      # - --confirm  // TODO(cblecker): Restore when https://github.com/kubernetes/test-infra/issues/9001 is resolved
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/token
@@ -173,7 +173,7 @@ periodics:
         /lifecycle stale
       - --template
       - --ceiling=10
-      # - --confirm  // TODO(cblecker): Restore when https://github.com/kubernetes/test-infra/issues/9001 is resolved
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/token
@@ -224,7 +224,7 @@ periodics:
 
         /remove-lifecycle frozen
       - --ceiling=10
-      # - --confirm  // TODO(cblecker): Restore when https://github.com/kubernetes/test-infra/issues/9001 is resolved
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/token


### PR DESCRIPTION
This reverts commit 3150971e3f86b84af6eeb1cb24c328031bad12e7.

#9001 is fixed now.