### PR TITLE
Support using an http.cookiefile secret to clone

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -171,6 +171,9 @@ type DecorationConfig struct {
 	// SkipCloning determines if we should clone source code in the
 	// initcontainers for jobs that specify refs
 	SkipCloning bool `json:"skip_cloning,omitempty"`
+	// CookieFileSecret is the name of a kubernetes secret that contains
+	// a git http.cookiefile, which should be used during the cloning process.
+	CookiefileSecret string `json:"cookiefile_secret,omitempty"`
 }
 
 // UtilityImages holds pull specs for the utility images
@@ -319,7 +322,7 @@ func (r Refs) String() string {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// VirtualMachineList is a list of VirtualMachine resources
+// ProwJobList is a list of ProwJob resources
 type ProwJobList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/prow/clonerefs/options.go
+++ b/prow/clonerefs/options.go
@@ -58,10 +58,11 @@ type Options struct {
 	MaxParallelWorkers int `json:"max_parallel_workers,omitempty"`
 
 	// used to hold flag values
-	refs      gitRefs
-	clonePath orgRepoFormat
-	cloneURI  orgRepoFormat
-	keys      stringSlice
+	refs       gitRefs
+	clonePath  orgRepoFormat
+	cloneURI   orgRepoFormat
+	keys       stringSlice
+	cookiePath string
 }
 
 // Validate ensures that the configuration options are valid
@@ -152,6 +153,7 @@ func BindOptions(options *Options, fs *flag.FlagSet) {
 	fs.Var(&options.clonePath, "clone-alias", "Format string for the path to clone to")
 	fs.Var(&options.cloneURI, "uri-prefix", "Format string for the URI prefix to clone from")
 	fs.IntVar(&options.MaxParallelWorkers, "max-workers", 0, "Maximum number of parallel workers, unset for unlimited.")
+	fs.StringVar(&options.cookiePath, "cookiefile", "", "Path to git http.coookiefile")
 }
 
 type gitRefs struct {

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -62,7 +62,7 @@ func (o Options) Run() error {
 		go func() {
 			defer wg.Done()
 			for ref := range input {
-				output <- clone.Run(ref, o.SrcRoot, o.GitUserName, o.GitUserEmail, env)
+				output <- clone.Run(ref, o.SrcRoot, o.GitUserName, o.GitUserEmail, o.cookiePath, env)
 			}
 		}()
 	}

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -29,7 +29,7 @@ import (
 
 // Run clones the refs under the prescribed directory and optionally
 // configures the git username and email in the repository as well.
-func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail string, env []string) Record {
+func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail, cookiePath string, env []string) Record {
 	logrus.WithFields(logrus.Fields{"refs": refs}).Info("Cloning refs")
 	record := Record{Refs: refs}
 	repositoryURI := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
@@ -50,6 +50,9 @@ func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail string, env []string) R
 	}
 	if gitUserEmail != "" {
 		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "config", "user.email", gitUserEmail))
+	}
+	if cookiePath != "" {
+		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "config", "http.cookiefile", cookiePath))
 	}
 	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, "--tags", "--prune"))
 	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, refs.BaseRef))


### PR DESCRIPTION
Enables prow to use google cloud source repositories and other https
based systems, with something like the following:

```bash
bazel run //prow/cmd/clonerefs -- \
  --repo my-project,my-repo=master \
  --uri-prefix 'https://source.developers.google.com/p/{{.Org}}/r/{{.Repo}}' \
  --cookiefile ~/my/cookies
```

Will result in clonerefs doing the equivalent of:
```bash
  git -c http.cookiefile=~/my/cookies fetch https://source.developers.google.com/p/my-project/r/my-repo
```

ref #9270 

/assign @stevekuznetsov @mithrav @krzyzacy @BenTheElder 