### PR TITLE
Enable merge blocking issues for Tide.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -340,6 +340,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-incubator/service-catalog: squash
   target_url: https://prow.k8s.io/tide.html
+  blocker_label: merge-blocker
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
Retry of #9031 now that the issue search bug has been fixed (#9042) and deployed.

I tested this out in dry run mode without a blocking issue and didn't run into any problems so hopefully this won't jam Tide this time.

/area prow
/assign @fejta 