### PR TITLE
kind: overhaul docs

### DIFF
--- a/kind/README.md
+++ b/kind/README.md
@@ -1,20 +1,20 @@
 <!--TODO(bentheelder): fill this in much more thoroughly-->
 # `kind` - **K**ubernetes **IN** **D**ocker
 
-## WARNING: `kind` is still a work in progress! See [docs/todo.md](./docs/todo.md)
+## WARNING: `kind` is still a work in progress! See [docs/todo.md][todo]
 
 `kind` is a toolset for running local Kubernetes clusters using Docker container "nodes".
 `kind` is designed to be suitable for testing Kubernetes, initially targeting the conformance suite.
 
 It consists of:
- - Go [packages](./pkg) implementing [cluster creation](./pkg/cluster), [image build](./pkg/build), etc.
- - A command line interface ([`kind`](./cmd/kind)) built on these packages.
- - Docker [image(s)](./images) written to run systemd, Kubernetes, etc.
- - [`kubetest`](https://github.com/kubernetes/test-infra/tree/master/kubetest) integration also built on these packages (WIP)
+ - Go [packages][packages] implementing [cluster creation][cluster package], [image build][build package], etc.
+ - A command line interface ([`kind`][kind cli]) built on these packages.
+ - Docker [image(s)][images] written to run systemd, Kubernetes, etc.
+ - [`kubetest`][kubetest] integration also built on these packages (WIP)
 
-Kind bootstraps each "node" with [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/).
+Kind bootstraps each "node" with [kubeadm][kubeadm].
 
-For more details see [the design documentation](./docs/design.md).
+For more details see [the design documentation][design doc].
 
 ## Building
 
@@ -33,3 +33,13 @@ For more usage, run `kind --help` or `kind [command] --help`.
 `kind build base` will build the base image.
 
 `kind build node` will build the node image.
+
+[todo]: ./docs/todo.md
+[packages]: ./pkg
+[cluster package]: ./pkg/cluster
+[build package]: ./pkg/build
+[kind cli]: ./main.go
+[images]: ./images
+[kubetest]: https://github.com/kubernetes/test-infra/tree/master/kubetest
+[kubeadm]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/
+[design doc]: ./docs/design.md

--- a/kind/docs/base-image.md
+++ b/kind/docs/base-image.md
@@ -1,0 +1,27 @@
+# The Base Image
+
+The ["base" image][base image] is a small-ish Docker image for running
+nested containers, systemd, and kubernetes components.
+
+To do this we need to set up an environment that will meet the CRI 
+(currently just docker) and systemd's particular needs. Documentation for each
+step we take is inline to the image's [Dockerfile][dockerfile]),
+but essentially:
+
+- we preinstall tools / packages expected by systemd / Docker / Kubernetes other
+than Kubernetes itself
+
+- we install a custom entrypoint that allows us to perform some actions before
+the container truly boots
+
+- we set up a systemd service to forward journal logs to the container tty
+
+- we do a few tricks to minimize unnecessary services and inform systemd that it
+is in docker (see the [Dockerfile][dockerfile])
+
+This image is based on a minimal debian image (currently `k8s.gcr.io/debian-base`)
+due to high availability of tooling.  
+We strive to minimize the image size where possible.
+
+[base image]: ./../images/base
+[dockerfile]: ./../images/base/Dockerfile

--- a/kind/docs/design.md
+++ b/kind/docs/design.md
@@ -1,7 +1,7 @@
 # Design
 
 This is the root design documentation for `kind`. See also the project
-[README.md](./../README.md).
+[README.md][README.md].
 
 ## Overview
 
@@ -12,10 +12,10 @@ Kubernetes "clusters" where each "node" is a Docker container.
 `kind` is divided into go packages implementing most of the functionality, a
 command line for users, and a "node" base image. The intent is that the `kind`
 the suite of packages should eventually be importable and reusable by other
-tools (e.g. [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest))
+tools (e.g. [kubetest][kubetest])
 while the CLI provides a quick way to use and debug these packages.
 
-For [the original proposal](https://docs.google.com/document/d/1VL0shYfKl7goy5Zj4Rghpixbye4M8zs_N2gWoQTSKh0/) by [Q-Lee](https://github.com/q-lee) see [the kubernetes-sig-testing post](https://groups.google.com/d/msg/kubernetes-sig-testing/uVkosorBnVc/8DDC3qvMAwAJ) (NOTE: this document is shared with [kubernetes-sig-testing](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)).
+For [the original proposal][original proposal] by [Q-Lee][q-lee] see [the kubernetes-sig-testing post][sig-testing-post] (NOTE: this document is shared with [kubernetes-sig-testing][kubernetes-sig-testing]).
 
 In short `kind` targets local clusters for testing purposes. While not all 
 testing can be performed without "real" clusters in "the cloud" with provider 
@@ -29,7 +29,7 @@ enabled CCMs, enough can that we want something that:
 
 ## Clusters
 
-Clusters are managed by logic in [`pkg/cluster`](./../pkg/cluster), which the
+Clusters are managed by logic in [`pkg/cluster`][pkg/cluster], which the
 `kind` cli wraps.
 
 Each "cluster" is identified by an internal but well-known [docker object label](https://docs.docker.com/config/labels-custom-metadata/) key, with the cluster
@@ -47,26 +47,54 @@ capable of detecting this from the containers and providing helpers to use it.
 ## Images
 
 To run Kubernetes in a container, we first need suitable container image(s).
-A single standard base layer is used, containing basic utilities like systemd,
-certificates, mount, etc. 
+A single standard [base layer][base-image.md] is used, containing basic
+utilities like systemd, certificates, mount, etc.
 
 Installing Kubernetes etc. is performed on top of this image, and may be cached
 in pre-built images. We expect to provide images with releases already installed
 for use in integrating against Kubernetes.
 
-For more see [node-image.md](./node-image.md).
+For more see [node-image.md][node-image.md].
 
-## Nodes
+## Cluster Lifecycle
 
-### Lifecycle 
+### Cluster Creation
 
 Each "node" runs as a docker container. Each container initially boots to a
-pseudo "paused" state, with [the entrypoint](./images/node/entrypoint) 
-waiting for `SIGUSR1`. This allows us to manipulate and inspect the container 
-with `docker exec ...` and other tools prior to starting systemd and 
-all of the components.
+pseudo "paused" state, with [the entrypoint][entrypoint] waiting for `SIGUSR1`.
+This allows us to manipulate and inspect the container with `docker exec ...`
+and other tools prior to starting systemd and all of the components.
+
+This setup includes fixing mounts and pre-loading saved docker images.
 
 Once the nodes are sufficiently prepared, we signal the entrypoint to actually
 "boot" the node.
 
-# TODO(bentheelder): elaborate on bootup, installation as this stabilizes
+We then wait for the Docker service to be ready on the node before running
+`kubeadm` to initialize the node.
+
+Once kubeadm has booted, we export the [KUBECONFIG][kubeconfig], then apply
+an [overlay network][overlay network].
+
+At this point users can test Kubernetes by using the exported kubeconfig.
+
+
+### Cluster Deletion
+
+All "node" containers in the cluster are tagged with docker labels identifying
+the cluster by the chosen cluster name (default is "1"), to delete a cluster
+we can simply list and delete containers with this label.
+
+
+[README.md]: ./../README.md 
+[kubetest]: https://github.com/kubernetes/test-infra/tree/master/kubetest
+[original proposal]: https://docs.google.com/document/d/1VL0shYfKl7goy5Zj4Rghpixbye4M8zs_N2gWoQTSKh0/
+[q-lee]: https://github.com/q-lee
+[sig-testing-post]: https://groups.google.com/d/msg/kubernetes-sig-testing/uVkosorBnVc/8DDC3qvMAwAJ
+[kubernetes-sig-testing]: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
+[pkg/cluster]: ./../pkg/cluster
+[base-image.md]: ./base-image.md
+[node-image.md]: ./node-image.md
+[entrypoint]: ./images/node/entrypoint
+[kubeconfig]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+[overlay network]: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network


### PR DESCRIPTION
- move to using markdown reference links instead of all inline links
- expand upon cluster lifecycle
- expand image docs, split to base and node images, document expectations of the node image