### PR TITLE
Prow: Improve labelling resources with job names

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -32,14 +32,12 @@ import (
 )
 
 const (
-	jobNameLabel = "prow.k8s.io/job"
-	jobTypeLabel = "prow.k8s.io/type"
-	orgLabel     = "prow.k8s.io/refs.org"
-	repoLabel    = "prow.k8s.io/refs.repo"
-	pullLabel    = "prow.k8s.io/refs.pull"
+	orgLabel  = "prow.k8s.io/refs.org"
+	repoLabel = "prow.k8s.io/refs.repo"
+	pullLabel = "prow.k8s.io/refs.pull"
 )
 
-// NewProwJob initializes a ProwJob out of a ProwJobSpec with annotations.
+// NewProwJobWithAnnotation initializes a ProwJob out of a ProwJobSpec with annotations.
 func NewProwJobWithAnnotation(spec kube.ProwJobSpec, labels, annotations map[string]string) kube.ProwJob {
 	return newProwJob(spec, labels, annotations)
 }
@@ -50,9 +48,18 @@ func NewProwJob(spec kube.ProwJobSpec, labels map[string]string) kube.ProwJob {
 }
 
 func newProwJob(spec kube.ProwJobSpec, labels, annotations map[string]string) kube.ProwJob {
+	jobNameForLabel := spec.Job
+	if len(jobNameForLabel) > validation.LabelValueMaxLength {
+		jobNameForLabel = spec.Job[:validation.LabelValueMaxLength]
+		logrus.Warnf("Cannot use full job name '%s' for '%s' label, will be truncated to '%s'",
+			spec.Job,
+			kube.ProwJobAnnotation,
+			jobNameForLabel,
+		)
+	}
 	allLabels := map[string]string{
-		jobNameLabel: spec.Job,
-		jobTypeLabel: string(spec.Type),
+		kube.ProwJobAnnotation: jobNameForLabel,
+		kube.ProwJobTypeLabel:  string(spec.Type),
 	}
 	if spec.Type != kube.PeriodicJob {
 		allLabels[orgLabel] = spec.Refs.Org
@@ -64,6 +71,12 @@ func newProwJob(spec kube.ProwJobSpec, labels, annotations map[string]string) ku
 	for key, value := range labels {
 		allLabels[key] = value
 	}
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[kube.ProwJobAnnotation] = spec.Job
 
 	// let's validate labels
 	for key, value := range allLabels {

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -279,6 +279,27 @@ func TestNewProwJob(t *testing.T) {
 				"prow.k8s.io/refs.repo": "repo",
 				"prow.k8s.io/refs.pull": "1",
 			},
+		}, {
+			name: "job with name too long to fit in a label",
+			spec: kube.ProwJobSpec{
+				Job:  "job-created-by-someone-who-loves-very-very-very-long-names-so-long-that-it-does-not-fit-into-the-Kubernetes-label-so-it-needs-to-be-truncated-to-63-characters",
+				Type: kube.PresubmitJob,
+				Refs: &kube.Refs{
+					Org:  "org",
+					Repo: "repo",
+					Pulls: []kube.Pull{
+						{Number: 1},
+					},
+				},
+			},
+			labels: map[string]string{},
+			expectedLabels: map[string]string{
+				"prow.k8s.io/job":       "job-created-by-someone-who-loves-very-very-very-long-names-so-l",
+				"prow.k8s.io/type":      "presubmit",
+				"prow.k8s.io/refs.org":  "org",
+				"prow.k8s.io/refs.repo": "repo",
+				"prow.k8s.io/refs.pull": "1",
+			},
 		},
 	}
 
@@ -306,11 +327,13 @@ func TestNewProwJobWithAnnotations(t *testing.T) {
 				Job:  "job",
 				Type: kube.PeriodicJob,
 			},
-			annotations:         nil,
-			expectedAnnotations: nil,
+			annotations: nil,
+			expectedAnnotations: map[string]string{
+				"prow.k8s.io/job": "job",
+			},
 		},
 		{
-			name: "job with empty annotation",
+			name: "job with annotation",
 			spec: kube.ProwJobSpec{
 				Job:  "job",
 				Type: kube.PeriodicJob,
@@ -319,7 +342,8 @@ func TestNewProwJobWithAnnotations(t *testing.T) {
 				"annotation": "foo",
 			},
 			expectedAnnotations: map[string]string{
-				"annotation": "foo",
+				"annotation":      "foo",
+				"prow.k8s.io/job": "job",
 			},
 		},
 	}

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -1,6 +1,8 @@
 apiVersion: prow.k8s.io/v1
 kind: ProwJob
 metadata:
+  annotations:
+    prow.k8s.io/job: kubernetes-defaulted-decoration
   creationTimestamp: null
   labels:
     prow.k8s.io/job: kubernetes-defaulted-decoration

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -1,6 +1,8 @@
 apiVersion: prow.k8s.io/v1
 kind: ProwJob
 metadata:
+  annotations:
+    prow.k8s.io/job: kubernetes-explicit-decoration
   creationTimestamp: null
   labels:
     prow.k8s.io/job: kubernetes-explicit-decoration

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -1,6 +1,8 @@
 apiVersion: prow.k8s.io/v1
 kind: ProwJob
 metadata:
+  annotations:
+    prow.k8s.io/job: kubernetes-no-decoration
   creationTimestamp: null
   labels:
     prow.k8s.io/job: kubernetes-no-decoration


### PR DESCRIPTION
Previously, `pjutil` attempted to label ProwJob resources with job
name, but when the job name was longer than 63 characters, the label was
not applied (because labels have a 63 character cap).

Apply truncated job name as a label in this case, which is better than
no label. Full job name is now always present as an annotation with the
same key, just like `pod-utils/decorate` does this.