### PR TITLE
kind: put built kubectl in path before testing, cleanup test script, ...

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kind.yaml
@@ -46,3 +46,55 @@ periodics:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+# conformance test against kubernetes master branch with `kind`, skipping
+# serial tests so it runs in ~20m
+- interval: 20m
+  name: ci-kubernetes-kind-conformance-parallel
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=master"
+      - "--repo=k8s.io/test-infra=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../test-infra/experiment/kind-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory

--- a/config/jobs/kubernetes/sig-testing/kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kind.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
-    preset-dind-memory-backed: "true"
+    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20180907-890a61046-experimental

--- a/config/jobs/kubernetes/sig-testing/kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kind.yaml
@@ -20,11 +20,10 @@ periodics:
       - "--scenario=execute"
       - "--"
       - "./../test-infra/experiment/kind-e2e.sh"
-      # Bazel needs privileged mode in order to sandbox builds.
+      # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
+      # kind needs /lib/modules and cgroups from the host
       volumeMounts:
       - mountPath: /lib/modules
         name: modules

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2735,6 +2735,9 @@ test_groups:
 - name: ci-kubernetes-kind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kind-conformance
   num_columns_recent: 3
+- name: ci-kubernetes-kind-conformance-parallel
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kind-conformance-parallel
+  num_columns_recent: 3
 
 # cloud-provider-openstack e2e conformance tests
 # name format: PR trigger ci-presubmit-${zuul-job-name}
@@ -2873,6 +2876,9 @@ dashboards:
   - name: kind, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance
+  - name: kind, master (dev) [non-serial]
+    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
+    test_group_name: ci-kubernetes-kind-conformance-parallel
   - name: local-up-cluster, master (dev)
     description: Runs conformance tests using kubetest with hack/local-up-cluster.sh
     test_group_name: ci-kubernetes-local-e2e
@@ -2948,6 +2954,9 @@ dashboards:
   - name: kind, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance
+  - name: kind, master (dev) [non-serial]
+    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
+    test_group_name: ci-kubernetes-kind-conformance-parallel
   - name: local-up-cluster, master (dev)
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e


### PR DESCRIPTION
... and switch back to normal emptyDir preset for dind
... and add a parallel / non-serial conformance suite job for faster feedback on k/k master (~20m)

I noticed in the logs that the gcloud `kubectl` was being used instead of the built kubectl, this fixes that by finding the built kubectl and putting it in the path

test run here: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-kind-conformance/115/