### PR TITLE
kubekins-e2e: optional newer docker, kind: optimize ci job

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -89,7 +89,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -52,7 +52,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -68,7 +68,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
       args:
       - --repo=github.com/containerd/containerd=release/1.1
       - --repo=github.com/containerd/cri=release/1.0
@@ -280,7 +280,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src

--- a/config/jobs/kubernetes/sig-testing/kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kind.yaml
@@ -6,10 +6,10 @@ periodics:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
-    preset-dind-enabled: "true"
+    preset-dind-memory-backed: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -33,8 +33,11 @@ periodics:
         name: cgroup
       resources:
         requests:
-          # We can adjust this after we know the requirements.
-          memory: "6Gi"
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
     volumes:
     - name: modules
       hostPath:

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -64,7 +64,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -53,7 +53,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -99,7 +99,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -126,7 +126,7 @@ presubmits:
       - name: test
         command:
         - ./hack/verify-config.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         env:
         - name: TEST_TMPDIR
           value: /bazel-scratch/.cache/bazel
@@ -151,7 +151,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -175,7 +175,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         command:
         - ./hack/verify-codegen.sh
         resources:
@@ -225,7 +225,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180829-29e661965-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --root=/go/src

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -67,6 +67,9 @@ bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/gi
 mkdir -p "_output/bin/"
 cp bazel-bin/test/e2e/e2e.test "_output/bin/"
 
+# release some memory after building
+sync || true
+echo 1 > /proc/sys/vm/drop_caches || true
 
 # ginkgo regexes
 FOCUS="${FOCUS:-"\\[Conformance\\]"}"

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -65,6 +65,15 @@ RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
     wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
     chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
 
+# if UPGRADE_DOCKER_ARG, then install the latest docker over whatever we have
+# in the base image.
+# TODO(bentheelder): after code freeze, roll out newer docker in the
+# base image and possibly remove this ...
+ARG UPGRADE_DOCKER_ARG=false
+RUN [ "${UPGRADE_DOCKER_ARG}" = "true" ] && \
+    apt-get install -y --no-install-recommends docker-ce && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker || true
+
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -19,6 +19,7 @@ TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 K8S ?= master
 GO ?= 1.10.2
 BAZEL ?= 0.16.1
+UPGRADE_DOCKER ?=false
 # TODO(bentheelder,cblecker): this is aging and bad
 CFSSL ?= R1.2
 
@@ -27,6 +28,7 @@ ifeq ($(K8S), experimental)
 	GO = 1.10.2
 	BAZEL = 0.16.1
 	CFSSL = R1.2
+	UPGRADE_DOCKER = true
 endif
 
 # kubernetes release-X branch configs
@@ -63,7 +65,7 @@ kubetest:
 
 build: kubetest
 	@echo Building with go:$(GO) and bazel:$(BAZEL)
-	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION_ARG=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) --build-arg IMAGE_ARG=$(IMG):$(TAG)-$(K8S) -t $(IMG):$(TAG)-$(K8S) .
+	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION_ARG=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) --build-arg IMAGE_ARG=$(IMG):$(TAG)-$(K8S) --build-arg=UPGRADE_DOCKER_ARG=$(UPGRADE_DOCKER) -t $(IMG):$(TAG)-$(K8S) .
 	docker tag $(IMG):$(TAG)-$(K8S) $(IMG):latest-$(K8S)
 	rm kubetest
 	@echo Built $(IMG):$(TAG)-$(K8S) and tagged with latest-$(K8S)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -545,3 +545,16 @@ presets:
   volumeMounts:
   - name: docker-graph
     mountPath: /docker-graph
+# experimental preset for dind, prefer the one above
+- labels:
+    preset-dind-memory-backed: "true"
+  env:
+  - name: DOCKER_IN_DOCKER_ENABLED
+    value: "true"
+  volumes:
+  - name: docker-graph
+    emptyDir:
+      medium: "Memory"
+  volumeMounts:
+  - name: docker-graph
+    mountPath: /docker-graph


### PR DESCRIPTION
- enable latest stable debian docker in kubekins-e2e behind a build arg, enable it for experimental images (so not k/k master, but places like test-infra)
- bump the experimental image
- optimize the kind CI job to:
  - flush memory after building (the same as kubetest)
  - use the new experimental image with newer docker
  - make better resource requests
  - use a new preset for in-memory docker graph (which will hopefully make nested containers faster)

/cc @munnerz 