### PR TITLE
Fix tide search to not accumulate date tokens from prior searches in the query string.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -38,7 +38,7 @@ deck:
 
 prowjob_namespace: default
 pod_namespace: test-pods
-log_level: info
+log_level: debug
 
 branch-protection:
   allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website


### PR DESCRIPTION
Also set Prow's log level to debug so that we can more carefully monitor Tide's actions on k/k when we roll it out on Monday.

/kind bug
/assign @BenTheElder 
/cc @stevekuznetsov @munnerz @spiffxp 