### PR TITLE
Add a check for non-decorated kubernetes jobs

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -7,8 +7,10 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/checkconfig",
     visibility = ["//visibility:private"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/errorutil:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",


### PR DESCRIPTION
It's not good practice to create new kubernetes agent jobs that do not
use the pod utilites through decoration. This is a very aggressive
check, however, so it is now possible to ask for individual checks from
the config checker, as well as optionally treating warnings as errors.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind feature
/assign @cjwagner 
/cc @BenTheElder @fejta 

FYI if you are running `checkconfig` this is a breaking change, will have to add `--warnings=mismatched-tide` to get back the old behavior. Should be the only breaking change going forward though.

Sidenote: we're 100% decorated now :)