### PR TITLE
Allow trusted test-infra jobs

### DIFF
--- a/prow/cmd/mkbuild-cluster/README.md
+++ b/prow/cmd/mkbuild-cluster/README.md
@@ -42,12 +42,13 @@ Append additional entries to `cluster.yaml`:
 
 ```sh
 # Get current values:
-kubectl get secrets/build-cluster -o yaml > old.yaml
+kubectl get secrets/build-cluster -o yaml > ~/old.yaml
 # Add new value
-cat old.yaml | bazel run //prow/cmd/mkbuild-cluster -- \
+cat ~/old.yaml | bazel run //prow/cmd/mkbuild-cluster -- \
   --project=P --zone=Z --cluster=C --alias=NEW_CLUSTER \
-  > updated.yaml
-kubectl apply -f updated.yaml
+  > ~/updated.yaml
+diff ~/old.yaml ~/updated.yaml
+kubectl apply -f ~/updated.yaml
 ```
 
 Note: restart plank to see the updated values.

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -127,6 +127,9 @@ type Presubmit struct {
 	// We'll set these when we load it.
 	re        *regexp.Regexp // from Trigger.
 	reChanges *regexp.Regexp // from RunIfChanged
+
+	// SourcePath contains the path where this job is defined
+	SourcePath string `json:"-"`
 }
 
 // Postsubmit runs on push events.
@@ -149,6 +152,9 @@ type Postsubmit struct {
 
 	// Run these jobs after successfully running this one.
 	RunAfterSuccess []Postsubmit `json:"run_after_success,omitempty"`
+
+	// SourcePath contains the path where this job is defined
+	SourcePath string `json:"-"`
 }
 
 // Periodic runs on a timer.
@@ -174,6 +180,9 @@ type Periodic struct {
 	UtilityConfig
 
 	interval time.Duration
+
+	// SourcePath contains the path where this job is defined
+	SourcePath string `json:"-"`
 }
 
 // SetInterval updates interval, the frequency duration it runs.


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/9171

* add `SourcePath` field to jobs
* make `yamlToConfig()` set SourcePath
* unit tests to enforce that only `config/jobs/kubernetes/test-infra/test-infra-trusted.yaml` uses the trusted cluster
* Example trusted jobs which both pass and fail validation (I'll remove them once reviewers are satisfied)
* Update instructions for adding a cluster name

```console
INFO: From Testing //config/tests/jobs:go_default_test:
==================== Test output for //config/tests/jobs:go_default_test:
--- FAIL: TestTrustedJobs (0.00s)
	jobs_test.go:350: pull-test-infra-verify-trusted: presubmits cannot use trusted clusters
	jobs_test.go:360: post-test-infra-verify-trusted-BAD defined in ../../jobs/kubernetes/test-infra/test-infra-canaries.yaml may not run in trusted cluster
	jobs_test.go:370: post-test-infra-verify-trusted-BAD defined in ../../jobs/kubernetes/test-infra/test-infra-canaries.yaml may not run in trusted cluster
FAIL
```

/assign @cjwagner @spiffxp 

(note right now the test-infra-trusted cluster doesn't exist, so any jobs using this will fail)