### PR TITLE
Update podutils image to use go_image with goos and goarch

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -14,11 +15,22 @@ go_library(
     ],
 )
 
+go_image(
+    name = "clonerefs-go_image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "image",
-    base = "@git-base//image",
-    directory = "/",
-    files = [":clonerefs"],
+    base = ":clonerefs-go_image",
+    symlinks = {
+        "/clonerefs": "/app/prow/cmd/clonerefs",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -28,11 +29,22 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+go_image(
+    name = "entrypoint-go_image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "image",
-    base = "@git-base//image",
-    directory = "/",
-    files = [":entrypoint"],
+    base = ":entrypoint-go_image",
+    symlinks = {
+        "/entrypoint": "/app/prow/cmd/entrypoint",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_image(
     name = "initupload-go_image",
-    base = "@git-base//image",
+    base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -1,11 +1,23 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_image(
+    name = "initupload-go_image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
 
 container_image(
     name = "image",
-    base = "@alpine-base//image",
-    directory = "/",
-    files = [":initupload"],
+    base = ":initupload-go_image",
+    symlinks = {
+        "/initupload": "/app/prow/cmd/initupload",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -1,5 +1,25 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_image(
+    name = "sidecar-go_image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":sidecar-go_image",
+    symlinks = {
+        "/sidecar": "/app/prow/cmd/sidecar",
+    },
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",
@@ -12,14 +32,6 @@ go_library(
         "//prow/sidecar:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
-)
-
-container_image(
-    name = "image",
-    base = "@git-base//image",
-    directory = "/",
-    files = [":sidecar"],
-    visibility = ["//visibility:public"],
 )
 
 go_binary(


### PR DESCRIPTION
This is a follow-up to #9207.

It adds bazel build rules to the podutils, using a symlink to ensure that they are accessible at `/`.

/cc @BenTheElder 