### PR TITLE
Adding clusterloader2 job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
@@ -713,9 +713,38 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-clusterloader
       - --gcp-zone=us-central1-f
-      - --perf-tests
       - --provider=gce
       - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-args=cluster-loader
+      - --test-cmd-name=ClusterLoader
+      - --timeout=60m
+
+- name: ci-perf-tests-e2e-gce-clusterloader2
+  interval: 2h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180730-8b7ab3104-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
+      - --timeout=80
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --extract=ci/latest
+      - --gcp-nodes=3
+      - --gcp-project=k8s-jkns-clusterloader
+      - --gcp-zone=us-central1-f
+      - --provider=gce
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-args=cluster-loader2 --testconfig=testing/density/config.yaml --nodes=3
+      - --test-cmd-name=ClusterLoaderV2
       - --timeout=60m
 
 - name: ci-perf-tests-kubemark-100-benchmark

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1566,6 +1566,8 @@ test_groups:
 # perf tests
 - name: ci-perf-tests-e2e-gce-clusterloader
   gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-e2e-gce-clusterloader
+- name: ci-perf-tests-e2e-gce-clusterloader2
+  gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-e2e-gce-clusterloader2
 - name: ci-perf-tests-kubemark-100-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-kubemark-100-benchmark
 # benchmarks
@@ -5667,6 +5669,8 @@ dashboards:
     test_group_name: ci-perf-tests-kubemark-100-benchmark
   - name: cluster-loader
     test_group_name: ci-perf-tests-e2e-gce-clusterloader
+  - name: cluster-loader2
+    test_group_name: ci-perf-tests-e2e-gce-clusterloader2
 
 - name: sig-scalability-benchmarks
   dashboard_tab:


### PR DESCRIPTION
Adding new ci job for clusterloader2.
Adjusting previous clusterloader job, so it will use `test-cmd` flags.