### PR TITLE
logexporter should support --enable-hollow-node-logs in gce as well

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = k8s-testimages
 IMG = gcr.io/$(PROJECT)/logexporter
-TAG = v0.1.2
+TAG = v0.1.3
 
 .PHONY: build push
 

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v0.1.2
+        image: gcr.io/k8s-testimages/logexporter:v0.1.3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/k8s-testimages/logexporter:v0.1.2
+    image: gcr.io/k8s-testimages/logexporter:v0.1.3
     env:
     - name: NODE_NAME
       valueFrom:

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -132,16 +132,15 @@ func prepareLogfiles(logDir string) {
 	switch *cloudProvider {
 	case "gce", "gke":
 		logfiles = append(logfiles, gceLogs...)
-	case "kubemark":
-		// TODO(shyamjvs): Pick logs based on kubemark's real provider.
-		logfiles = append(logfiles, gceLogs...)
-		if *enableHollowNodeLogs {
-			logfiles = append(logfiles, kubemarkLogs...)
-		}
 	case "aws":
 		logfiles = append(logfiles, awsLogs...)
 	default:
 		glog.Errorf("Unknown cloud provider '%v' provided, skipping any provider specific logs", *cloudProvider)
+	}
+
+	// Grab kubemark logs too, if asked for.
+	if *enableHollowNodeLogs {
+		logfiles = append(logfiles, kubemarkLogs...)
 	}
 
 	// Select system/service specific logs.


### PR DESCRIPTION
This is a copy of PR https://github.com/kubernetes/test-infra/pull/9163 from @mborsz with comments addressed (as he'll be OOO for a while).

/cc @wojtek-t 