### PR TITLE
cleanup some prow config nits

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -284,6 +284,7 @@ tide:
     - kubernetes-sigs/kubebuilder
     - kubernetes-sigs/kustomize
     - kubernetes-incubator/ip-masq-agent
+    - kubernetes-incubator/service-catalog
     - client-go/unofficial-docs
     labels:
     - lgtm
@@ -322,18 +323,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-ok-to-test
-  - repos:
-    - kubernetes-incubator/service-catalog
-    labels:
-    - lgtm
-    - approved
-    - "cncf-cla: yes"
-    missingLabels:
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-ok-to-test
-    - needs-rebase
   merge_method:
     helm/charts: squash
     kubeflow: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -240,6 +240,26 @@ plugins:
   - lgtm
   - trigger
 
+  kubernetes:
+  - assign
+  - cat
+  - cla
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - slackevents
+  - wip
+  - yuks
+
   kubernetes/client-go:
   - approve
 
@@ -416,26 +436,6 @@ plugins:
   - approve
   - blunderbuss
 
-  kubernetes:
-  - assign
-  - cat
-  - cla
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - shrug
-  - sigmention
-  - size
-  - skip
-  - slackevents
-  - wip
-  - yuks
-
   kubernetes-client:
   - assign
   - cla
@@ -492,6 +492,9 @@ plugins:
   - hold
   - trigger
 
+  kubernetes-security/kubernetes:
+  - trigger
+
   kubernetes-sigs:
   - approve
   - assign
@@ -545,9 +548,6 @@ plugins:
   - lgtm
   - lifecycle
   - size
-  - trigger
-
-  kubernetes-security/kubernetes:
   - trigger
 
   tensorflow/k8s:


### PR DESCRIPTION
Including:
- plugins.yaml should have org before org/repos
- k-i/service-catalog no longer needs its own tide query (it used to
  when it was using LGTM1 and LGTM2, but those days are behind us
  now)