### PR TITLE
kind: support config files

### DIFF
--- a/kind/cmd/kind/create/create.go
+++ b/kind/cmd/kind/create/create.go
@@ -48,18 +48,22 @@ func NewCommand() *cobra.Command {
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
-	config := cluster.NewConfig(flags.Name)
+	config := cluster.NewCreateConfig()
 	err := config.Validate()
 	if err != nil {
-		glog.Error("Invalid Configuration!")
+		glog.Error("Invalid configuration!")
 		configErrors := err.(cluster.ConfigErrors)
 		for _, problem := range configErrors.Errors() {
 			glog.Error(problem)
 		}
 		os.Exit(-1)
 	}
-	ctx := cluster.NewContext(config)
-	err = ctx.Create()
+	ctx, err := cluster.NewContext(flags.Name)
+	if err != nil {
+		glog.Error("Failed to create cluster context! %v", err)
+		os.Exit(-1)
+	}
+	err = ctx.Create(config)
 	if err != nil {
 		glog.Errorf("Failed to create cluster: %v", err)
 		os.Exit(-1)

--- a/kind/cmd/kind/delete/delete.go
+++ b/kind/cmd/kind/delete/delete.go
@@ -48,17 +48,11 @@ func NewCommand() *cobra.Command {
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
-	config := cluster.NewConfig(flags.Name)
-	err := config.Validate()
+	ctx, err := cluster.NewContext(flags.Name)
 	if err != nil {
-		glog.Error("Invalid Configuration!")
-		configErrors := err.(cluster.ConfigErrors)
-		for _, problem := range configErrors.Errors() {
-			glog.Error(problem)
-		}
+		glog.Error("Failed to create cluster context! %v", err)
 		os.Exit(-1)
 	}
-	ctx := cluster.NewContext(config)
 	err = ctx.Delete()
 	if err != nil {
 		glog.Errorf("Failed to delete cluster: %v", err)

--- a/kind/docs/todo.md
+++ b/kind/docs/todo.md
@@ -20,8 +20,8 @@ A non-exhaustive list of tasks (in no-particular order) includes:
   - [ ] etcd
   - [ ] overlay network images?
 - [ ] support multiple overlay networks
-- [ ] support advanced configuration via config file
-  - [ ] kubeadm config template override
+- [x] support advanced configuration via config file
+  - [x] kubeadm config template override
 - [ ] more advanced network configuration (not docker0)
 - [ ] support for other CRI within the "node" containers (containerd, cri-o)
 - [ ] switch from `exec.Command("docker", ...)` to the Docker client library

--- a/kind/docs/todo.md
+++ b/kind/docs/todo.md
@@ -3,6 +3,7 @@
 A non-exhaustive list of tasks (in no-particular order) includes:
 - [x] basic single "node" clusters
 - [x] multiple clusters per host / named clusters
+- [ ] preflight checks
 - [ ] multi-node clusters
 - [x] support for multiple kubernetes builds:
   - [x] bazel build from source
@@ -24,6 +25,8 @@ A non-exhaustive list of tasks (in no-particular order) includes:
 - [ ] more advanced network configuration (not docker0)
 - [ ] support for other CRI within the "node" containers (containerd, cri-o)
 - [ ] switch from `exec.Command("docker", ...)` to the Docker client library
+- [ ] log dumping functionality
+  - [ ] support audit logging
 
 # Wishlist
 

--- a/kind/pkg/cluster/BUILD.bazel
+++ b/kind/pkg/cluster/BUILD.bazel
@@ -38,6 +38,9 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "cluster_test.go",
+        "config_test.go",
+    ],
     embed = [":go_default_library"],
 )

--- a/kind/pkg/cluster/BUILD.bazel
+++ b/kind/pkg/cluster/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//kind/pkg/cluster/kubeadm:go_default_library",
         "//kind/pkg/exec:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
     ],

--- a/kind/pkg/cluster/cluster.go
+++ b/kind/pkg/cluster/cluster.go
@@ -89,7 +89,7 @@ func (c *Context) KubeConfigPath() string {
 }
 
 // Create provisions and starts a kubernetes-in-docker cluster
-func (c *Context) Create(config CreateConfig) error {
+func (c *Context) Create(config *CreateConfig) error {
 	// validate config first
 	if err := config.Validate(); err != nil {
 		return err
@@ -129,7 +129,7 @@ func (c *Context) Delete() error {
 
 // provisionControlPlane provisions the control plane node
 // and the cluster kubeadm config
-func (c *Context) provisionControlPlane(nodeName string, config CreateConfig) (kubeadmConfigPath string, err error) {
+func (c *Context) provisionControlPlane(nodeName string, config *CreateConfig) (kubeadmConfigPath string, err error) {
 	// create the "node" container (docker run, but it is paused, see createNode)
 	node, err := createNode(nodeName, c.ClusterLabel())
 	if err != nil {
@@ -176,10 +176,13 @@ func (c *Context) provisionControlPlane(nodeName string, config CreateConfig) (k
 	}
 
 	// create kubeadm config file
-	kubeadmConfig, err := c.createKubeadmConfig("", kubeadm.ConfigData{
-		ClusterName:       c.ClusterName(),
-		KubernetesVersion: kubeVersion,
-	})
+	kubeadmConfig, err := c.createKubeadmConfig(
+		config.KubeadmConfigTemplate,
+		kubeadm.ConfigData{
+			ClusterName:       c.ClusterName(),
+			KubernetesVersion: kubeVersion,
+		},
+	)
 
 	// copy the config to the node
 	if err := node.CopyTo(kubeadmConfig, "/kind/kubeadm.conf"); err != nil {

--- a/kind/pkg/cluster/cluster_test.go
+++ b/kind/pkg/cluster/cluster_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import "testing"
+
+func TestNewContext(t *testing.T) {
+	cases := []struct {
+		TestName    string
+		Name        string
+		ExpectError bool
+	}{
+		{
+			TestName:    "defaults",
+			Name:        "",
+			ExpectError: false,
+		},
+		{
+			TestName:    "2",
+			Name:        "2",
+			ExpectError: false,
+		},
+		{
+			TestName:    "foo is fine",
+			Name:        "foo",
+			ExpectError: false,
+		},
+		{
+			TestName:    "Invalid name - commas",
+			Name:        ",,,,,,",
+			ExpectError: true,
+		},
+		{
+			TestName:    "Invalid name - invalid character in the middle",
+			Name:        "almost-valid@nope",
+			ExpectError: true,
+		},
+		{
+			TestName:    "Invalid name - emojis :(",
+			Name:        "😬",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := NewContext(tc.Name)
+		// the error can be:
+		// - nil, in which case we should expect no errors or fail
+		if err == nil && tc.ExpectError {
+			t.Errorf("expected an error for case: '%s'", tc.TestName)
+		}
+		if err != nil && !tc.ExpectError {
+			t.Errorf("did an error for case: '%s' but got error: %v", tc.TestName, err)
+		}
+	}
+}

--- a/kind/pkg/cluster/config.go
+++ b/kind/pkg/cluster/config.go
@@ -19,46 +19,25 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
 )
 
-// ClusterLabelKey is applied to each "node" docker container for identification
-const ClusterLabelKey = "io.k8s.test-infra.kind-cluster"
-
-// similar to valid docker container names, but since we will prefix
-// and suffix this name, we can relax it a little
-// see Validate() for usage
-var validNameRE = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
-
-// Config contains cluster options
-type Config struct {
-	// the cluster name
-	Name string
-	// the number of nodes (currently only one is supported)
+// CreateConfig contains cluster creation config
+type CreateConfig struct {
+	// NumNodes is the number of nodes to create (currently only one is supported)
 	NumNodes int
-	// TODO(bentheelder): fill this in
 }
 
-// NewConfig returns a new cluster config with name
-func NewConfig(name string) Config {
-	return Config{
-		Name:     name,
+// NewCreateConfig returns a new default CreateConfig
+func NewCreateConfig() CreateConfig {
+	return CreateConfig{
 		NumNodes: 1,
 	}
 }
 
 // Validate returns a ConfigErrors with an entry for each problem
 // with the config, or nil if there are none
-func (c *Config) Validate() error {
+func (c *CreateConfig) Validate() error {
 	errs := []error{}
-	if !validNameRE.MatchString(c.Name) {
-		errs = append(errs, fmt.Errorf(
-			"'%s' is not a valid cluster name, cluster names must match `%s`",
-			c.Name, validNameRE.String(),
-		))
-	}
 	// TODO(bentheelder): support multiple nodes
 	if c.NumNodes != 1 {
 		errs = append(errs, fmt.Errorf(
@@ -93,27 +72,4 @@ func (c ConfigErrors) Error() string {
 // Errors returns the slice of errors contained by ConfigErrors
 func (c ConfigErrors) Errors() []error {
 	return c.errors
-}
-
-// internal helper used to identify the cluster containers based on config
-func (c *Config) clusterLabel() string {
-	return fmt.Sprintf("%s=%s", ClusterLabelKey, c.Name)
-}
-
-// ClusterName returns the Kubernetes cluster name based on the config
-// currently this is .Name prefixed with "kind-"
-func (c *Config) ClusterName() string {
-	return fmt.Sprintf("kind-%s", c.Name)
-}
-
-// KubeConfigPath returns the path to where the Kubeconfig would be placed
-// by kind based on the configuration.
-func (c *Config) KubeConfigPath() string {
-	// TODO(bentheelder): Windows?
-	// configDir matches the standard directory expected by kubectl etc
-	configDir := filepath.Join(os.Getenv("HOME"), ".kube")
-	// note that the file name however does not, we do not want to overwite
-	// the standard config, though in the future we may (?) merge them
-	fileName := fmt.Sprintf("kind-config-%s", c.Name)
-	return filepath.Join(configDir, fileName)
 }

--- a/kind/pkg/cluster/config_test.go
+++ b/kind/pkg/cluster/config_test.go
@@ -18,45 +18,20 @@ package cluster
 
 import "testing"
 
-func TestConfigValidate(t *testing.T) {
+func TestCreateConfigValidate(t *testing.T) {
 	cases := []struct {
-		Name           string
-		Config         Config
+		TestName       string
+		Config         *CreateConfig
 		ExpectedErrors int
 	}{
 		{
-			Name:           "Canonical config",
-			Config:         NewConfig("1"),
+			TestName:       "Canonical config",
+			Config:         NewCreateConfig(),
 			ExpectedErrors: 0,
 		},
 		{
-			Name: "Invalid name - commas",
-			Config: Config{
-				Name:     ",,,,,,",
-				NumNodes: 1,
-			},
-			ExpectedErrors: 1,
-		},
-		{
-			Name: "Invalid name - zero length",
-			Config: Config{
-				Name:     "",
-				NumNodes: 1,
-			},
-			ExpectedErrors: 1,
-		},
-		{
-			Name: "Invalid name - invalid character in the middle",
-			Config: Config{
-				Name:     "almost-valid@nope",
-				NumNodes: 1,
-			},
-			ExpectedErrors: 1,
-		},
-		{
-			Name: "Invalid number of nodes (not yet supported",
-			Config: Config{
-				Name:     "2",
+			TestName: "Invalid number of nodes (not yet supported",
+			Config: &CreateConfig{
 				NumNodes: 2,
 			},
 			ExpectedErrors: 1,
@@ -69,20 +44,20 @@ func TestConfigValidate(t *testing.T) {
 		// - nil, in which case we should expect no errors or fail
 		if err == nil {
 			if tc.ExpectedErrors != 0 {
-				t.Errorf("received no errors but expected errors for case %s", tc.Name)
+				t.Errorf("received no errors but expected errors for case %s", tc.TestName)
 			}
 			continue
 		}
 		// - not castable to ConfigErrors, in which case we have the wrong error type ...
 		configErrors, ok := err.(ConfigErrors)
 		if !ok {
-			t.Errorf("config.Validate should only return nil or ConfigErrors{...}, got: %v for case: %s", err, tc.Name)
+			t.Errorf("config.Validate should only return nil or ConfigErrors{...}, got: %v for case: %s", err, tc.TestName)
 			continue
 		}
 		// - ConfigErrors, in which case expect a certain number of errors
 		errors := configErrors.Errors()
 		if len(errors) != tc.ExpectedErrors {
-			t.Errorf("expected %d errors but got len(%v) = %d for case: %s", tc.ExpectedErrors, errors, len(errors), tc.Name)
+			t.Errorf("expected %d errors but got len(%v) = %d for case: %s", tc.ExpectedErrors, errors, len(errors), tc.TestName)
 		}
 	}
 }


### PR DESCRIPTION
- refactor config structs in cluster package, move the name to context and use config just for create
- add functionality to load create config from file
- add flag for config file to create cli
- add kubeadm config template to create command

/area kind