### PR TITLE
Kubemark: Use Taint based evictions.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
@@ -532,7 +532,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-100
-      - --env=KUBE_FEATURE_GATES=TaintBasedEvictions=true
       - --env-file=jobs/env/ci-kubernetes-e2e-kubemark-common.env
       - --extract=ci/latest
       - --gcp-master-size=n1-standard-2

--- a/jobs/env/ci-kubernetes-e2e-kubemark-common.env
+++ b/jobs/env/ci-kubernetes-e2e-kubemark-common.env
@@ -12,3 +12,8 @@ SCHEDULER_TEST_ARGS=--profiling
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Reduce etcd compaction frequency to match production.
 KUBEMARK_ETCD_COMPACTION_INTERVAL_SEC=150
+
+# Use Taint based evictions to control hollow node recreation in case of
+# node VM restart.
+# See https://github.com/kubernetes/kubernetes/issues/67120 for context.
+KUBE_FEATURE_GATES=TaintBasedEvictions=true


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/67120:

In https://github.com/kubernetes/kubernetes/pull/67490 I added required tolerations to hollow nodes and keep it running on kubemark-100.
White the test is green, we can push the change further to all kubemarks.

/assign @shyamjvs 