### PR TITLE
Don't gather logs sizes in ci-kubernetes-e2e-gci-gce-scalability.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
@@ -25,7 +25,7 @@ periodics:
       - --gcp-project=k8s-jenkins-gci-scalability
       - --gcp-zone=us-central1-f
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --minStartupPods=8
       - --timeout=120m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180730-8b7ab3104-master


### PR DESCRIPTION
We have never used that feature for debugging our tests and this feature doesn't work in some cases:

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-kubemark-gce-scale/1149