### PR TITLE
add a non-generic alias to the service account key path

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -468,6 +468,10 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/service-account/service-account.json
+  # storage e2e tests borrow this as a preconfigured key instead of creating and
+  # injecting a new key. this allows us to avoid mass key download warnings
+  - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/service-account/service-account.json
   volumes:
   - name: service
     secret:
@@ -480,6 +484,10 @@ presets:
     preset-gke-alpha-service: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/service-account/service-account.json
+  # storage e2e tests borrow this as a preconfigured key instead of creating and
+  # injecting a new key. this allows us to avoid mass key download warnings
+  - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/service-account/service-account.json
   volumes:
   - name: service
@@ -494,6 +502,10 @@ presets:
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /etc/service-account/istio-service-account.json
+  # storage e2e tests borrow this as a preconfigured key instead of creating and
+  # injecting a new key. this allows us to avoid mass key download warnings
+  - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/service-account/service-account.json
   volumes:
   - name: service
     secret:


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/pull/68253

This PR adds `E2E_GOOGLE_APPLICATION_CREDENTIALS` as an alias to the CI resources service account, so that the storage tests can consume this if present. `GOOGLE_APPLICATION_CREDENTIALS` is a standard key so it's presence is not sufficient to switch to a preconfigured key instead of generating and injecting a new one

/area config