### PR TITLE
Setup merge automation for kubernetes-client repos

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -259,6 +259,16 @@ tide:
     - kubernetes/test-infra
     - kubernetes/utils
     - kubernetes/website
+    - kubernetes-client/csharp
+    - kubernetes-client/gen
+    - kubernetes-client/go
+    - kubernetes-client/go-base
+    - kubernetes-client/haskell
+    - kubernetes-client/java
+    - kubernetes-client/javascript
+    - kubernetes-client/python
+    - kubernetes-client/python-base
+    - kubernetes-client/ruby
     - kubernetes-csi/csi-test
     - kubernetes-csi/docs
     - kubernetes-csi/driver-registrar
@@ -332,6 +342,8 @@ tide:
     kubernetes/website: squash
     kubernetes/kubernetes-docs-ja: squash
     kubernetes/kubernetes-docs-ko: squash
+    kubernetes-client/csharp: squash
+    kubernetes-client/gen: squash
     kubernetes-sigs/cluster-api: squash
     kubernetes-sigs/cluster-api-provider-aws: squash
     kubernetes-sigs/cluster-api-provider-gcp: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -442,17 +442,23 @@ plugins:
   - blunderbuss
 
   kubernetes-client:
+  - approve
   - assign
+  - blunderbuss
+  - cat
   - cla
+  - dog
+  - heart
+  - help
+  - hold
   - label
   - lgtm
   - lifecycle
+  - shrug
   - size
+  - skip
   - wip
-  - hold
-  - help
-  - cat
-  - dog
+  - yuks
 
   kubernetes-csi:
   - approve

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -5,6 +5,7 @@
 triggers:
 - repos:
   - kubernetes
+  - kubernetes-client
   - kubernetes-csi
   - kubernetes-incubator
   - kubernetes-security
@@ -28,6 +29,7 @@ triggers:
   join_org_url: "https://github.com/tensorflow/minigo/blob/master/CONTRIBUTING.md"
 - repos:
   - bazelbuild
+
 owners:
   mdyamlrepos:
   - kubernetes/website
@@ -67,6 +69,7 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 - repos:
+  - kubernetes-client
   - kubernetes-csi
   - kubernetes-sigs
   - client-go/unofficial-docs


### PR DESCRIPTION
This will turn on /lgtm, /approve, and auto-merging via tide. Same automation
that's used by all repos in kubernetes-sigs and kubernetes-csi.

/sig contributor-experience
/area github-management
/kind cleanup
/sig api-machinery

/cc @brendandburns @mbohlool
You have admin/write access to most of the kubernetes-client repos

/cc @roycaihw @yliaog @dims @lavalamp
You have admin/write access to the rest (as collaborators). Since you're already kubernetes
members I'd encourage you to [file a membership request for kubernetes-client](https://github.com/kubernetes/org/issues/new?template=membership.md)
and mention that. The requirements/sponsors and PR/issue lists can be skipped in that case

/hold
for comment

This is the main audience impacted, so I'm not inclined to send a k-dev@ lazy conensus e-mail. 
I'm most interested in hearing from @brendandburns and @yliaog as the most active mergers recently.