### PR TITLE
Make Tide initially search for open PRs in individual orgs/repos instead of all orgs/repos.

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -176,20 +176,6 @@ func (tq *TideQuery) Query() string {
 	return strings.Join(toks, " ")
 }
 
-// AllOpenPRs returns all open PRs in the repos covered by the query.
-func (tqs TideQueries) AllOpenPRs() string {
-	toks := []string{"is:pr", "state:open"}
-
-	orgs, repos := tqs.OrgsAndRepos()
-	for _, o := range orgs.List() {
-		toks = append(toks, fmt.Sprintf("org:\"%s\"", o))
-	}
-	for _, r := range repos.List() {
-		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
-	}
-	return strings.Join(toks, " ")
-}
-
 // OrgsAndRepos returns the set of orgs and repos present in any query.
 func (tqs TideQueries) OrgsAndRepos() (sets.String, sets.String) {
 	orgs := sets.NewString()

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -54,43 +54,6 @@ func TestTideQuery(t *testing.T) {
 	checkTok("review:approved")
 }
 
-func TestAllOpenPRs(t *testing.T) {
-	var q string
-	checkTok := func(tok string, shouldExist bool) {
-		if shouldExist == strings.Contains(q, " "+tok+" ") {
-			return
-		} else if shouldExist {
-			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
-		} else {
-			t.Errorf("Expected query to not contain \"%s\", got \"%s\"", tok, q)
-
-		}
-	}
-
-	queries := TideQueries([]TideQuery{
-		testQuery,
-		{
-			Orgs:   []string{"foo"},
-			Repos:  []string{"k/foo"},
-			Labels: []string{"lgtm", "mergeable"},
-		},
-	})
-	q = " " + queries.AllOpenPRs() + " "
-	checkTok("is:pr", true)
-	checkTok("state:open", true)
-	checkTok("org:\"org\"", true)
-	checkTok("org:\"foo\"", true)
-	checkTok("repo:\"k/k\"", true)
-	checkTok("repo:\"k/t-i\"", true)
-	checkTok("repo:\"k/foo\"", true)
-	checkTok("label:\"lgtm\"", false)
-	checkTok("label:\"approved\"", false)
-	checkTok("label:\"mergeable\"", false)
-	checkTok("-label:\"foo\"", false)
-	checkTok("milestone:\"milestone\"", false)
-	checkTok("review:approved", false)
-}
-
 func TestMergeMethod(t *testing.T) {
 	ti := &Tide{
 		MergeType: map[string]github.PullRequestMergeType{

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -62,6 +62,12 @@ type statusController struct {
 	// cheaper.
 	lastSuccessfulQueryStart time.Time
 
+	// trackedOrgs and trackedRepos are the sets of orgs and repos that are
+	// 'up to date' on, in the sense that we have already processed all open PRs
+	// updated before lastSuccessfulQueryStart for these orgs and repos.
+	trackedOrgs  sets.String
+	trackedRepos sets.String
+
 	sync.Mutex
 	poolPRs map[string]PullRequest
 }
@@ -360,19 +366,79 @@ func (sc *statusController) sync(pool map[string]PullRequest) {
 		tideMetrics.statusUpdateDuration.Set(duration.Seconds())
 	}()
 
-	// Query for PRs changed since the last time we successfully queried.
+	sc.setStatuses(sc.search(), pool)
+}
+
+func (sc *statusController) search() []PullRequest {
+	orgs, repos := sc.ca.Config().Tide.Queries.OrgsAndRepos()
+	freshOrgs, freshRepos := orgs.Difference(sc.trackedOrgs), repos.Difference(sc.trackedRepos)
+	oldOrgs, oldRepos := sc.trackedOrgs.Difference(orgs), sc.trackedRepos.Difference(repos)
+	// Stop tracking orgs and repos that aren't queried this loop.
+	sc.trackedOrgs.Delete(oldOrgs.UnsortedList()...)
+	sc.trackedRepos.Delete(oldRepos.UnsortedList()...)
+	// Determine the query for tracked PRs now before we modify 'trackedOrgs' and 'trackedRepos'.
+	var trackedQuery string
+	if sc.trackedOrgs.Len() > 0 || sc.trackedRepos.Len() > 0 {
+		trackedQuery = openPRsQuery(sc.trackedOrgs.UnsortedList(), sc.trackedRepos.UnsortedList())
+	}
+	queryStartTime := time.Now()
+
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+	var allPRs []PullRequest
+	// Query fresh orgs and repos individually and since the beginning of time.
+	// These queries are larger and more likely to fail so we query for targets individually.
+	singleTargetSearch := func(query, target string, tracked sets.String) {
+		defer wg.Done()
+		searcher := newSearchExecutor(context.Background(), sc.ghc, sc.logger, query)
+		prs, err := searcher.search()
+		if err != nil {
+			sc.logger.WithError(err).Errorf("Searching for open PRs in %s.", target)
+			return
+		}
+		func() {
+			lock.Lock()
+			defer lock.Unlock()
+			allPRs = append(allPRs, prs...)
+			tracked.Insert(target)
+		}()
+	}
+
+	wg.Add(freshOrgs.Len() + freshRepos.Len())
+	for _, org := range freshOrgs.UnsortedList() {
+		go singleTargetSearch(openPRsQuery([]string{org}, nil), org, sc.trackedOrgs)
+	}
+	for _, repo := range freshRepos.UnsortedList() {
+		go singleTargetSearch(openPRsQuery(nil, []string{repo}), repo, sc.trackedRepos)
+	}
+	wg.Wait()
+
+	// Query tracked orgs and repos together and only since the last time we queried.
 	// We offset for 30 seconds of overlap because GitHub sometimes doesn't
 	// include recently changed/new PRs in the query results.
-	sinceTime := sc.lastSuccessfulQueryStart.Add(-30 * time.Second)
-	query := sc.ca.Config().Tide.Queries.AllOpenPRs()
-	queryStartTime := time.Now()
-	searcher := newSearchExecutor(context.Background(), sc.ghc, sc.logger, query)
-	allPRs, err := searcher.searchSince(sinceTime)
-	if err != nil {
-		sc.logger.WithError(err).Errorf("Searching for open PRs.")
-		return
+	if trackedQuery != "" {
+		sinceTime := sc.lastSuccessfulQueryStart.Add(-30 * time.Second)
+		searcher := newSearchExecutor(context.Background(), sc.ghc, sc.logger, trackedQuery)
+		prs, err := searcher.searchSince(sinceTime)
+		if err != nil {
+			sc.logger.WithError(err).Error("Searching for open PRs from 'tracked' orgs and repos.")
+		} else {
+			allPRs = append(allPRs, prs...)
+		}
 	}
+
 	// We were able to find all open PRs so update the last successful query time.
 	sc.lastSuccessfulQueryStart = queryStartTime
-	sc.setStatuses(allPRs, pool)
+	return allPRs
+}
+
+func openPRsQuery(orgs, repos []string) string {
+	toks := []string{"is:pr", "state:open"}
+	for _, o := range orgs {
+		toks = append(toks, fmt.Sprintf("org:\"%s\"", o))
+	}
+	for _, r := range repos {
+		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
+	}
+	return strings.Join(toks, " ")
 }

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -18,6 +18,7 @@ package tide
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	githubql "github.com/shurcooL/githubv4"
@@ -437,4 +438,21 @@ func TestTargetUrl(t *testing.T) {
 			t.Errorf("%s: expected target URL %s but got %s", tc.name, expected, actual)
 		}
 	}
+}
+
+func TestAllOpenPRs(t *testing.T) {
+	var q string
+	checkTok := func(tok string) {
+		if !strings.Contains(q, " "+tok+" ") {
+			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
+		}
+	}
+
+	q = " " + openPRsQuery([]string{"k8s", "kuber"}, []string{"k8s/k8s", "k8s/t-i"}) + " "
+	checkTok("is:pr")
+	checkTok("state:open")
+	checkTok("org:\"k8s\"")
+	checkTok("org:\"kuber\"")
+	checkTok("repo:\"k8s/k8s\"")
+	checkTok("repo:\"k8s/t-i\"")
 }

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -188,6 +188,9 @@ func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, ca *confi
 		ca:             ca,
 		newPoolPending: make(chan bool, 1),
 		shutDown:       make(chan bool),
+
+		trackedOrgs:  sets.NewString(),
+		trackedRepos: sets.NewString(),
 	}
 	go sc.run()
 	return &Controller{


### PR DESCRIPTION
I tested this out locally in dry-run mode. It doesn't completely avoid the errors, but the status controller gets past them pretty quickly now. This change also allows us to set statuses on some orgs and repos instead of aborting if we fail to search for open PRs in a single repo.

/kind bug
/cc @stevekuznetsov @BenTheElder 