### PR TITLE
Make Tide use a higher diff weight for more critical requirement differences.

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -74,11 +74,12 @@ func (sc *statusController) shutdown() {
 // requirementDiff calculates the diff between a PR and a TideQuery.
 // This diff is defined with a string that describes some subset of the
 // differences and an integer counting the total number of differences.
-// The diff count should always reflect the total number of differences between
+// The diff count should always reflect the scale of the differences between
 // the current state of the PR and the query, but the message returned need not
 // attempt to convey all of that information if some differences are more severe.
 // For instance, we need to convey that a PR is open against a forbidden branch
 // more than we need to detail which status contexts are failed against the PR.
+// To this end, some differences are given a higher diff weight than others.
 // Note: an empty diff can be returned if the reason that the PR does not match
 // the TideQuery is unknown. This can happen happen if this function's logic
 // does not match GitHub's and does not indicate that the PR matches the query.
@@ -99,26 +100,40 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 		return labels[:i]
 	}
 
+	// Weight incorrect branches with very high diff so that we select the query
+	// for the correct branch.
+	targetBranchBlacklisted := false
 	for _, excludedBranch := range q.ExcludedBranches {
 		if string(pr.BaseRef.Name) == excludedBranch {
-			desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)
-			diff = 1
+			targetBranchBlacklisted = true
+			break
 		}
 	}
-
 	// if no whitelist is configured, the target is OK by default
 	targetBranchWhitelisted := len(q.IncludedBranches) == 0
 	for _, includedBranch := range q.IncludedBranches {
 		if string(pr.BaseRef.Name) == includedBranch {
 			targetBranchWhitelisted = true
+			break
+		}
+	}
+	if targetBranchBlacklisted || !targetBranchWhitelisted {
+		diff += 1000
+		if desc == "" {
+			desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)
 		}
 	}
 
-	if !targetBranchWhitelisted {
-		desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)
-		diff++
+	// Weight incorrect milestone with relatively high diff so that we select the
+	// query for the correct milestone (but choose favor query for correct branch).
+	if q.Milestone != "" && (pr.Milestone == nil || string(pr.Milestone.Title) != q.Milestone) {
+		diff += 100
+		if desc == "" {
+			desc = fmt.Sprintf(" Must be in milestone %s.", q.Milestone)
+		}
 	}
 
+	// Weight incorrect labels and statues with low (normal) diff values.
 	var missingLabels []string
 	for _, l1 := range q.Labels {
 		var found bool
@@ -180,13 +195,6 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 			desc = fmt.Sprintf(" Job %s has not succeeded.", trunced[0])
 		} else {
 			desc = fmt.Sprintf(" Jobs %s have not succeeded.", strings.Join(trunced, ", "))
-		}
-	}
-
-	if q.Milestone != "" && (pr.Milestone == nil || string(pr.Milestone.Title) != q.Milestone) {
-		diff++
-		if desc == "" {
-			desc = fmt.Sprintf(" Must be in milestone %s.", q.Milestone)
 		}
 	}
 


### PR DESCRIPTION
Tide is adding the status `Pending — Not mergeable. Merging to branch master is forbidden.` to PRs that *do* have a query for the `master` branch. This is occurring because Tide chooses the query that the PR is 'closest' to matching and compares against that query. In order to force Tide to favor queries that match the branch, and then favor queries that match the milestone even if there are fewer label differences with a different query, I increased the weight of the diff value for incorrect branches and incorrect milestones.

I used 2 orders of magnitude to distinguish significant differences from non significant differences and made branches 1 order of magnitude more significant than milestones.

/kind bug
/cc @cblecker @tpepper @BenTheElder @stevekuznetsov 