### PR TITLE
Remove sig-release blockade

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -129,11 +129,6 @@ blockades:
   - ^events/2016
   - ^events/elections/2017
   explanation: "These files are historical, and from events that have already occurred."
-- repos:
-  - kubernetes/sig-release
-  blockregexps:
-  - ^releases/release-1\.[0-9]/
-  explanation: "These files represent previous release collateral and have been protected for historical purposes."
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
After some discussion, we're not going to do this: https://kubernetes.slack.com/archives/C2C40FMNF/p1536184807000100

/sig release
/assign @spiffxp @calebamiles 

Signed-off-by: Stephen Augustus <foo@agst.us>