### PR TITLE
prow/label: allow custom prefixes via config

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -23,6 +23,11 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *August 29, 2018* `label` plugin will now be a slice of label configs.
+ It will now support organization and repository-scoped configs and
+ custom label prefixes.
+ `area`, `kind`, `priority` and `triage` are the default prefixes.
+ Prefixes specified in the label config will replace these default prefixes.
  - *July 9, 2018* `milestone` format has changed from
     ```yaml
     milestone:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -199,6 +199,25 @@ config_updater:
     config/jobs/**/*.yaml:
       name: job-config
 
+label:
+- repos:
+  - client-go/unofficial-docs
+  - containerd/cri
+  - kubeflow
+  - kubernetes
+  - kubernetes-client
+  - kubernetes-csi
+  - kubernetes-incubator
+  - kubernetes-sigs
+  prefixes:
+    - area
+    - committee
+    - kind
+    - priority
+    - sig
+    - triage
+    - wg
+
 plugins:
   bazelbuild/rules_k8s:
   - approve  # Allow OWNERS to /approve

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -167,7 +167,7 @@ type Configuration struct {
 	Cat                  Cat                  `json:"cat,omitempty"`
 	ConfigUpdater        ConfigUpdater        `json:"config_updater,omitempty"`
 	Heart                Heart                `json:"heart,omitempty"`
-	Label                *Label               `json:"label,omitempty"`
+	Label                []Label              `json:"label,omitempty"`
 	Lgtm                 []Lgtm               `json:"lgtm,omitempty"`
 	RepoMilestone        map[string]Milestone `json:"repo_milestone,omitempty"`
 	RequireSIG           RequireSIG           `json:"requiresig,omitempty"`
@@ -363,10 +363,21 @@ type Cat struct {
 	KeyPath string `json:"key_path,omitempty"`
 }
 
+// Label is the config for the label plugin.
 type Label struct {
+	// Repos is either of the form org/repos or just org.
+	// The AdditionalLabels and Prefixes values are applicable
+	// to these repos.
+	Repos []string `json:"repos,omitempty"`
 	// AdditionalLabels is a set of additional labels enabled for use
-	// on top of the existing "kind/*", "priority/*", and "area/*" labels.
-	AdditionalLabels []string `json:"additional_labels"`
+	// on top of the existing "kind/*", "priority/*", "area/*"
+	// and "triage/*" labels.
+	// Labels can be used with `/[remove-]label <additionalLabel>` commands.
+	AdditionalLabels []string `json:"additional_labels,omitempty"`
+	// Prefixes is a set of label prefixes which replaces the existing
+	// "area", "kind", "priority" and "triage" label prefixes.
+	// Labels can be used with `/[remove-]<prefix> <target>` commands.
+	Prefixes []string `json:"prefixes,omitempty"`
 }
 
 type Trigger struct {
@@ -541,6 +552,13 @@ func (c *Configuration) setDefaults() {
 This PR is not for the master branch but does not have the ` + "`cherry-pick-approved`" + `  label. Adding the ` + "`do-not-merge/cherry-pick-not-approved`" + `  label.
 To approve the cherry-pick, please assign the patch release manager for the release branch by writing ` + "`/assign @username`" + ` in a comment when ready.
 The list of patch release managers for each release can be found [here](https://git.k8s.io/sig-release/release-managers.md).`
+	}
+	if c.Label != nil {
+		for _, labelConfig := range c.Label {
+			if labelConfig.Prefixes == nil {
+				labelConfig.Prefixes = []string{"area", "kind", "priority", "triage"}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/8648

Currently, the only prefixes supported are `area|committee|kind|priority|sig|triage|wg`. These prefixes are also hard-coded.

This PR supports org/repo scoped configs for the label plugin. It also allows to specify custom prefixes via config. The `area|kind|priority|triage` prefixes are enabled by default. The prefixes specified in config override the default prefixes.

/cc BenTheElder cjwagner cblecker stevekuznetsov 