### PR TITLE
Setup branch-protection for kubernetes-client and kubernetes-incubator

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -155,6 +155,11 @@ branch-protection:
               protect: true
             release-1.9:
               protect: true
+    kubernetes-client:
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/linuxfoundation
     kubernetes-csi:
       protect: true
       required_status_checks:
@@ -185,6 +190,11 @@ branch-protection:
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
+    kubernetes-incubator:
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/linuxfoundation
     kubernetes-sigs:
       protect: true
       required_status_checks:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -160,6 +160,15 @@ branch-protection:
       required_status_checks:
         contexts:
         - cla/linuxfoundation
+      repos:
+        python:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        python-base:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
     kubernetes-csi:
       protect: true
       required_status_checks:
@@ -195,6 +204,19 @@ branch-protection:
       required_status_checks:
         contexts:
         - cla/linuxfoundation
+      repos:
+        bootkube:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        kube-arbitrator:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        node-feature-discovery:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
     kubernetes-sigs:
       protect: true
       required_status_checks:


### PR DESCRIPTION
Every repo already should have cla/linuxfoundation as required, but there are
a number that don't.  This fixes that.

Repos that have other required status contexts have those enabled as well

ref: https://github.com/kubernetes/test-infra/issues/6227

/hold
for comment / lazy consensus, no objections by friday 10am PT and I'll merge this