### PR TITLE
Make kind go_default_library public

### DIFF
--- a/kind/BUILD.bazel
+++ b/kind/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/kind",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = ["//kind/cmd/kind:go_default_library"],
 )
 


### PR DESCRIPTION
This will allow us to build kind for various architectures from external bazel projects

/cc @BenTheElder 