### PR TITLE
prow: fix plugins for the CRI-O repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -606,6 +606,9 @@ plugins:
   kubernetes-sigs/gcp-filestore-csi-driver:
   - trigger
 
+  kubernetes-sigs/cri-o:
+  - trigger
+
   containerd/cri:
   - assign
   - cla


### PR DESCRIPTION
@spiffxp @mrunalp @smarterclayton PTAL we do have some misconfigurations (autoapproved PRs and the like https://github.com/kubernetes-sigs/cri-o/pull/1785)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>