### PR TITLE
[WIP] prow: Disable self-approval for fedv2 repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -61,6 +61,12 @@ approve:
   - kubernetes/test-infra
   implicit_self_approve: true
   lgtm_acts_as_approve: true
+# Disabling implicit self-approval for a given repo in the
+# kubernetes-sigs org requires that repo configuration appear before
+# the org configuration.
+- repos:
+  - kubernetes-sigs/federation-v2
+  implicit_self_approve: false
 - repos:
   - kubernetes-csi
   - kubernetes-sigs


### PR DESCRIPTION
Since anyone in the `kubernetes-sigs` org can lgtm, self-approval has the potential to merge PRs by owners without the oversight of other reviews or owners.  To avoid this possibility, this PR attempts to disable self-approval for the federation-v2 repo.

~~Looking at [the code](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/approve/approve.go#L594) for determining what options to use for a given approval, it looks like putting repo configuration before the org configuration should work (assuming order in the yaml is the same as the resultant order in the `Approve` slice).~~ This approach doesn't work.

cc: @irfanurrehman @font @shashidharatd @pmorie 