### PR TITLE
port over focus from the -beta node job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -320,7 +320,7 @@ periodics:
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=8 --skip="\[Flaky\]|\[Serial\]"
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
       - --timeout=65m
       env:
       - name: GOPATH


### PR DESCRIPTION
I diffed the 1.12 and 1.11 version of kubelet job and found the ginkgo focus has been changed

/area jobs
/assign @yguo0905 @yujuhong @crimsonfaith91 

should fix https://k8s-testgrid.appspot.com/sig-release-1.11-blocking#node-kubelet-1.11