### PR TITLE
kind: don't populate non-existent assets when building node image

### DIFF
--- a/kind/pkg/build/node_image.go
+++ b/kind/pkg/build/node_image.go
@@ -20,21 +20,18 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	"k8s.io/test-infra/kind/pkg/build/kube"
-	"k8s.io/test-infra/kind/pkg/build/sources"
 	"k8s.io/test-infra/kind/pkg/exec"
 )
 
 // NodeImageBuildContext is used to build the kind node image, and contains
 // build configuration
 type NodeImageBuildContext struct {
-	SourceDir string
 	ImageTag  string
 	Arch      string
 	BaseImage string
@@ -78,30 +75,11 @@ func (c *NodeImageBuildContext) Build() (err error) {
 	glog.Infof("Finished building Kubernetes")
 
 	// create tempdir to build the image in
-	tmpDir, err := TempDir("", "kind-node-image")
+	buildDir, err := TempDir("", "kind-node-image")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
-
-	// populate with image sources
-	// if SourceDir is unset, use the baked in sources
-	buildDir := tmpDir
-	if c.SourceDir == "" {
-		// populate with image sources
-		err = sources.RestoreAssets(buildDir, "images/node")
-		if err != nil {
-			return err
-		}
-		buildDir = filepath.Join(buildDir, "images", "node")
-
-	} else {
-		err = copyDir(c.SourceDir, buildDir)
-		if err != nil {
-			glog.Errorf("failed to copy sources to build dir %v", err)
-			return err
-		}
-	}
+	defer os.RemoveAll(buildDir)
 
 	glog.Infof("Building node image in: %s", buildDir)
 


### PR DESCRIPTION
we aren't currently using any fixed assets for this image, this drops some complexity from the node build, if we were to want it back in the future we can easily port it back over from the base image build.