### PR TITLE
Revert "Update cat plugin to use new JSON cat api"

### DIFF
--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -18,7 +18,7 @@ limitations under the License.
 package cat
 
 import (
-	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -39,7 +39,7 @@ import (
 var (
 	match = regexp.MustCompile(`(?mi)^/meow( .+)?\s*$`)
 	meow  = &realClowder{
-		url: "https://api.thecatapi.com/api/images/get?format=json",
+		url: "http://thecatapi.com/api/images/get?format=xml&results_per_page=1",
 	}
 )
 
@@ -61,7 +61,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Add a cat image to the issue",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
-		Examples:    []string{"/meow"},
+		Examples:    []string{"/meow", "/meow caturday"},
 	})
 	return pluginHelp, nil
 }
@@ -71,7 +71,7 @@ type githubClient interface {
 }
 
 type clowder interface {
-	readCat() (string, error)
+	readCat(string) (string, error)
 }
 
 type realClowder struct {
@@ -103,34 +103,44 @@ func (c *realClowder) setKey(keyPath string, log *logrus.Entry) {
 }
 
 type catResult struct {
-	Id  string `json:"id"`
-	URL string `json:"url"`
+	Source string `xml:"data>images>image>source_url"`
+	Image  string `xml:"data>images>image>url"`
 }
 
 func (cr catResult) Format() (string, error) {
-	if cr.URL == "" {
+	if cr.Source == "" {
+		return "", errors.New("empty source_url")
+	}
+	if cr.Image == "" {
 		return "", errors.New("empty image url")
 	}
-	url, err := url.Parse(cr.URL)
+	src, err := url.Parse(cr.Source)
 	if err != nil {
-		return "", fmt.Errorf("invalid image url %s: %v", cr.URL, err)
+		return "", fmt.Errorf("invalid source_url %s: %v", cr.Source, err)
+	}
+	img, err := url.Parse(cr.Image)
+	if err != nil {
+		return "", fmt.Errorf("invalid image url %s: %v", cr.Image, err)
 	}
 
-	return fmt.Sprintf("[![cat image](%s)](%s)", url, url), nil
+	return fmt.Sprintf("[![cat image](%s)](%s)", img, src), nil
 }
 
-func (r *realClowder) Url() string {
+func (r *realClowder) Url(category string) string {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	uri := string(r.url)
+	if category != "" {
+		uri += "&category=" + url.QueryEscape(category)
+	}
 	if r.key != "" {
 		uri += "&api_key=" + url.QueryEscape(r.key)
 	}
 	return uri
 }
 
-func (r *realClowder) readCat() (string, error) {
-	uri := r.Url()
+func (r *realClowder) readCat(category string) (string, error) {
+	uri := r.Url(category)
 	resp, err := http.Get(uri)
 	if err != nil {
 		return "", fmt.Errorf("could not read cat from %s: %v", uri, err)
@@ -139,23 +149,19 @@ func (r *realClowder) readCat() (string, error) {
 	if sc := resp.StatusCode; sc > 299 || sc < 200 {
 		return "", fmt.Errorf("failing %d response from %s", sc, uri)
 	}
-	cats := make([]catResult, 0)
-	if err = json.NewDecoder(resp.Body).Decode(&cats); err != nil {
+	var a catResult
+	if err = xml.NewDecoder(resp.Body).Decode(&a); err != nil {
 		return "", err
 	}
-	if len(cats) < 1 {
-		return "", fmt.Errorf("no cats in response from %s", uri)
-	}
-	var a catResult = cats[0]
-	if a.URL == "" {
+	if a.Image == "" {
 		return "", fmt.Errorf("no image url in response from %s", uri)
 	}
 	// checking size, GitHub doesn't support big images
-	toobig, err := github.ImageTooBig(a.URL)
+	toobig, err := github.ImageTooBig(a.Image)
 	if err != nil {
-		return "", fmt.Errorf("could not validate image size %s: %v", a.URL, err)
+		return "", fmt.Errorf("could not validate image size %s: %v", a.Image, err)
 	} else if toobig {
-		return "", fmt.Errorf("longcat is too long: %s", a.URL)
+		return "", fmt.Errorf("longcat is too long: %s", a.Image)
 	}
 	return a.Format()
 }
@@ -184,19 +190,17 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 	// Now that we know this is a relevant event we can set the key.
 	setKey()
 
+	category := mat[1]
+	if len(category) > 1 {
+		category = category[1:]
+	}
+
 	org := e.Repo.Owner.Login
 	repo := e.Repo.Name
 	number := e.Number
 
-	// Provide an error message when a category is requested
-	// TODO: remove after a grace period
-	if len(strings.TrimSpace(mat[1])) > 0 {
-		msg := "**chomp** CATegories are no longer supported"
-		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
-	}
-
 	for i := 0; i < 3; i++ {
-		resp, err := c.readCat()
+		resp, err := c.readCat(category)
 		if err != nil {
 			log.WithError(err).Error("Failed to get cat img")
 			continue
@@ -204,7 +208,12 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
 	}
 
-	msg := "https://thecatapi.com appears to be down"
+	var msg string
+	if category != "" {
+		msg = "Bad category. Please see http://thecatapi.com/api/categories/list"
+	} else {
+		msg = "http://thecatapi.com appears to be down"
+	}
 	if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg)); err != nil {
 		log.WithError(err).Error("Failed to leave comment")
 	}

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -18,7 +18,7 @@ limitations under the License.
 package cat
 
 import (
-	"encoding/xml"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -39,7 +39,7 @@ import (
 var (
 	match = regexp.MustCompile(`(?mi)^/meow( .+)?\s*$`)
 	meow  = &realClowder{
-		url: "http://thecatapi.com/api/images/get?format=xml&results_per_page=1",
+		url: "https://api.thecatapi.com/api/images/get?format=json&results_per_page=1",
 	}
 )
 
@@ -103,8 +103,8 @@ func (c *realClowder) setKey(keyPath string, log *logrus.Entry) {
 }
 
 type catResult struct {
-	Source string `xml:"data>images>image>source_url"`
-	Image  string `xml:"data>images>image>url"`
+	Source string `json:"source_url"`
+	Image  string `json:"url"`
 }
 
 func (cr catResult) Format() (string, error) {
@@ -149,10 +149,14 @@ func (r *realClowder) readCat(category string) (string, error) {
 	if sc := resp.StatusCode; sc > 299 || sc < 200 {
 		return "", fmt.Errorf("failing %d response from %s", sc, uri)
 	}
-	var a catResult
-	if err = xml.NewDecoder(resp.Body).Decode(&a); err != nil {
+	cats := make([]catResult, 0)
+	if err = json.NewDecoder(resp.Body).Decode(&cats); err != nil {
 		return "", err
 	}
+	if len(cats) < 1 {
+		return "", fmt.Errorf("no cats in response from %s", uri)
+	}
+	a := cats[0]
 	if a.Image == "" {
 		return "", fmt.Errorf("no image url in response from %s", uri)
 	}
@@ -210,9 +214,9 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 
 	var msg string
 	if category != "" {
-		msg = "Bad category. Please see http://thecatapi.com/api/categories/list"
+		msg = "Bad category. Please see https://api.thecatapi.com/api/categories/list"
 	} else {
-		msg = "http://thecatapi.com appears to be down"
+		msg = "https://thecatapi.com appears to be down"
 	}
 	if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg)); err != nil {
 		log.WithError(err).Error("Failed to leave comment")

--- a/prow/plugins/cat/cat_test.go
+++ b/prow/plugins/cat/cat_test.go
@@ -197,7 +197,7 @@ func TestHttpResponse(t *testing.T) {
 	img := ts2.URL + "/cat.jpg"
 	bigimg := ts2.URL + "/bigcat.jpg"
 	src := "http://localhost?kind=source_url"
-	validResponse := fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, img, src)
+	validResponse := fmt.Sprintf(`[{"id":"valid","url":"%s","source_url":"%s"}]`, img, src)
 	var testcases = []struct {
 		name     string
 		path     string
@@ -208,13 +208,13 @@ func TestHttpResponse(t *testing.T) {
 		{
 			name:     "valid",
 			path:     "/valid",
-			response: fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, img, src),
+			response: validResponse,
 			valid:    true,
 		},
 		{
 			name:     "image too big",
 			path:     "/too-big",
-			response: fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, bigimg, src),
+			response: fmt.Sprintf(`[{"id":"toobig","url":"%s","source_url":"%s"}]`, bigimg, src),
 		},
 		{
 			name: "return-406",
@@ -234,9 +234,14 @@ Available variants:
 </body></html>`,
 		},
 		{
-			name:     "no-image-in-xml",
-			path:     "/no-image-in-xml",
-			response: "<random><xml/></random>",
+			name:     "no-cats-in-json",
+			path:     "/no-cats-in-json",
+			response: "[]",
+		},
+		{
+			name:     "no-image-in-json",
+			path:     "/no-image-in-json",
+			response: "[{}]",
 		},
 	}
 

--- a/prow/plugins/cat/cat_test.go
+++ b/prow/plugins/cat/cat_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cat
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -35,21 +36,25 @@ import (
 type fakeClowder string
 
 var human = flag.Bool("human", false, "Enable to run additional manual tests")
+var category = flag.String("category", "", "Request a particular category if set")
 var path = flag.String("key-path", "", "Path to api key if set")
 
-func (c fakeClowder) readCat() (string, error) {
+func (c fakeClowder) readCat(category string) (string, error) {
+	if category == "error" {
+		return "", errors.New(string(c))
+	}
 	return fmt.Sprintf("![fake cat image](%s)", c), nil
 }
 
 func TestRealCat(t *testing.T) {
 	if !*human {
-		t.Skip("Real cats disabled for automation. Manual users can add --human")
+		t.Skip("Real cats disabled for automation. Manual users can add --human [--category=foo]")
 	}
 	if *path != "" {
 		meow.setKey(*path, logrus.WithField("plugin", pluginName))
 	}
 
-	if cat, err := meow.readCat(); err != nil {
+	if cat, err := meow.readCat(*category); err != nil {
 		t.Errorf("Could not read cats from %#v: %v", meow, err)
 	} else {
 		fmt.Println(cat)
@@ -58,10 +63,12 @@ func TestRealCat(t *testing.T) {
 
 func TestUrl(t *testing.T) {
 	cases := []struct {
-		name    string
-		url     string
-		key     string
-		require []string
+		name     string
+		url      string
+		category string
+		key      string
+		require  []string
+		deny     []string
 	}{
 		{
 			name: "only url",
@@ -72,6 +79,21 @@ func TestUrl(t *testing.T) {
 			url:     "http://foo",
 			key:     "blah",
 			require: []string{"api_key=blah"},
+			deny:    []string{"category="},
+		},
+		{
+			name:     "category",
+			url:      "http://foo",
+			category: "bar",
+			require:  []string{"category=bar"},
+			deny:     []string{"api_key="},
+		},
+		{
+			name:     "category and key",
+			url:      "http://foo",
+			category: "this",
+			key:      "that",
+			require:  []string{"category=this", "api_key=that", "&"},
 		},
 	}
 
@@ -80,10 +102,15 @@ func TestUrl(t *testing.T) {
 			url: tc.url,
 			key: tc.key,
 		}
-		url := rc.Url()
+		url := rc.Url(tc.category)
 		for _, r := range tc.require {
 			if !strings.Contains(url, r) {
 				t.Errorf("%s: %s does not contain %s", tc.name, url, r)
+			}
+		}
+		for _, d := range tc.deny {
+			if strings.Contains(url, d) {
+				t.Errorf("%s: %s contained unexpected %s", tc.name, url, d)
 			}
 		}
 	}
@@ -94,29 +121,45 @@ func TestFormat(t *testing.T) {
 	basicURL := "http://example.com"
 	testcases := []struct {
 		name string
-		url  string
+		src  string
+		img  string
 		err  bool
 	}{
 		{
 			name: "basically works",
-			url:  basicURL,
+			src:  basicURL,
+			img:  basicURL,
 			err:  false,
 		},
 		{
+			name: "empty source",
+			src:  "",
+			img:  basicURL,
+			err:  true,
+		},
+		{
 			name: "empty image",
-			url:  "",
+			src:  basicURL,
+			img:  "",
+			err:  true,
+		},
+		{
+			name: "bad source",
+			src:  "http://this is not a url",
+			img:  basicURL,
 			err:  true,
 		},
 		{
 			name: "bad image",
-			url:  "http://still a bad url",
+			src:  basicURL,
+			img:  "http://still a bad url",
 			err:  true,
 		},
 	}
 	for _, tc := range testcases {
 		ret, err := catResult{
-			Id:  tc.name,
-			URL: tc.url,
+			Source: tc.src,
+			Image:  tc.img,
 		}.Format()
 		switch {
 		case tc.err:
@@ -153,7 +196,8 @@ func TestHttpResponse(t *testing.T) {
 	// create test cases for handling http responses
 	img := ts2.URL + "/cat.jpg"
 	bigimg := ts2.URL + "/bigcat.jpg"
-	validResponse := fmt.Sprintf(`[{"id":"valid","url":"%s"}]`, img)
+	src := "http://localhost?kind=source_url"
+	validResponse := fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, img, src)
 	var testcases = []struct {
 		name     string
 		path     string
@@ -164,13 +208,13 @@ func TestHttpResponse(t *testing.T) {
 		{
 			name:     "valid",
 			path:     "/valid",
-			response: validResponse,
+			response: fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, img, src),
 			valid:    true,
 		},
 		{
 			name:     "image too big",
 			path:     "/too-big",
-			response: fmt.Sprintf(`[{"id":"toobig","url":"%s"}]`, bigimg),
+			response: fmt.Sprintf(`<response><data><images><image><url>%s</url><source_url>%s</source_url></image></images></data></response>`, bigimg, src),
 		},
 		{
 			name: "return-406",
@@ -190,9 +234,9 @@ Available variants:
 </body></html>`,
 		},
 		{
-			name:     "no-cats-in-json",
-			path:     "/no-cats-in-json",
-			response: "[]",
+			name:     "no-image-in-xml",
+			path:     "/no-image-in-xml",
+			response: "<random><xml/></random>",
 		},
 	}
 
@@ -226,7 +270,7 @@ Available variants:
 	// run test for each case
 	for _, testcase := range testcases {
 		fakemeow := &realClowder{url: ts.URL + testcase.path}
-		cat, err := fakemeow.readCat()
+		cat, err := fakemeow.readCat(*category)
 		if testcase.valid && err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", testcase.name, err)
 		} else if !testcase.valid && err == nil {
@@ -255,7 +299,10 @@ Available variants:
 	}
 	if c := fc.IssueComments[5][0]; !strings.Contains(c.Body, img) {
 		t.Errorf("missing image url: %s from comment: %v", img, c)
+	} else if !strings.Contains(c.Body, src) {
+		t.Errorf("missing source url: %s from comment: %v", src, c)
 	}
+
 }
 
 // Small, unit tests
@@ -267,7 +314,7 @@ func TestCats(t *testing.T) {
 		state         string
 		pr            bool
 		shouldComment bool
-		shouldImage   bool
+		shouldError   bool
 	}{
 		{
 			name:          "ignore edited comment",
@@ -275,7 +322,7 @@ func TestCats(t *testing.T) {
 			action:        github.GenericCommentActionEdited,
 			body:          "/meow",
 			shouldComment: false,
-			shouldImage:   true,
+			shouldError:   false,
 		},
 		{
 			name:          "leave cat on pr",
@@ -284,7 +331,7 @@ func TestCats(t *testing.T) {
 			body:          "/meow",
 			pr:            true,
 			shouldComment: true,
-			shouldImage:   true,
+			shouldError:   false,
 		},
 		{
 			name:          "leave cat on issue",
@@ -292,7 +339,7 @@ func TestCats(t *testing.T) {
 			action:        github.GenericCommentActionCreated,
 			body:          "/meow",
 			shouldComment: true,
-			shouldImage:   true,
+			shouldError:   false,
 		},
 		{
 			name:          "leave cat on issue, trailing space",
@@ -300,7 +347,7 @@ func TestCats(t *testing.T) {
 			action:        github.GenericCommentActionCreated,
 			body:          "/meow \r",
 			shouldComment: true,
-			shouldImage:   true,
+			shouldError:   false,
 		},
 		{
 			name:          "categorical cat",
@@ -308,7 +355,15 @@ func TestCats(t *testing.T) {
 			action:        github.GenericCommentActionCreated,
 			body:          "/meow clothes",
 			shouldComment: true,
-			shouldImage:   false,
+			shouldError:   false,
+		},
+		{
+			name:          "bad cat",
+			state:         "open",
+			action:        github.GenericCommentActionCreated,
+			body:          "/meow error",
+			shouldComment: true,
+			shouldError:   true,
 		},
 	}
 	for _, tc := range testcases {
@@ -323,18 +378,22 @@ func TestCats(t *testing.T) {
 			IsPR:       tc.pr,
 		}
 		err := handle(fc, logrus.WithField("plugin", pluginName), e, fakeClowder("tubbs"), func() {})
-		if err != nil {
+		if !tc.shouldError && err != nil {
 			t.Errorf("%s: didn't expect error: %v", tc.name, err)
+			continue
+		} else if tc.shouldError && err == nil {
+			t.Errorf("%s: expected an error to occur", tc.name)
 			continue
 		}
 		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
 			t.Errorf("%s: should have commented.", tc.name)
 		} else if tc.shouldComment {
+			shouldImage := !tc.shouldError
 			body := fc.IssueComments[5][0].Body
 			hasImage := strings.Contains(body, "![")
-			if hasImage && !tc.shouldImage {
+			if hasImage && !shouldImage {
 				t.Errorf("%s: unexpected image in %s", tc.name, body)
-			} else if !hasImage && tc.shouldImage {
+			} else if !hasImage && shouldImage {
 				t.Errorf("%s: no image in %s", tc.name, body)
 			}
 		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {


### PR DESCRIPTION
This reverts commit b4d4f9e0e595a8a8ce9369ba1cb05493d7346e67 (#9153).

The Cat API has added the missing `source_url` back to the XML response, so `/meow` is working again.

Also, apparently CATegories are not deprecated after all; the docs are just incorrect.

ref:
 * https://twitter.com/adenforshaw/status/1033068924840095744 
 * https://twitter.com/adenforshaw/status/1033069970564018176

We might still want to convert to the JSON API at some point, but I want to wait for docs to be correct first.

/assign @fejta @amwat 
cc @AdenForshaw
x-ref #9135