### PR TITLE
Update force push warning with more detail

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -438,6 +438,7 @@ type PushEvent struct {
 	Before  string   `json:"before"`
 	After   string   `json:"after"`
 	Compare string   `json:"compare"`
+	Size    int      `json:"size"`
 	Commits []Commit `json:"commits"`
 	// Pusher is the user that pushed the commit, valid in a webhook event.
 	Pusher User `json:"pusher"`

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -103,7 +103,7 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	if mw := getMergeWarning(pc.SlackConfig.MergeWarnings, pe.Repo.Owner.Login, pe.Repo.Name); mw != nil {
 		//If the MergeWarning whitelist has the merge user then no need to send a message.
 		if wl := !isWhiteListed(mw, pe); wl {
-			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %s", pe.Sender.Login, pe.Sender.Login, pe.Compare)
+			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, pe.Size, pe.Branch(), pe.Compare)
 			for _, channel := range mw.Channels {
 				if err := pc.SlackClient.WriteMessage(message, channel); err != nil {
 					return err

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -41,6 +41,7 @@ func TestPush(t *testing.T) {
   "ref": "refs/heads/master",
   "before": "d73a75b4b1ddb63870954b9a60a63acaa4cb1ca5",
   "after": "045a6dca07840efaf3311450b615e19b5c75f787",
+  "size": 2,
   "compare": "https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784",
   "commits": [
     {
@@ -92,8 +93,8 @@ func TestPush(t *testing.T) {
 
 	noMessages := map[string][]string{}
 	stdWarningMessages := map[string][]string{
-		"sig-contribex":  {"*Warning:* tester (<@tester>) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
-		"kubernetes-dev": {"*Warning:* tester (<@tester>) manually merged https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
+		"sig-contribex":  {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
+		"kubernetes-dev": {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
 
 	type testCase struct {
 		name             string


### PR DESCRIPTION
Quick win! This updates the force push warning to include size and branch details in the message.

https://developer.github.com/v3/activity/events/types/#pushevent