### PR TITLE
kind: implement lifecycle hooks

### DIFF
--- a/kind/cmd/kind/kind.go
+++ b/kind/cmd/kind/kind.go
@@ -51,7 +51,7 @@ func Main() {
 	// particularly useful, they're relative to the command start
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp:   true,
-		TimestampFormat: "15:04:05-0700",
+		TimestampFormat: "0102-15:04:05",
 	})
 	if err := Run(); err != nil {
 		log.Fatal(err)

--- a/kind/docs/kind-example-config.yaml
+++ b/kind/docs/kind-example-config.yaml
@@ -1,0 +1,23 @@
+# this config file contains all config fields with comments
+apiVersion: kind.sigs.k8s.io/v1alpha1
+kind: Config
+# number of nodes in the cluster (currently only 1 is supported)
+numNodes: 1
+# template for kubeadm config, "" -> the default template
+kubeadmConfigTemplate: ""
+# node lifecycle hooks
+nodeLifecycle:
+  # commands run before systemd boots
+  preBoot:
+  - name: "should fail"
+    command: [ "yep-not-a-real-command" ]
+  # commands run before kubeadm init
+  preKubeadm: []
+  # commands run after kubeadm init
+  postKubeadm: []
+  # commands run after all other setup on the node
+  postSetup:
+  - name: "list containers"
+    command: [ "docker", "ps" ]
+    # this command cannot fail, or else kind will fail during create
+    mustSucceed: true

--- a/kind/pkg/cluster/config/deepcopy.go
+++ b/kind/pkg/cluster/config/deepcopy.go
@@ -59,6 +59,12 @@ func (in *NodeLifecycle) DeepCopy() *NodeLifecycle {
 			out.PostKubeadm[i] = *(in.PostKubeadm[i].DeepCopy())
 		}
 	}
+	if in.PostSetup != nil {
+		out.PostSetup = make([]LifecycleHook, len(in.PostSetup))
+		for i := range in.PostSetup {
+			out.PostSetup[i] = *(in.PostSetup[i].DeepCopy())
+		}
+	}
 	return out
 }
 
@@ -69,10 +75,10 @@ func (in *LifecycleHook) DeepCopy() *LifecycleHook {
 	}
 	out := new(LifecycleHook)
 	*out = *in
-	if in.Args != nil {
-		out.Args = make([]string, len(in.Args))
-		for i := range in.Args {
-			out.Args[i] = in.Args[i]
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
 		}
 	}
 	return out

--- a/kind/pkg/cluster/config/deepcopy_test.go
+++ b/kind/pkg/cluster/config/deepcopy_test.go
@@ -37,22 +37,26 @@ func TestDeepCopy(t *testing.T) {
 				cfg.NodeLifecycle = &NodeLifecycle{
 					PreBoot: []LifecycleHook{
 						{
-							Command: "ps",
-							Args:    []string{"aux"},
+							Command: []string{"ps", "aux"},
 						},
 					},
 					PreKubeadm: []LifecycleHook{
 						{
 							Name:    "docker ps",
-							Command: "docker",
-							Args:    []string{"ps"},
+							Command: []string{"docker", "ps"},
 						},
 					},
 					PostKubeadm: []LifecycleHook{
 						{
 							Name:    "docker ps again",
-							Command: "docker",
-							Args:    []string{"ps", "-a"},
+							Command: []string{"docker", "ps", "-a"},
+						},
+					},
+					PostSetup: []LifecycleHook{
+						{
+							Name:        "docker ps again again",
+							Command:     []string{"docker", "ps", "-a"},
+							MustSucceed: true,
 						},
 					},
 				}

--- a/kind/pkg/cluster/config/encoding/encoding_test.go
+++ b/kind/pkg/cluster/config/encoding/encoding_test.go
@@ -127,11 +127,10 @@ apiVersion: kind.sigs.k8s.io/v1alpha1
 nodeLifecycle:
   preKubeadm:
   - name: "pull an image"
-    command: "docker"
-    args: [ "pull", "ubuntu" ]
+    command: [ "docker", "pull", "ubuntu" ]
   - name: "pull another image"
-    command: "docker"
-    args: [ "pull", "debian" ]
+    command: [ "docker", "pull", "debian" ]
+    mustSucceed: true
 `),
 			ExpectedConfig: func() config.Any {
 				cfg := &config.Config{
@@ -139,13 +138,12 @@ nodeLifecycle:
 						PreKubeadm: []config.LifecycleHook{
 							{
 								Name:    "pull an image",
-								Command: "docker",
-								Args:    []string{"pull", "ubuntu"},
+								Command: []string{"docker", "pull", "ubuntu"},
 							},
 							{
-								Name:    "pull another image",
-								Command: "docker",
-								Args:    []string{"pull", "debian"},
+								Name:        "pull another image",
+								Command:     []string{"docker", "pull", "debian"},
+								MustSucceed: true,
 							},
 						},
 					},

--- a/kind/pkg/cluster/config/encoding/testdata/valid-with-lifecyclehooks.yaml
+++ b/kind/pkg/cluster/config/encoding/testdata/valid-with-lifecyclehooks.yaml
@@ -3,8 +3,6 @@ apiVersion: kind.sigs.k8s.io/v1alpha1
 nodeLifecycle:
   preKubeadm:
   - name: "pull an image"
-    command: "docker"
-    args: [ "pull", "ubuntu" ]
+    command: [ "docker", "pull", "ubuntu" ]
   - name: "pull another image"
-    command: "docker"
-    args: [ "pull", "debian" ]
+    command: [ "docker", "pull", "debian" ]

--- a/kind/pkg/cluster/config/types.go
+++ b/kind/pkg/cluster/config/types.go
@@ -43,10 +43,12 @@ var _ Any = &Config{}
 type NodeLifecycle struct {
 	// PreBoot hooks run before starting systemd
 	PreBoot []LifecycleHook `json:"preBoot,omitempty"`
-	// PreKubeadm hooks run before `kubeadm`
+	// PreKubeadm hooks run immediately before `kubeadm`
 	PreKubeadm []LifecycleHook `json:"preKubeadm,omitempty"`
-	// PostKubeadm hooks run after `kubeadm`
+	// PostKubeadm hooks run immediately after `kubeadm`
 	PostKubeadm []LifecycleHook `json:"postKubeadm,omitempty"`
+	// PostSetup hooks run after any standard `kind` setup on the node
+	PostSetup []LifecycleHook `json:"postSetup,omitempty"`
 }
 
 // LifecycleHook represents a command to run at points in the node lifecycle
@@ -54,7 +56,9 @@ type LifecycleHook struct {
 	// Name is used to improve logging (optional)
 	Name string `json:"name,omitempty"`
 	// Command is the command to run on the node
-	Command string `json:"command"`
-	// Args are the arguments to the command (optional)
-	Args []string `json:"args,omitempty"`
+	Command []string `json:"command"`
+	// MustSucceed - if true then the hook / command failing will cause
+	// cluster creation to fail, otherwise the error will just be logged and
+	// the boot process will continue
+	MustSucceed bool `json:"mustSucceed,omitempty"`
 }

--- a/kind/pkg/cluster/config/validate.go
+++ b/kind/pkg/cluster/config/validate.go
@@ -34,7 +34,7 @@ func (c *Config) Validate() error {
 	}
 	if c.NodeLifecycle != nil {
 		for _, hook := range c.NodeLifecycle.PreBoot {
-			if hook.Command == "" {
+			if len(hook.Command) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"preBoot hooks must set command to a non-empty value",
 				))
@@ -44,7 +44,7 @@ func (c *Config) Validate() error {
 			}
 		}
 		for _, hook := range c.NodeLifecycle.PreKubeadm {
-			if hook.Command == "" {
+			if len(hook.Command) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"preKubeadm hooks must set command to a non-empty value",
 				))
@@ -54,7 +54,7 @@ func (c *Config) Validate() error {
 			}
 		}
 		for _, hook := range c.NodeLifecycle.PostKubeadm {
-			if hook.Command == "" {
+			if len(hook.Command) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"postKubeadm hooks must set command to a non-empty value",
 				))

--- a/kind/pkg/cluster/config/validate_test.go
+++ b/kind/pkg/cluster/config/validate_test.go
@@ -45,7 +45,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.NodeLifecycle = &NodeLifecycle{
 					PreBoot: []LifecycleHook{
 						{
-							Command: "",
+							Command: []string{},
 						},
 					},
 				}
@@ -61,7 +61,7 @@ func TestConfigValidate(t *testing.T) {
 					PreKubeadm: []LifecycleHook{
 						{
 							Name:    "pull an image",
-							Command: "",
+							Command: []string{},
 						},
 					},
 				}
@@ -77,7 +77,7 @@ func TestConfigValidate(t *testing.T) {
 					PostKubeadm: []LifecycleHook{
 						{
 							Name:    "pull an image",
-							Command: "",
+							Command: []string{},
 						},
 					},
 				}


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/9245

- implement node lifecycle hooks
  - add a `MustSucceed` field to mark hooks that must exit cleanly or otherwise cause `kind create` to fail
 - add `PostSetup` hooks, which run after all other normal `kind` setup on the node
- add an example kind config to kind/docs
- tweak log formatting, I think the day/month is more useful than the timezone but the format is still terse, a very similar format (space instead of `-` is used by the kubernetes build scripts)