### PR TITLE
Setup automation for kubernetes-incubator/kubespray

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -285,6 +285,7 @@ tide:
     - kubernetes-sigs/kubebuilder
     - kubernetes-sigs/kustomize
     - kubernetes-incubator/ip-masq-agent
+    - kubernetes-incubator/kubespray
     - kubernetes-incubator/service-catalog
     - client-go/unofficial-docs
     labels:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -476,6 +476,10 @@ plugins:
   - lifecycle
   - size
 
+  kubernetes-incubator/kubespray:
+  - approve
+  - blunderbuss
+
   kubernetes-incubator/service-catalog:
   - approve
   - blunderbuss


### PR DESCRIPTION
Including:
- turn on approve and blunderbuss
- add to tide queries

I'll be enforcing branch protection separately becuase I'd rather turn
it on org-wide