### PR TITLE
Improve Tide's queries details on Tide page and PR Dashboard

### DIFF
--- a/prow/cmd/deck/static/pr.html
+++ b/prow/cmd/deck/static/pr.html
@@ -76,9 +76,21 @@
 <dialog id="query-dialog" class="pr-status-dialog mdl-dialog">
     <h4 class="mdl-dialog__title">Query Details</h4>
     <div class="mdl-dialog__content">
-        <p class="query-details-section">All required labels</p>
+        <div id="query-detail-milestone" class="hidden">
+            <p class="detail-title">Milestone</p>
+            <p class="detail-data"></p>
+        </div>
+        <div id="query-detail-exclude" class="hidden">
+            <p class="detail-title">Exclude branches</p>
+            <p class="detail-data"></p>
+        </div>
+        <div id="query-detail-include" class="hidden">
+            <p class="detail-title">Include branches</p>
+            <p class="detail-data"></p>
+        </div>
+        <p class="detail-title">All required labels</p>
         <p id="query-all-required"></p>
-        <p class="query-details-section">All forbidden labels</p>
+        <p class="detail-title">All forbidden labels</p>
         <p id="query-all-forbidden"></p>
     </div>
     <div class="mdl-dialog__actions">

--- a/prow/cmd/deck/static/pr.html
+++ b/prow/cmd/deck/static/pr.html
@@ -81,11 +81,11 @@
             <p class="detail-data"></p>
         </div>
         <div id="query-detail-exclude" class="hidden">
-            <p class="detail-title">Exclude branches</p>
+            <p class="detail-title">Excluded branches</p>
             <p class="detail-data"></p>
         </div>
         <div id="query-detail-include" class="hidden">
-            <p class="detail-title">Include branches</p>
+            <p class="detail-title">Included branches</p>
             <p class="detail-data"></p>
         </div>
         <p class="detail-title">All required labels</p>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -560,7 +560,6 @@ Plugin Help style
 }
 
 .job-list-item.mdl-list__item {
-    height: 32px;
     min-height: 32px;
     padding: 4px;
 }

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -21,6 +21,10 @@ a:link {
     color: #3F51B5;
 }
 
+a:visited {
+    color: #3F51B5;
+}
+
 .header-title {
     margin-left: 24px;
 }
@@ -470,7 +474,7 @@ Plugin Help style
 }
 
 /*
- * User dashboard style sheet
+ * PR dashboard style sheet
  */
 #loading-progress {
     margin: 0 8px;
@@ -487,16 +491,16 @@ Plugin Help style
     text-align: center;
 }
 
-.pr-status-dialog > .mdl-dialog__content p {
-    font-size: 16px;
-}
-
 #merge-help-dialog.mdl-dialog, #status-help-dialog.mdl-dialog, #search-dialog.mdl-dialog {
     width: 600px;
 }
 
 #query-dialog.mdl-dialog {
-    width: 1000px;
+    width: 600px;
+}
+
+#query-dialog .label {
+    line-height: 18px;
 }
 
 #search-action {
@@ -666,12 +670,13 @@ Plugin Help style
 
 .pr-card.mdl-card {
     border: 1px solid #e5e5e5;
-    max-width: 1200px;
+    max-width: 800px;
     min-width: 500px;
     width: 100%;
 }
 
 .pr-card > .mdl-card__supporting-text {
+    color: #3c3c3c;
     padding-top: 0;
     width: auto;
 }
@@ -704,13 +709,31 @@ Plugin Help style
     padding-left: 8px;
 }
 
+.pr-status-dialog > .mdl-dialog__title {
+    font-size: 32px;
+}
+
+.detail-data {
+    color: #3c3c3c;
+    margin: 0;
+}
+
+.detail-branch {
+    margin-right: 8px;
+}
+
+.detail-title {
+    color: #3f51b5;
+    font-size: 16px;
+    margin: 8px 0;
+}
+
 .status {
     align-items: center;
     cursor: pointer;
     background-color: #ffffff;
     display: flex;
     font-size: 16px;
-    font-weight: bold;
     height: 24px;
     line-height: 24px;
     padding: 12px 16px 2px 17px;
@@ -771,15 +794,6 @@ Plugin Help style
 
 .search-title .mdl-button--icon .material-icons {
     font-size: 20px;
-}
-
-.query-details-section {
-    font-size: 20px;
-    font-weight: bold;
-}
-
-.pr-status-dialog > .mdl-dialog__title {
-    font-size: 32px;
 }
 
 @media (max-device-width: 768px) {


### PR DESCRIPTION
* Fixes PR & tide query matching. The matching function should take `includedBranches` and `excludedBranches` into account.
* Add information about `milestone`, `includedBranches`, `excludedBranches` to PR Dashboard Query detail & Tide page
* Minor UI treatment
* Fixes #9335
* Fixes #9361
* Screenshots:
<img width="1440" alt="screen shot 2018-09-13 at 7 07 16 pm" src="https://user-images.githubusercontent.com/24363693/45478871-4708e280-b788-11e8-85f3-9f39e4e1f514.png">

<img width="1440" alt="screen shot 2018-09-13 at 7 06 57 pm" src="https://user-images.githubusercontent.com/24363693/45478856-42442e80-b788-11e8-91e1-faf53fe82ee8.png">

![screen shot 2018-09-14 at 10 18 12 am](https://user-images.githubusercontent.com/24363693/45522656-a2c68080-b807-11e8-9000-0e6c1417dbe4.png)

/cc @BenTheElder 
/cc @stevekuznetsov 
/cc @amwat 