### PR TITLE
Add goos and goarch to label_sync

### DIFF
--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -37,8 +37,9 @@ go_image(
     name = "label_sync-image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
     pure = "on",
-    tags = ["automanaged"],
 )
 
 go_test(


### PR DESCRIPTION
Similar to other recent PRs, this adds the goarch and goos arg to label_sync's go_image target.

This allows the image to be built from any supported platform without additional flags.