### PR TITLE
Fix AddedLines() when patch contains \ No newline...

### DIFF
--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -282,6 +282,10 @@ func AddedLines(patch string) (map[int]int, error) {
 	}
 	lines := strings.Split(patch, "\n")
 	for i := 0; i < len(lines); i++ {
+		// dodge the "\ No newline at end of file" line
+		if lines[i] == "\\ No newline at end of file" {
+			continue
+		}
 		_, oldLen, newLine, newLen, err := parseHunkLine(lines[i])
 		if err != nil {
 			return nil, fmt.Errorf("couldn't parse hunk on line %d in patch %s: %v", i, patch, err)

--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -203,6 +203,10 @@ func TestAddedLines(t *testing.T) {
 			lines: map[int]int{1: 1},
 		},
 		{
+			patch: "@@ -0,0 +1 @@\n+wow\n\\ No newline at end of file",
+			lines: map[int]int{1: 1},
+		},
+		{
 			patch: "@@ -1 +1 @@\n-doge\n+wow",
 			lines: map[int]int{2: 1},
 		},


### PR DESCRIPTION
Fixes one error that appeared in #8430 when using AddedLines() inside verify-owners.