### PR TITLE
_actually_ work around ginkgo-e2e.sh limitations

### DIFF
--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -61,10 +61,12 @@ kind build node --type=bazel
 #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"
 bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
 # e2e.test does not show up in a path with platform in it and will not be found
-# by kube::util::find-binary, so we will add it to the PATH until this is
-# fixed upstream
+# by kube::util::find-binary, so we will copy it to an acceptable location
+# until this is fixed upstream
 # https://github.com/kubernetes/kubernetes/issues/68306
-export PATH="${PWD}/bazel-bin/test/e2e/:${PATH}"
+mkdir -p "_output/bin/"
+cp bazel-bin/test/e2e/e2e.test "_output/bin/"
+
 
 # ginkgo regexes
 FOCUS="${FOCUS:-"\\[Conformance\\]"}"


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/9276
See: https://github.com/kubernetes/kubernetes/blob/ca43f007a3599bdb01f40564941439b47f10b55e/hack/lib/util.sh#L156-L175

One of the locations searched is just `"${KUBE_ROOT}/_output/bin/${lookfor}"`, we can just ensure this location exists and move the binary there.

This is a bit gross, but better than cutting an entire release and extracting it just to get in the platform path, and probably better than having to depend on sourcing the k8s build scripts.

Eventually I will make sure we just use ginkgo directly for kind (and probably all kubetest usage) instead of this script, but extricating it currently is a bit more involved.