### PR TITLE
Add --dump-pre-test-logs option to kubetest.

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -67,6 +67,7 @@ type options struct {
 	dindImage           string
 	down                bool
 	dump                string
+	dumpPreTestLogs     string
 	extract             extractStrategies
 	extractFederation   extractFederationStrategies
 	extractSource       bool
@@ -132,7 +133,8 @@ func defineFlags() *options {
 	flag.StringVar(&o.deployment, "deployment", "bash", "Choices: none/bash/conformance/dind/gke/kops/kubernetes-anywhere/node/local")
 	flag.StringVar(&o.dindImage, "dind-image", "", "The dind image to use to start a cluster. Defaults to the docker tag produced by bazel.")
 	flag.BoolVar(&o.down, "down", false, "If true, tear down the cluster before exiting.")
-	flag.StringVar(&o.dump, "dump", "", "If set, dump cluster logs to this location on test or cluster-up failure")
+	flag.StringVar(&o.dump, "dump", "", "If set, dump bring-up and cluster logs to this location on test or cluster-up failure")
+	flag.StringVar(&o.dumpPreTestLogs, "dump-pre-test-logs", "", "If set, dump cluster logs to this location before running tests")
 	flag.Var(&o.extract, "extract", "Extract k8s binaries from the specified release location")
 	flag.Var(&o.extractFederation, "extract-federation", "Extract federation binaries from the specified release location")
 	flag.BoolVar(&o.extractSource, "extract-source", false, "Extract k8s src together with other tarballs")

--- a/kubetest/util/util.go
+++ b/kubetest/util/util.go
@@ -74,6 +74,20 @@ func InsertPath(path string) error {
 	return os.Setenv("PATH", fmt.Sprintf("%v:%v", path, os.Getenv("PATH")))
 }
 
+// OptionalAbsPath returns an absolute path if the provided path wasn't empty, and otherwise
+// returns an empty string.
+func OptionalAbsPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	if absPath, err := filepath.Abs(path); err != nil {
+		return "", fmt.Errorf("failed to make %s an absolute directory: %v", absPath, err)
+	} else {
+		return absPath, nil
+	}
+}
+
 // JoinURL converts input (gs://foo, "bar") to gs://foo/bar
 func JoinURL(urlPath, path string) (string, error) {
 	u, err := url.Parse(urlPath)

--- a/kubetest/util/util.go
+++ b/kubetest/util/util.go
@@ -81,11 +81,7 @@ func OptionalAbsPath(path string) (string, error) {
 		return "", nil
 	}
 
-	if absPath, err := filepath.Abs(path); err != nil {
-		return "", fmt.Errorf("failed to make %s an absolute directory: %v", absPath, err)
-	} else {
-		return absPath, nil
-	}
+	return filepath.Abs(path)
 }
 
 // JoinURL converts input (gs://foo, "bar") to gs://foo/bar


### PR DESCRIPTION
This PR adds a `--dump-pre-test-logs` option to kubetest, which fetches the logs from each node of the test cluster before running any tests. Unlike `--dump`, this is the _only_ thing it does; no other logs are written out. This is specifically useful for coverage-enabled tests, which require both before and after dumps to determine what precisely the test covered, while excluding any code run before the test started.

It also updates the description of `--dump` to more accurately reflect its behaviour.

/cc @BenTheElder 
/sig testing
/area kubetest