### PR TITLE
kind: improve some error handling

### DIFF
--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -20,11 +20,12 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 # get and isntall `kind` to tempdir
 TMP_GOPATH=$(mktemp -d)
-trap "rm -rf ${TMP_GOPATH}" EXIT
-go get k8s.io/test-infra/kind
+trap 'rm -rf ${TMP_GOPATH}' EXIT
+env "GOPATH=${TMP_GOPATH}" go get k8s.io/test-infra/kind
 PATH="${TMP_GOPATH}/bin:${PATH}"
 
 # build the base image
@@ -34,7 +35,7 @@ kind build base
 kind build node
 
 # make sure we have e2e requirements
-make -C "${GOPATH}/src/k8s.io/kubernetes" all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo"
+make -C "$(go env GOPATH)/src/k8s.io/kubernetes" all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo"
 
 # ginkgo regexes
 FOCUS="${FOCUS:-"\\[Conformance\\]"}"

--- a/kind/pkg/build/kube/bazelbuildbits.go
+++ b/kind/pkg/build/kube/bazelbuildbits.go
@@ -56,9 +56,6 @@ func (b *BazelBuildBits) Build() error {
 	// make sure we cd back when done
 	defer os.Chdir(cwd)
 
-	// capture version info
-	buildVersionFile(b.kubeRoot)
-
 	// build artifacts
 	cmd := exec.Command("bazel", "build")
 	cmd.Args = append(cmd.Args,
@@ -73,7 +70,12 @@ func (b *BazelBuildBits) Build() error {
 	)
 	cmd.Debug = true
 	cmd.InheritOutput = true
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// capture version info
+	return buildVersionFile(b.kubeRoot)
 }
 
 // Paths implements Bits.Paths


### PR DESCRIPTION
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-kind-conformance-parallel/2/

It looks like we failed to obtain the kubernetes gitVersion when building the node image, but the logging for this is subpar, so I improved that.

I think maybe what happened is we wrote the version file into `_output`, and some other part of the build removed it, so I'm moving creating the version file to the end after the rest of the build because it's non-standard and there's no reason it needs to be first.

I also improved the e2e script slightly, it should trace output and leverage a temp gopath corretly