### PR TITLE
Add conditional enabling of IPv6 for bootstrap container

### DIFF
--- a/images/bootstrap/entrypoint.sh
+++ b/images/bootstrap/entrypoint.sh
@@ -17,6 +17,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# enable IPv6 if requested (requires container to be run privileged mode)
+export IPV6_ENABLED=${IPV6_ENABLED:-false}
+if [[ "${IPV6_ENABLED}" == "true" ]]; then
+    sysctl -w net.ipv6.conf.all.disable_ipv6=0
+fi
+
 # get test-infra for latest bootstrap etc
 git clone https://github.com/kubernetes/test-infra
 


### PR DESCRIPTION
This change adds a mechanism for enabling IPv6 in any Prow containers that
are built from the bootstrap container, based on an "IPV6_ENABLED"
environment variable that can be passed to the container.

This mechanism will be used by an IPv6 CI test that will be based on
kubekins-e2e (see PR #7529).