### PR TITLE
Fix timeout in kops test config

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -85,7 +85,7 @@ presubmits:
         - --kops-build
         - --provider=aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55
+        - --timeout=55m
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
I think this will fix some of the errors we're currently seeing in kops PRs (see https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/kops/5602/pull-kops-e2e-kubernetes-aws/7224/ , https://github.com/kubernetes/kops/pull/5602).

I could be wrong here so just opening this up in case!