### PR TITLE
Require travis-ci status for external-snapshotter repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -177,6 +177,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
+        external-snapshotter:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
         livenessprobe:
           required_status_checks:
             contexts:


### PR DESCRIPTION
This PR adds requirement for travis-ci to pass before merging on the external-snapshotter repo under kubernetes-csi.