### PR TITLE
kind: make name configurable, validate config

### DIFF
--- a/kind/cmd/kind/cmd/delete/delete.go
+++ b/kind/cmd/kind/cmd/delete/delete.go
@@ -42,15 +42,24 @@ func NewCommand() *cobra.Command {
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.Name, "name", "", "the cluster name")
+	cmd.Flags().StringVar(&flags.Name, "name", "1", "the cluster name")
 	return cmd
 }
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	config := cluster.NewConfig(flags.Name)
+	err := config.Validate()
+	if err != nil {
+		glog.Error("Invalid Configuration!")
+		configErrors := err.(cluster.ConfigErrors)
+		for _, problem := range configErrors.Errors() {
+			glog.Error(problem)
+		}
+		os.Exit(-1)
+	}
 	ctx := cluster.NewContext(config)
-	err := ctx.Delete()
+	err = ctx.Delete()
 	if err != nil {
 		glog.Errorf("Failed to delete cluster: %v", err)
 		os.Exit(-1)

--- a/kind/pkg/cluster/BUILD.bazel
+++ b/kind/pkg/cluster/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -23,4 +23,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
 )

--- a/kind/pkg/cluster/BUILD.bazel
+++ b/kind/pkg/cluster/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cluster.go"],
+    srcs = [
+        "cluster.go",
+        "config.go",
+    ],
     importpath = "k8s.io/test-infra/kind/pkg/cluster",
     visibility = ["//visibility:public"],
     deps = ["//kind/pkg/exec:go_default_library"],

--- a/kind/pkg/cluster/config.go
+++ b/kind/pkg/cluster/config.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+// ClusterLabelKey is applied to each "node" docker container for identification
+const ClusterLabelKey = "io.k8s.test-infra.kind-cluster"
+
+// similar to valid docker container names, but since we will prefix
+// and suffix this name, we can relax it a little
+// see Validate() for usage
+var validClusterName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+
+// Config contains cluster options
+type Config struct {
+	// the cluster name
+	Name string
+	// TODO(bentheelder): fill this in
+}
+
+// NewConfig returns a new cluster config with name
+func NewConfig(name string) Config {
+	return Config{
+		Name: name,
+	}
+}
+
+// Validate returns a ConfigErrors with an entry for each problem
+// with the config, or nil if there are none
+func (c *Config) Validate() error {
+	errs := []error{}
+	if !validClusterName.MatchString(c.Name) {
+		errs = append(errs, fmt.Errorf(
+			"'%s' is not a valid cluster name, cluster names must match `%s`",
+			c.Name, validClusterName.String(),
+		))
+	}
+	if len(errs) > 0 {
+		return ConfigErrors{errs}
+	}
+	return nil
+}
+
+// ConfigErrors implements error and contains all config errors
+// This is returned by Config.Validate
+type ConfigErrors struct {
+	errors []error
+}
+
+// assert ConfigErrors implements error
+var _ error = &ConfigErrors{}
+
+func (c ConfigErrors) Error() string {
+	var buff bytes.Buffer
+	for _, err := range c.errors {
+		buff.WriteString(err.Error())
+		buff.WriteRune('\n')
+	}
+	return buff.String()
+}
+
+// Errors returns the slice of errors contained by ConfigErrors
+func (c ConfigErrors) Errors() []error {
+	return c.errors
+}
+
+// internal helper used to identify the cluster containers based on config
+func (c *Config) clusterLabel() string {
+	return fmt.Sprintf("%s=%s", ClusterLabelKey, c.Name)
+}

--- a/kind/pkg/cluster/config_test.go
+++ b/kind/pkg/cluster/config_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import "testing"
+
+func TestConfigValidate(t *testing.T) {
+	cases := []struct {
+		Name           string
+		Config         Config
+		ExpectedErrors int
+	}{
+		{
+			Name:           "Canonical config",
+			Config:         NewConfig("1"),
+			ExpectedErrors: 0,
+		},
+		{
+			Name: "Invalid name - commas",
+			Config: Config{
+				Name: ",,,,,,",
+			},
+			ExpectedErrors: 1,
+		},
+		{
+			Name: "Invalid name - zero length",
+			Config: Config{
+				Name: "",
+			},
+			ExpectedErrors: 1,
+		},
+		{
+			Name: "Invalid name - invalid character in the middle",
+			Config: Config{
+				Name: "almost-valid@nope",
+			},
+			ExpectedErrors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		err := tc.Config.Validate()
+		// the error can be:
+		// - nil, in which case we should expect no errors or fail
+		if err == nil {
+			if tc.ExpectedErrors != 0 {
+				t.Errorf("received no errors but expected errors for case %s", tc.Name)
+			}
+			continue
+		}
+		// - not castable to ConfigErrors, in which case we have the wrong error type ...
+		configErrors, ok := err.(ConfigErrors)
+		if !ok {
+			t.Errorf("config.Validate should only return nil or ConfigErrors{...}, got: %v for case: %s", err, tc.Name)
+			continue
+		}
+		// - ConfigErrors, in which case expect a certain number of errors
+		errors := configErrors.Errors()
+		if len(errors) != tc.ExpectedErrors {
+			t.Errorf("expected %d errors but got len(%v) = %d for case: %s", tc.ExpectedErrors, errors, len(errors), tc.Name)
+		}
+	}
+}


### PR DESCRIPTION
This is a pretty small one, but necessary to move forward, basically I broke out the config logic a bit, added validation and tests, then added a flag to the cli to set the "cluster" name and made the CLI validate the config.

/assign @amwat @munnerz