### PR TITLE
Kubetest - Removing perftest flags

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -249,10 +249,6 @@ func run(deploy deployer, o options) error {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "Helm Charts", chartsTest))
 	}
 
-	if o.perfTest != "" {
-		errs = util.AppendError(errs, control.XMLWrap(&suite, "Perf Tests", perfTest(o.perfTest, o.perfTestArgs)))
-	}
-
 	if dump != "" {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "DumpClusterLogs", func() error {
 			return deploy.DumpClusterLogs(dump, o.logexporterGCSPath)
@@ -539,19 +535,6 @@ func dumpFederationLogs(location string) error {
 	}
 	log.Printf("Could not find %s. This is expected if running tests against a Kubernetes 1.6 or older tree.", logDumpPath)
 	return nil
-}
-
-func perfTest(tool, args string) func() error {
-	// Run perf tests
-	flagArgs := []string{tool}
-	flagArgs = append(flagArgs, argFields(args, "", "")...)
-	return func() error {
-		cmdline := util.K8s("perf-tests", "run-e2e.sh")
-		if err := control.FinishRunning(exec.Command(cmdline, flagArgs...)); err != nil {
-			return err
-		}
-		return nil
-	}
 }
 
 func chartsTest() error {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -100,8 +100,6 @@ type options struct {
 	nodeArgs            string
 	nodeTestArgs        string
 	nodeTests           bool
-	perfTest            string
-	perfTestArgs        string
 	provider            string
 	publish             string
 	runtimeConfig       string
@@ -169,8 +167,6 @@ func defineFlags() *options {
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")
 	flag.BoolVar(&o.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
 	flag.BoolVar(&o.nodeTests, "node-tests", false, "If true, run node-e2e tests.")
-	flag.StringVar(&o.perfTest, "perf-test", "", "If not empty, runs tests from perf-tests repo using run-e2e.sh from the main directory with pertfTests value as a first parameter.")
-	flag.StringVar(&o.perfTestArgs, "perf-test-args", "", "Specifies args for perf-tests testing.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -244,7 +244,6 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
             '--kubemark',
             '--extract=this',
             '--extract=that',
-            '--perf-tests',
             '--save=somewhere',
             '--skew',
             '--publish=location',


### PR DESCRIPTION
Removing perftest flags.
Perf tests can be run using test-cmd = "$GOPATH/src/k8s.io/perf-tests/run-e2e.sh".