### PR TITLE
Add DCO sign-off checker plugin

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2260,11 +2260,8 @@ func (c *Client) ListPRCommits(org, repo string, number int) ([]RepositoryCommit
 		return nil, nil
 	}
 	var commits []RepositoryCommit
-	err := c.readPaginatedResultsWithValues(
+	err := c.readPaginatedResults(
 		fmt.Sprintf("/repos/%v/%v/pulls/%d/commits", org, repo, number),
-		url.Values{
-			"per_page": []string{"100"},
-		},
 		acceptNone,
 		func() interface{} { // newObj returns a pointer to the type of object to create
 			return &[]RepositoryCommit{}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1626,3 +1626,19 @@ func TestListMilestones(t *testing.T) {
 		t.Errorf("Didn't expect error: %v", err)
 	}
 }
+
+func TestListPRCommits(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/theorg/therepo/pulls/3/commits" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	if err, _ := c.ListPRCommits("theorg", "therepo", 3); err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1628,17 +1628,18 @@ func TestListMilestones(t *testing.T) {
 }
 
 func TestListPRCommits(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("Bad method: %s", r.Method)
-		}
-		if r.URL.Path != "/repos/theorg/therepo/pulls/3/commits" {
-			t.Errorf("Bad request path: %s", r.URL.Path)
-		}
-	}))
+	ts := simpleTestServer(t, "/repos/theorg/therepo/pulls/3/commits",
+		[]RepositoryCommit{
+			{SHA: "sha"},
+			{SHA: "sha2"},
+		})
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if err, _ := c.ListPRCommits("theorg", "therepo", 3); err != nil {
+	if commits, err := c.ListPRCommits("theorg", "therepo", 3); err != nil {
 		t.Errorf("Didn't expect error: %v", err)
+	} else {
+		if len(commits) != 2 {
+			t.Errorf("Expected 2 commits to be returned, but got %d", len(commits))
+		}
 	}
 }

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -69,6 +69,10 @@ type FakeClient struct {
 	Milestone    int
 	MilestoneMap map[string]int
 
+	// list of commits for each PR
+	// org/repo#number:[]commit
+	CommitMap map[string][]github.RepositoryCommit
+
 	// Fake remote git storage. File name are keys
 	// and values map SHA to content
 	RemoteFiles map[string]map[string]string
@@ -391,4 +395,10 @@ func (f *FakeClient) ListMilestones(org, repo string) ([]github.Milestone, error
 		milestones = append(milestones, github.Milestone{Title: k, Number: v})
 	}
 	return milestones, nil
+}
+
+// ListPRCommits lists commits for a given PR.
+func (f *FakeClient) ListPRCommits(org, repo string, prNumber int) ([]github.RepositoryCommit, error) {
+	k := fmt.Sprintf("%s/%s#%d", org, repo, prNumber)
+	return f.CommitMap[k], nil
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -779,3 +779,23 @@ type Milestone struct {
 	Title  string `json:"title"`
 	Number int    `json:"number"`
 }
+
+// RepositoryCommit represents a commit in a repo.
+// Note that it's wrapping a GitCommit, so author/committer information is in two places,
+// but contain different details about them: in RepositoryCommit "github details", in GitCommit - "git details".
+type RepositoryCommit struct {
+	SHA         *string    `json:"sha,omitempty"`
+	Commit      *GitCommit `json:"commit,omitempty"`
+	Author      *User      `json:"author,omitempty"`
+	Committer   *User      `json:"committer,omitempty"`
+	Parents     []Commit   `json:"parents,omitempty"`
+	HTMLURL     *string    `json:"html_url,omitempty"`
+	URL         *string    `json:"url,omitempty"`
+	CommentsURL *string    `json:"comments_url,omitempty"`
+}
+
+// GitCommit represents a GitHub commit.
+type GitCommit struct {
+	SHA     *string `json:"sha,omitempty"`
+	Message *string `json:"message,omitempty"`
+}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -784,18 +784,18 @@ type Milestone struct {
 // Note that it's wrapping a GitCommit, so author/committer information is in two places,
 // but contain different details about them: in RepositoryCommit "github details", in GitCommit - "git details".
 type RepositoryCommit struct {
-	SHA         *string    `json:"sha,omitempty"`
-	Commit      *GitCommit `json:"commit,omitempty"`
-	Author      *User      `json:"author,omitempty"`
-	Committer   *User      `json:"committer,omitempty"`
-	Parents     []Commit   `json:"parents,omitempty"`
-	HTMLURL     *string    `json:"html_url,omitempty"`
-	URL         *string    `json:"url,omitempty"`
-	CommentsURL *string    `json:"comments_url,omitempty"`
+	SHA         string    `json:"sha"`
+	Commit      GitCommit `json:"commit"`
+	Author      User      `json:"author"`
+	Committer   User      `json:"committer"`
+	Parents     []Commit  `json:"parents,omitempty"`
+	HTMLURL     string    `json:"html_url"`
+	URL         string    `json:"url"`
+	CommentsURL string    `json:"comments_url"`
 }
 
 // GitCommit represents a GitHub commit.
 type GitCommit struct {
-	SHA     *string `json:"sha,omitempty"`
-	Message *string `json:"message,omitempty"`
+	SHA     string `json:"sha,omitempty"`
+	Message string `json:"message,omitempty"`
 }

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//prow/plugins/cat:go_default_library",
         "//prow/plugins/cherrypickunapproved:go_default_library",
         "//prow/plugins/cla:go_default_library",
+        "//prow/plugins/dco:go_default_library",
         "//prow/plugins/docs-no-retest:go_default_library",
         "//prow/plugins/dog:go_default_library",
         "//prow/plugins/golint:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/cat"
 	_ "k8s.io/test-infra/prow/plugins/cherrypickunapproved"
 	_ "k8s.io/test-infra/prow/plugins/cla"
+	_ "k8s.io/test-infra/prow/plugins/dco"
 	_ "k8s.io/test-infra/prow/plugins/docs-no-retest"
 	_ "k8s.io/test-infra/prow/plugins/dog"
 	_ "k8s.io/test-infra/prow/plugins/golint"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -58,6 +58,7 @@ filegroup(
         "//prow/plugins/cat:all-srcs",
         "//prow/plugins/cherrypickunapproved:all-srcs",
         "//prow/plugins/cla:all-srcs",
+        "//prow/plugins/dco:all-srcs",
         "//prow/plugins/docs-no-retest:all-srcs",
         "//prow/plugins/dog:all-srcs",
         "//prow/plugins/golint:all-srcs",

--- a/prow/plugins/dco/BUILD.bazel
+++ b/prow/plugins/dco/BUILD.bazel
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dco.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/dco",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["dco_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package dco implements a DCO (https://developercertificate.org/) checker plugin
 package dco
 
 import (

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -298,8 +298,13 @@ func shouldPrune(log *logrus.Entry) func(github.IssueComment) bool {
 	}
 }
 
-func handlePullRequestEvent(pc plugins.PluginClient, pe github.PullRequestEvent) error {
-	return handlePullRequest(pc.GitHubClient, pc.CommentPruner, pc.Logger, pe)
+func handlePullRequestEvent(pc plugins.Agent, pe github.PullRequestEvent) error {
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+
+	return handlePullRequest(pc.GitHubClient, cp, pc.Logger, pe)
 }
 
 func handlePullRequest(gc gitHubClient, cp commentPruner, log *logrus.Entry, pe github.PullRequestEvent) error {
@@ -322,8 +327,13 @@ func handlePullRequest(gc gitHubClient, cp commentPruner, log *logrus.Entry, pe 
 	return handle(gc, cp, log, org, repo, pe.PullRequest, shouldComment)
 }
 
-func handleCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {
-	return handleComment(pc.GitHubClient, pc.CommentPruner, pc.Logger, ce)
+func handleCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) error {
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+
+	return handleComment(pc.GitHubClient, cp, pc.Logger, ce)
 }
 
 func handleComment(gc gitHubClient, cp commentPruner, log *logrus.Entry, ce github.GenericCommentEvent) error {

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -325,9 +325,9 @@ func handlePullRequestEvent(pc plugins.PluginClient, pe github.PullRequestEvent)
 		return nil
 	}
 
-	synchronizeEvent := pe.Action == github.PullRequestActionSynchronize
+	shouldComment := pe.Action == github.PullRequestActionSynchronize || pe.Action == github.PullRequestActionOpened
 
-	return handle(pc.GitHubClient, pc.CommentPruner, pc.Logger, org, repo, pe.PullRequest, synchronizeEvent)
+	return handle(pc.GitHubClient, pc.CommentPruner, pc.Logger, org, repo, pe.PullRequest, shouldComment)
 }
 
 func handleCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dco
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"regexp"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	pluginName               = "dco"
+	dcoContextName           = "dco"
+	dcoContextMessageFailed  = "A commit in PR is missing Signed-off-by"
+	dcoContextMessageSuccess = "All commits have Signed-off-by"
+
+	dcoYesLabel        = "dco-signoff: yes"
+	dcoNoLabel         = "dco-signoff: no"
+	dcoMsgPruneMatch   = "Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits."
+	dcoNotFoundMessage = `Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+
+<details>
+
+%s
+</details>
+`
+)
+
+var (
+	checkDCORe = regexp.MustCompile(`(?mi)^/check-dco\s*$`)
+	testRe     = regexp.MustCompile(`(?mi)^signed-off-by:`)
+)
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleCommentEvent, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The {WhoCanUse, Usage, Examples, Config} fields are omitted because this plugin cannot be
+	// manually triggered and is not configurable.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The dco plugin checks pull request commits for 'DCO sign off' and maintains the '" + dcoContextName + "' status context, as well as the 'dco' label.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/check-dco",
+		Description: "Forces rechecking of the DCO status.",
+		Featured:    true,
+		WhoCanUse:   "Anyone",
+		Examples:    []string{"/check-dco"},
+	})
+	return pluginHelp, nil
+}
+
+type gitHubClient interface {
+	BotName() (string, error)
+	CreateComment(owner, repo string, number int, comment string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	ListStatuses(org, repo, ref string) ([]github.Status, error)
+	CreateStatus(owner, repo, ref string, status github.Status) error
+	ListPRCommits(org, repo string, number int) ([]github.RepositoryCommit, error)
+	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+// checkCommitMessages will perform the actual DCO check by retrieving all
+// commits contained within the PR with the given number.
+// *All* commits in the pull request *must* match the 'testRe' in order to pass.
+func checkCommitMessages(gc gitHubClient, l *logrus.Entry, org, repo string, number int) (bool, error) {
+	allCommits, err := gc.ListPRCommits(org, repo, number)
+	if err != nil {
+		return false, fmt.Errorf("error listing commits for pull request: %v", err)
+	}
+	l.Infof("Found %d commits in PR", len(allCommits))
+
+	signMissing := false
+	for _, commit := range allCommits {
+		if !testRe.MatchString(*commit.Commit.Message) {
+			signMissing = true
+			break
+		}
+	}
+
+	l.Infof("All commits in PR have DCO signoff: %t", !signMissing)
+	return !signMissing, nil
+}
+
+// checkExistingStatus will retrieve the current status of the DCO context for
+// the provided SHA.
+func checkExistingStatus(gc gitHubClient, l *logrus.Entry, org, repo, sha string) (string, error) {
+	statuses, err := gc.ListStatuses(org, repo, sha)
+	if err != nil {
+		return "", fmt.Errorf("error listing pull request statuses: %v", err)
+	}
+
+	existingStatus := ""
+	for _, status := range statuses {
+		if status.Context != dcoContextName {
+			continue
+		}
+		existingStatus = status.State
+		break
+	}
+	l.Infof("Existing DCO status context status is %q", existingStatus)
+	return existingStatus, nil
+}
+
+// checkExistingLabels will check the provided PR for the dco sign off labels,
+// returning bool's indicating whether the 'yes' and the 'no' label are present.
+func checkExistingLabels(gc gitHubClient, l *logrus.Entry, org, repo string, number int) (hasYesLabel, hasNoLabel bool, err error) {
+	labels, err := gc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return false, false, fmt.Errorf("error getting pull request labels: %v", err)
+	}
+
+	for _, l := range labels {
+		if l.Name == dcoYesLabel {
+			hasYesLabel = true
+		}
+		if l.Name == dcoNoLabel {
+			hasNoLabel = true
+		}
+	}
+
+	return hasYesLabel, hasNoLabel, nil
+}
+
+// takeAction will take appropriate action on the pull request according to its
+// current state.
+func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo string, pr github.PullRequest, signedOff bool, existingStatus string, hasYesLabel, hasNoLabel bool) error {
+	targetURL := fmt.Sprintf("https://github.com/%s/%s/blob/master/CONTRIBUTING.md", org, repo)
+	botName, err := gc.BotName()
+	if err != nil {
+		return fmt.Errorf("failed to get bot name: %v", err)
+	}
+
+	// handle the 'all commits signed off' case by adding appropriate labels
+	// TODO: clean-up old comments?
+	if signedOff {
+		if hasNoLabel {
+			l.Infof("Removing %q label", dcoNoLabel)
+			// remove 'dco-signoff: no' label
+			if err := gc.RemoveLabel(org, repo, pr.Number, dcoNoLabel); err != nil {
+				return fmt.Errorf("error removing label: %v", err)
+			}
+		}
+		if !hasYesLabel {
+			l.Infof("Adding %q label", dcoYesLabel)
+			// add 'dco-signoff: yes' label
+			if err := gc.AddLabel(org, repo, pr.Number, dcoYesLabel); err != nil {
+				return fmt.Errorf("error adding label: %v", err)
+			}
+		}
+		if existingStatus != github.StatusSuccess {
+			l.Infof("Setting DCO status context to succeeded")
+			if err := gc.CreateStatus(org, repo, pr.Head.SHA, github.Status{
+				Context:     dcoContextName,
+				State:       github.StatusSuccess,
+				TargetURL:   targetURL,
+				Description: dcoContextMessageSuccess,
+			}); err != nil {
+				return fmt.Errorf("error setting pull request status: %v", err)
+			}
+		}
+
+		cp.PruneComments(shouldPrune(l, botName))
+		return nil
+	}
+
+	// handle the 'not all commits signed off' case
+
+	// we handle this 'base case' early on to avoid adding more comments when
+	// they are not needed.
+	if hasNoLabel && !hasYesLabel && existingStatus == github.StatusFailure {
+		l.Infof("DCO status context and label already up to date")
+		return nil
+	}
+
+	if !hasNoLabel {
+		l.Infof("Adding %q label", dcoNoLabel)
+		// add 'dco-signoff: no' label
+		if err := gc.AddLabel(org, repo, pr.Number, dcoNoLabel); err != nil {
+			return fmt.Errorf("error adding label: %v", err)
+		}
+	}
+	if hasYesLabel {
+		l.Infof("Removing %q label", dcoYesLabel)
+		// remove 'dco-signoff: yes' label
+		if err := gc.RemoveLabel(org, repo, pr.Number, dcoYesLabel); err != nil {
+			return fmt.Errorf("error removing label: %v", err)
+		}
+	}
+	if existingStatus != github.StatusFailure {
+		l.Infof("Setting DCO status context to failed")
+		if err := gc.CreateStatus(org, repo, pr.Head.SHA, github.Status{
+			Context:     dcoContextName,
+			State:       github.StatusFailure,
+			TargetURL:   targetURL,
+			Description: dcoContextMessageFailed,
+		}); err != nil {
+			return fmt.Errorf("error setting pull request status: %v", err)
+		}
+	}
+
+	cp.PruneComments(shouldPrune(l, botName))
+	l.Infof("Commenting on PR to advise users of DCO check")
+	if err := gc.CreateComment(org, repo, pr.Number, fmt.Sprintf(dcoNotFoundMessage, plugins.AboutThisBot)); err != nil {
+		l.WithError(err).Warning("Could not create DCO not found comment.")
+	}
+
+	return nil
+}
+
+// 1. Check commit messages in the pull request for the sign-off string
+// 2. Check the existing status context value
+// 3. Check the existing PR labels
+// 4. If signed off, apply appropriate labels and status context.
+// 5. If not signed off, apply appropriate labels and status context and add a comment.
+func handle(gc gitHubClient, cp commentPruner, log *logrus.Entry, org, repo string, pr github.PullRequest) error {
+	l := log.WithField("pr", pr.Number)
+
+	signedOff, err := checkCommitMessages(gc, l, org, repo, pr.Number)
+	if err != nil {
+		l.WithError(err).Infof("Error running DCO check against commits in PR")
+		return err
+	}
+
+	existingStatus, err := checkExistingStatus(gc, l, org, repo, pr.Head.SHA)
+	if err != nil {
+		l.WithError(err).Infof("Error checking existing PR status")
+		return err
+	}
+
+	hasYesLabel, hasNoLabel, err := checkExistingLabels(gc, l, org, repo, pr.Number)
+	if err != nil {
+		l.WithError(err).Infof("Error checking existing PR labels")
+		return err
+	}
+
+	return takeAction(gc, cp, l, org, repo, pr, signedOff, existingStatus, hasYesLabel, hasNoLabel)
+}
+
+// shouldPrune finds comments left by this plugin.
+func shouldPrune(log *logrus.Entry, botName string) func(github.IssueComment) bool {
+	return func(comment github.IssueComment) bool {
+		if comment.User.Login != botName {
+			return false
+		}
+		return strings.Contains(comment.Body, dcoMsgPruneMatch)
+	}
+}
+
+func handlePullRequestEvent(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+	org := pe.Repo.Owner.Login
+	repo := pe.Repo.Name
+
+	// we only reprocess on label, unlabel, open, reopen and synchronize events
+	// this will reduce our API token usage and save processing of unrelated events
+	switch pe.Action {
+	case github.PullRequestActionLabeled,
+		github.PullRequestActionUnlabeled,
+		github.PullRequestActionOpened,
+		github.PullRequestActionReopened,
+		github.PullRequestActionSynchronize:
+	default:
+		return nil
+	}
+
+	return handle(pc.GitHubClient, pc.CommentPruner, pc.Logger, org, repo, pe.PullRequest)
+}
+
+func handleCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {
+	// Only consider open PRs and new comments.
+	if ce.IssueState != "open" || ce.Action != github.GenericCommentActionCreated || !ce.IsPR {
+		return nil
+	}
+	// Only consider "/check-dco" comments.
+	if !checkDCORe.MatchString(ce.Body) {
+		return nil
+	}
+
+	gc := pc.GitHubClient
+	org := ce.Repo.Owner.Login
+	repo := ce.Repo.Name
+
+	pr, err := gc.GetPullRequest(org, repo, ce.Number)
+	if err != nil {
+		return fmt.Errorf("error getting pull request for comment: %v", err)
+	}
+
+	return handle(gc, pc.CommentPruner, pc.Logger, org, repo, *pr)
+
+}

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -37,8 +37,8 @@ const (
 
 	dcoYesLabel        = "dco-signoff: yes"
 	dcoNoLabel         = "dco-signoff: no"
-	dcoMsgPruneMatch   = "Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits."
-	dcoNotFoundMessage = `Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+	dcoMsgPruneMatch   = "Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits."
+	dcoNotFoundMessage = `Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
 
 :memo: **Please follow instructions in the [contributing guide](%s) to update your commits with the DCO**
 

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -66,9 +66,9 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "should add 'no' label & status context and add a comment if no commits have sign off. should not add a comment.",
+			name: "should add 'no' label & status context and add a comment if no commits have sign off",
 			pullRequestEvent: github.PullRequestEvent{
-				Action:      github.PullRequestActionLabeled,
+				Action:      github.PullRequestActionOpened,
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
@@ -80,6 +80,21 @@ func TestHandlePullRequest(t *testing.T) {
 
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			expectedStatus: github.StatusFailure,
+			addedComment: `/#3:Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
+
+:memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
+
+Full details of the Developer Certificate of Origin can be found at [developercertificate.org](https://developercertificate.org/).
+
+**The list of commits missing DCO signoff**:
+
+- [sha](https://github.com///commits/sha) not a sign off
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
 		},
 		{
 			name: "should add 'no' label & status context, remove old labels and add a comment if no commits have sign off",
@@ -222,10 +237,10 @@ Instructions for interacting with me using PR comments are available [here](http
 				},
 			}
 			if tc.hasDCOYes {
-				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoYesLabel))
+				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("/#3:%s", dcoYesLabel))
 			}
 			if tc.hasDCONo {
-				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoNoLabel))
+				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("/#3:%s", dcoNoLabel))
 			}
 			if tc.status != "" {
 				fc.CreatedStatuses["sha"] = []github.Status{
@@ -237,7 +252,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}
 			ok := tc.addedLabel == ""
 			if !ok {
-				for _, label := range fc.LabelsAdded {
+				for _, label := range fc.IssueLabelsAdded {
 					if reflect.DeepEqual(tc.addedLabel, label) {
 						ok = true
 						break
@@ -245,11 +260,11 @@ Instructions for interacting with me using PR comments are available [here](http
 				}
 			}
 			if !ok {
-				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.LabelsAdded, tc.name)
+				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.IssueLabelsAdded, tc.name)
 			}
 			ok = tc.removedLabel == ""
 			if !ok {
-				for _, label := range fc.LabelsRemoved {
+				for _, label := range fc.IssueLabelsRemoved {
 					if reflect.DeepEqual(tc.removedLabel, label) {
 						ok = true
 						break
@@ -257,7 +272,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				}
 			}
 			if !ok {
-				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.LabelsRemoved, tc.name)
+				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.IssueLabelsRemoved, tc.name)
 			}
 
 			// check status is set as expected
@@ -378,10 +393,10 @@ Instructions for interacting with me using PR comments are available [here](http
 				},
 			}
 			if tc.hasDCOYes {
-				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoYesLabel))
+				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("/#3:%s", dcoYesLabel))
 			}
 			if tc.hasDCONo {
-				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoNoLabel))
+				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("/#3:%s", dcoNoLabel))
 			}
 			if tc.status != "" {
 				fc.CreatedStatuses["sha"] = []github.Status{
@@ -393,7 +408,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}
 			ok := tc.addedLabel == ""
 			if !ok {
-				for _, label := range fc.LabelsAdded {
+				for _, label := range fc.IssueLabelsAdded {
 					if reflect.DeepEqual(tc.addedLabel, label) {
 						ok = true
 						break
@@ -401,11 +416,11 @@ Instructions for interacting with me using PR comments are available [here](http
 				}
 			}
 			if !ok {
-				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.LabelsAdded, tc.name)
+				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.IssueLabelsAdded, tc.name)
 			}
 			ok = tc.removedLabel == ""
 			if !ok {
-				for _, label := range fc.LabelsRemoved {
+				for _, label := range fc.IssueLabelsRemoved {
 					if reflect.DeepEqual(tc.removedLabel, label) {
 						ok = true
 						break
@@ -413,7 +428,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				}
 			}
 			if !ok {
-				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.LabelsRemoved, tc.name)
+				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.IssueLabelsRemoved, tc.name)
 			}
 
 			// check status is set as expected

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -222,7 +222,7 @@ Instructions for interacting with me using PR comments are available [here](http
 					{Context: dcoContextName, State: tc.status},
 				}
 			}
-			if err := handle(fc, &fakePruner{}, logrus.WithField("plugin", pluginName), "", "", tc.pullRequest); err != nil {
+			if err := handle(fc, &fakePruner{}, logrus.WithField("plugin", pluginName), "", "", tc.pullRequest, true); err != nil {
 				t.Errorf("For case %s, didn't expect error from dco plugin: %v", tc.name, err)
 			}
 			ok := tc.addedLabel == ""

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dco
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+type fakePruner struct{}
+
+func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
+
+func strP(str string) *string {
+	return &str
+}
+
+func TestCheckDCO(t *testing.T) {
+	var testcases = []struct {
+		// test settings
+		name string
+
+		// PR settings
+		pullRequest github.PullRequest
+		commits     []github.RepositoryCommit
+		issueState  string
+		hasDCOYes   bool
+		hasDCONo    bool
+		// status of the DCO github context
+		status string
+
+		// expectations
+		addedLabel     string
+		removedLabel   string
+		expectedStatus string
+	}{
+		{
+			name: "should add 'dco-signoff: no' label and status context if no commits have sign off",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    false,
+			hasDCOYes:   false,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
+			expectedStatus: github.StatusFailure,
+		},
+		{
+			name: "should add 'dco-signoff: no' label and status context and remove old labels if no commits have sign off",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    false,
+			hasDCOYes:   true,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
+			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
+			expectedStatus: github.StatusFailure,
+		},
+		{
+			name: "should do nothing if labels and status are up to date and sign off is failing",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    true,
+			hasDCOYes:   false,
+			status:      github.StatusFailure,
+
+			expectedStatus: github.StatusFailure,
+		},
+		{
+			name: "should mark the PR as failed if just one commit is missing sign-off",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not signed off")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    false,
+			hasDCOYes:   true,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
+			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
+			expectedStatus: github.StatusFailure,
+		},
+		{
+			name: "should add label and update status context if all commits are signed-off",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    false,
+			hasDCOYes:   false,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoYesLabel),
+			expectedStatus: github.StatusSuccess,
+		},
+		{
+			name: "should add label and update status context and remove old labels if all commits are signed-off",
+			commits: []github.RepositoryCommit{
+				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+			},
+			issueState:  "open",
+			pullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			hasDCONo:    true,
+			hasDCOYes:   false,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoYesLabel),
+			removedLabel:   fmt.Sprintf("/#3:%s", dcoNoLabel),
+			expectedStatus: github.StatusSuccess,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakegithub.FakeClient{
+				CreatedStatuses: make(map[string][]github.Status),
+				PullRequests:    map[int]*github.PullRequest{tc.pullRequest.Number: &tc.pullRequest},
+				IssueComments:   make(map[int][]github.IssueComment),
+				CommitMap: map[string][]github.RepositoryCommit{
+					"/#3": tc.commits,
+				},
+			}
+			if tc.hasDCOYes {
+				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoYesLabel))
+			}
+			if tc.hasDCONo {
+				fc.LabelsAdded = append(fc.LabelsAdded, fmt.Sprintf("/#3:%s", dcoNoLabel))
+			}
+			if tc.status != "" {
+				fc.CreatedStatuses["sha"] = []github.Status{
+					{Context: dcoContextName, State: tc.status},
+				}
+			}
+			if err := handle(fc, &fakePruner{}, logrus.WithField("plugin", pluginName), "", "", tc.pullRequest); err != nil {
+				t.Errorf("For case %s, didn't expect error from dco plugin: %v", tc.name, err)
+			}
+			ok := tc.addedLabel == ""
+			if !ok {
+				for _, label := range fc.LabelsAdded {
+					if reflect.DeepEqual(tc.addedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.LabelsAdded, tc.name)
+			}
+			ok = tc.removedLabel == ""
+			if !ok {
+				for _, label := range fc.LabelsRemoved {
+					if reflect.DeepEqual(tc.removedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.LabelsRemoved, tc.name)
+			}
+
+			// check status is set as expected
+			statuses := fc.CreatedStatuses["sha"]
+			if len(statuses) == 0 && tc.expectedStatus != "" {
+				t.Errorf("Expected dco status to be %q, but it was not set", tc.expectedStatus)
+			}
+			found := false
+			for _, s := range statuses {
+				if s.Context == dcoContextName {
+					found = true
+					if s.State != tc.expectedStatus {
+						t.Errorf("Expected dco status to be %q but it was %q", tc.expectedStatus, s.State)
+					}
+				}
+			}
+			if !found && tc.expectedStatus != "" {
+				t.Errorf("Expect dco status to be %q, but it was not found", tc.expectedStatus)
+			}
+		})
+	}
+}

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -206,3 +206,40 @@ func TestCheckDCO(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkdownSHAList(t *testing.T) {
+	var testcases = []struct {
+		name string
+
+		org, repo    string
+		commits      []github.GitCommit
+		expectedList string
+	}{
+		{
+			name: "return a single git commit in a list",
+			org:  "org",
+			repo: "repo",
+			commits: []github.GitCommit{
+				{SHA: strP("sha"), Message: strP("msg")},
+			},
+			expectedList: `- [sha](https://github.com/org/repo/commits/sha) msg`,
+		},
+		{
+			name: "return two git commits in a list",
+			org:  "org",
+			repo: "repo",
+			commits: []github.GitCommit{
+				{SHA: strP("sha1"), Message: strP("msg1")},
+				{SHA: strP("sha2"), Message: strP("msg2")},
+			},
+			expectedList: `- [sha1](https://github.com/org/repo/commits/sha1) msg1
+- [sha2](https://github.com/org/repo/commits/sha2) msg2`,
+		},
+	}
+	for _, tc := range testcases {
+		actualList := markdownSHAList(tc.org, tc.repo, tc.commits)
+		if actualList != tc.expectedList {
+			t.Errorf("Expected returned list to be %q but it was %q", tc.expectedList, actualList)
+		}
+	}
+}

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -72,7 +72,7 @@ func TestHandlePullRequest(t *testing.T) {
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "not a sign off"}},
 			},
 			issueState: "open",
 			hasDCONo:   false,
@@ -88,7 +88,7 @@ func TestHandlePullRequest(t *testing.T) {
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "not a sign off"}},
 			},
 			issueState: "open",
 			hasDCONo:   false,
@@ -120,7 +120,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "not a sign off"}},
 			},
 			issueState: "open",
 			hasDCONo:   true,
@@ -151,8 +151,8 @@ Instructions for interacting with me using PR comments are available [here](http
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha1"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not signed off")}},
+				{SHA: "sha1", Commit: github.GitCommit{Message: "Signed-off-by: someone"}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "not signed off"}},
 			},
 			issueState: "open",
 			hasDCONo:   false,
@@ -184,7 +184,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "Signed-off-by: someone"}},
 			},
 			issueState: "open",
 			hasDCONo:   false,
@@ -200,7 +200,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "Signed-off-by: someone"}},
 			},
 			issueState: "open",
 			hasDCONo:   true,
@@ -342,7 +342,7 @@ func TestHandleComment(t *testing.T) {
 				3: {Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
+				{SHA: "sha", Commit: github.GitCommit{Message: "not a sign off"}},
 			},
 			issueState: "open",
 			hasDCONo:   false,

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -70,7 +70,7 @@ func TestCheckDCO(t *testing.T) {
 
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			expectedStatus: github.StatusFailure,
-			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+			addedComment: `/#3:Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
 
 :memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
 
@@ -99,7 +99,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
 			expectedStatus: github.StatusFailure,
-			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+			addedComment: `/#3:Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
 
 :memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
 
@@ -127,7 +127,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			status:      github.StatusFailure,
 
 			expectedStatus: github.StatusFailure,
-			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+			addedComment: `/#3:Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
 
 :memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
 
@@ -157,7 +157,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
 			expectedStatus: github.StatusFailure,
-			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+			addedComment: `/#3:Thanks for your pull request. Before we can look at it, you'll need to add a 'DCO signoff' to your commits.
 
 :memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
 

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -53,9 +53,13 @@ func TestCheckDCO(t *testing.T) {
 		addedLabel     string
 		removedLabel   string
 		expectedStatus string
+		// org/repo#number:body
+		addedComment string
+		// org/repo#issuecommentid
+		removedComment string
 	}{
 		{
-			name: "should add 'dco-signoff: no' label and status context if no commits have sign off",
+			name: "should add 'no' label & status context and add a comment if no commits have sign off",
 			commits: []github.RepositoryCommit{
 				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
 			},
@@ -66,9 +70,24 @@ func TestCheckDCO(t *testing.T) {
 
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			expectedStatus: github.StatusFailure,
+			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+
+:memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
+
+Full details of the Developer Certificate of Origin can be found at [developercertificate.org](https://developercertificate.org/).
+
+**The list of commits missing DCO signoff**:
+
+- [sha](https://github.com///commits/sha) not a sign off
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
 		},
 		{
-			name: "should add 'dco-signoff: no' label and status context and remove old labels if no commits have sign off",
+			name: "should add 'no' label & status context, remove old labels and add a comment if no commits have sign off",
 			commits: []github.RepositoryCommit{
 				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
 			},
@@ -80,9 +99,24 @@ func TestCheckDCO(t *testing.T) {
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
 			expectedStatus: github.StatusFailure,
+			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+
+:memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
+
+Full details of the Developer Certificate of Origin can be found at [developercertificate.org](https://developercertificate.org/).
+
+**The list of commits missing DCO signoff**:
+
+- [sha](https://github.com///commits/sha) not a sign off
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
 		},
 		{
-			name: "should do nothing if labels and status are up to date and sign off is failing",
+			name: "should update comment if labels and status are up to date and sign off is failing",
 			commits: []github.RepositoryCommit{
 				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not a sign off")}},
 			},
@@ -93,11 +127,26 @@ func TestCheckDCO(t *testing.T) {
 			status:      github.StatusFailure,
 
 			expectedStatus: github.StatusFailure,
+			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+
+:memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
+
+Full details of the Developer Certificate of Origin can be found at [developercertificate.org](https://developercertificate.org/).
+
+**The list of commits missing DCO signoff**:
+
+- [sha](https://github.com///commits/sha) not a sign off
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
 		},
 		{
 			name: "should mark the PR as failed if just one commit is missing sign-off",
 			commits: []github.RepositoryCommit{
-				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
+				{SHA: strP("sha1"), Commit: &github.GitCommit{Message: strP("Signed-off-by: someone")}},
 				{SHA: strP("sha"), Commit: &github.GitCommit{Message: strP("not signed off")}},
 			},
 			issueState:  "open",
@@ -108,6 +157,21 @@ func TestCheckDCO(t *testing.T) {
 			addedLabel:     fmt.Sprintf("/#3:%s", dcoNoLabel),
 			removedLabel:   fmt.Sprintf("/#3:%s", dcoYesLabel),
 			expectedStatus: github.StatusFailure,
+			addedComment: `/#3:Thanks for your pull request. Before we can look at your pull request, you'll need to add a 'DCO signoff' to your commits.
+
+:memo: **Please follow instructions in the [contributing guide](https://github.com///blob/master/CONTRIBUTING.md) to update your commits with the DCO**
+
+Full details of the Developer Certificate of Origin can be found at [developercertificate.org](https://developercertificate.org/).
+
+**The list of commits missing DCO signoff**:
+
+- [sha](https://github.com///commits/sha) not signed off
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
 		},
 		{
 			name: "should add label and update status context if all commits are signed-off",
@@ -202,6 +266,18 @@ func TestCheckDCO(t *testing.T) {
 			}
 			if !found && tc.expectedStatus != "" {
 				t.Errorf("Expect dco status to be %q, but it was not found", tc.expectedStatus)
+			}
+
+			comments := fc.IssueCommentsAdded
+			if len(comments) == 0 && tc.addedComment != "" {
+				t.Errorf("Expected comment with body %q to be added, but it was not", tc.addedComment)
+				return
+			}
+			if len(comments) > 1 {
+				t.Errorf("did not expect more than one comment to be created")
+			}
+			if len(comments) != 0 && comments[0] != tc.addedComment {
+				t.Errorf("expected comment to be %q but it was %q", tc.addedComment, comments[0])
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds an initial attempt at a DCO sign-off checker, as detailed in #9187.

It is loosely based off https://github.com/heptiolabs/sign-off-checker.

I have marked this WIP as it needs testing, including unit tests written. I have pushed this up just for visibility in the direction!

Fixes #9187 

/cc @BenTheElder 