### PR TITLE
Add code_search_path to TestGroup.

### DIFF
--- a/testgrid/cmd/configurator/yaml2proto.go
+++ b/testgrid/cmd/configurator/yaml2proto.go
@@ -70,7 +70,9 @@ func ReconcileTestGroup(currentTestGroup *config.TestGroup, defaultTestGroup *co
 	if currentTestGroup.NumFailuresToAlert == 0 {
 		currentTestGroup.NumFailuresToAlert = defaultTestGroup.NumFailuresToAlert
 	}
-
+	if currentTestGroup.CodeSearchPath == "" {
+		currentTestGroup.CodeSearchPath = defaultTestGroup.CodeSearchPath
+	}
 	if currentTestGroup.NumPassesToDisableAlert == 0 {
 		currentTestGroup.NumPassesToDisableAlert = defaultTestGroup.NumPassesToDisableAlert
 	}

--- a/testgrid/config.proto
+++ b/testgrid/config.proto
@@ -46,7 +46,7 @@ message Notification {
 
 // Specifies a group of tests to gather.
 message TestGroup {
-  reserved 5, 7, 8, 10, 13, 14, 16 to 23, 28 to 37;
+  reserved 5, 7, 8, 10, 13, 16 to 23, 28 to 37;
 
   // Name of this TestGroup, for mapping dashboard tabs to tests.
   string name = 1;
@@ -88,6 +88,10 @@ message TestGroup {
   // The number of consecutive test result failures to see before alerting of
   // a consistent failure. If zero, no alerts are raised.
   int32 num_failures_to_alert = 12;
+
+  // Default code search path for searching regressions. Overridden by
+  // code_search_path in DashboardTab.
+  string code_search_path = 14;
 
   // The number of columns to consider "recent" for a variety of purposes.
   int32 num_columns_recent = 15;
@@ -158,7 +162,9 @@ message DashboardTab {
   // Default bug component for manually filing bugs from the dashboard
   int32 bug_component = 3;
 
-  // Default code search path for changelist search links
+  // Default code search path for searching regressions. This value overrides
+  // the default in the TestGroup config so that dashboards may be customized
+  // separately.
   string code_search_path = 4;
 
   // See TestGroup.num_columns_recent. This value overrides the default in the

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -23,6 +23,7 @@ default_test_group:
   alert_stale_results_hours: 0 # Don't alert for staleness by default.
   num_failures_to_alert: 3 # Consider a test failed if it has 3 or more consecutive failures.
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes.
+  code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
 
 default_dashboard_tab:
   open_test_template: # The URL template to visit after clicking on a cell


### PR DESCRIPTION
Adding this to TestGroup since we sometimes need some reasonable default specified here, and not just in the DashboardTab. (Ideally this wouldn't be the case, but that's not how it goes right now).