### PR TITLE
Fixing clusterloader2 job node flag

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-config.yaml
@@ -746,7 +746,6 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--nodes=3
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=60m
 


### PR DESCRIPTION
Removing (currently) unparsable flag, which causes `clusterloader2` job to fail.