### PR TITLE
Add Chinese docs repo to tide, approve, blunderbuss

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -245,6 +245,7 @@ tide:
     - kubernetes/kubeadm
     - kubernetes/kubernetes-docs-ja
     - kubernetes/kubernetes-docs-ko
+    - kubernetes/kubernetes-docs-zh
     - kubernetes/kubernetes-template-project
     - kubernetes/minikube
     - kubernetes/node-problem-detector

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -347,6 +347,10 @@ plugins:
   - approve
   - blunderbuss
 
+  kubernetes/kubernetes-docs-zh:
+  - approve
+  - blunderbuss
+
   kubernetes/kubernetes-template-project:
   - approve
 


### PR DESCRIPTION
This PR adds `k/kubernetes-docs-zh` to the list of repos that enable tide, blunderbuss, and approve.

For reference: https://github.com/kubernetes/kubernetes-docs-zh/pull/499#issuecomment-414438007

/area prow

/assign @spiffxp 