### PR TITLE
Enable trigger plugin for perf-tests

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -409,6 +409,7 @@ plugins:
   kubernetes/perf-tests:
   - approve
   - blunderbuss
+  - trigger
 
   kubernetes/publishing-bot:
   - approve


### PR DESCRIPTION
To make `/retest`, etc work for perf-tests. I'm not sure if this would work rightaway, but let's try?

/cc @wojtek-t 
fyi - @cjwagner @krzyzacy 