### PR TITLE
specify gcloud timeout flag for upgrade regional cluster test

### DIFF
--- a/config/jobs/gke/gke-staging-upgrade.yaml
+++ b/config/jobs/gke/gke-staging-upgrade.yaml
@@ -212,5 +212,5 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|Initializers|Dashboard --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci
+      - --upgrade_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=gke-latest-1.11 --upgrade-image=gci --timeout=2700
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master


### PR DESCRIPTION
Some GKE staging tests [fail](https://k8s-testgrid.appspot.com/google-gke-staging#gke-staging-1-10-1-11-upgrade-regional-cluster) even the upgrades are successful due to `gcloud` timeout. To remedy this, a `timeout` flag is added to `gcloud`. May need to specify gcloud timeout flag for upgrade regional cluster test in `gke-staging-upgrade.yaml` for the tests to pass.

/cc @krzyzacy