### PR TITLE
verify-owners: use pre.PullRequest.Head.SHA instead of MergeSHA for review

### DIFF
--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -204,8 +204,8 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 			Action:   github.Comment,
 			Comments: comments,
 		}
-		if pre.PullRequest.MergeSHA != nil {
-			draftReview.CommitSHA = *pre.PullRequest.MergeSHA
+		if pre.PullRequest.Head.SHA != "" {
+			draftReview.CommitSHA = pre.PullRequest.Head.SHA
 		}
 		err := ghc.CreateReview(org, repo, pre.Number, draftReview)
 		if err != nil {


### PR DESCRIPTION
Fixes error in #8430:
`Commit is not part of the pull request`

It fails because at that moment the PR hasn't been merged yet.
Thanks @cjwagner !