### PR TITLE
LGTM in `kubernetes/cloud-provider-azure` should act as `/approve`

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -34,6 +34,7 @@ owners:
 
 approve:
 - repos:
+  - kubernetes/cloud-provider-azure
   - kubernetes/cluster-registry
   - kubernetes/contrib
   - kubernetes/dashboard


### PR DESCRIPTION
/sig azure
/cc @khenidak @feiskyer @andyzhangx

Signed-off-by: Stephen Augustus <foo@agst.us>