### PR TITLE
Specify image for NVMe test for now

### DIFF
--- a/config/jobs/kubernetes/sig-aws/sig-aws-config.yaml
+++ b/config/jobs/kubernetes/sig-aws/sig-aws-config.yaml
@@ -91,7 +91,7 @@ periodics:
       - --env=KUBE_SSH_USER=admin
       - --extract=ci/latest
       - --ginkgo-parallel
-      - --kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha
+      - --kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha --image kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-west-2a
       - --provider=aws


### PR DESCRIPTION
We now error on m5 usage unless stretch image is specified
https://github.com/kubernetes/kops/pull/5660

Once stretch is back in the alpha channel we can remove this but for now I think it's be great to get this test going again! Comments welcome.