### PR TITLE
Generate job URL using pod-utils for decorated jobs

### DIFF
--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -28,10 +28,12 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plank",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/gcsupload:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/report:go_default_library",
         "//vendor/github.com/bwmarrin/snowflake:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1421,3 +1421,71 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 		}
 	}
 }
+
+func TestJobURL(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		plank    config.Plank
+		pj       kube.ProwJob
+		expected string
+	}{
+		{
+			name: "non-decorated job uses template",
+			plank: config.Plank{
+				Controller: config.Controller{
+					JobURLTemplate: template.Must(template.New("test").Parse("{{.Spec.Type}}")),
+				},
+			},
+			pj:       kube.ProwJob{Spec: kube.ProwJobSpec{Type: kube.PeriodicJob}},
+			expected: "periodic",
+		},
+		{
+			name: "non-decorated job with broken template gives empty string",
+			plank: config.Plank{
+				Controller: config.Controller{
+					JobURLTemplate: template.Must(template.New("test").Parse("{{.Garbage}}")),
+				},
+			},
+			pj:       kube.ProwJob{},
+			expected: "",
+		},
+		{
+			name: "decorated job without prefix uses template",
+			plank: config.Plank{
+				Controller: config.Controller{
+					JobURLTemplate: template.Must(template.New("test").Parse("{{.Spec.Type}}")),
+				},
+			},
+			pj:       kube.ProwJob{Spec: kube.ProwJobSpec{Type: kube.PeriodicJob}},
+			expected: "periodic",
+		},
+		{
+			name: "decorated job with prefix uses gcslib",
+			plank: config.Plank{
+				JobURLPrefix: "https://gubernator.com/build",
+			},
+			pj: kube.ProwJob{Spec: kube.ProwJobSpec{
+				Type: kube.PresubmitJob,
+				Refs: &kube.Refs{
+					Org:   "org",
+					Repo:  "repo",
+					Pulls: []kube.Pull{{Number: 1}},
+				},
+				DecorationConfig: &kube.DecorationConfig{GCSConfiguration: &kube.GCSConfiguration{
+					Bucket:       "bucket",
+					PathStrategy: kube.PathStrategyExplicit,
+				}},
+			}},
+			expected: "https:/gubernator.com/build/bucket/pr-logs/pull/org_repo/1",
+		},
+	}
+
+	logger := logrus.New()
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := jobURL(testCase.plank, testCase.pj, logger.WithField("name", testCase.name)), testCase.expected; actual != expected {
+				t.Errorf("%s: expected URL to be %q but got %q", testCase.name, expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When we are decorating a job with the pod utilities, we also know in
`plank` the exact place that the artifacts will go, so there is no need
to use a report template. In the future, when all jobs are decorated, we
can remove the template entirely.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @BenTheElder @fejta 
/cc @cjwagner 
/hold

Still need to figure out what sort of test we need for this