### PR TITLE
initial setup for kubernetes/cluster-api-provider-vsphere

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -276,6 +276,7 @@ tide:
     - kubernetes-sigs/cluster-api-provider-aws
     - kubernetes-sigs/cluster-api-provider-gcp
     - kubernetes-sigs/cluster-api-provider-openstack
+    - kubernetes-sigs/cluster-api-provider-vsphere
     - kubernetes-sigs/contributor-site
     - kubernetes-sigs/controller-runtime
     - kubernetes-sigs/controller-tools
@@ -346,6 +347,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-aws: squash
     kubernetes-sigs/cluster-api-provider-gcp: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
+    kubernetes-sigs/cluster-api-provider-vsphere: squash
     kubernetes-incubator/service-catalog: squash
   target_url: https://prow.k8s.io/tide.html
   blocker_label: merge-blocker

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -532,6 +532,9 @@ plugins:
   kubernetes-sigs/cluster-api-provider-openstack:
   - trigger
 
+  kubernetes-sigs/cluster-api-provider-vsphere:
+  - trigger
+
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - trigger
 


### PR DESCRIPTION
There's a new repo called https://github.com/kubernetes-sigs/cluster-api-provider-vsphere

This is for adding an external cluster api provider for vSphere

This is just for initial configuration, CI jobs will come later on