### PR TITLE
Set lgtm_acts_as_approve to false for k/k approval

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -52,7 +52,6 @@ approve:
   - kubernetes/kube-deploy
   - kubernetes/kubeadm
   - kubernetes/kubectl
-  - kubernetes/kubernetes
   - kubernetes/kubernetes-template-project
   - kubernetes/kube-state-metrics
   - kubernetes/minikube
@@ -69,6 +68,7 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 - repos:
+  - kubernetes/kubernetes
   - kubernetes-client
   - kubernetes-csi
   - kubernetes-sigs


### PR DESCRIPTION
Currently folks who are in the top level OWNERS files have an issue when the use `/lgtm'. As currently configured the bots assume that the `/lgtm` is the same as `/approve` and end up merging PRs. 

Sometimes, the OWNERS want to just say (for example) that this looks good, but go ask others for approvals. So let's explicitly require them to specify their approval when they wish and not confuse it with a LGTM.

Please note that the behavior for implicit_self_approve is unchanged. Also note that `lgtm_acts_as_approve` when not specified to true, the default is false. 

Following up on discussion in:
https://groups.google.com/d/msg/kubernetes-dev/PJJxV9roXI8/aIeHQdKoBwAJ

Change-Id: Ic4378e1432b2463b9227a729ec8edc232222478a