### PR TITLE
kind: ditch glog for logrus

### DIFF
--- a/kind/cmd/kind/BUILD.bazel
+++ b/kind/cmd/kind/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//kind/cmd/kind/build:go_default_library",
         "//kind/cmd/kind/create:go_default_library",
         "//kind/cmd/kind/delete:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/kind/cmd/kind/build/node/BUILD.bazel
+++ b/kind/cmd/kind/build/node/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kind/pkg/build:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/kind/cmd/kind/build/node/node.go
+++ b/kind/cmd/kind/build/node/node.go
@@ -19,7 +19,7 @@ package node
 import (
 	"os"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"k8s.io/test-infra/kind/pkg/build"
@@ -50,12 +50,12 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	ctx, err := build.NewNodeImageBuildContext(flags.BuildType)
 	if err != nil {
-		glog.Errorf("Error creating build context: %v", err)
+		log.Errorf("Error creating build context: %v", err)
 		os.Exit(-1)
 	}
 	err = ctx.Build()
 	if err != nil {
-		glog.Errorf("Error building node image: %v", err)
+		log.Errorf("Error building node image: %v", err)
 		os.Exit(-1)
 	}
 }

--- a/kind/cmd/kind/create/BUILD.bazel
+++ b/kind/cmd/kind/create/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kind/pkg/cluster:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/kind/cmd/kind/create/create.go
+++ b/kind/cmd/kind/create/create.go
@@ -20,7 +20,7 @@ package create
 import (
 	"os"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"k8s.io/test-infra/kind/pkg/cluster"
@@ -53,28 +53,28 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 	// load the config
 	config, err := cluster.LoadCreateConfig(flags.Config)
 	if err != nil {
-		glog.Errorf("Error loading config: %v", err)
+		log.Errorf("Error loading config: %v", err)
 		os.Exit(-1)
 	}
 	// validate the config
 	err = config.Validate()
 	if err != nil {
-		glog.Error("Invalid configuration!")
+		log.Error("Invalid configuration!")
 		configErrors := err.(cluster.ConfigErrors)
 		for _, problem := range configErrors.Errors() {
-			glog.Error(problem)
+			log.Error(problem)
 		}
 		os.Exit(-1)
 	}
 	// create a cluster context and create the cluster
 	ctx, err := cluster.NewContext(flags.Name)
 	if err != nil {
-		glog.Error("Failed to create cluster context! %v", err)
+		log.Errorf("Failed to create cluster context! %v", err)
 		os.Exit(-1)
 	}
 	err = ctx.Create(config)
 	if err != nil {
-		glog.Errorf("Failed to create cluster: %v", err)
+		log.Errorf("Failed to create cluster: %v", err)
 		os.Exit(-1)
 	}
 }

--- a/kind/cmd/kind/delete/BUILD.bazel
+++ b/kind/cmd/kind/delete/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kind/pkg/cluster:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/kind/cmd/kind/delete/delete.go
+++ b/kind/cmd/kind/delete/delete.go
@@ -20,7 +20,7 @@ package delete
 import (
 	"os"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"k8s.io/test-infra/kind/pkg/cluster"
@@ -50,12 +50,12 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
 	ctx, err := cluster.NewContext(flags.Name)
 	if err != nil {
-		glog.Error("Failed to create cluster context! %v", err)
+		log.Errorf("Failed to create cluster context! %v", err)
 		os.Exit(-1)
 	}
 	err = ctx.Delete()
 	if err != nil {
-		glog.Errorf("Failed to delete cluster: %v", err)
+		log.Errorf("Failed to delete cluster: %v", err)
 		os.Exit(-1)
 	}
 }

--- a/kind/cmd/kind/kind.go
+++ b/kind/cmd/kind/kind.go
@@ -18,10 +18,7 @@ limitations under the License.
 package kind
 
 import (
-	"flag"
-	"fmt"
-	"os"
-
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"k8s.io/test-infra/kind/cmd/kind/build"
@@ -45,23 +42,18 @@ func NewCommand() *cobra.Command {
 
 // Run runs the `kind` root command
 func Run() error {
-	// Trick to avoid glog's 'logging before flag.Parse' warning
-	flag.CommandLine.Parse([]string{})
-	// glog logs to files by default, grr
-	flag.Set("logtostderr", "true")
-
-	cmd := NewCommand()
-	// glog registers global flags on flag.CommandLine...
-	cmd.Flags().AddGoFlagSet(flag.CommandLine)
-
-	// actually execute the cobra commands now...
-	return cmd.Execute()
+	return NewCommand().Execute()
 }
 
-// Main wraps Run, adding an Exit(1) on error
+// Main wraps Run, adding a log.Fatal(err) on error, and setting the log formatter
 func Main() {
+	// this formatter is the default, but the timestamps output aren't
+	// particularly useful, they're relative to the command start
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "15:04:05-0700",
+	})
 	if err := Run(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/kind/docs/todo.md
+++ b/kind/docs/todo.md
@@ -3,6 +3,8 @@
 A non-exhaustive list of tasks (in no-particular order) includes:
 - [x] basic single "node" clusters
 - [x] multiple clusters per host / named clusters
+- [ ] user guides for common usage
+  - [ ] user guides for more advanced usage
 - [ ] preflight checks
 - [ ] multi-node clusters
 - [x] support for multiple kubernetes builds:
@@ -25,8 +27,9 @@ A non-exhaustive list of tasks (in no-particular order) includes:
 - [ ] more advanced network configuration (not docker0)
 - [ ] support for other CRI within the "node" containers (containerd, cri-o)
 - [ ] switch from `exec.Command("docker", ...)` to the Docker client library
-- [ ] log dumping functionality
+- [ ] log dumping functionality / cli commands
   - [ ] support audit logging
+- [ ] cli command to list clusters
 
 # Wishlist
 

--- a/kind/pkg/build/BUILD.bazel
+++ b/kind/pkg/build/BUILD.bazel
@@ -14,8 +14,8 @@ go_library(
         "//kind/pkg/build/kube:go_default_library",
         "//kind/pkg/build/sources:go_default_library",
         "//kind/pkg/exec:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 

--- a/kind/pkg/build/base_image.go
+++ b/kind/pkg/build/base_image.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/kind/pkg/build/sources"
 	"k8s.io/test-infra/kind/pkg/exec"
@@ -72,12 +72,12 @@ func (c *BaseImageBuildContext) Build() (err error) {
 	} else {
 		err = copyDir(c.SourceDir, buildDir)
 		if err != nil {
-			glog.Errorf("failed to copy sources to build dir %v", err)
+			log.Errorf("failed to copy sources to build dir %v", err)
 			return err
 		}
 	}
 
-	glog.Infof("Building base image in: %s", buildDir)
+	log.Infof("Building base image in: %s", buildDir)
 
 	// build the entrypoint binary first
 	if err := c.buildEntrypoint(buildDir); err != nil {
@@ -99,14 +99,14 @@ func (c *BaseImageBuildContext) buildEntrypoint(dir string) error {
 	cmd.Env = []string{"GOOS=linux", "GOARCH=" + c.Arch}
 
 	// actually build
-	glog.Info("Building entrypoint binary ...")
+	log.Info("Building entrypoint binary ...")
 	cmd.Debug = true
 	cmd.InheritOutput = true
 	if err := cmd.Run(); err != nil {
-		glog.Errorf("Entrypoint build Failed! %v", err)
+		log.Errorf("Entrypoint build Failed! %v", err)
 		return err
 	}
-	glog.Info("Entrypoint build completed.")
+	log.Info("Entrypoint build completed.")
 	return nil
 }
 
@@ -116,12 +116,12 @@ func (c *BaseImageBuildContext) buildImage(dir string) error {
 	cmd.Debug = true
 	cmd.InheritOutput = true
 
-	glog.Info("Starting Docker build ...")
+	log.Info("Starting Docker build ...")
 	err := cmd.Run()
 	if err != nil {
-		glog.Errorf("Docker build Failed! %v", err)
+		log.Errorf("Docker build Failed! %v", err)
 		return err
 	}
-	glog.Info("Docker build completed.")
+	log.Info("Docker build completed.")
 	return nil
 }

--- a/kind/pkg/build/kube/BUILD.bazel
+++ b/kind/pkg/build/kube/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kind/pkg/exec:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 

--- a/kind/pkg/build/kube/aptbits.go
+++ b/kind/pkg/build/kube/aptbits.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 )
 
 // AptBits implements Bits for the official upstream debian packages
@@ -57,32 +57,32 @@ func (b *AptBits) Install(install InstallContext) error {
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF`
 	if err := install.Run("/bin/sh", "-c", addKey); err != nil {
-		glog.Errorf("Adding Kubernetes apt key failed! %v", err)
+		log.Errorf("Adding Kubernetes apt key failed! %v", err)
 		return err
 	}
 	if err := install.Run("/bin/sh", "-c", addSources); err != nil {
-		glog.Errorf("Adding Kubernetes apt repository failed! %v", err)
+		log.Errorf("Adding Kubernetes apt repository failed! %v", err)
 		return err
 	}
 	// install packages
 	if err := install.Run("/bin/sh", "-c", `clean-install kubelet kubeadm kubectl`); err != nil {
-		glog.Errorf("Installing Kubernetes packages failed! %v", err)
+		log.Errorf("Installing Kubernetes packages failed! %v", err)
 		return err
 	}
 	// get version to version file
 	lines, err := install.CombinedOutputLines("/bin/sh", "-c", `kubelet --version`)
 	if err != nil {
-		glog.Errorf("Failed to get Kubernetes version! %v", err)
+		log.Errorf("Failed to get Kubernetes version! %v", err)
 		return err
 	}
 	// the output should be one line of the form `Kubernetes ${VERSION}`
 	if len(lines) != 1 {
-		glog.Errorf("Failed to parse Kubernetes version with unexpected output: %v", lines)
+		log.Errorf("Failed to parse Kubernetes version with unexpected output: %v", lines)
 		return fmt.Errorf("failed to parse Kubernetes version")
 	}
 	version := strings.SplitN(lines[0], " ", 2)[1]
 	if err := install.Run("/bin/sh", "-c", fmt.Sprintf(`echo "%s" >> /kind/version`, version)); err != nil {
-		glog.Errorf("Failed to get Kubernetes version! %v", err)
+		log.Errorf("Failed to get Kubernetes version! %v", err)
 		return err
 	}
 	return nil

--- a/kind/pkg/build/kube/bazelbuildbits.go
+++ b/kind/pkg/build/kube/bazelbuildbits.go
@@ -21,8 +21,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/golang/glog"
-
+	log "github.com/sirupsen/logrus"
 	"k8s.io/test-infra/kind/pkg/exec"
 )
 
@@ -110,7 +109,7 @@ func (b *BazelBuildBits) Install(install InstallContext) error {
 	debs := path.Join(base, "debs", "*.deb")
 
 	if err := install.Run("/bin/sh", "-c", "dpkg -i "+debs); err != nil {
-		glog.Errorf("Image install failed! %v", err)
+		log.Errorf("Image install failed! %v", err)
 		return err
 	}
 
@@ -118,7 +117,7 @@ func (b *BazelBuildBits) Install(install InstallContext) error {
 		"rm -rf /kind/bits/debs/*.deb"+
 			" /var/cache/debconf/* /var/lib/apt/lists/* /var/log/*kg",
 	); err != nil {
-		glog.Errorf("Image install failed! %v", err)
+		log.Errorf("Image install failed! %v", err)
 		return err
 	}
 

--- a/kind/pkg/cluster/BUILD.bazel
+++ b/kind/pkg/cluster/BUILD.bazel
@@ -14,8 +14,8 @@ go_library(
         "//kind/pkg/cluster/kubeadm:go_default_library",
         "//kind/pkg/exec:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 

--- a/kind/pkg/cluster/cluster.go
+++ b/kind/pkg/cluster/cluster.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 
@@ -111,9 +111,10 @@ func (c *Context) Create(config *CreateConfig) error {
 		return err
 	}
 
-	println("\nYou can now use the cluster with:\n")
-	println("export KUBECONFIG=\"" + c.KubeConfigPath() + "\"")
-	println("kubectl cluster-info\n")
+	log.Infof(
+		"You can now use the cluster with:\n\nexport KUBECONFIG=\"%s\"\nkubectl cluster-info",
+		c.KubeConfigPath(),
+	)
 
 	return nil
 }
@@ -255,7 +256,7 @@ func (c *Context) createKubeadmConfig(template string, data kubeadm.ConfigData) 
 		os.Remove(path)
 		return "", err
 	}
-	glog.Infof("Using KubeadmConfig:\n\n%s\n", config)
+	log.Infof("Using KubeadmConfig:\n\n%s\n", config)
 	_, err = f.WriteString(config)
 	if err != nil {
 		os.Remove(path)

--- a/kind/pkg/cluster/node.go
+++ b/kind/pkg/cluster/node.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/kind/pkg/cluster/kubeadm"
 	"k8s.io/test-infra/kind/pkg/exec"
@@ -163,7 +163,7 @@ func (nh *nodeHandle) LoadImages() {
 		"-name", "*.tar",
 		"-exec", "docker", "load", "-i", "{}", ";",
 	); err != nil {
-		glog.Warningf("Failed to preload docker images: %v", err)
+		log.Warningf("Failed to preload docker images: %v", err)
 		return
 	}
 	// retag images that are missing -amd64 as image:tag -> image-amd64:tag
@@ -173,7 +173,7 @@ func (nh *nodeHandle) LoadImages() {
 		"/bin/bash", "-c",
 		`docker images --format='{{.Repository}}:{{.Tag}}' | grep -v amd64 | xargs -L 1 -I '{}' /bin/bash -c 'docker tag "{}" "$(echo "{}" | sed s/:/-amd64:/)"'`,
 	); err != nil {
-		glog.Warningf("Failed to re-tag docker images: %v", err)
+		log.Warningf("Failed to re-tag docker images: %v", err)
 	}
 
 	nh.Run("docker", "images")

--- a/kind/pkg/exec/BUILD.bazel
+++ b/kind/pkg/exec/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["exec.go"],
     importpath = "k8s.io/test-infra/kind/pkg/exec",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
 )
 
 filegroup(

--- a/kind/pkg/exec/exec.go
+++ b/kind/pkg/exec/exec.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 )
 
 // Cmd wraps os/exec.Cmd, with extra options for logging etc. when running
@@ -54,7 +54,7 @@ func Command(name string, arg ...string) *Cmd {
 // Run wraps cmd.Run(), respecting CmdOpts
 func (cmd *Cmd) Run() error {
 	if cmd.Debug {
-		glog.Infof("Running: %v %v", cmd.Path, cmd.Args)
+		log.Infof("Running: %v %v", cmd.Path, cmd.Args)
 	}
 
 	if cmd.LogOutputOnFail {
@@ -74,10 +74,10 @@ func (cmd *Cmd) runLoggingOutputOnFail() error {
 	cmd.Stderr = &buff
 	err := cmd.Cmd.Run()
 	if cmd.LogOutputOnFail {
-		glog.Error("failed with:")
+		log.Error("failed with:")
 		scanner := bufio.NewScanner(&buff)
 		for scanner.Scan() {
-			glog.Error(scanner.Text())
+			log.Error(scanner.Text())
 		}
 	}
 	return err
@@ -88,7 +88,7 @@ func (cmd *Cmd) runLoggingOutputOnFail() error {
 // it scans these for lines and returns a slice of output line strings
 func (cmd *Cmd) CombinedOutputLines() (lines []string, err error) {
 	if cmd.Debug {
-		glog.Infof("Running: %v %v", cmd.Path, cmd.Args)
+		log.Infof("Running: %v %v", cmd.Path, cmd.Args)
 	}
 
 	var buff bytes.Buffer


### PR DESCRIPTION
cons:
- glog has arbitrary logging levels (-v=9999 anyone?)
- glog is used in most of the kubernetes code base :(

pros:
- test-infra tooling generally uses logrus
- other than arbitrary integer log levels, logrus is very flexible
- logrus does not require gross hacks in `main()` to deal with `glog`'s global flags
- logrus has different formatters, in particular switching to json formatting can be very good for automation logs, while text formatting is nicer for CLI users
- logrus also does colored output, structured logging, etc.
