### PR TITLE
Enable v1.12 code slush.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -94,7 +94,7 @@ nonblocking-jobs: "\
   ci-kubernetes-soak-gke-test,\
   ci-kubernetes-integration-master,\
   ci-kubernetes-verify-master"
-do-not-merge-milestones: ""
+do-not-merge-milestones: "v1.13,v1.14,next-candidate,NO-MILESTONE"
 additional-required-labels: ""
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg


### PR DESCRIPTION
This release we aren't using the milestone munger and we are not requiring the `status/approved-for-milestone` label.
This PR just adds the requirement that PRs are in the v1.12 milestone or an earlier milestone in order to merge. PRs without milestones or for future milestones will be blocked.
I'll deploy this as soon as it merges.

/area mungegithub
/cc @tpepper @amwat 