### PR TITLE
Make barnacle go_library public

### DIFF
--- a/images/bootstrap/barnacle/BUILD.bazel
+++ b/images/bootstrap/barnacle/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/images/bootstrap/barnacle",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/docker/docker/api/types:go_default_library",
         "//vendor/github.com/docker/docker/api/types/filters:go_default_library",


### PR DESCRIPTION
I am building barnacle in my github.com/jetstack/testing repository in order to drop it into an image built with bazel.

In order to do this, I need to build a copy of barnacle for the appropriate architecture.

To save making assumptions in this repository about what architecture the built binary should be, I would like to be able to simply reference the go_library for barnacle and specify my own build options.

You can see an example of how I want to use this here: https://github.com/jetstack/testing/blob/master/images/BUILD.bazel#L21-L28

(note: I am currently referencing my own fork with this patch applied, hence why that works)

/cc @BenTheElder 