### PR TITLE
remove soak-stable2 from release-blocking dashboard

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4285,8 +4285,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-reboot
   - name: gke-cos-1.10-reboot
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable2-reboot
-  - name: soak-gci-gce-1.10
-    test_group_name: ci-kubernetes-soak-gci-gce-stable2
   - name: gci-gce-scalability-1.10
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-stable2
   - name: gce-device-plugin-gpu-1.10


### PR DESCRIPTION
you can still find the soak job in https://k8s-testgrid.appspot.com/sig-release-1.10-all#soak-gci-gce-1.10

/assign @MaciekPytel