### PR TITLE
Allow authors and collaborators to close and reopen without assignment

### DIFF
--- a/prow/plugins/lifecycle/close.go
+++ b/prow/plugins/lifecycle/close.go
@@ -29,11 +29,10 @@ import (
 var closeRe = regexp.MustCompile(`(?mi)^/close\s*$`)
 
 type closeClient interface {
+	IsCollaborator(owner, repo, login string) (bool, error)
 	CreateComment(owner, repo string, number int, comment string) error
 	CloseIssue(owner, repo string, number int) error
 	ClosePR(owner, repo string, number int) error
-	IsMember(owner, login string) (bool, error)
-	AssignIssue(owner, repo string, number int, assignees []string) error
 	GetIssueLabels(owner, repo string, number int) ([]github.Label, error)
 }
 
@@ -65,47 +64,42 @@ func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEven
 	number := e.Number
 	commentAuthor := e.User.Login
 
-	// Allow assignees and authors to close issues.
-	isAssignee := false
-	for _, assignee := range e.Assignees {
-		if commentAuthor == assignee.Login {
-			isAssignee = true
-			break
-		}
-	}
 	isAuthor := e.IssueAuthor.Login == commentAuthor
 
-	if !isAssignee && !isAuthor {
-		active, err := isActive(gc, org, repo, number)
-		if err != nil {
-			log.Infof("Cannot determine if issue is active: %v", err)
-			active = true // Fail active
-		}
-
-		if active {
-			// Try to assign the issue to the comment author
-			log.Infof("Assign to %s", commentAuthor)
-			if err := gc.AssignIssue(org, repo, number, []string{commentAuthor}); err != nil {
-				msg := "Assigning you to the issue failed."
-				if ok, merr := gc.IsMember(org, commentAuthor); merr == nil && !ok {
-					msg = "Can only assign issues to org members and/or repo collaborators."
-				} else if merr != nil {
-					log.WithError(merr).Errorf("Failed IsMember(%s, %s)", org, commentAuthor)
-				} else {
-					log.WithError(err).Errorf("Failed AssignIssue(%s, %s, %d, %s)", org, repo, number, commentAuthor)
-				}
-				resp := fmt.Sprintf("you can't close an active issue unless you authored it or you are assigned to it, %s.", msg)
-				log.Infof("Commenting \"%s\".", resp)
-				return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, resp))
-			}
-		}
+	isCollaborator, err := gc.IsCollaborator(org, repo, commentAuthor)
+	if err != nil {
+		log.WithError(err).Errorf("Failed IsCollaborator(%s, %s, %s)", org, repo, commentAuthor)
 	}
 
+	active, err := isActive(gc, org, repo, number)
+	if err != nil {
+		log.Infof("Cannot determine if issue is active: %v", err)
+		active = true // Fail active
+	}
+
+	// Only authors and collaborators are allowed to close active issues.
+	if !isAuthor && !isCollaborator && active {
+		response := fmt.Sprintf("You can't close an active issue/PR unless you authored it or you are a collaborator.")
+		log.Infof("Commenting \"%s\".", response)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response))
+	}
+
+	// Add a comment before closing the PR or issue
+	// to leave an audit trail of who asked to close it.
 	if e.IsPR {
+		response := fmt.Sprintf("Closing this PR.")
+		if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response)); err != nil {
+			log.WithError(err).Errorf("Failed adding comment while closing the PR")
+		}
+
 		log.Info("Closing PR.")
 		return gc.ClosePR(org, repo, number)
 	}
 
+	response := fmt.Sprintf("Closing this issue.")
+	if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response)); err != nil {
+		log.WithError(err).Errorf("Failed adding comment while closing the issue")
+	}
 	log.Info("Closing issue.")
 	return gc.CloseIssue(org, repo, number)
 }

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -47,14 +47,14 @@ func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.Plu
 		Usage:       "/close",
 		Description: "Closes an issue or PR.",
 		Featured:    false,
-		WhoCanUse:   "Authors and assignees can triggers this command.",
+		WhoCanUse:   "Authors and collaborators on the repository can trigger this command.",
 		Examples:    []string{"/close"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/reopen",
 		Description: "Reopens an issue or PR",
 		Featured:    false,
-		WhoCanUse:   "Authors and assignees can trigger this command.",
+		WhoCanUse:   "Authors and collaborators on the repository can trigger this command.",
 		Examples:    []string{"/reopen"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/8450

Before this PR, closing are reopening required actual assignment to the issue or the PR.

This meant that if you needed to reopen an issue, you would need to use three commands - "/assign", "/reopen" and "/unassign". This is not really helpful.

This PR allows only authors and collaborators to close and reopen issues. It does not require assignment to the issue or PR.

A comment is also added before closing or reopening an issue or PR to make sure that there is an audit trail for who asked to close or reopen. This is necessary to make sure that there is no abuse of these commands.