### PR TITLE
Make Tide partition queries into subqueries with less than 1000 results.

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
-const timeFormatISO8601 = "2006-01-02T15:04:05Z"
-
 // TideQueries is a TideQuery slice.
 type TideQueries []TideQuery
 
@@ -173,9 +171,8 @@ func (tq *TideQuery) Query() string {
 	return strings.Join(toks, " ")
 }
 
-// AllPRsSince returns all open PRs in the repos covered by the query that
-// have changed since time t.
-func (tqs TideQueries) AllPRsSince(t time.Time) string {
+// AllOpenPRs returns all open PRs in the repos covered by the query.
+func (tqs TideQueries) AllOpenPRs() string {
 	toks := []string{"is:pr", "state:open"}
 
 	orgs, repos := tqs.OrgsAndRepos()
@@ -184,12 +181,6 @@ func (tqs TideQueries) AllPRsSince(t time.Time) string {
 	}
 	for _, r := range repos.List() {
 		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
-	}
-	// Github's GraphQL API silently fails if you provide it with an invalid time
-	// string.
-	// Dates before 1970 are considered invalid.
-	if t.Year() >= 1970 {
-		toks = append(toks, fmt.Sprintf("updated:>=%s", t.Format(timeFormatISO8601)))
 	}
 	return strings.Join(toks, " ")
 }

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
@@ -55,15 +54,7 @@ func TestTideQuery(t *testing.T) {
 	checkTok("review:approved")
 }
 
-func TestAllPRsSince(t *testing.T) {
-	testTime, err := time.Parse(time.UnixDate, "Sat Mar  7 11:06:39 PST 2015")
-	if err != nil {
-		t.Fatalf("Error parsing test time string: %v.", err)
-	}
-	testTimeOld, err := time.Parse(time.UnixDate, "Sat Mar  7 11:06:39 PST 1915")
-	if err != nil {
-		t.Fatalf("Error parsing test time string: %v.", err)
-	}
+func TestAllOpenPRs(t *testing.T) {
 	var q string
 	checkTok := func(tok string, shouldExist bool) {
 		if shouldExist == strings.Contains(q, " "+tok+" ") {
@@ -84,7 +75,7 @@ func TestAllPRsSince(t *testing.T) {
 			Labels: []string{"lgtm", "mergeable"},
 		},
 	})
-	q = " " + queries.AllPRsSince(testTime) + " "
+	q = " " + queries.AllOpenPRs() + " "
 	checkTok("is:pr", true)
 	checkTok("state:open", true)
 	checkTok("org:\"org\"", true)
@@ -98,14 +89,6 @@ func TestAllPRsSince(t *testing.T) {
 	checkTok("-label:\"foo\"", false)
 	checkTok("milestone:\"milestone\"", false)
 	checkTok("review:approved", false)
-	checkTok("updated:>=2015-03-07T11:06:39Z", true)
-
-	// Test that if time is the zero time value, the token is not included.
-	q = " " + queries.AllPRsSince(time.Time{}) + " "
-	checkTok("updated:>=0001-01-01T00:00:00Z", false)
-	// Test that if time is before 1970, the token is not included.
-	q = " " + queries.AllPRsSince(testTimeOld) + " "
-	checkTok("updated:>=1915-03-07T11:06:39Z", false)
 }
 
 func TestMergeMethod(t *testing.T) {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -37,6 +37,16 @@ const (
 	// RepoLogField is the repository of a PR.
 	// Used as a log field across prow.
 	RepoLogField = "repo"
+
+	// SearchTimeFormat is a time.Time format string for ISO8601 which is the
+	// format that GitHub requires for times specified as part of a search query.
+	SearchTimeFormat = "2006-01-02T15:04:05Z"
+)
+
+var (
+	// FoundingYear is the year GitHub was founded. This is just used so that
+	// we can lower bound dates related to PRs and issues.
+	FoundingYear, _ = time.Parse(SearchTimeFormat, "2007-01-01T00:00:00Z")
 )
 
 // These are possible State entries for a Status.

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "search.go",
         "status.go",
         "tide.go",
     ],
@@ -42,6 +43,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "search_test.go",
         "status_test.go",
         "tide_test.go",
     ],

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/test-infra/prow/github"
+
+	githubql "github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+)
+
+type searchExecutor func(start, end time.Time) ([]PullRequest, int /*true match count*/, error)
+
+func newSearchExecutor(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) searchExecutor {
+	return func(start, end time.Time) ([]PullRequest, int, error) {
+		q = fmt.Sprintf("%s %s", q, dateToken(start, end))
+		vars := map[string]interface{}{
+			"query":        githubql.String(q),
+			"searchCursor": (*githubql.String)(nil),
+		}
+		var totalCost, remaining int
+		var totalMatches int
+		var ret []PullRequest
+		for {
+			sq := searchQuery{}
+			if err := ghc.Query(ctx, &sq, vars); err != nil {
+				return nil, 0, err
+			}
+			totalCost += int(sq.RateLimit.Cost)
+			remaining = int(sq.RateLimit.Remaining)
+			totalMatches = int(sq.Search.IssueCount)
+			// If the search won't return all results, abort.
+			if totalMatches > 1000 {
+				return nil, totalMatches, nil
+			}
+			for _, n := range sq.Search.Nodes {
+				ret = append(ret, n.PullRequest)
+			}
+			if !sq.Search.PageInfo.HasNextPage {
+				break
+			}
+			vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
+		}
+		log.WithFields(logrus.Fields{
+			"query": q,
+			"start": start.String(),
+			"end":   start.String(),
+		}).Debugf("Query returned %d PRs and cost %d point(s). %d remaining.", len(ret), totalCost, remaining)
+		return ret, totalMatches, nil
+	}
+}
+
+func (q searchExecutor) search() ([]PullRequest, error) {
+	prs, _, err := q.searchRange(time.Time{}, time.Now())
+	return prs, err
+}
+
+func (q searchExecutor) searchSince(t time.Time) ([]PullRequest, error) {
+	prs, _, err := q.searchRange(t, time.Now())
+	return prs, err
+}
+
+func (q searchExecutor) searchRange(start, end time.Time) ([]PullRequest, int, error) {
+	// Adjust times to be after GitHub was founded to avoid querying empty time
+	// ranges.
+	if start.Before(github.FoundingYear) {
+		start = github.FoundingYear
+	}
+	if end.Before(github.FoundingYear) {
+		end = github.FoundingYear
+	}
+
+	prs, count, err := q(start, end)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if count <= 1000 {
+		// The search returned all the results for the query.
+		return prs, len(prs), nil
+	}
+	// The query returned too many results, we need to partition it.
+	prs, err = q.partitionSearchRange(start, end, count)
+	return prs, len(prs), err
+}
+
+func (q searchExecutor) partitionSearchRange(start, end time.Time, count int) ([]PullRequest, error) {
+	partition := partitionTime(start, end, count, 900)
+	// Search right side...
+	rPRs, rCount, err := q.searchRange(partition, end)
+	if err != nil {
+		return nil, err
+	}
+
+	// Search left side...
+	// For the left side we can deduce the count in advance.
+	lCount := count - rCount
+	// If the count is too large we can skip the initial search and go straight to
+	// partitioning to save an API token.
+	var lPRs []PullRequest
+	if lCount <= 1000 {
+		lPRs, _, err = q.searchRange(start, partition)
+	} else {
+		lPRs, err = q.partitionSearchRange(start, partition, lCount)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return append(lPRs, rPRs...), nil
+}
+
+func partitionTime(start, end time.Time, count, goalSize int) time.Time {
+	duration := end.Sub(start)
+	if count < goalSize*2 {
+		// Choose the midpoint.
+		return start.Add(duration / 2)
+	}
+	// Choose the point that will make the partitionTime->end range contain goalSize
+	// many results assuming a uniform distribution over time.
+	// Use floats to avoid duration overflow.
+	// ->    end - (duration * goalSize / count)
+	diff := time.Duration(-float64(duration) * (float64(goalSize) / float64(count)))
+	return end.Add(diff)
+}
+
+// dateToken generates a GitHub search query token for the specified date range.
+// See: https://help.github.com/articles/understanding-the-search-syntax/#query-for-dates
+func dateToken(start, end time.Time) string {
+	// Github's GraphQL API silently fails if you provide it with an invalid time
+	// string.
+	// Dates before 1970 (unix epoch) are considered invalid.
+	startString, endString := "*", "*"
+	if start.Year() >= 1970 {
+		startString = start.Format(github.SearchTimeFormat)
+	}
+	if end.Year() >= 1970 {
+		endString = end.Format(github.SearchTimeFormat)
+	}
+	return fmt.Sprintf("updated:%s..%s", startString, endString)
+}

--- a/prow/tide/search_test.go
+++ b/prow/tide/search_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"testing"
+	"time"
+
+	githubql "github.com/shurcooL/githubv4"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+)
+
+func uniformRangeAgeFunc(start, end time.Time, count int) func(int) time.Time {
+	diff := end.Sub(start)
+	step := diff / time.Duration(count)
+	return func(prNum int) time.Time {
+		return start.Add(step * time.Duration(prNum))
+	}
+}
+
+func testSearchExecutor(ageFunc func(int) time.Time, count int) searchExecutor {
+	prs := make(map[time.Time]PullRequest, count)
+	for i := 0; i < count; i++ {
+		prs[ageFunc(i)] = PullRequest{Number: githubql.Int(i)}
+	}
+	return func(start, end time.Time) ([]PullRequest, int, error) {
+		var res []PullRequest
+		for t, pr := range prs {
+			if t.Before(start) || t.After(end) {
+				continue
+			}
+			res = append(res, pr)
+		}
+		return res, len(res), nil
+	}
+}
+
+func TestSearch(t *testing.T) {
+	month := time.Hour * time.Duration(24*30)
+
+	now := time.Now()
+	recent := now.Add(-month)
+	old := now.Add(-month * time.Duration(24))
+	ancient := github.FoundingYear.Add(month * time.Duration(12))
+
+	// For each test case, create 'count' PRs using 'ageFunc' to define their
+	// distribution over time. Validate that all 'count' PRs are found.
+	tcs := []struct {
+		name    string
+		ageFunc func(prNum int) time.Time
+		count   int
+	}{
+		{
+			name:    "less than 1000, recent->now",
+			ageFunc: uniformRangeAgeFunc(recent, now, 900),
+			count:   900,
+		},
+		{
+			name:    "exactly 1000, old->now",
+			ageFunc: uniformRangeAgeFunc(old, now, 1000),
+			count:   1000,
+		},
+		{
+			name:    "1500, recent->now",
+			ageFunc: uniformRangeAgeFunc(recent, now, 1500),
+			count:   1500,
+		},
+		{
+			name:    "3500, recent->now",
+			ageFunc: uniformRangeAgeFunc(recent, now, 3500),
+			count:   3500,
+		},
+		{
+			name:    "1500, ancient->now",
+			ageFunc: uniformRangeAgeFunc(ancient, now, 1500),
+			count:   1500,
+		},
+		{
+			name:    "3500, ancient->now",
+			ageFunc: uniformRangeAgeFunc(ancient, now, 3500),
+			count:   3500,
+		},
+		{
+			name:    "1500, ancient->old",
+			ageFunc: uniformRangeAgeFunc(ancient, old, 1500),
+			count:   1500,
+		},
+		{
+			name:    "3500, ancient->old",
+			ageFunc: uniformRangeAgeFunc(ancient, old, 3500),
+			count:   3500,
+		},
+		{
+			name:    "7000, old->now",
+			ageFunc: uniformRangeAgeFunc(old, now, 7000),
+			count:   7000,
+		},
+		{
+			name:  "0 PRs",
+			count: 0,
+		},
+	}
+
+	for _, tc := range tcs {
+		prs, err := testSearchExecutor(tc.ageFunc, tc.count).search()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v.", err)
+		}
+
+		// Validate that there are 'tc.count' unique PRs in 'prs'.
+		found := sets.NewInt()
+		for _, pr := range prs {
+			if found.Has(int(pr.Number)) {
+				t.Errorf("Found PR #%d multiple times.", int(pr.Number))
+			}
+			found.Insert(int(pr.Number))
+		}
+		if found.Len() != tc.count {
+			t.Errorf("Expected to find %d PRs, but found %d instead.", tc.count, found.Len())
+		}
+	}
+}

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package tide contains a controller for managing a tide pool of PRs. The
-// controller will automatically retest PRs in the pool and merge them if they
-// pass tests.
 package tide
 
 import (
@@ -359,9 +356,10 @@ func (sc *statusController) sync(pool map[string]PullRequest) {
 	// We offset for 30 seconds of overlap because GitHub sometimes doesn't
 	// include recently changed/new PRs in the query results.
 	sinceTime := sc.lastSuccessfulQueryStart.Add(-30 * time.Second)
-	query := sc.ca.Config().Tide.Queries.AllPRsSince(sinceTime)
+	query := sc.ca.Config().Tide.Queries.AllOpenPRs()
 	queryStartTime := time.Now()
-	allPRs, err := search(context.Background(), sc.ghc, sc.logger, query)
+	searcher := newSearchExecutor(context.Background(), sc.ghc, sc.logger, query)
+	allPRs, err := searcher.searchSince(sinceTime)
 	if err != nil {
 		sc.logger.WithError(err).Errorf("Searching for open PRs.")
 		return

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -257,7 +257,7 @@ func (c *Controller) Sync() error {
 	c.logger.Debug("Building tide pool.")
 	prs := make(map[string]PullRequest)
 	for _, q := range c.ca.Config().Tide.Queries {
-		results, err := search(ctx, c.ghc, c.logger, q.Query())
+		results, err := newSearchExecutor(ctx, c.ghc, c.logger, q.Query()).search()
 		if err != nil {
 			return err
 		}
@@ -1101,33 +1101,6 @@ func (c *Controller) dividePool(pool map[string]PullRequest, pjs []kube.ProwJob)
 	return sps, nil
 }
 
-func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) ([]PullRequest, error) {
-	var ret []PullRequest
-	vars := map[string]interface{}{
-		"query":        githubql.String(q),
-		"searchCursor": (*githubql.String)(nil),
-	}
-	var totalCost int
-	var remaining int
-	for {
-		sq := searchQuery{}
-		if err := ghc.Query(ctx, &sq, vars); err != nil {
-			return nil, err
-		}
-		totalCost += int(sq.RateLimit.Cost)
-		remaining = int(sq.RateLimit.Remaining)
-		for _, n := range sq.Search.Nodes {
-			ret = append(ret, n.PullRequest)
-		}
-		if !sq.Search.PageInfo.HasNextPage {
-			break
-		}
-		vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
-	}
-	log.Debugf("Search for query \"%s\" returned %d PRs and cost %d point(s). %d remaining.", q, len(ret), totalCost, remaining)
-	return ret, nil
-}
-
 // PullRequest holds graphql data about a PR, including its commits and their contexts.
 type PullRequest struct {
 	Number githubql.Int
@@ -1193,7 +1166,8 @@ type searchQuery struct {
 			HasNextPage githubql.Boolean
 			EndCursor   githubql.String
 		}
-		Nodes []struct {
+		IssueCount githubql.Int
+		Nodes      []struct {
 			PullRequest PullRequest `graphql:"... on PullRequest"`
 		}
 	} `graphql:"search(type: ISSUE, first: 100, after: $searchCursor, query: $query)"`


### PR DESCRIPTION
This should let us get around GitHub's 1000 query result limit documented here: https://developer.github.com/enterprise/2.1/v3/search/#about-the-search-api

/kind bug
/cc @stevekuznetsov @BenTheElder 