### PR TITLE
make command-help work better without fullscreen

### DIFF
--- a/prow/cmd/deck/static/command-help.html
+++ b/prow/cmd/deck/static/command-help.html
@@ -51,7 +51,7 @@
                             <th></th>
                             <th class="mdl-data-table__cell--non-numeric">Command</th>
                             <th class="mdl-data-table__cell--non-numeric">Example</th>
-                            <th class="mdl-data-table__cell--non-numeric">Description</th>
+                            <th id="description-col" class="mdl-data-table__cell--non-numeric">Description</th>
                             <th id="usage-col" class="mdl-data-table__cell--non-numeric">Who Can Use</th>
                             <th class="mdl-data-table__cell--non-numeric">Plugin</th>
                             <th></th>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -318,6 +318,7 @@ span.label:not(.merge-table-label):hover {
     color: #757575;
     font-size: 15px;
     font-weight: bolder;
+    max-width: 170px;
 }
 
 .command-example-list {
@@ -346,6 +347,10 @@ span.label:not(.merge-table-label):hover {
 }
 
 #usage-col {
+    min-width: 200px;
+}
+
+#description-col {
     min-width: 200px;
 }
 

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -57,7 +57,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Adds or removes the 'lgtm' label which is typically used to gate merging.",
 		Featured:    true,
 		WhoCanUse:   "Collaborators on the repository. '/lgtm cancel' can be used additionally by the PR author.",
-		Examples:    []string{"/lgtm", "/lgtm cancel", "toggle the Review button to 'Approve' or 'Request Changes' in the github GUI"},
+		Examples:    []string{"/lgtm", "/lgtm cancel", "<a href=\"https://help.github.com/articles/about-pull-request-reviews/\">'Approve' or 'Request Changes'</a>"},
 	})
 	return pluginHelp, nil
 }

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -112,7 +112,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Forces a github status context to green (one per line).",
 		Featured:    false,
 		WhoCanUse:   "Repo administrators",
-		Examples:    []string{"/override pull-repo-whatever", "/override continuous-integration/travis\n/override deleted-job"},
+		Examples:    []string{"/override pull-repo-whatever", "/override ci/circleci", "/override deleted-job"},
 	})
 	return pluginHelp, nil
 }


### PR DESCRIPTION
before:
<img width="1335" alt="screen shot 2018-08-29 at 12 00 52 am" src="https://user-images.githubusercontent.com/917931/44771001-a1fed080-ab1e-11e8-805c-9ad3a4ae7f11.png">

after:
<img width="1332" alt="screen shot 2018-08-29 at 12 00 11 am" src="https://user-images.githubusercontent.com/917931/44770967-872c5c00-ab1e-11e8-8284-b4178f16e5d0.png">
