### PR TITLE
logexporter should support --enable-hollow-node-logs in gce as well

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = k8s-testimages
 IMG = gcr.io/$(PROJECT)/logexporter
-TAG = v0.1.2
+TAG = v0.1.3
 
 .PHONY: build push
 

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v0.1.2
+        image: gcr.io/k8s-testimages/logexporter:v0.1.3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/k8s-testimages/logexporter:v0.1.2
+    image: gcr.io/k8s-testimages/logexporter:v0.1.3
     env:
     - name: NODE_NAME
       valueFrom:

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -130,9 +130,7 @@ func prepareLogfiles(logDir string) {
 	logfiles := nodeLogs[:]
 
 	switch *cloudProvider {
-	case "gce", "gke":
-		logfiles = append(logfiles, gceLogs...)
-	case "kubemark":
+	case "gce", "gke", "kubemark":
 		// TODO(shyamjvs): Pick logs based on kubemark's real provider.
 		logfiles = append(logfiles, gceLogs...)
 		if *enableHollowNodeLogs {


### PR DESCRIPTION
Right now, I see that kubemark-5000 tests are running logexporter with --cloud-provider=gce and --enable-hollow-node-logs is ignored.

I think 'gce' is a reasonable value in that context (we fetch logs from gce nodes, not from virtual kubemark logs) so I think this change (vs. changing cloud-provider in log-dump.sh) is a correct one.

/assign @shyamjvs 
/assign @wojtek-t 