### PR TITLE
kubeadm: re-arrange, update and deprecate tests

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-network.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-network.yaml
@@ -1,86 +1,7 @@
-# kubeadm release and master tests
+# kubeadm network tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
   interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
-      args:
-      - --repo=k8s.io/kubernetes=release-1.10
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.10
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
-      - --timeout=300m
-
-- name: ci-kubernetes-e2e-kubeadm-gce-1-11
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
-      args:
-      - --repo=k8s.io/kubernetes=release-1.11
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.11
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
-      - --timeout=300m
-
-- name: ci-kubernetes-e2e-kubeadm-gce-1-12
-  interval: 12h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
-      args:
-      - --repo=k8s.io/kubernetes=release-1.12
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.12
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.12
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.12
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
-      - --timeout=300m
-
-- name: ci-kubernetes-e2e-kubeadm-gce-master
-  interval: 2h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -94,7 +15,60 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
-      # TODO(bentheelder): --kubernetes-anywhere-kubernetes-version should really be ci/latest-bazel but we need changes to kubeadm and possibly kubernetes-anywhere first
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --extract=ci/latest-bazel
+      - --gcp-zone=us-central1-f
+      - --kubeadm=ci
+      - --kubernetes-anywhere-cni=flannel
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=kubernetes-anywhere
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
+      - --timeout=300m
+
+- name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
+  interval: 6h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+      - --timeout=320
+      - --upload=gs://kubernetes-jenkins/logs
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --extract=ci/latest-bazel
+      - --gcp-zone=us-central1-f
+      - --kubeadm=ci
+      - --kubernetes-anywhere-kubeadm-feature-gates=CoreDNS=true
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=kubernetes-anywhere
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
+      - --timeout=300m
+
+- name: ci-kubernetes-e2e-kubeadm-gce-ipvs
+  interval: 6h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+      - --timeout=320
+      - --upload=gs://kubernetes-jenkins/logs
+      - --scenario=kubernetes_e2e
+      - --
       - --cluster=
       - --deployment=kubernetes-anywhere
       - --extract=ci/latest-bazel
@@ -102,7 +76,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
       - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --kubernetes-anywhere-proxy-mode=ipvs
       - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
-

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
@@ -1,6 +1,6 @@
-# kubeadm release and master tests
+# kubeadm upgrade tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
   interval: 6h
   labels:
     preset-service-account: "true"
@@ -15,19 +15,24 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
+      - --check-version-skew=false
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.10
+      - --extract=release/latest-1.10
+      - --extract=ci/latest-bazel-1.9
       - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
+      - --kubeadm=periodic
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
+      - --kubernetes-anywhere-upgrade-method=upgrade
       - --provider=kubernetes-anywhere
+      - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
       - --timeout=300m
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.10
 
-- name: ci-kubernetes-e2e-kubeadm-gce-1-11
-  interval: 6h
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+  interval: 2h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -41,23 +46,27 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
+      - --check-version-skew=false
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.11
+      - --extract=release/latest-1.11
+      - --extract=ci/latest-bazel-1.10
       - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
+      - --kubeadm=periodic
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
+      - --kubernetes-anywhere-upgrade-method=upgrade
       - --provider=kubernetes-anywhere
+      - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.11
 
-- name: ci-kubernetes-e2e-kubeadm-gce-1-12
-  interval: 12h
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
+  interval: 6h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
@@ -68,19 +77,24 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
+      - --check-version-skew=false
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.12
+      - --extract=release/latest-1.12
+      - --extract=ci/latest-bazel-1.11
       - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.12
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.12
+      - --kubeadm=periodic
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
+      - --kubernetes-anywhere-upgrade-method=upgrade
       - --provider=kubernetes-anywhere
+      - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.9
 
-- name: ci-kubernetes-e2e-kubeadm-gce-master
-  interval: 2h
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
+  interval: 6h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -94,15 +108,18 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
-      # TODO(bentheelder): --kubernetes-anywhere-kubernetes-version should really be ci/latest-bazel but we need changes to kubeadm and possibly kubernetes-anywhere first
+      - --check-version-skew=false
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel
+      - --extract=ci/latest
+      - --extract=release/stable
       - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --kubeadm=periodic
+      - --kubernetes-anywhere-kubelet-version=stable
+      - --kubernetes-anywhere-kubernetes-version=stable
+      - --kubernetes-anywhere-upgrade-method=upgrade
       - --provider=kubernetes-anywhere
+      - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
-
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=ci-cross/latest

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
@@ -1,6 +1,6 @@
-# kubeadm release and master tests
+# kubeadm x-on-y tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
   interval: 6h
   labels:
     preset-service-account: "true"
@@ -17,16 +17,16 @@ periodics:
       - --
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.10
+      - --extract=ci/latest-bazel-1.9
       - --gcp-zone=us-central1-f
       - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
       - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
-- name: ci-kubernetes-e2e-kubeadm-gce-1-11
+- name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
   interval: 6h
   labels:
     preset-service-account: "true"
@@ -43,21 +43,20 @@ periodics:
       - --
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.11
+      - --extract=ci/latest-bazel-1.10
       - --gcp-zone=us-central1-f
       - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
       - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
-- name: ci-kubernetes-e2e-kubeadm-gce-1-12
+- name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   interval: 12h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180829-29d5569b7
@@ -70,17 +69,17 @@ periodics:
       - --
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.12
+      - --extract=ci/latest-bazel-1.11
       - --gcp-zone=us-central1-f
       - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.12
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.12
+      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
+      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
       - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
-- name: ci-kubernetes-e2e-kubeadm-gce-master
-  interval: 2h
+- name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+  interval: 6h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -94,15 +93,13 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=kubernetes_e2e
       - --
-      # TODO(bentheelder): --kubernetes-anywhere-kubernetes-version should really be ci/latest-bazel but we need changes to kubeadm and possibly kubernetes-anywhere first
       - --cluster=
       - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel
+      - --extract=release/stable
       - --gcp-zone=us-central1-f
       - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --kubernetes-anywhere-kubelet-version=stable
+      - --kubernetes-anywhere-kubernetes-version=stable
       - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
-

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/package.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/package.yaml
@@ -1,0 +1,17 @@
+# package tests
+periodics:
+- name: periodic-kubernetes-e2e-packages-pushed
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=60
+      - --repo=k8s.io/kubeadm=master
+      - --scenario=execute
+      - --
+      - ./tests/e2e/verify_packages_published.sh
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1464,47 +1464,48 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-garbage
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-garbage
 # kubeadm tests
-- name: ci-kubernetes-e2e-kubeadm-gce
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce
-- name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-selfhosting
+- name: ci-kubernetes-e2e-kubeadm-gce-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-1-11
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11
+- name: ci-kubernetes-e2e-kubeadm-gce-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-12
+- name: ci-kubernetes-e2e-kubeadm-gce-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master
+# kubeadm x-on-y tests
+- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
+- name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
+- name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+# kubeadm upgrade tests
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
+# kubeadm network tests
 - name: ci-kubernetes-e2e-kubeadm-gce-ipvs
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-ipvs
 - name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-cni-flannel
 - name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-dns-coredns
-- name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-stable-on-master
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
-- name: ci-kubernetes-e2e-kubeadm-gce-1-8
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-8
-- name: ci-kubernetes-e2e-kubeadm-gce-1-9
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-9
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10
-- name: ci-kubernetes-e2e-kubeadm-gce-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11
-- name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
+# packages tests
 - name: periodic-kubernetes-e2e-packages-pushed
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-packages-pushed
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
-# upgrade CI tests
+# etcd tests
 - name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
 - name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -3795,10 +3796,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: kubeadm-gce
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce
-  - name: kubeadm-gce-selfhosting
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
+  - name: kubeadm-gce-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
   - name: periodic-kubernetes-e2e-packages-pushed
     test_group_name: periodic-kubernetes-e2e-packages-pushed
 
@@ -4310,8 +4309,6 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-test-1-9
   - name: kops-aws-1.9
     test_group_name: ci-kubernetes-e2e-kops-aws-stable3
-  - name: kubeadm-gce-1-9
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
   - name: node-kubelet-1.9
     test_group_name: ci-kubernetes-node-kubelet-stable3
   - name: gce-cos-1.9-alphafeatures
@@ -4362,8 +4359,6 @@ dashboards:
   - name: gce-conformance-latest-1-9
     description: Runs conformance tests using kubetest against kubernetes release 1.9 branch on GCE
     test_group_name: ci-kubernetes-gce-conformance-latest-1-9
-  - name: kubeadm-gce-1-9
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
   - name: node-kubelet-1.9
     test_group_name: ci-kubernetes-node-kubelet-stable3
   - name: gce-cos-1.9-ingress
@@ -4903,41 +4898,36 @@ dashboards:
 
 - name: sig-cluster-lifecycle-all
   dashboard_tab:
-  - name: kubeadm-gce-1.8
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
-  - name: kubeadm-gce-1.8-on-1.9
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
-  - name: kubeadm-gce-upgrade-1.8-1.9
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
-  - name: kubeadm-gce-1.9
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
-  - name: kubeadm-gce-1.9-on-1.10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  - name: kubeadm-gce-upgrade-1.9-1.10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+# kubeadm tests
   - name: kubeadm-gce-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  - name: periodic-kubernetes-e2e-packages-pushed
-    test_group_name: periodic-kubernetes-e2e-packages-pushed
+  - name: kubeadm-gce-1.11
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11
+  - name: kubeadm-gce-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-12
+  - name: kubeadm-gce-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
+# kubeadm x-on-y tests
+  - name: kubeadm-gce-1.9-on-1.10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
   - name: gce-kubeadm-1.10-on-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
-  - name: ci-gce-kubeadm-1.11
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11
-  - name: gce-kubeadm-upgrade-1.10-1.11
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+  - name: kubeadm-gce-1.11-on-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   - name: kubeadm-gce-stable-on-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+# kubeadm upgrade tests
+  - name: kubeadm-gce-upgrade-1.9-1.10
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
+  - name: gce-kubeadm-upgrade-1.10-1.11
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
+  - name: kubeadm-gce-upgrade-1.11-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
   - name: kubeadm-gce-upgrade-stable-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
-  - name: kubeadm-gce
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce
-  - name: kubeadm-gce-selfhosting
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-selfhosting
-  - name: kubeadm-gce-cni-flannel
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
-  - name: kubeadm-gce-dns-coredns
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
-
+# packages tests
+  - name: periodic-kubernetes-e2e-packages-pushed
+    test_group_name: periodic-kubernetes-e2e-packages-pushed
 
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:


### PR DESCRIPTION
- remove 1.8 and 1.9 tests
- add 1.12 tests (includes "1.11 on 1.12" and "1.11 -> 1.12")
- keep "1.9 on 1.10" and "1.9 -> 1.10" tests
- group tests in the following manner:
    * kubeadm tests
    * kubeadm x-on-y tests
    * kubeadm upgrade tests
    * ...
(applies to both testgrid/config.yaml and
sig-cluster-lifecycle/kubeadm.yaml)
- remove networking tests from 'sig-cluster-lifecycle-all'
(these are tracked by sig-networking)
- remove ci-kubernetes-e2e-kubeadm-gce-selfhosting completely
(selfhosting is now deprecated in kubeadm)
- rename ci-kubernetes-e2e-kubeadm-gce -> ci-kubernetes-e2e-kubeadm-gce-master

note: the diff ain't pretty for this. better have a look at:
https://github.com/neolit123/test-infra/blob/kubeadm-e2e/testgrid/config.yaml#L4903
https://github.com/neolit123/test-infra/blob/kubeadm-e2e/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml

/assign @BenTheElder @timothysc 
/area config
/fixes kubernetes/kubeadm#863
