### PR TITLE
Make Splice ignore pending batches for other repos.

### DIFF
--- a/prow/cmd/splice/main.go
+++ b/prow/cmd/splice/main.go
@@ -336,6 +336,10 @@ func main() {
 			if job.Spec.Type != kube.BatchJob {
 				continue
 			}
+			// Ignore batches for other repos.
+			if job.Spec.Refs == nil || job.Spec.Refs.Org != o.orgName || job.Spec.Refs.Repo != o.repoName {
+				continue
+			}
 			if !job.Complete() {
 				running = append(running, job.Spec.Job)
 			}


### PR DESCRIPTION
Currently if Splice sees **any** pending batch it will not trigger a new batch for k/k. This means that whenever Tide is running a batch for any repo Splice is blocked from triggering batches for k/k!

I don't care to clean this component up too much given that we will stop using it soon, but this is a pretty bad bug with a trivial fix.
/kind bug
/area prow
/cc @stevekuznetsov @BenTheElder @krzyzacy 