### PR TITLE
Enable Tide for k/k!

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -184,6 +184,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    optional: true
     rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
     skip_branches:
     - release-1.10
@@ -244,6 +245,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    optional: true
     rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
     spec:
       containers:
@@ -301,6 +303,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 12
     name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    optional: true
     rerun_command: /test pull-security-kubernetes-e2e-gce-device-plugin-gpu
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-presubmit.yaml
@@ -5,7 +5,7 @@ presubmits:
     - release-1.10  # per-release image
     - release-1.9  # per-release image
     always_run: true
-    skip_report: false
+    optional: true
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -49,7 +49,7 @@ presubmits:
     branches:
     - release-1.10  # per-release image
     always_run: true
-    skip_report: false
+    optional: true
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -93,7 +93,7 @@ presubmits:
     branches:
     - release-1.9 # per-release image
     always_run: true
-    skip_report: false
+    optional: true
     max_concurrency: 12
     labels:
       preset-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -38,7 +38,7 @@ deck:
 
 prowjob_namespace: default
 pod_namespace: test-pods
-log_level: info
+log_level: debug
 
 branch-protection:
   allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
@@ -396,6 +396,44 @@ tide:
     - do-not-merge/work-in-progress
     - needs-ok-to-test
     - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.12
+    includedBranches:
+    - master
+    - release-1.12
+    labels:
+    - lgtm
+    - approved
+    - priority/critical-urgent
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    - release-1.12
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
   merge_method:
     helm/charts: squash
     kubeflow: squash
@@ -415,9 +453,13 @@ tide:
   pr_status_base_url: https://prow.k8s.io/pr
   blocker_label: merge-blocker
   squash_label: tide/squash
+  context_options:
+    optional-contexts:
+    - "Submit Queue"
 
 push_gateway:
   endpoint: pushgateway
+
 
 presets:
 # credential presets


### PR DESCRIPTION
Redo of #6417 (Apparently you can't reopen PRs if you force push to the branch after the PR is closed.)
It looks like `pull-kubernetes-e2e-gce-device-plugin-gpu` job is not intended to be required for merge because it is not a SQ required-retest-context and is not marked required on GH. I set `optional:true` to indicate this to Tide. All other jobs that are not marked required on GH are `run_if_changed` jobs and will be handled appropriately as is.

I'll delete the SQ configs in a follow up PR (I'll just temporarily disable them by setting replicas to 0 before rolling out Tide in case we need to quickly revert).

/hold
/cc @spiffxp @tpepper @stevekuznetsov @BenTheElder @fejta 