### PR TITLE
add 1.12 branch manager shadows to auth list

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -164,6 +164,8 @@ slack:
             - foxish # 1.11 patch release manager
         release-1.12:
             - dougm # 1.12 branch manager
+            - hoegaarden # 1.12 branch manager shadow
+            - idealhack # 1.12 branch manager shadow
         feature-serverside-apply:
             - lavalamp # feature-serverside-apply "branch manager"
             - apelisse # feature-serverside-apply "branch manager"


### PR DESCRIPTION
We're going to have the 1.12 release branch managers (see
https://git.k8s.io/sig-release/releases/release-1.12/release_team.md) run
some branchff's over the next week and don't want to spam warnings
around.

Signed-off-by: Tim Pepper <tpepper@vmware.com>