### PR TITLE
enable trigger plugin on org repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -404,6 +404,7 @@ plugins:
   - approve
   - blunderbuss
   - owners-label
+  - trigger
 
   kubernetes/perf-tests:
   - approve


### PR DESCRIPTION
Otherwise /test etc commands do not work