### PR TITLE
add an e2e job for kind

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dind.yaml
+++ b/config/jobs/kubernetes/sig-testing/dind.yaml
@@ -105,3 +105,50 @@ periodics:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+- interval: 1h
+  name: ci-kubernetes-kind-conformance-parallel
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-dind-enabled: "true"
+  env:
+  # run tests in parallel
+  - name: "PARALLEL"
+    value: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=master"
+      - "--repo=k8s.io/test-infra=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../test-infra/experiment/kind-e2e.sh"
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # We can adjust this after we know the requirements.
+          memory: "6Gi"
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# hack script for running a kind e2e
+# TODO(bentheelder): replace this with kubetest integration
+# Usage: SKIP="ginkgo skip regex" FOCUS="ginkgo focus regex" kind-e2e.sh 
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# get and isntall `kind` to tempdir
+TMP_GOPATH=$(mktemp -d)
+trap "rm -rf ${TMP_GOPATH}" EXIT
+go get k8s.io/test-infra/kind
+PATH="${TMP_GOPATH}/bin:${PATH}"
+
+# build the base image
+# TODO(bentheelder): eliminate this once we publish this image
+kind build base
+# build the node image w/ kubernetes
+kind build node
+
+# make sure we have e2e requirements
+make -C "${GOPATH}/src/k8s.io/kubernetes" all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo"
+
+# ginkgo regexes
+FOCUS="${FOCUS:-"\\[Conformance\\]"}"
+SKIP="${SKIP:-"Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"}"
+
+# arguments to kubetest for the e2e
+KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP}\" --dump=$HOME/make-logs/ --check-version-skew=false"
+
+# if we set PARALLEL=true, then skip serial tests and add --ginkgo-parallel to the args
+PARALLEL="{PARALLEL:-false}"
+if [[ "${PARALLEL}" == "true" ]]; then
+    SKIP="${SKIP}|\\[Serial\\]"
+    KUBETEST_ARGS="${KUBETEST_ARGS} --ginkgo-parallel"
+fi
+
+# disable errexit so we can manually cleanup
+set +o errexit
+
+# run kind create, if it fails clean up and exit failure
+if ! kind create
+then
+    kind delete
+    exit 1
+fi
+
+# export the KUBECONFIG
+# TODO(bentheelder): provide a `kind` command that can be eval'ed instead
+export KUBECONFIG="${HOME}/.config/kind-config-1"
+
+# run kubetest, if it fails clean up and exit failure
+if ! kubetest "${KUBETEST_ARGS}"
+then
+    kind delete
+    exit 1
+fi
+
+# re-enable errexit now that we aren't trying to do any catch and cleanup
+set -o errexit
+
+# delete the cluster
+kind delete

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2745,6 +2745,9 @@ test_groups:
 - name: ci-kubernetes-dind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-dind-conformance
   num_columns_recent: 3
+- name: ci-kubernetes-kind-conformance-parallel
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kind-conformance-parallel
+  num_columns_recent: 3
 
 # cloud-provider-openstack e2e conformance tests
 # name format: PR trigger ci-presubmit-${zuul-job-name}
@@ -5775,6 +5778,9 @@ dashboards:
   - name: dind
     description: Runs e2e tests against a dind cluster.
     test_group_name: pull-kubernetes-dind-e2e
+  - name: ci-kind-conformance-parallel
+    description: Runs parallel conformance e2e tests against a dind cluster.
+    test_group_name: ci-kubernetes-kind-conformance-parallel
   - name: bazel
     description: Runs bazel test //... on the test-infra repo.
     test_group_name: ci-test-infra-bazel


### PR DESCRIPTION
- add an e2e job for non-serial conformance tests, based on the dind job
- add a temporary `experiment/` script to make this easier. in the future kubetest integration will more or less void the need for this, but that will probably make more sense once kubetest can consume a stable version

/area jobs
/area kind

/assign @amwat @krzyzacy 