### PR TITLE
Prow: Load job config from .yml files too

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -345,7 +345,7 @@ func loadConfig(prowConfig, jobConfig string) (*Config, error) {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".yaml" {
+		if filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml" {
 			return nil
 		}
 


### PR DESCRIPTION
Unfortunately, people still use .yml, it's hard to notice during reviews
and it leads to jobs being silently not created.