### PR TITLE
Avoid highlighting diffs in pathological logs.

### DIFF
--- a/triage/render.js
+++ b/triage/render.js
@@ -233,6 +233,10 @@ function renderSpans(text, spans) {
   if (!spans) {
     return [text];
   }
+  if (spans.length > 1000) {
+    console.warn(`Not highlighting excessive number of spans to avoid browser hang: ${spans.length}`);
+    return [text];
+  }
   var out = [];
   var c = 0;
   for (var i = 0; i < spans.length; i += 2) {


### PR DESCRIPTION
Extremely long logs with many, many mismatches are going to result in the creation of a ridiculous number of DOM nodes. Browsers generally do not respond well to hundreds of thousands of DOM nodes suddenly appearing, and so hang for a while:

![hanging on style recalculation](https://user-images.githubusercontent.com/110792/44179386-5f171480-a0ab-11e8-9186-08329800ff0e.png)

Limit the number of mismatch spans to 1,000 (several times the observed number on any reasonable test case) before we just show the unhighlighted log.

Fixes #9025, which you can reproduce by viewing [this specific failure](https://storage.googleapis.com/k8s-gubernator/triage/index.html?ci=0&pr=1&job=pull-kubernetes-integration&test=.*#92aa5bd20a7666eaca1e) (warning: clicking this link _will hang your browser_)

/area triage
/assign @BenTheElder