### PR TITLE
implement gerrit reporter

### DIFF
--- a/prow/cmd/gerrit-crier/BUILD.bazel
+++ b/prow/cmd/gerrit-crier/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//prow/client/clientset/versioned:go_default_library",
         "//prow/client/informers/externalversions:go_default_library",
         "//prow/crier:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//prow/gerrit/reporter:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/gerrit/adapter:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/gerrit/client/gerrit.go
+++ b/prow/gerrit/client/gerrit.go
@@ -28,6 +28,32 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client
+type ProjectsFlag map[string][]string
+
+func (p ProjectsFlag) String() string {
+	var hosts []string
+	for host, repos := range p {
+		hosts = append(hosts, host+"="+strings.Join(repos, ","))
+	}
+	return strings.Join(hosts, " ")
+}
+
+// Set populates ProjectsFlag upon flag.Parse()
+func (p ProjectsFlag) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("%s not in the form of host=repo-a,repo-b,etc", value)
+	}
+	host := parts[0]
+	if _, ok := p[host]; ok {
+		return fmt.Errorf("duplicate host: %s", host)
+	}
+	repos := strings.Split(parts[1], ",")
+	p[host] = repos
+	return nil
+}
+
 type gerritAuthentication interface {
 	SetCookieAuth(name, value string)
 }

--- a/prow/gerrit/reporter/BUILD.bazel
+++ b/prow/gerrit/reporter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
@@ -23,4 +24,14 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["reporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/prow/gerrit/reporter/reporter.go
+++ b/prow/gerrit/reporter/reporter.go
@@ -18,26 +18,80 @@ limitations under the License.
 package reporter
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/gerrit/client"
 )
 
-// Client holds a gerrit client
+type gerritClient interface {
+	SetReview(instance, id, revision, message string) error
+}
+
+// Client is a gerrit reporter client
 type Client struct {
-	// TODO(krzyzacy): fill this up
-	// gc gerrit.Client
+	gc gerritClient
 }
 
 // NewReporter returns a reporter client
-func NewReporter() *Client {
-	return &Client{}
+func NewReporter(cookiefilePath string, projects map[string][]string) (*Client, error) {
+	gc, err := gerrit.NewClient(projects)
+	if err != nil {
+		return nil, err
+	}
+	gc.Start(cookiefilePath)
+	return &Client{
+		gc: gc,
+	}, nil
+}
+
+// GetName returns the name of the reporter
+func (c *Client) GetName() string {
+	return "gerrit-reporter"
+}
+
+// ShouldReport returns if this prowjob should be reported by the gerrit reporter
+func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
+
+	if pj.Status.State == v1.TriggeredState || pj.Status.State == v1.PendingState {
+		// not done yet
+		return false
+	}
+
+	// has gerrit metadata (scheduled by gerrit adapter)
+	return pj.ObjectMeta.Annotations["gerrit-id"] != "" &&
+		pj.ObjectMeta.Annotations["gerrit-instance"] != "" &&
+		pj.ObjectMeta.Labels["gerrit-revision"] != ""
 }
 
 // Report will send the current prowjob status as a gerrit review
 func (c *Client) Report(pj *v1.ProwJob) error {
-	logrus.Infof("Reporting %s to gerrit, state %s", pj.Spec.Job, pj.Status.State)
 	// TODO(krzyzacy): we should also do an aggregate report, as golang does in their repo
 	// see https://go-review.googlesource.com/c/go/+/132155
+	// also add ability to set code-review labels
+	// ref: https://github.com/kubernetes/test-infra/issues/9433
+
+	if pj.Spec.Refs == nil {
+		return errors.New("no pj.Spec.Refs, not a presubmit job (should not happen?!)")
+	}
+
+	// bootstrap crap, fix it
+	url := strings.Replace(pj.Status.URL, pj.Spec.Refs.Repo, strings.Replace(pj.Spec.Refs.Repo, "/", "_", -1), 1)
+	message := fmt.Sprintf("Job %s finished with %s\n Gubernator URL: %s", pj.Spec.Job, pj.Status.State, url)
+
+	// report back
+	gerritID := pj.ObjectMeta.Annotations["gerrit-id"]
+	gerritInstance := pj.ObjectMeta.Annotations["gerrit-instance"]
+	gerritRevision := pj.ObjectMeta.Labels["gerrit-revision"]
+
+	logrus.Infof("Reporting job %s to instance %s on id %s with message %s", pj.Spec.Job, gerritInstance, gerritID, message)
+	if err := c.gc.SetReview(gerritInstance, gerritID, gerritRevision, message); err != nil {
+		return errors.New("cannot comment to gerrit")
+	}
+
 	return nil
 }

--- a/prow/gerrit/reporter/reporter_test.go
+++ b/prow/gerrit/reporter/reporter_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+const (
+	testPubSubProjectName = "test-project"
+	testPubSubTopicName   = "test-topic"
+	testPubSubRunID       = "test-id"
+)
+
+type fgc struct {
+	reportMessage string
+	instance      string
+}
+
+func (f *fgc) SetReview(instance, id, revision, message string) error {
+	if instance != f.instance {
+		return fmt.Errorf("wrong instance: %s", instance)
+	}
+	f.reportMessage = message
+	return nil
+}
+
+func TestReport(t *testing.T) {
+	var testcases = []struct {
+		name          string
+		pj            *v1.ProwJob
+		expectReport  bool
+		expectError   bool
+		reportMessage string
+	}{
+		{
+			name: "unfinished pj",
+			pj: &v1.ProwJob{
+				Status: v1.ProwJobStatus{
+					State: v1.PendingState,
+				},
+			},
+		},
+		{
+			name: "finished non-gerrit pj",
+			pj: &v1.ProwJob{
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+		},
+		{
+			name: "finished pj, missing gerrit id",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"gerrit-revision": "abc",
+					},
+					Annotations: map[string]string{
+						"gerrit-instance": "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+		},
+		{
+			name: "finished pj, missing gerrit revision",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"gerrit-id":       "123-abc",
+						"gerrit-instance": "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+		},
+		{
+			name: "finished pj, missing gerrit instance",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"gerrit-revision": "abc",
+					},
+					Annotations: map[string]string{
+						"gerrit-id": "123-abc",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+		},
+		{
+			name: "finished pj, no spec",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"gerrit-revision": "abc",
+					},
+					Annotations: map[string]string{
+						"gerrit-id":       "123-abc",
+						"gerrit-instance": "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+			expectReport: true,
+			expectError:  true,
+		},
+		{
+			name: "finished pj",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"gerrit-revision": "abc",
+					},
+					Annotations: map[string]string{
+						"gerrit-id":       "123-abc",
+						"gerrit-instance": "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			expectReport:  true,
+			reportMessage: "Job ci-foo finished with success\n Gubernator URL: guber/foo",
+		},
+		{
+			name: "finished pj, slash in repo name",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"gerrit-revision": "abc",
+					},
+					Annotations: map[string]string{
+						"gerrit-id":       "123-abc",
+						"gerrit-instance": "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo/bar",
+				},
+				Spec: v1.ProwJobSpec{
+					Refs: &v1.Refs{
+						Repo: "foo/bar",
+					},
+					Job: "ci-foo-bar",
+				},
+			},
+			expectReport:  true,
+			reportMessage: "Job ci-foo-bar finished with success\n Gubernator URL: guber/foo_bar",
+		},
+	}
+
+	for _, tc := range testcases {
+		fgc := &fgc{instance: "gerrit"}
+		reporter := &Client{gc: fgc}
+
+		shouldReport := reporter.ShouldReport(tc.pj)
+		if shouldReport != tc.expectReport {
+			t.Errorf("test: %s: shouldReport: %v, expectReport: %v", tc.name, shouldReport, tc.expectReport)
+		}
+
+		if !shouldReport {
+			continue
+		}
+
+		err := reporter.Report(tc.pj)
+		if err == nil && tc.expectError {
+			t.Errorf("test: %s: expect error but did not happen", tc.name)
+		} else if err != nil && !tc.expectError {
+			t.Errorf("test: %s: expect no error but got error %v", tc.name, err)
+		}
+
+		if err == nil {
+			if fgc.reportMessage != tc.reportMessage {
+				t.Errorf("test: %s: reported with : %s, expect: %s", tc.name, fgc.reportMessage, tc.reportMessage)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Gerrit API doesn't support update/delete comment... it won't be compatible with the report lib... Just make a temporary workaround, maybe informer will help but I'm not sure how much

/shrug
/assign
I'll do a bit more cleanups

cc @AishSundar @amwat @yutongz @bowei 

edit: this is not the current state of the world anymore... now it is built into the gerrit reporter and added tests.