### PR TITLE
Allow create prowjob with annotations

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -39,8 +39,17 @@ const (
 	pullLabel    = "prow.k8s.io/refs.pull"
 )
 
+// NewProwJob initializes a ProwJob out of a ProwJobSpec with annotations.
+func NewProwJobWithAnnotation(spec kube.ProwJobSpec, labels, annotations map[string]string) kube.ProwJob {
+	return newProwJob(spec, labels, annotations)
+}
+
 // NewProwJob initializes a ProwJob out of a ProwJobSpec.
 func NewProwJob(spec kube.ProwJobSpec, labels map[string]string) kube.ProwJob {
+	return newProwJob(spec, labels, nil)
+}
+
+func newProwJob(spec kube.ProwJobSpec, labels, annotations map[string]string) kube.ProwJob {
 	allLabels := map[string]string{
 		jobNameLabel: spec.Job,
 		jobTypeLabel: string(spec.Type),
@@ -76,8 +85,9 @@ func NewProwJob(spec kube.ProwJobSpec, labels map[string]string) kube.ProwJob {
 			Kind:       "ProwJob",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   uuid.NewV1().String(),
-			Labels: allLabels,
+			Name:        uuid.NewV1().String(),
+			Labels:      allLabels,
+			Annotations: annotations,
 		},
 		Spec: spec,
 		Status: kube.ProwJobStatus{

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -292,3 +292,45 @@ func TestNewProwJob(t *testing.T) {
 		}
 	}
 }
+
+func TestNewProwJobWithAnnotations(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		spec                kube.ProwJobSpec
+		annotations         map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "job without annotation",
+			spec: kube.ProwJobSpec{
+				Job:  "job",
+				Type: kube.PeriodicJob,
+			},
+			annotations:         nil,
+			expectedAnnotations: nil,
+		},
+		{
+			name: "job with empty annotation",
+			spec: kube.ProwJobSpec{
+				Job:  "job",
+				Type: kube.PeriodicJob,
+			},
+			annotations: map[string]string{
+				"annotation": "foo",
+			},
+			expectedAnnotations: map[string]string{
+				"annotation": "foo",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		pj := NewProwJobWithAnnotation(testCase.spec, nil, testCase.annotations)
+		if actual, expected := pj.Spec, testCase.spec; !equality.Semantic.DeepEqual(actual, expected) {
+			t.Errorf("%s: incorrect ProwJobSpec created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
+		}
+		if actual, expected := pj.Annotations, testCase.expectedAnnotations; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: incorrect ProwJob labels created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
+		}
+	}
+}


### PR DESCRIPTION
So I need to store some extra into into the prowjob, however label is restricted to 256 chars and a certain charaterset, which I cannot store a string in run time (see #9045).. Try to make annotation first class

/area prow
/assign @stevekuznetsov @BenTheElder @cjwagner 