### PR TITLE
Re-enable webhook status reporting

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -32,7 +32,6 @@ import (
 
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -96,7 +95,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -33,7 +33,9 @@ import (
 	"k8s.io/test-infra/prow/external-plugins/needs-rebase/plugin"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/hook"
+	// TODO: Remove the need for this import; it's currently required to allow the plugin config loader to function correctly (it expects plugins to be initialised)
+	// See https://github.com/kubernetes/test-infra/pull/8933#issuecomment-411511180
+	_ "k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -113,7 +115,7 @@ type Server struct {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO: Move webhook handling logic out of hook binary so that we don't have to import all
 	// plugins just to validate the webhook.
-	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -29,7 +29,6 @@ import (
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -62,7 +61,7 @@ type server struct {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
 	if !ok {
 		return
 	}

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
+	"strconv"
 )
 
 // Server implements http.Handler. It validates incoming GitHub webhooks and
@@ -50,7 +51,15 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok := ValidateWebhook(w, r, s.TokenGenerator())
+	eventType, eventGUID, payload, ok, resp := github.ValidateWebhook(w, r, s.TokenGenerator())
+	if counter, err := s.Metrics.WebhookCounter.GetMetricWithLabelValues(strconv.Itoa(resp)); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"status-code": resp,
+		}).WithError(err).Warn("Failed to get metric for reporting webhook status code")
+	} else {
+		counter.Inc()
+	}
+
 	if !ok {
 		return
 	}
@@ -59,73 +68,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := s.demuxEvent(eventType, eventGUID, payload, r.Header); err != nil {
 		logrus.WithError(err).Error("Error parsing event.")
 	}
-}
-
-// ValidateWebhook ensures that the provided request conforms to the
-// format of a Github webhook and the payload can be validated with
-// the provided hmac secret. It returns the event type, the event guid,
-// the payload of the request, and whether the webhook is valid or not.
-func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) (string, string, []byte, bool) {
-	defer r.Body.Close()
-
-	// Our health check uses GET, so just kick back a 200.
-	if r.Method == http.MethodGet {
-		return "", "", nil, false
-	}
-
-	// Header checks: It must be a POST with an event type and a signature.
-	if r.Method != http.MethodPost {
-		resp := "405 Method not allowed"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusMethodNotAllowed)
-		return "", "", nil, false
-	}
-	eventType := r.Header.Get("X-GitHub-Event")
-	if eventType == "" {
-		resp := "400 Bad Request: Missing X-GitHub-Event Header"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusBadRequest)
-		return "", "", nil, false
-	}
-	eventGUID := r.Header.Get("X-GitHub-Delivery")
-	if eventGUID == "" {
-		resp := "400 Bad Request: Missing X-GitHub-Delivery Header"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusBadRequest)
-		return "", "", nil, false
-	}
-	sig := r.Header.Get("X-Hub-Signature")
-	if sig == "" {
-		resp := "403 Forbidden: Missing X-Hub-Signature"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusForbidden)
-		return "", "", nil, false
-	}
-	contentType := r.Header.Get("content-type")
-	if contentType != "application/json" {
-		resp := "400 Bad Request: Hook only accepts content-type: application/json - please reconfigure this hook on GitHub"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusBadRequest)
-		return "", "", nil, false
-	}
-
-	payload, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		resp := "500 Internal Server Error: Failed to read request body"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusInternalServerError)
-		return "", "", nil, false
-	}
-
-	// Validate the payload with our HMAC secret.
-	if !github.ValidatePayload(payload, sig, hmacSecret) {
-		resp := "403 Forbidden: Invalid X-Hub-Signature"
-		logrus.Debug(resp)
-		http.Error(w, resp, http.StatusForbidden)
-		return "", "", nil, false
-	}
-
-	return eventType, eventGUID, payload, true
 }
 
 func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.Header) error {


### PR DESCRIPTION
This PR re-implements https://github.com/kubernetes/test-infra/pull/8931 and https://github.com/kubernetes/test-infra/pull/8933, which were reverted due to an issue where `needs-rebase` would break down with a real-world configuration file, as plugin loading has an implicit dependency on Hook's side-effect imports of all plugins.

To temporarily patch this, I've kept a side-effect import of hook in needs-rebase, which is the same approach used in `cmd/checkconfig`.

Sadly these imports can't be done inside the `plugins` package due to a circular dependency. I think a possible cleaner fix for this is to extract the plugin config loading into a different package, which itself imports all of the plugins. This would remove the gotcha factor, and mean that a package which wants to load plugin config won't have to do a separate side-effect import. I'll assess the viability of doing that and send up another PR if it's possible to split the code without exposing too many private things in `plugins`.