### PR TITLE
always run verify config on test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -93,7 +93,7 @@ presubmits:
   - name: pull-test-infra-verify-config
     branches:
     - master
-    run_if_changed: '^prow/config.yaml$'
+    always_run: true
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"


### PR DESCRIPTION
we changed config serialization in https://github.com/kubernetes/test-infra/pull/9024#issuecomment-412609544 but did not run the validation job... making it always run instead of run if changed.

/area jobs