### PR TITLE
testgrid: fix CRI-O links

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5311,14 +5311,14 @@ dashboards:
   - name: crio-e2e-fedora
     test_group_name: test_pull_request_crio_e2e_fedora
     open_test_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>/artifacts/artifacts/junit_01.xml
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10
   - name: crio-e2e-rhel
     test_group_name: test_pull_request_crio_e2e_rhel
     open_test_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>/artifacts/artifacts/junit_01.xml
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10


### PR DESCRIPTION
This is now finally fixing CRI-O's testgrid as we've fixed results reporting and publishing on our side.

@stevekuznetsov @BenTheElder @michelle192837 @krzyzacy PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>