### PR TITLE
Add require-matching-label plugin to Prow.

### DIFF
--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -71,6 +71,7 @@ filegroup(
         "//prow/plugins/override:all-srcs",
         "//prow/plugins/owners-label:all-srcs",
         "//prow/plugins/releasenote:all-srcs",
+        "//prow/plugins/require-matching-label:all-srcs",
         "//prow/plugins/requiresig:all-srcs",
         "//prow/plugins/shrug:all-srcs",
         "//prow/plugins/sigmention:all-srcs",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -161,22 +161,23 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
-	Approve              []Approve            `json:"approve,omitempty"`
-	Blockades            []Blockade           `json:"blockades,omitempty"`
-	Blunderbuss          Blunderbuss          `json:"blunderbuss,omitempty"`
-	Cat                  Cat                  `json:"cat,omitempty"`
-	ConfigUpdater        ConfigUpdater        `json:"config_updater,omitempty"`
-	Heart                Heart                `json:"heart,omitempty"`
-	Label                *Label               `json:"label,omitempty"`
-	Lgtm                 []Lgtm               `json:"lgtm,omitempty"`
-	RepoMilestone        map[string]Milestone `json:"repo_milestone,omitempty"`
-	RequireSIG           RequireSIG           `json:"requiresig,omitempty"`
-	Slack                Slack                `json:"slack,omitempty"`
-	SigMention           SigMention           `json:"sigmention,omitempty"`
-	Size                 *Size                `json:"size,omitempty"`
-	Triggers             []Trigger            `json:"triggers,omitempty"`
-	Welcome              Welcome              `json:"welcome,omitempty"`
-	CherryPickUnapproved CherryPickUnapproved `json:"cherry_pick_unapproved,omitempty"`
+	Approve              []Approve              `json:"approve,omitempty"`
+	Blockades            []Blockade             `json:"blockades,omitempty"`
+	Blunderbuss          Blunderbuss            `json:"blunderbuss,omitempty"`
+	Cat                  Cat                    `json:"cat,omitempty"`
+	CherryPickUnapproved CherryPickUnapproved   `json:"cherry_pick_unapproved,omitempty"`
+	ConfigUpdater        ConfigUpdater          `json:"config_updater,omitempty"`
+	Heart                Heart                  `json:"heart,omitempty"`
+	Label                *Label                 `json:"label,omitempty"`
+	Lgtm                 []Lgtm                 `json:"lgtm,omitempty"`
+	RepoMilestone        map[string]Milestone   `json:"repo_milestone,omitempty"`
+	RequireMatchingLabel []RequireMatchingLabel `json:"require_matching_label,omitempty"`
+	RequireSIG           RequireSIG             `json:"requiresig,omitempty"`
+	Slack                Slack                  `json:"slack,omitempty"`
+	SigMention           SigMention             `json:"sigmention,omitempty"`
+	Size                 *Size                  `json:"size,omitempty"`
+	Triggers             []Trigger              `json:"triggers,omitempty"`
+	Welcome              Welcome                `json:"welcome,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -472,6 +473,101 @@ type CherryPickUnapproved struct {
 	Comment string `json:"comment,omitempty"`
 }
 
+// RequireMatchingLabel is the config for the require-matching-label plugin.
+type RequireMatchingLabel struct {
+	// Org is the GitHub organization that this config applies to.
+	Org string `json:"org,omitempty"`
+	// Repo is the GitHub repository within Org that this config applies to.
+	// This fields may be omitted to apply this config across all repos in Org.
+	Repo string `json:"repo,omitempty"`
+	// Branch is the branch ref of PRs that this config applies to.
+	// This field is only valid if `prs: true` and may be omitted to apply this
+	// config across all branches in the repo or org.
+	Branch string `json:"branch,omitempty"`
+	// PRs is a bool indicating if this config applies to PRs.
+	PRs bool `json:"prs,omitempty"`
+	// Issues is a bool indicating if this config applies to issues.
+	Issues bool `json:"issues,omitempty"`
+
+	// Regexp is the string specifying the regular expression used to look for
+	// matching labels.
+	Regexp string `json:"regexp,omitempty"`
+	// Re is the compiled version of Regexp. It should not be specified in config.
+	Re *regexp.Regexp `json:"-"`
+
+	// MissingLabel is the label to apply if an issue does not have any label
+	// matching the Regexp.
+	MissingLabel string `json:"missing_label,omitempty"`
+	// MissingComment is the comment to post when we add the MissingLabel to an
+	// issue. This is typically used to explain why MissingLabel was added and
+	// how to move forward.
+	// This field is optional. If unspecified, no comment is created when labeling.
+	MissingComment string `json:"missing_comment,omitempty"`
+}
+
+// validate checks the following properties:
+// - Org, Regexp, and MissingLabel must be non-empty.
+// - Repo does not contain a '/' (should use Org+Repo).
+// - At least one of PRs or Issues must be true.
+// - Branch only specified if 'prs: true'
+func (r RequireMatchingLabel) validate() error {
+	if r.Org == "" {
+		return errors.New("must specify 'org'")
+	}
+	if strings.Contains(r.Repo, "/") {
+		return errors.New("'repo' may not contain '/'; specify the organization with 'org'")
+	}
+	if r.Regexp == "" {
+		return errors.New("must specify 'regexp'")
+	}
+	if r.MissingLabel == "" {
+		return errors.New("must specify 'missing_label'")
+	}
+	if !r.PRs && !r.Issues {
+		return errors.New("must specify 'prs: true' and/or 'issues: true'")
+	}
+	if !r.PRs && r.Branch != "" {
+		return errors.New("branch cannot be specified without `prs: true'")
+	}
+	if r.Re.MatchString(r.MissingLabel) {
+		return errors.New("'regexp' must not match 'missing_label'")
+	}
+	return nil
+}
+
+// Describe generates a human readable description of the behavior that this
+// configuration specifies.
+func (r RequireMatchingLabel) Describe() string {
+	str := &strings.Builder{}
+	fmt.Fprintf(str, "Applies the '%s' label ", r.MissingLabel)
+	if r.MissingComment == "" {
+		fmt.Fprint(str, "to ")
+	} else {
+		fmt.Fprint(str, "and comments on ")
+	}
+
+	if r.Issues {
+		fmt.Fprint(str, "Issues ")
+		if r.PRs {
+			fmt.Fprint(str, "and ")
+		}
+	}
+	if r.PRs {
+		if r.Branch != "" {
+			fmt.Fprintf(str, "'%s' branch ", r.Branch)
+		}
+		fmt.Fprint(str, "PRs ")
+	}
+
+	if r.Repo == "" {
+		fmt.Fprintf(str, "in the '%s' GitHub org ", r.Org)
+	} else {
+		fmt.Fprintf(str, "in the '%s/%s' GitHub repo ", r.Org, r.Repo)
+	}
+	fmt.Fprintf(str, "that have no labels matching the regular expression '%s'.", r.Regexp)
+	return str.String()
+}
+
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -562,6 +658,11 @@ func (pa *PluginAgent) Load(path string) error {
 
 	// Defaulting should run before validation.
 	np.setDefaults()
+	// Regexp compilation should run after defaulting, but before validation.
+	if err := compileRegexps(np); err != nil {
+		return err
+	}
+
 	if err := validatePlugins(np.Plugins); err != nil {
 		return err
 	}
@@ -577,11 +678,9 @@ func (pa *PluginAgent) Load(path string) error {
 	if err := validateSizes(np.Size); err != nil {
 		return err
 	}
-	// regexp compilation should run after defaulting
-	if err := compileRegexps(np); err != nil {
+	if err := validateRequireMatchingLabel(np.RequireMatchingLabel); err != nil {
 		return err
 	}
-
 	pa.Set(np)
 	return nil
 }
@@ -712,6 +811,15 @@ func validateConfigUpdater(updater *ConfigUpdater) error {
 	return nil
 }
 
+func validateRequireMatchingLabel(rs []RequireMatchingLabel) error {
+	for i, r := range rs {
+		if err := r.validate(); err != nil {
+			return fmt.Errorf("error validating require_matching_label config #%d: %v", i, err)
+		}
+	}
+	return nil
+}
+
 func compileRegexps(pc *Configuration) error {
 	cRe, err := regexp.Compile(pc.SigMention.Regexp)
 	if err != nil {
@@ -725,6 +833,14 @@ func compileRegexps(pc *Configuration) error {
 	}
 	pc.CherryPickUnapproved.BranchRe = branchRe
 
+	rs := pc.RequireMatchingLabel
+	for i := range rs {
+		re, err := regexp.Compile(rs[i].Regexp)
+		if err != nil {
+			return fmt.Errorf("failed to compile label regexp: %q, error: %v", rs[i].Regexp, err)
+		}
+		rs[i].Re = re
+	}
 	return nil
 }
 

--- a/prow/plugins/require-matching-label/BUILD.bazel
+++ b/prow/plugins/require-matching-label/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["require-matching-label.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/require-matching-label",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["require-matching-label_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/require-matching-label/require-matching-label.go
+++ b/prow/plugins/require-matching-label/require-matching-label.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package requirematchinglabel implements the `require-matching-label` plugin.
+// This is a configurable plugin that applies a label (and possibly comments)
+// when an issue or PR does not have any labels matching a regexp. If a label
+// is added that matches the regexp, the 'MissingLabel' is removed and the comment
+// is deleted.
+package requirematchinglabel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	handlePRActions = map[github.PullRequestEventAction]bool{
+		github.PullRequestActionOpened:    true,
+		github.PullRequestActionReopened:  true,
+		github.PullRequestActionLabeled:   true,
+		github.PullRequestActionUnlabeled: true,
+	}
+
+	handleIssueActions = map[github.IssueEventAction]bool{
+		github.IssueActionOpened:    true,
+		github.IssueActionReopened:  true,
+		github.IssueActionLabeled:   true,
+		github.IssueActionUnlabeled: true,
+	}
+
+	// sleep is mocked in tests.
+	sleep = time.Sleep
+)
+
+const (
+	pluginName = "require-matching-label"
+)
+
+type githubClient interface {
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+	CreateComment(org, repo string, number int, content string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+func init() {
+	plugins.RegisterIssueHandler(pluginName, handleIssue, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, _ []string) (*pluginhelp.PluginHelp, error) {
+	descs := make([]string, 0, len(config.RequireMatchingLabel))
+	for _, cfg := range config.RequireMatchingLabel {
+		descs = append(descs, cfg.Describe())
+	}
+	// Only the 'Description' and 'Config' fields are necessary because this plugin does not react
+	// to any commands.
+	return &pluginhelp.PluginHelp{
+			Description: `The require-matching-label plugin is a configurable plugin that applies a label to issues and/or PRs that do not have any labels matching a regular expression. An example of this is applying a 'needs-sig' label to all issues that do not have a 'sig/*' label. This plugin can have multiple configurations to provide this kind of behavior for multiple different label sets. The configuration allows issue type, PR branch, and an optional explanation comment to be specified.`,
+			Config: map[string]string{
+				"": fmt.Sprintf("The plugin has the following configurations:\n<ul><li>%s</li></ul>", strings.Join(descs, "</li><li>")),
+			},
+		},
+		nil
+}
+
+type event struct {
+	org    string
+	repo   string
+	number int
+	author string
+	// The PR's base branch. If empty this is an Issue, not a PR.
+	branch string
+	// The label that was added or removed. If empty this is an open or reopen event.
+	label string
+	// The labels currently on the issue. For PRs this is not contained in the webhook payload and may be omitted.
+	currentLabels []github.Label
+}
+
+func handleIssue(pc plugins.PluginClient, ie github.IssueEvent) error {
+	if !handleIssueActions[ie.Action] {
+		return nil
+	}
+	e := &event{
+		org:           ie.Repo.Owner.Login,
+		repo:          ie.Repo.Name,
+		number:        ie.Issue.Number,
+		author:        ie.Issue.User.Login,
+		label:         ie.Label.Name, // This will be empty for non-label events.
+		currentLabels: ie.Issue.Labels,
+	}
+	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, pc.PluginConfig.RequireMatchingLabel, e)
+}
+
+func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+	if !handlePRActions[pre.Action] {
+		return nil
+	}
+	e := &event{
+		org:    pre.Repo.Owner.Login,
+		repo:   pre.Repo.Name,
+		number: pre.PullRequest.Number,
+		author: pre.PullRequest.User.Login,
+		label:  pre.Label.Name, // This will be empty for non-label events.
+	}
+	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, pc.PluginConfig.RequireMatchingLabel, e)
+}
+
+// matchingConfigs filters irrelevant RequireMtchingLabel configs from
+// the list of all configs.
+// `branch` should be empty for Issues and non-empty for PRs.
+// `label` should be omitted in the case of 'open' and 'reopen' actions.
+func matchingConfigs(org, repo, branch, label string, allConfigs []plugins.RequireMatchingLabel) []plugins.RequireMatchingLabel {
+	var filtered []plugins.RequireMatchingLabel
+	for _, cfg := range allConfigs {
+		// Check if the config applies to this issue type.
+		if (branch == "" && !cfg.Issues) || (branch != "" && !cfg.PRs) {
+			continue
+		}
+		// Check if the config applies to this 'org[/repo][/branch]'.
+		if org != cfg.Org ||
+			(cfg.Repo != "" && cfg.Repo != repo) ||
+			(cfg.Branch != "" && branch != "" && cfg.Branch != branch) {
+			continue
+		}
+		// If we are reacting to a label event, see if it is relevant.
+		if label != "" && !cfg.Re.MatchString(label) {
+			continue
+		}
+		filtered = append(filtered, cfg)
+	}
+	return filtered
+}
+
+func handle(log *logrus.Entry, ghc githubClient, cp commentPruner, configs []plugins.RequireMatchingLabel, e *event) error {
+	// Find any configs that may be relevant to this event.
+	matchConfigs := matchingConfigs(e.org, e.repo, e.branch, e.label, configs)
+	if len(matchConfigs) == 0 {
+		return nil
+	}
+
+	if e.label == "" /* not a label event */ {
+		// If we are reacting to a PR or Issue being created or reopened, we should wait a
+		// few seconds to allow other automation to apply labels in order to minimize thrashing.
+		sleep(time.Second * 5)
+		// If currentLabels was populated it is now stale.
+		e.currentLabels = nil
+	}
+	if e.currentLabels == nil {
+		var err error
+		e.currentLabels, err = ghc.GetIssueLabels(e.org, e.repo, e.number)
+		if err != nil {
+			return fmt.Errorf("error getting the issue or pr's labels: %v", err)
+		}
+	}
+
+	// Handle the potentially relevant configs.
+	for _, cfg := range matchConfigs {
+		hasMissingLabel := false
+		hasMatchingLabel := false
+		for _, label := range e.currentLabels {
+			hasMissingLabel = hasMissingLabel || label.Name == cfg.MissingLabel
+			hasMatchingLabel = hasMatchingLabel || cfg.Re.MatchString(label.Name)
+		}
+
+		if hasMatchingLabel && hasMissingLabel {
+			if err := ghc.RemoveLabel(e.org, e.repo, e.number, cfg.MissingLabel); err != nil {
+				log.WithError(err).Errorf("Failed to remove %q label.", cfg.MissingLabel)
+			}
+			if cfg.MissingComment != "" {
+				cp.PruneComments(func(comment github.IssueComment) bool {
+					return strings.Contains(comment.Body, cfg.MissingComment)
+				})
+			}
+		} else if !hasMatchingLabel && !hasMissingLabel {
+			if err := ghc.AddLabel(e.org, e.repo, e.number, cfg.MissingLabel); err != nil {
+				log.WithError(err).Errorf("Failed to add %q label.", cfg.MissingLabel)
+			}
+			if cfg.MissingComment != "" {
+				msg := plugins.FormatSimpleResponse(e.author, cfg.MissingComment)
+				if err := ghc.CreateComment(e.org, e.repo, e.number, msg); err != nil {
+					log.WithError(err).Error("Failed to create comment.")
+				}
+			}
+		}
+
+	}
+	return nil
+}

--- a/prow/plugins/require-matching-label/require-matching-label_test.go
+++ b/prow/plugins/require-matching-label/require-matching-label_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirematchinglabel
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+type fakeGitHub struct {
+	labels                     sets.String
+	labelsAdded, labelsRemoved sets.String
+	commented                  bool
+}
+
+func newFakeGitHub(initialLabels ...string) *fakeGitHub {
+	return &fakeGitHub{
+		labels:        sets.NewString(initialLabels...),
+		labelsAdded:   sets.NewString(),
+		labelsRemoved: sets.NewString(),
+	}
+}
+
+func (f *fakeGitHub) AddLabel(org, repo string, number int, label string) error {
+	f.labels.Insert(label)
+	f.labelsAdded.Insert(label)
+	return nil
+}
+
+func (f *fakeGitHub) RemoveLabel(org, repo string, number int, label string) error {
+	f.labels.Delete(label)
+	f.labelsRemoved.Insert(label)
+	return nil
+}
+
+func (f *fakeGitHub) CreateComment(org, repo string, number int, content string) error {
+	f.commented = true
+	return nil
+}
+
+func (f *fakeGitHub) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	res := make([]github.Label, 0, len(f.labels))
+	for label := range f.labels {
+		res = append(res, github.Label{Name: label})
+	}
+	return res, nil
+}
+
+type fakePruner struct{}
+
+func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
+
+func TestHandle(t *testing.T) {
+	// Disable sleeping for testing.
+	sleep = func(_ time.Duration) {}
+	defer func() { sleep = time.Sleep }()
+
+	configs := []plugins.RequireMatchingLabel{
+		// needs-sig over k8s org (issues)
+		{
+			Org:          "k8s",
+			Issues:       true,
+			Re:           regexp.MustCompile(`^(sig|wg|committee)/`),
+			MissingLabel: "needs-sig",
+		},
+
+		// needs-kind over k8s/t-i repo (PRs)
+		{
+			Org:          "k8s",
+			Repo:         "t-i",
+			PRs:          true,
+			Re:           regexp.MustCompile(`^kind/`),
+			MissingLabel: "needs-kind",
+		},
+		// needs-cat over k8s/t-i:meow branch (issues and PRs) (will comment)
+		{
+			Org:            "k8s",
+			Repo:           "t-i",
+			Branch:         "meow",
+			Issues:         true,
+			PRs:            true,
+			Re:             regexp.MustCompile(`^(cat|floof|loaf)$`),
+			MissingLabel:   "needs-cat",
+			MissingComment: "Meow?",
+		},
+	}
+
+	tcs := []struct {
+		name          string
+		event         *event
+		initialLabels []string
+
+		expectComment   bool
+		expectedAdded   sets.String
+		expectedRemoved sets.String
+	}{
+		{
+			name: "ignore PRs",
+			event: &event{
+				org:    "k8s",
+				repo:   "k8s",
+				branch: "foo",
+			},
+			initialLabels: []string{"lgtm"},
+		},
+		{
+			name: "ignore wrong org",
+			event: &event{
+				org:  "fejtaverse",
+				repo: "repo",
+			},
+			initialLabels: []string{"lgtm"},
+		},
+		{
+			name: "ignore unrelated label change",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "master",
+				label:  "unrelated",
+			},
+			initialLabels: []string{"lgtm"},
+		},
+		{
+			name: "add needs-kind label to PR",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "master",
+			},
+			initialLabels: []string{"lgtm"},
+			expectedAdded: sets.NewString("needs-kind"),
+		},
+		{
+			name: "remove needs-kind label from PR based on label change",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "master",
+				label:  "kind/best",
+			},
+			initialLabels:   []string{"lgtm", "needs-kind", "kind/best"},
+			expectedRemoved: sets.NewString("needs-kind"),
+		},
+		{
+			name: "don't remove needs-kind label from issue based on label change (ignore issues)",
+			event: &event{
+				org:   "k8s",
+				repo:  "t-i",
+				label: "kind/best",
+			},
+			initialLabels: []string{"lgtm", "needs-kind", "kind/best", "sig/cats"},
+		},
+		{
+			name: "don't remove needs-kind label from PR already missing it",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "master",
+				label:  "kind/best",
+			},
+			initialLabels: []string{"lgtm", "kind/best"},
+		},
+		{
+			name: "add org scoped needs-sig to issue",
+			event: &event{
+				org:   "k8s",
+				repo:  "k8s",
+				label: "sig/bash",
+			},
+			initialLabels: []string{"lgtm", "kind/best"},
+			expectedAdded: sets.NewString("needs-sig"),
+		},
+		{
+			name: "don't add org scoped needs-sig to issue when another sig/* label remains",
+			event: &event{
+				org:   "k8s",
+				repo:  "k8s",
+				label: "sig/bash",
+			},
+			initialLabels: []string{"lgtm", "kind/best", "wg/foo"},
+		},
+		{
+			name: "add branch scoped needs-cat to issue",
+			event: &event{
+				org:   "k8s",
+				repo:  "t-i",
+				label: "cat",
+			},
+			initialLabels: []string{"lgtm", "wg/foo"},
+			expectedAdded: sets.NewString("needs-cat"),
+			expectComment: true,
+		},
+		{
+			name: "add branch scoped needs-cat to PR",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "meow",
+			},
+			initialLabels: []string{"lgtm", "kind/best"},
+			expectedAdded: sets.NewString("needs-cat"),
+			expectComment: true,
+		},
+		{
+			name: "remove branch scoped needs-cat from PR, add repo scoped needs-kind",
+			event: &event{
+				org:    "k8s",
+				repo:   "t-i",
+				branch: "meow",
+			},
+			initialLabels:   []string{"lgtm", "needs-cat", "cat", "floof"},
+			expectedAdded:   sets.NewString("needs-kind"),
+			expectedRemoved: sets.NewString("needs-cat"),
+		},
+		{
+			name: "add branch scoped needs-cat to issue, remove org scoped needs-sig",
+			event: &event{
+				org:  "k8s",
+				repo: "t-i",
+			},
+			initialLabels:   []string{"lgtm", "needs-sig", "wg/foo"},
+			expectedAdded:   sets.NewString("needs-cat"),
+			expectedRemoved: sets.NewString("needs-sig"),
+			expectComment:   true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("Running test case %q...", tc.name)
+		log := logrus.WithField("plugin", "require-matching-label")
+		fghc := newFakeGitHub(tc.initialLabels...)
+		if err := handle(log, fghc, &fakePruner{}, configs, tc.event); err != nil {
+			t.Fatalf("Unexpected error from handle: %v.", err)
+		}
+
+		if tc.expectComment && !fghc.commented {
+			t.Error("Expected a comment, but didn't get one.")
+		} else if !tc.expectComment && fghc.commented {
+			t.Error("Expected no comments to be created but got one.")
+		}
+
+		if !tc.expectedAdded.Equal(fghc.labelsAdded) {
+			t.Errorf("Expected the %q labels to be added, but got %q.", tc.expectedAdded.List(), fghc.labelsAdded.List())
+		}
+
+		if !tc.expectedRemoved.Equal(fghc.labelsRemoved) {
+			t.Errorf("Expected the %q labels to be removed, but got %q.", tc.expectedRemoved.List(), fghc.labelsRemoved.List())
+		}
+	}
+}

--- a/prow/plugins/require-matching-label/require-matching-label_test.go
+++ b/prow/plugins/require-matching-label/require-matching-label_test.go
@@ -19,7 +19,6 @@ package requirematchinglabel
 import (
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -71,10 +70,6 @@ type fakePruner struct{}
 func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
 
 func TestHandle(t *testing.T) {
-	// Disable sleeping for testing.
-	sleep = func(_ time.Duration) {}
-	defer func() { sleep = time.Sleep }()
-
 	configs := []plugins.RequireMatchingLabel{
 		// needs-sig over k8s org (issues)
 		{


### PR DESCRIPTION
This is a generalized config-driven version of `requiresig` that we can use to require `kind/*` and `sig/*` labels on PRs for code freeze. cc @tpepper 
fixes #9115 

The plugin consumes a list of these structs as its configuration:
```go

type RequireMatchingLabel struct {
	// Org is the GitHub organization that this config applies to.
	Org string `json:"org,omitempty"`
	// Repo is the GitHub repository within Org that this config applies to.
	// This fields may be omitted to apply this config across all repos in Org.
	Repo string `json:"repo,omitempty"`
	// Branch is the branch ref of PRs that this config applies to.
	// This field is only valid if `prs: true` and may be omitted to apply this
	// config across all branches in the repo or org.
	Branch string `json:"branch,omitempty"`
	// PRs is a bool indicating if this config applies to PRs.
	PRs bool `json:"prs,omitempty"`
	// Issues is a bool indicating if this config applies to issues.
	Issues bool `json:"issues,omitempty"`

	// Regexp is the string specifying the regular expression used to look for
	// matching labels.
	Regexp string `json:"regexp,omitempty"`
	// Re is the compiled version of Regexp. It should not be specified in config.
	Re *regexp.Regexp `json:"-"`

	// MissingLabel is the label to apply if an issue does not have any label
	// matching the Regexp.
	MissingLabel string `json:"missing_label,omitempty"`
	// MissingComment is the comment to post when we add the MissingLabel to an
	// issue. This is typically used to explain why MissingLabel was added and
	// how to move forward.
	// This field is optional. If unspecified, no comment is created when labeling.
	MissingComment string `json:"missing_comment,omitempty"`
}
```

/area prow
/cc @stevekuznetsov @BenTheElder @amwat 