### PR TITLE
Allow specifying node image to boot in kind Config type

### DIFF
--- a/kind/cmd/kind/build/base/base.go
+++ b/kind/cmd/kind/build/base/base.go
@@ -24,7 +24,8 @@ import (
 )
 
 type flags struct {
-	Source string
+	Source    string
+	ImageName string
 }
 
 // NewCommand returns a new cobra.Command for building the base image
@@ -40,12 +41,13 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.Source, "source", "", "path to the base image sources")
+	cmd.Flags().StringVar(&flags.ImageName, "image", "kind-base", "name of the resulting image to be built")
 	return cmd
 }
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
-	ctx := build.NewBaseImageBuildContext()
+	ctx := build.NewBaseImageBuildContext(flags.ImageName)
 	ctx.SourceDir = flags.Source
 	err := ctx.Build()
 	if err != nil {

--- a/kind/cmd/kind/build/node/node.go
+++ b/kind/cmd/kind/build/node/node.go
@@ -24,8 +24,10 @@ import (
 )
 
 type flags struct {
-	Source    string
-	BuildType string
+	Source        string
+	BuildType     string
+	ImageName     string
+	BaseImageName string
 }
 
 // NewCommand returns a new cobra.Command for building the node image
@@ -41,12 +43,14 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.BuildType, "type", "docker", "build type, one of [bazel, docker, apt]")
+	cmd.Flags().StringVar(&flags.ImageName, "image", "kind-node", "name of the resulting image to be built")
+	cmd.Flags().StringVar(&flags.BaseImageName, "base-image", "kind-base", "name of the base image to use for the build")
 	return cmd
 }
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	// TODO(bentheelder): make this more configurable
-	ctx, err := build.NewNodeImageBuildContext(flags.BuildType)
+	ctx, err := build.NewNodeImageBuildContext(flags.BuildType, flags.ImageName, flags.BaseImageName)
 	if err != nil {
 		log.Fatalf("Error creating build context: %v", err)
 	}

--- a/kind/pkg/build/base_image.go
+++ b/kind/pkg/build/base_image.go
@@ -40,9 +40,9 @@ type BaseImageBuildContext struct {
 
 // NewBaseImageBuildContext creates a new BaseImageBuildContext with
 // default configuration
-func NewBaseImageBuildContext() *BaseImageBuildContext {
+func NewBaseImageBuildContext(imageName string) *BaseImageBuildContext {
 	return &BaseImageBuildContext{
-		ImageTag: "kind-base",
+		ImageTag: imageName,
 		GoCmd:    "go",
 		Arch:     "amd64",
 	}

--- a/kind/pkg/build/node_image.go
+++ b/kind/pkg/build/node_image.go
@@ -41,7 +41,7 @@ type NodeImageBuildContext struct {
 
 // NewNodeImageBuildContext creates a new NodeImageBuildContext with
 // default configuration
-func NewNodeImageBuildContext(mode string) (ctx *NodeImageBuildContext, err error) {
+func NewNodeImageBuildContext(mode, imageName, baseImageName string) (ctx *NodeImageBuildContext, err error) {
 	kubeRoot := ""
 	// apt should not fail on finding kube root as it does not use it
 	if mode != "apt" {
@@ -55,9 +55,9 @@ func NewNodeImageBuildContext(mode string) (ctx *NodeImageBuildContext, err erro
 		return nil, err
 	}
 	return &NodeImageBuildContext{
-		ImageTag:  "kind-node",
+		ImageTag:  imageName,
 		Arch:      "amd64",
-		BaseImage: "kind-base",
+		BaseImage: baseImageName,
 		KubeRoot:  kubeRoot,
 		Bits:      bits,
 	}, nil

--- a/kind/pkg/cluster/cluster.go
+++ b/kind/pkg/cluster/cluster.go
@@ -140,7 +140,7 @@ func (c *Context) provisionControlPlane(
 	config *config.Config,
 ) (kubeadmConfigPath string, err error) {
 	// create the "node" container (docker run, but it is paused, see createNode)
-	node, err := createNode(nodeName, c.ClusterLabel())
+	node, err := createNode(nodeName, config.Image, c.ClusterLabel())
 	if err != nil {
 		return "", err
 	}

--- a/kind/pkg/cluster/config/default.go
+++ b/kind/pkg/cluster/config/default.go
@@ -25,6 +25,9 @@ func New() *Config {
 
 // ApplyDefaults replaces unset fields with defaults
 func (c *Config) ApplyDefaults() {
+	if c.Image == "" {
+		c.Image = "kind-node"
+	}
 	if c.NumNodes == 0 {
 		c.NumNodes = 1
 	}

--- a/kind/pkg/cluster/config/types.go
+++ b/kind/pkg/cluster/config/types.go
@@ -23,6 +23,8 @@ package config
 // This is the current internal config type used by cluster
 // Other API versions can be converted to this struct with Convert()
 type Config struct {
+	// Image is the node image to use when running the cluster
+	Image string `json:"image,omitempty"`
 	// NumNodes is the number of nodes to create (currently only one is supported)
 	NumNodes int `json:"numNodes,omitempty"`
 	// KubeadmConfigTemplate allows overriding the default template in

--- a/kind/pkg/cluster/config/validate.go
+++ b/kind/pkg/cluster/config/validate.go
@@ -22,6 +22,9 @@ import "fmt"
 // with the config, or nil if there are none
 func (c *Config) Validate() error {
 	errs := []error{}
+	if c.Image == "" {
+		errs = append(errs, fmt.Errorf("image is a required field"))
+	}
 	// TODO(bentheelder): support multiple nodes
 	if c.NumNodes != 1 {
 		errs = append(errs, fmt.Errorf(

--- a/kind/pkg/cluster/config/validate_test.go
+++ b/kind/pkg/cluster/config/validate_test.go
@@ -31,9 +31,11 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			TestName: "Invalid number of nodes (not yet supported",
-			Config: &Config{
-				NumNodes: 2,
-			},
+			Config: func() *Config {
+				cfg := New()
+				cfg.NumNodes = 2
+				return cfg
+			}(),
 			ExpectedErrors: 1,
 		},
 		{
@@ -79,6 +81,15 @@ func TestConfigValidate(t *testing.T) {
 						},
 					},
 				}
+				return cfg
+			}(),
+			ExpectedErrors: 1,
+		},
+		{
+			TestName: "Empty image field",
+			Config: func() *Config {
+				cfg := New()
+				cfg.Image = ""
 				return cfg
 			}(),
 			ExpectedErrors: 1,

--- a/kind/pkg/cluster/node.go
+++ b/kind/pkg/cluster/node.go
@@ -40,7 +40,7 @@ type nodeHandle struct {
 // createNode `docker run`s the node image, note that due to
 // images/node/entrypoint being the entrypoint, this container will
 // effectively be paused until we call actuallyStartNode(...)
-func createNode(name, clusterLabel string) (handle *nodeHandle, err error) {
+func createNode(name, image, clusterLabel string) (handle *nodeHandle, err error) {
 	cmd := exec.Command("docker", "run")
 	cmd.Args = append(cmd.Args,
 		"-d", // run the container detached
@@ -64,7 +64,7 @@ func createNode(name, clusterLabel string) (handle *nodeHandle, err error) {
 		"--expose", "6443", // expose API server port
 		// pick a random ephemeral port to forward to the API server
 		"--publish-all",
-		"kind-node", // use our image, TODO: make this configurable
+		image,
 	)
 	cmd.Debug = true
 	err = cmd.Run()


### PR DESCRIPTION
I opted to make this a field in the Config structure for now.

Do you think we're better having this as a flag to `create` instead? This seemed like a simple solution and in-keeping with other config options.

/cc @BenTheElder 