### PR TITLE
make podutil canary run more tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -155,8 +155,8 @@ periodics:
       - --gcp-nodes=2
       - --gcp-zone=us-central1-f
       - --provider=gce
-      - --test_args=--ginkgo.focus=Variable.Expansion --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
-      - --timeout=40m
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 


### PR DESCRIPTION
The current one does basically nothing :-) let's run some actual e2e test cases to see if stuff like ssh keys are populated properly.

/assign @BenTheElder @Katharine @stevekuznetsov 