### PR TITLE
Adding new error to parse strange GitHub error

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -255,12 +255,28 @@ type request struct {
 }
 
 type requestError struct {
-	ClientError
+	ClientError error
 	ErrorString string
 }
 
 func (r requestError) Error() string {
 	return r.ErrorString
+}
+
+func (r requestError) ErrorMessages() []string {
+	clientErr, isClientError := r.ClientError.(ClientError)
+	if isClientError {
+		errors := []string{}
+		for _, subErr := range clientErr.Errors {
+			errors = append(errors, subErr.Message)
+		}
+		return errors
+	}
+	alternativeClientErr, isAlternativeClientError := r.ClientError.(AlternativeClientError)
+	if isAlternativeClientError {
+		return alternativeClientErr.Errors
+	}
+	return []string{}
 }
 
 // Make a request with retries. If ret is not nil, unmarshal the response body
@@ -301,16 +317,13 @@ func (c *Client) requestRaw(r *request) (int, []byte, error) {
 		}
 	}
 	if !okCode {
-		clientError := ClientError{}
-		if err := json.Unmarshal(b, &clientError); err != nil {
-			return resp.StatusCode, b, err
-		}
-		return resp.StatusCode, b, requestError{
+		clientError := unmarshalClientError(b)
+		err = requestError{
 			ClientError: clientError,
 			ErrorString: fmt.Sprintf("status code %d not one of %v, body: %s", resp.StatusCode, r.exitCodes, string(b)),
 		}
 	}
-	return resp.StatusCode, b, nil
+	return resp.StatusCode, b, err
 }
 
 // Retry on transport failures. Retries on 500s, retries after sleep on
@@ -1546,11 +1559,11 @@ var _ error = (*StateCannotBeChanged)(nil)
 // convert to a StateCannotBeChanged if appropriate or else return the original error
 func stateCannotBeChangedOrOriginalError(err error) error {
 	requestErr, ok := err.(requestError)
-	if ok && len(requestErr.Errors) > 0 {
-		for _, subErr := range requestErr.Errors {
-			if strings.Contains(subErr.Message, stateCannotBeChangedMessagePrefix) {
+	if ok {
+		for _, errorMsg := range requestErr.ErrorMessages() {
+			if strings.Contains(errorMsg, stateCannotBeChangedMessagePrefix) {
 				return StateCannotBeChanged{
-					Message: subErr.Message,
+					Message: errorMsg,
 				}
 			}
 		}

--- a/prow/github/types_test.go
+++ b/prow/github/types_test.go
@@ -52,3 +52,58 @@ func TestIssueCapsLogin(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshalClientError(t *testing.T) {
+	var testcases = []struct {
+		name string
+		body string
+	}{
+		{
+			name: "invalid JSON",
+			body: `{"message":"Problems parsing JSON"}`,
+		},
+		{
+			name: "wrong type of JSON values",
+			body: `{"message":"Body should be a JSON object"}`,
+		},
+		{
+			name: "invalid fields",
+			body: `{
+				"message": "Validation Failed",
+				"errors": [
+				  {
+					"resource": "Issue",
+					"field": "title",
+					"code": "missing_field"
+				  }
+				]
+			  }`,
+		},
+		{
+			name: "requires authentication",
+			body: `{
+				"message": "Requires authentication",
+				"documentation_url": "https://developer.github.com/v3"
+			  }`,
+		},
+		{
+			name: "validation failed, position is invalid",
+			body: `{
+				"message": "Validation Failed",
+				"errors": [
+				  "Position is invalid"
+				],
+				"documentation_url": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
+			  }`,
+		},
+	}
+	for _, tc := range testcases {
+		b := []byte(tc.body)
+		err := unmarshalClientError(b)
+		_, isClientError := err.(ClientError)
+		_, isAlternativeClientError := err.(AlternativeClientError)
+		if !(isClientError || isAlternativeClientError) {
+			t.Errorf("For case %s, json.Unmarshal error: %v", tc.name, err)
+		}
+	}
+}


### PR DESCRIPTION
I have found a new error format from [reviews API](https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review) when sending an invalid line number which does not comply with what is described [here](https://developer.github.com/v3/#client-errors):
```
{
  "message": "Validation Failed",
  "errors": [
    "Position is invalid"
  ],
  "documentation_url": "https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"
}
```
I have already contacted GitHub support regarding that, but I thought it would be good to parse this kind of error anyways.
This PR adds a new struct, some parsing tests and the fallback code in `requestRaw()`.