### PR TITLE
Enable owners-label plugin for k/test-infra

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -393,6 +393,7 @@ plugins:
   - blunderbuss
   - config-updater
   - milestone
+  - owners-label
   - override
   - trigger
   - verify-owners


### PR DESCRIPTION
Although, as I submit this PR, I wonder if we should just pull this into an org-wide plugin?