### PR TITLE
Enable merge blocking issues for Tide.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -305,6 +305,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-incubator/service-catalog: squash
   target_url: https://prow.k8s.io/tide.html
+  blocker_label: merge-blocker
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
This will allow issues with the `merge-blocker` label to block Tide for a repo or a specific branch.

I'll try out a blocking issue in this repo once this is deployed. The label must be added by hand now, but #8131 includes a plugin that allows members of a specific GitHub team to control the label.

/area prow
/cc @stevekuznetsov @BenTheElder @fejta 