### PR TITLE
Store tree-hash inside a comment and compare it before removing lgtm

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1014,11 +1014,11 @@ func (c *Client) ListReviews(org, repo string, number int) ([]Review, error) {
 // CreateStatus creates or updates the status of a commit.
 //
 // See https://developer.github.com/v3/repos/statuses/#create-a-status
-func (c *Client) CreateStatus(org, repo, sha string, s Status) error {
-	c.log("CreateStatus", org, repo, sha, s)
+func (c *Client) CreateStatus(org, repo, SHA string, s Status) error {
+	c.log("CreateStatus", org, repo, SHA, s)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
-		path:        fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, sha),
+		path:        fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, SHA),
 		requestBody: &s,
 		exitCodes:   []int{201},
 	}, nil)
@@ -1087,6 +1087,20 @@ func (c *Client) GetRepos(org string, isUser bool) ([]Repo, error) {
 		return nil, err
 	}
 	return repos, nil
+}
+
+// GetSingleCommit returns a single commit.
+//
+// See https://developer.github.com/v3/repos/#get
+func (c *Client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
+	c.log("GetSingleCommit", org, repo, SHA)
+	var commit SingleCommit
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("/repos/%s/%s/commits/%s", org, repo, SHA),
+		exitCodes: []int{200},
+	}, &commit)
+	return commit, err
 }
 
 // GetBranches returns all branches in the repo.
@@ -1681,7 +1695,7 @@ func (e *FileNotFound) Error() string {
 	return fmt.Sprintf("%s/%s/%s @ %s not found", e.org, e.repo, e.path, e.commit)
 }
 
-// GetFile uses GitHub repo contents API to retrieve the content of a file with commit sha.
+// GetFile uses GitHub repo contents API to retrieve the content of a file with commit SHA.
 // If commit is empty, it will grab content from repo's default branch, usually master.
 // TODO(krzyzacy): Support retrieve a directory
 //
@@ -2088,7 +2102,7 @@ func (c *Client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent,
 // IsMergeable determines if a PR can be merged.
 // Mergeability is calculated by a background job on GitHub and is not immediately available when
 // new commits are added so the PR must be polled until the background job completes.
-func (c *Client) IsMergeable(org, repo string, number int, sha string) (bool, error) {
+func (c *Client) IsMergeable(org, repo string, number int, SHA string) (bool, error) {
 	backoff := time.Second * 3
 	maxTries := 3
 	for try := 0; try < maxTries; try++ {
@@ -2096,8 +2110,8 @@ func (c *Client) IsMergeable(org, repo string, number int, sha string) (bool, er
 		if err != nil {
 			return false, err
 		}
-		if pr.Head.SHA != sha {
-			return false, fmt.Errorf("pull request head changed while checking mergeability (%s -> %s)", sha, pr.Head.SHA)
+		if pr.Head.SHA != SHA {
+			return false, fmt.Errorf("pull request head changed while checking mergeability (%s -> %s)", SHA, pr.Head.SHA)
 		}
 		if pr.Merged {
 			return false, errors.New("pull request was merged while checking mergeability")

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -312,11 +312,37 @@ func TestGetRef(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	sha, err := c.GetRef("k8s", "kuber", "heads/mastah")
+	SHA, err := c.GetRef("k8s", "kuber", "heads/mastah")
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
-	} else if sha != "abcde" {
-		t.Errorf("Wrong sha: %s", sha)
+	} else if SHA != "abcde" {
+		t.Errorf("Wrong SHA: %s", SHA)
+	}
+}
+
+func TestGetSingleCommit(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{
+			"commit": {
+			  "tree": {
+				"sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+			  }
+		        }
+		  }`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	commit, err := c.GetSingleCommit("octocat", "Hello-World", "6dcb09b5b57875f334f61aebed695e2e4193db5e")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if commit.Commit.Tree.SHA != "6dcb09b5b57875f334f61aebed695e2e4193db5e" {
+		t.Errorf("Wrong tree-hash: %s", commit.Commit.Tree.SHA)
 	}
 }
 

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -24,6 +24,8 @@ import (
 )
 
 const botName = "k8s-ci-robot"
+
+// Bot is the exported botName
 const Bot = botName
 
 // FakeClient is like client, but fake.
@@ -41,6 +43,7 @@ type FakeClient struct {
 	CombinedStatuses    map[string]*github.CombinedStatus
 	CreatedStatuses     map[string][]github.Status
 	IssueEvents         map[int][]github.ListedIssueEvent
+	Commits             map[string]github.SingleCommit
 
 	//All Labels That Exist In The Repo
 	ExistingLabels []string
@@ -183,12 +186,17 @@ func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
 	return "abcde", nil
 }
 
+// GetSingleCommit returns a single commit.
+func (f *FakeClient) GetSingleCommit(org, repo, SHA string) (github.SingleCommit, error) {
+	return f.Commits[SHA], nil
+}
+
 // CreateStatus adds a status context to a commit.
-func (f *FakeClient) CreateStatus(owner, repo, sha string, s github.Status) error {
+func (f *FakeClient) CreateStatus(owner, repo, SHA string, s github.Status) error {
 	if f.CreatedStatuses == nil {
 		f.CreatedStatuses = make(map[string][]github.Status)
 	}
-	statuses := f.CreatedStatuses[sha]
+	statuses := f.CreatedStatuses[SHA]
 	var updated bool
 	for i := range statuses {
 		if statuses[i].Context == s.Context {
@@ -199,7 +207,7 @@ func (f *FakeClient) CreateStatus(owner, repo, sha string, s github.Status) erro
 	if !updated {
 		statuses = append(statuses, s)
 	}
-	f.CreatedStatuses[sha] = statuses
+	f.CreatedStatuses[SHA] = statuses
 	return nil
 }
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -510,6 +510,16 @@ type Commit struct {
 	Modified []string `json:"modified"`
 }
 
+// SingleCommit is the commit part received when requesting a single commit
+// https://developer.github.com/v3/repos/commits/#get-a-single-commit
+type SingleCommit struct {
+	Commit struct {
+		Tree struct {
+			SHA string `json:"sha"`
+		} `json:"tree"`
+	} `json:"commit"`
+}
+
 // ReviewEventAction enumerates the triggers for this
 // webhook payload type. See also:
 // https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -97,6 +97,9 @@ lgtm:
 - repos:
   - bazelbuild
   review_acts_as_lgtm: true
+- repos:
+  - kubernetes/test-infra
+  store_tree_hash: true
 
 blockades:
 - repos:

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -366,6 +366,9 @@ type Lgtm struct {
 	// ReviewActsAsLgtm indicates that a Github review of "approve" or "request changes"
 	// acts as adding or removing the lgtm label
 	ReviewActsAsLgtm bool `json:"review_acts_as_lgtm,omitempty"`
+	// StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
+	// squashed commits before removing lgtm labels
+	StoreTreeHash bool `json:"store_tree_hash,omitempty"`
 }
 
 type Cat struct {


### PR DESCRIPTION
Fixes #6353
I have decided to stick with statuses to avoid spamming reviewers.
Also it makes more sense to me, as a lgtm refers to a commit.