### PR TITLE
Add sanity checks for tide configuration to checkconfig

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,10 +8,14 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/approve:go_default_library",
+        "//prow/plugins/lgtm:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -42,4 +46,10 @@ go_binary(
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
 )

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -20,19 +20,27 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/plugins/approve"
 
 	"k8s.io/test-infra/prow/config"
 	_ "k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/lgtm"
 )
 
 type options struct {
 	configPath    string
 	jobConfigPath string
 	pluginConfig  string
+
+	strict bool
 }
 
 func (o *options) Validate() error {
@@ -50,6 +58,7 @@ func gatherOptions() options {
 	flag.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	flag.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	flag.StringVar(&o.pluginConfig, "plugin-config", "", "Path to plugin config file.")
+	flag.BoolVar(&o.strict, "strict", false, "If set, consider all warnings as errors.")
 	flag.Parse()
 	return o
 }
@@ -73,4 +82,118 @@ func main() {
 	if err := pluginAgent.Load(o.pluginConfig); err != nil {
 		logrus.WithError(err).Fatal("Error loading Prow plugin config.")
 	}
+
+	// the following checks are useful in finding user errors but their
+	// presence won't lead to strictly incorrect behavior, so we can
+	// detect them here but don't necessarily want to stop config re-load
+	// in all components on their failure.
+	if err := validateTideRequirements(configAgent, pluginAgent); err != nil {
+		reportWarning(o.strict, err, "Invalid tide merge configuration.")
+	}
+}
+
+func validateTideRequirements(configAgent config.Agent, pluginAgent plugins.PluginAgent) error {
+	lgtmPluginConfig := newOrgRepoConfig(pluginAgent.Config().EnabledReposForPlugin(lgtm.PluginName))
+	approvePluginConfig := newOrgRepoConfig(pluginAgent.Config().EnabledReposForPlugin(approve.PluginName))
+
+	lgtmTideConfig, approveTideConfig, overallTideConfig := newOrgRepoConfig([]string{}, []string{}), newOrgRepoConfig([]string{}, []string{}), newOrgRepoConfig([]string{}, []string{})
+	for _, query := range configAgent.Config().Tide.Queries {
+		requiresLgtm := sets.NewString(query.Labels...).Has(lgtm.LgtmLabel)
+		requiresApproval := sets.NewString(query.Labels...).Has(approve.ApprovedLabel)
+		for _, org := range query.Orgs {
+			if requiresLgtm {
+				lgtmTideConfig.orgs.Insert(org)
+			}
+			if requiresApproval {
+				approveTideConfig.orgs.Insert(org)
+			}
+			overallTideConfig.orgs.Insert(org)
+		}
+		for _, repo := range query.Repos {
+			if requiresLgtm {
+				lgtmTideConfig.repos.Insert(repo)
+			}
+			if requiresApproval {
+				approveTideConfig.repos.Insert(repo)
+			}
+			overallTideConfig.repos.Insert(repo)
+		}
+	}
+
+	var validationErrs []error
+	validationErrs = append(validationErrs, ensureValidConfiguration(lgtm.PluginName, lgtm.LgtmLabel, lgtmTideConfig, overallTideConfig, lgtmPluginConfig))
+	validationErrs = append(validationErrs, ensureValidConfiguration(approve.PluginName, approve.ApprovedLabel, approveTideConfig, overallTideConfig, approvePluginConfig))
+
+	return errorutil.NewAggregate(validationErrs...)
+}
+
+func newOrgRepoConfig(orgs, repos []string) orgRepoConfig {
+	return orgRepoConfig{
+		orgs:  sets.NewString(orgs...),
+		repos: sets.NewString(repos...),
+	}
+}
+
+type orgRepoConfig struct {
+	orgs, repos sets.String
+}
+
+func (c *orgRepoConfig) items() []string {
+	return c.orgs.Union(c.repos).UnsortedList()
+}
+
+func (c *orgRepoConfig) has(target string) bool {
+	return c.repos.Has(target) || c.orgs.Has(target) || (strings.Contains(target, "/") && c.orgs.Has(strings.Split(target, "/")[0]))
+}
+
+// ensureValidConfiguration enforces rules about tide and plugin config.
+// In this context, a subset is the set of repos or orgs for which a specific
+// plugin is either enabled (for plugins) or required for merge (for tide). The
+// tide superset is every org or repo that has any configuration at all in tide.
+// Specifically:
+//   - every item in the tide subset must also be in the plugins subset
+//   - every item in the plugins subset that is in the tide superset must also be in the tide subset
+// For example:
+//   - if org/repo is configured in tide to require lgtm, it must have the lgtm plugin enabled
+//   - if org/repo is configured in tide, the tide configuration must require the same set of
+//     plugins as are configured. If the repository has LGTM and approve enabled, the tide query
+//     must require both labels
+func ensureValidConfiguration(plugin, label string, tideSubSet, tideSuperSet, pluginsSubSet orgRepoConfig) error {
+	var notEnabled []string
+	for _, target := range tideSubSet.items() {
+		if !pluginsSubSet.has(target) {
+			notEnabled = append(notEnabled, target)
+		}
+	}
+
+	var tideConfigured []string
+	for _, target := range pluginsSubSet.items() {
+		if tideSuperSet.has(target) {
+			tideConfigured = append(tideConfigured, target)
+		}
+	}
+
+	var notRequired []string
+	for _, target := range tideConfigured {
+		if !tideSubSet.has(target) {
+			notRequired = append(notRequired, target)
+		}
+	}
+
+	var configErrors []error
+	if len(notEnabled) > 0 {
+		configErrors = append(configErrors, fmt.Errorf("the following orgs or repos require %s for merging but do not enable the %s plugin: %v", label, plugin, notEnabled))
+	}
+	if len(notRequired) > 0 {
+		configErrors = append(configErrors, fmt.Errorf("the following orgs or repos enables the %s plugin but do not require the %s label for merging: %v", plugin, label, notRequired))
+	}
+
+	return errorutil.NewAggregate(configErrors...)
+}
+
+func reportWarning(strict bool, err error, msg string) {
+	if strict {
+		logrus.WithError(err).Fatal(msg)
+	}
+	logrus.WithError(err).Warn(msg)
 }

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestEnsureValidConfiguration(t *testing.T) {
+	var testCases = []struct {
+		name                                    string
+		tideSubSet, tideSuperSet, pluginsSubSet orgRepoConfig
+		expectedErr                             bool
+	}{
+		{
+			name:          "nothing enabled makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{}),
+			expectedErr:   false,
+		},
+		{
+			name:          "plugin enabled on org without tide makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{"org"}, []string{}),
+			expectedErr:   false,
+		},
+		{
+			name:          "plugin enabled on repo without tide makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			expectedErr:   false,
+		},
+		{
+			name:          "plugin enabled on repo with tide on repo makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			expectedErr:   false,
+		},
+		{
+			name:          "plugin enabled on repo with tide on org makes error",
+			tideSubSet:    newOrgRepoConfig([]string{"org"}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{"org"}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			expectedErr:   true,
+		},
+		{
+			name:          "plugin enabled on org with tide on repo makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			pluginsSubSet: newOrgRepoConfig([]string{"org"}, []string{}),
+			expectedErr:   false,
+		},
+		{
+			name:          "plugin enabled on org with tide on org makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{"org"}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{"org"}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{"org"}, []string{}),
+			expectedErr:   false,
+		},
+		{
+			name:          "tide enabled on org without plugin makes error",
+			tideSubSet:    newOrgRepoConfig([]string{"org"}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{"org"}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{}),
+			expectedErr:   true,
+		},
+		{
+			name:          "tide enabled on repo without plugin makes error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{}),
+			expectedErr:   true,
+		},
+		{
+			name:          "plugin enabled on org with any tide record but no specific tide requirement makes error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{"org"}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{"org"}, []string{}),
+			expectedErr:   true,
+		},
+		{
+			name:          "plugin enabled on repo with any tide record but no specific tide requirement makes error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			expectedErr:   true,
+		},
+		{
+			name:          "any tide org record but no specific tide requirement or plugin makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{"org"}, []string{}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{}),
+			expectedErr:   false,
+		},
+		{
+			name:          "any tide repo record but no specific tide requirement or plugin makes no error",
+			tideSubSet:    newOrgRepoConfig([]string{}, []string{}),
+			tideSuperSet:  newOrgRepoConfig([]string{}, []string{"org/repo"}),
+			pluginsSubSet: newOrgRepoConfig([]string{}, []string{}),
+			expectedErr:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := ensureValidConfiguration("plugin", "label", testCase.tideSubSet, testCase.tideSuperSet, testCase.pluginsSubSet)
+			if testCase.expectedErr && err == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+		})
+	}
+}

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -34,10 +34,10 @@ import (
 )
 
 const (
-	pluginName = "approve"
+	PluginName = "approve"
 
 	approveCommand  = "APPROVE"
-	approvedLabel   = "approved"
+	ApprovedLabel   = "approved"
 	cancelArgument  = "cancel"
 	lgtmCommand     = "LGTM"
 	noIssueArgument = "no-issue"
@@ -90,9 +90,9 @@ type state struct {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterReviewEventHandler(pluginName, handleReviewEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, helpProvider)
+	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
+	plugins.RegisterReviewEventHandler(PluginName, handleReviewEvent, helpProvider)
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequestEvent, helpProvider)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -119,7 +119,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.ImplicitSelfApprove), willNot(opts.LgtmActsAsApprove), willNot(opts.ReviewActsAsApprove))
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The approve plugin implements a pull request approval process that manages the '` + approvedLabel + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
+		Description: `The approve plugin implements a pull request approval process that manages the '` + ApprovedLabel + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
 <br>
 <br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
 <br>For more information see <a href="https://git.k8s.io/test-infra/prow/plugins/approve/approvers/README.md">here</a>.`,
@@ -277,7 +277,7 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, oc ownersClient, con
 		return err
 	}
 	if pre.Action == github.PullRequestActionLabeled &&
-		(pre.Label.Name != approvedLabel || pre.Sender.Login == botName || pre.PullRequest.State == "closed") {
+		(pre.Label.Name != ApprovedLabel || pre.Sender.Login == botName || pre.PullRequest.State == "closed") {
 		return nil
 	}
 
@@ -352,7 +352,7 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, o
 	}
 	hasApprovedLabel := false
 	for _, label := range labels {
-		if label.Name == approvedLabel {
+		if label.Name == ApprovedLabel {
 			hasApprovedLabel = true
 			break
 		}
@@ -423,13 +423,13 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, o
 
 	if !approversHandler.IsApproved() {
 		if hasApprovedLabel {
-			if err := ghc.RemoveLabel(pr.org, pr.repo, pr.number, approvedLabel); err != nil {
-				log.WithError(err).Errorf("Failed to remove %q label from %s/%s#%d.", approvedLabel, pr.org, pr.repo, pr.number)
+			if err := ghc.RemoveLabel(pr.org, pr.repo, pr.number, ApprovedLabel); err != nil {
+				log.WithError(err).Errorf("Failed to remove %q label from %s/%s#%d.", ApprovedLabel, pr.org, pr.repo, pr.number)
 			}
 		}
 	} else if !hasApprovedLabel {
-		if err := ghc.AddLabel(pr.org, pr.repo, pr.number, approvedLabel); err != nil {
-			log.WithError(err).Errorf("Failed to add %q label to %s/%s#%d.", approvedLabel, pr.org, pr.repo, pr.number)
+		if err := ghc.AddLabel(pr.org, pr.repo, pr.number, ApprovedLabel); err != nil {
+			log.WithError(err).Errorf("Failed to add %q label to %s/%s#%d.", ApprovedLabel, pr.org, pr.repo, pr.number)
 		}
 	}
 	return nil
@@ -448,7 +448,7 @@ func humanAddedApproved(ghc githubClient, log *logrus.Entry, org, repo string, n
 		var lastAdded github.ListedIssueEvent
 		for _, event := range events {
 			// Only consider "approved" label added events.
-			if event.Event != github.IssueActionLabeled || event.Label.Name != approvedLabel {
+			if event.Event != github.IssueActionLabeled || event.Label.Name != ApprovedLabel {
 				continue
 			}
 			lastAdded = event

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1532,7 +1532,7 @@ func TestHandlePullRequestEvent(t *testing.T) {
 			prEvent: github.PullRequestEvent{
 				Action: github.PullRequestActionLabeled,
 				Label: github.Label{
-					Name: approvedLabel,
+					Name: ApprovedLabel,
 				},
 			},
 			expectHandle: true,
@@ -1552,7 +1552,7 @@ func TestHandlePullRequestEvent(t *testing.T) {
 			prEvent: github.PullRequestEvent{
 				Action: github.PullRequestActionLabeled,
 				Label: github.Label{
-					Name: approvedLabel,
+					Name: ApprovedLabel,
 				},
 				PullRequest: github.PullRequest{
 					State: "closed",

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -30,21 +30,21 @@ import (
 	"k8s.io/test-infra/prow/repoowners"
 )
 
-const pluginName = "lgtm"
+const PluginName = "lgtm"
 
 var (
-	lgtmLabel           = "lgtm"
+	LgtmLabel           = "lgtm"
 	lgtmRe              = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
 	lgtmCancelRe        = regexp.MustCompile(`(?mi)^/lgtm cancel\s*$`)
 	removeLGTMLabelNoti = "New changes are detected. LGTM label has been removed."
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, func(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
+	plugins.RegisterPullRequestHandler(PluginName, func(pc plugins.PluginClient, pe github.PullRequestEvent) error {
 		return handlePullRequest(pc.GitHubClient, pe, pc.Logger)
 	}, helpProvider)
-	plugins.RegisterReviewEventHandler(pluginName, handlePullRequestReviewEvent, helpProvider)
+	plugins.RegisterReviewEventHandler(PluginName, handlePullRequestReviewEvent, helpProvider)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -256,14 +256,14 @@ func handle(wantLGTM bool, config *plugins.Configuration, ownersClient repoowner
 		log.WithError(err).Errorf("Failed to get the labels on %s/%s#%d.", org, repoName, number)
 	}
 
-	hasLGTM = github.HasLabel(lgtmLabel, labels)
+	hasLGTM = github.HasLabel(LgtmLabel, labels)
 
 	if hasLGTM && !wantLGTM {
 		log.Info("Removing LGTM label.")
-		return gc.RemoveLabel(org, repoName, number, lgtmLabel)
+		return gc.RemoveLabel(org, repoName, number, LgtmLabel)
 	} else if !hasLGTM && wantLGTM {
 		log.Info("Adding LGTM label.")
-		if err := gc.AddLabel(org, repoName, number, lgtmLabel); err != nil {
+		if err := gc.AddLabel(org, repoName, number, LgtmLabel); err != nil {
 			return err
 		}
 		// Delete the LGTM removed noti after the LGTM label is added.
@@ -307,7 +307,7 @@ func handlePullRequest(gc ghLabelClient, pe github.PullRequestEvent, log *logrus
 	number := pe.PullRequest.Number
 
 	var labelNotFound bool
-	if err := gc.RemoveLabel(org, repo, number, lgtmLabel); err != nil {
+	if err := gc.RemoveLabel(org, repo, number, LgtmLabel); err != nil {
 		if _, labelNotFound = err.(*github.LabelNotFound); !labelNotFound {
 			return fmt.Errorf("failed removing lgtm label: %v", err)
 		}

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -261,14 +261,14 @@ func TestLGTMComment(t *testing.T) {
 			HTMLURL:     "<url>",
 		}
 		if tc.hasLGTM {
-			fc.LabelsAdded = []string{"org/repo#5:" + lgtmLabel}
+			fc.LabelsAdded = []string{"org/repo#5:" + LgtmLabel}
 		}
 		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
 		pc := &plugins.Configuration{}
 		if tc.skipCollab {
 			pc.Owners.SkipCollaborators = []string{"org/repo"}
 		}
-		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", pluginName), *e); err != nil {
+		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", PluginName), *e); err != nil {
 			t.Errorf("didn't expect error from lgtmComment: %v", err)
 			continue
 		}
@@ -410,7 +410,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 		fc.IssueComments[5] = append(fc.IssueComments[5], ic)
 		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
 		pc := &plugins.Configuration{}
-		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", pluginName), *e); err != nil {
+		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", PluginName), *e); err != nil {
 			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 			continue
 		}
@@ -543,11 +543,11 @@ func TestLGTMFromApproveReview(t *testing.T) {
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
 		if tc.hasLGTM {
-			fc.LabelsAdded = []string{"org/repo#5:" + lgtmLabel}
+			fc.LabelsAdded = []string{"org/repo#5:" + LgtmLabel}
 		}
 		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
 		pc := &plugins.Configuration{}
-		if err := handlePullRequestReview(fc, pc, oc, logrus.WithField("plugin", pluginName), *e); err != nil {
+		if err := handlePullRequestReview(fc, pc, oc, logrus.WithField("plugin", PluginName), *e); err != nil {
 			t.Errorf("For case %s, didn't expect error from pull request review: %v", tc.name, err)
 			continue
 		}
@@ -651,7 +651,7 @@ func TestHandlePullRequest(t *testing.T) {
 					},
 				},
 			},
-			labelsRemoved: []string{lgtmLabel},
+			labelsRemoved: []string{LgtmLabel},
 			issueComments: []fakeIssueComment{
 				{
 					Owner:   "kubernetes",
@@ -689,9 +689,9 @@ func TestHandlePullRequest(t *testing.T) {
 				Owner:  "kubernetes",
 				Repo:   "kubernetes",
 				Number: 101,
-				Label:  lgtmLabel,
+				Label:  LgtmLabel,
 			},
-			labelsRemoved:    []string{lgtmLabel},
+			labelsRemoved:    []string{LgtmLabel},
 			expectNoComments: true,
 		},
 	}
@@ -702,7 +702,7 @@ func TestHandlePullRequest(t *testing.T) {
 				removeLabelErr:   c.removeLabelErr,
 				createCommentErr: c.createCommentErr,
 			}
-			err := handlePullRequest(fakeGitHub, c.event, logrus.WithField("plugin", pluginName))
+			err := handlePullRequest(fakeGitHub, c.event, logrus.WithField("plugin", PluginName))
 
 			if err != nil && c.err == nil {
 				t.Fatalf("handlePullRequest error: %v", err)


### PR DESCRIPTION
When a repository or org is configured in a query in `tide`, we need to
sanity check that it has the appropriate plugins enabled in
`plugins.yaml`. Specifically, we need to detect and disallow the
configurations where:
 - a repo requires a label but does not enable the plugin that adds it
 - a repo adds a plugin but does not require it's label

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/kind bug
/cc @BenTheElder @fejta 
/cc @cjwagner 

This validation is the first that I know of that requires both agents. Should we try to wrap this up a little nicer and have any component that uses both agents run the validation? Would require a refactor to the load-time behavior for both agents.