### PR TITLE
Updating Helm to use new label instead of cla: yes

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -208,7 +208,7 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cncf-cla: yes"
+    - "Contribution Allowed"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths


### PR DESCRIPTION
Helm in moving to the DCO needs to apply a label to older cla: yes
and newwer commits with the DCO. The "Contribution Allowed" is
a common label the automation can use that is there in the
right situations.