### PR TITLE
remove 1.8 gce conformance jobs

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
@@ -21,27 +21,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master
 
 - interval: 6h
-  name: ci-kubernetes-gce-conformance-latest-1-8
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=220
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --extract=ci/latest-1.8
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-      - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master
-
-- interval: 6h
   name: ci-kubernetes-gce-conformance-latest-1-9
   labels:
     preset-service-account: "true"
@@ -124,27 +103,6 @@ periodics:
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master
-
-- interval: 6h
-  name: ci-kubernetes-gce-conformance-stable-1-8
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=220
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --extract=release/stable-1.8
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-      - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e@sha256:773f00d30eca8fc577729f65102aed86febca82a7ce52fbfe6d38ce6a5d63ba0
 
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-9

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2729,15 +2729,6 @@ test_groups:
   num_columns_recent: 3
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
-- name: ci-kubernetes-gce-conformance-stable-1-8
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-stable-1-8
-  alert_stale_results_hours: 24
-  num_failures_to_alert: 1
-- name: ci-kubernetes-gce-conformance-latest-1-8
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-8
-  num_columns_recent: 3
-  alert_stale_results_hours: 24
-  num_failures_to_alert: 1
 - name: ci-kubernetes-kind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kind-conformance
   num_columns_recent: 3
@@ -2870,18 +2861,6 @@ dashboards:
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
-  - name: GCE, v1.8 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-8
-    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
-    alert_options:
-      alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
-  - name: GCE, v1.8 (dev)
-    description: Runs conformance tests using kubetest against kubernetes release 1.8 branch on GCE
-    test_group_name: ci-kubernetes-gce-conformance-latest-1-8
-    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
-    alert_options:
-      alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
   - name: kind, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance
@@ -2945,18 +2924,6 @@ dashboards:
   - name: GCE, v1.9 (dev)
     description: Runs conformance tests using kubetest against kubernetes release 1.9 branch on GCE
     test_group_name: ci-kubernetes-gce-conformance-latest-1-9
-    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
-    alert_options:
-      alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
-  - name: GCE, v1.8 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.9 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-8
-    # TODO(bentheelder): there's probably a more appropriate alias to alert this to
-    alert_options:
-      alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
-  - name: GCE, v1.8 (dev)
-    description: Runs conformance tests using kubetest against kubernetes release 1.8 branch on GCE
-    test_group_name: ci-kubernetes-gce-conformance-latest-1-8
     # TODO(bentheelder): there's probably a more appropriate alias to alert this to
     alert_options:
       alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com


### PR DESCRIPTION
1.8 has been way out of scope, not sure if anything else is still left behind. hopefully next release cycle cleaning up will just be a regular part of the cycle.