### PR TITLE
kind: fix junit, disable log dump within ginkgo, enable kubernetes bazel caching

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kind.yaml
@@ -5,6 +5,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
   spec:
     containers:

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -66,7 +66,7 @@ FOCUS="${FOCUS:-"\\[Conformance\\]"}"
 SKIP="${SKIP:-"Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"}"
 
 # arguments to kubetest for the e2e
-KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${WORKSPACE}/_artifacts\" --check-version-skew=false"
+KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${WORKSPACE}/_artifacts --disable-log-dump=true\" --check-version-skew=false"
 
 # if we set PARALLEL=true, then skip serial tests and add --ginkgo-parallel to the args
 PARALLEL="${PARALLEL:-false}"

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -57,7 +57,7 @@ FOCUS="${FOCUS:-"\\[Conformance\\]"}"
 SKIP="${SKIP:-"Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"}"
 
 # arguments to kubetest for the e2e
-KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP}\" --check-version-skew=false"
+KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${WORKSPACE}/_artifacts\" --check-version-skew=false"
 
 # if we set PARALLEL=true, then skip serial tests and add --ginkgo-parallel to the args
 PARALLEL="${PARALLEL:-false}"

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -23,7 +23,7 @@ set -o pipefail
 set -x
 
 # get relative path to test infra root based on script source
-TREE="$(dirname ${BASH_SOURCE[0]})/.."
+TREE="$(dirname "${BASH_SOURCE[0]}")/.."
 # cd to the path
 ORIG_PWD="${PWD}"
 cd "${TREE}"
@@ -64,6 +64,8 @@ bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/gi
 # ginkgo regexes
 FOCUS="${FOCUS:-"\\[Conformance\\]"}"
 SKIP="${SKIP:-"Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"}"
+# default WORKSPACE if not in CI
+WORKSPACE="${WORKSPACE:-${PWD}}"
 
 # arguments to kubetest for the e2e
 KUBETEST_ARGS="--provider=skeleton --test --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${WORKSPACE}/_artifacts --disable-log-dump=true\" --check-version-skew=false"


### PR DESCRIPTION
- set ginkgo --report-dir so we get junit in artifacts
- build kubernetes and test binaries with bazel, enable remote cache
- fix bazel built image (wasn't enabling the kubelet service, not sure when that regressed, good thing we have CI now!)
- disable log dumping within the e2e framework, not just in kubetest ... (this doesn't appear to be necessary in CI, but locally it still tries to dump without this)