### PR TITLE
Disable the cache mutation detector.

### DIFF
--- a/jobs/env/pull-federation-e2e-gce.env
+++ b/jobs/env/pull-federation-e2e-gce.env
@@ -1,6 +1,3 @@
-# Panic if anything mutates a shared informer cache
-ENABLE_CACHE_MUTATION_DETECTOR=true
-
 FEDERATION=true
 FEDERATION_REPO=true
 KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn

--- a/jobs/env/pull-kubernetes-e2e-gce.env
+++ b/jobs/env/pull-kubernetes-e2e-gce.env
@@ -1,8 +1,5 @@
 # Force to use container-vm.
 
-# Panic if anything mutates a shared informer cache
-ENABLE_CACHE_MUTATION_DETECTOR=true
-
 # Enable the PodSecurityPolicy in tests.
 # TODO: Enable this by default in the test environment.
 ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
`ENABLE_CACHE_MUTATION_DETECTOR` has been set for over a year. However, a week after it was set, a bug in `configure-helper.sh` was introduced causing its value to be ignored. Fixing the bug such that it can run makes the tests time out. Since an hour is already a long time for presubmit tests, let's not make them even longer and instead just stop pretending that this works.

Note that this will have no effect due to a _another_ bug in the default configuration, which sets `ENABLE_CACHE_MUTATION_DETECTOR=false`, which is a non-empty string and will therefore cause it to be enabled anyway regardless of what is set here.

Both of the above bugs are fixed in kubernetes/kubernetes#67919, but that cannot pass tests as long as this is enabled here due to the aforementioned timeouts.

(There is some degree of conjecture in this, since I do not know of a good way to run these tests with this flag changed other than by actually doing it.)