### PR TITLE
Fix gke-canary extract target to point to latest gke releases

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -201,7 +201,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=gke-latest-1.8
+      - --extract=gke-latest
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel


### PR DESCRIPTION
currently busted: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-canary/19501/ because 1.8 is no longer supported.

/assign @amwat @BenTheElder 