### PR TITLE
Disallow at mentions and keywords which close issues in commit messages

### DIFF
--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -73,6 +73,7 @@ filegroup(
         "//prow/plugins/heart:all-srcs",
         "//prow/plugins/help:all-srcs",
         "//prow/plugins/hold:all-srcs",
+        "//prow/plugins/invalidcommitmsg:all-srcs",
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -232,7 +232,7 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 		// failing commits
 		cp.PruneComments(shouldPrune(l))
 		l.Debugf("Commenting on PR to advise users of DCO check")
-		if err := gc.CreateComment(org, repo, pr.Number, fmt.Sprintf(dcoNotFoundMessage, targetURL, markdownSHAList(org, repo, commitsMissingDCO), plugins.AboutThisBot)); err != nil {
+		if err := gc.CreateComment(org, repo, pr.Number, fmt.Sprintf(dcoNotFoundMessage, targetURL, MarkdownSHAList(org, repo, commitsMissingDCO), plugins.AboutThisBot)); err != nil {
 			l.WithError(err).Warning("Could not create DCO not found comment.")
 		}
 	}
@@ -269,7 +269,8 @@ func handle(gc gitHubClient, cp commentPruner, log *logrus.Entry, org, repo stri
 	return takeAction(gc, cp, l, org, repo, pr, commitsMissingDCO, existingStatus, hasYesLabel, hasNoLabel, addComment)
 }
 
-func markdownSHAList(org, repo string, list []github.GitCommit) string {
+// MardkownSHAList prints the list of commits in a markdown-friendly way.
+func MarkdownSHAList(org, repo string, list []github.GitCommit) string {
 	lines := make([]string, len(list))
 	lineFmt := "- [%s](https://github.com/%s/%s/commits/%s) %s"
 	for i, commit := range list {

--- a/prow/plugins/invalidcommitmsg/BUILD.bazel
+++ b/prow/plugins/invalidcommitmsg/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["invalidcommitmsg.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/invalidcommitmsg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/dco:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["invalidcommitmsg_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package invalidcommitmsg adds the "do-not-merge/invalid-commit-message"
+// label on PRs containing commit messages with @mentions or
+// keywords that can automatically close issues.
+package invalidcommitmsg
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/dco"
+)
+
+const (
+	pluginName            = "invalidcommitmsg"
+	invalidCommitMsgLabel = "do-not-merge/invalid-commit-message"
+	commentBody           = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+
+**The list of commits with invalid commit messages**:
+
+%s
+
+<details>
+
+%s
+</details>
+`
+)
+
+var (
+	closeIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
+	atMentionRegex  = regexp.MustCompile(`\B([@][\w_-]+)`)
+)
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
+	return &pluginhelp.PluginHelp{
+			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages contain @ mentions or keywords which can automatically close issues.",
+		},
+		nil
+}
+
+type githubClient interface {
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	CreateComment(owner, repo string, number int, comment string) error
+	ListPRCommits(org, repo string, number int) ([]github.RepositoryCommit, error)
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.GitHubClient, pc.Logger, pr, cp)
+}
+
+func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp commentPruner) error {
+	// Only consider actions indicating that the code diffs may have changed.
+	if !hasPRChanged(pr) {
+		return nil
+	}
+
+	var (
+		org    = pr.Repo.Owner.Login
+		repo   = pr.Repo.Name
+		number = pr.Number
+	)
+
+	labels, err := gc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return err
+	}
+	hasInvalidCommitMsgLabel := github.HasLabel(invalidCommitMsgLabel, labels)
+
+	allCommits, err := gc.ListPRCommits(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("error listing commits for pull request: %v", err)
+	}
+	log.Debugf("Found %d commits in PR", len(allCommits))
+
+	var invalidCommits []github.GitCommit
+	for _, commit := range allCommits {
+		if closeIssueRegex.MatchString(commit.Commit.Message) || atMentionRegex.MatchString(commit.Commit.Message) {
+			c := commit.Commit
+			c.SHA = commit.SHA
+			invalidCommits = append(invalidCommits, c)
+		}
+	}
+
+	// if we have the label but all commits are valid,
+	// remove the label and prune comments
+	if hasInvalidCommitMsgLabel && len(invalidCommits) == 0 {
+		if err := gc.RemoveLabel(org, repo, number, invalidCommitMsgLabel); err != nil {
+			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", invalidCommitMsgLabel)
+		}
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, commentBody)
+		})
+	}
+
+	// if we don't have the label and there are invalid commits,
+	// add the label
+	if !hasInvalidCommitMsgLabel && len(invalidCommits) != 0 {
+		if err := gc.AddLabel(org, repo, number, invalidCommitMsgLabel); err != nil {
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", invalidCommitMsgLabel)
+		}
+	}
+
+	// if there are invalid commits, add a comment
+	if len(invalidCommits) != 0 {
+		// prune old comments before adding a new one
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, commentBody)
+		})
+
+		log.Debugf("Commenting on PR to advise users of invalid commit messages")
+		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(commentBody, dco.MarkdownSHAList(org, repo, invalidCommits), plugins.AboutThisBot)); err != nil {
+			log.WithError(err).Errorf("Could not create comment for invalid commit messages")
+		}
+	}
+
+	return nil
+}
+
+// hasPRChanged indicates that the code diff may have changed.
+func hasPRChanged(pr github.PullRequestEvent) bool {
+	switch pr.Action {
+	case github.PullRequestActionOpened:
+		return true
+	case github.PullRequestActionReopened:
+		return true
+	case github.PullRequestActionSynchronize:
+		return true
+	default:
+		return false
+	}
+}

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package invalidcommitmsg
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+type fakePruner struct{}
+
+func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
+
+func strP(str string) *string {
+	return &str
+}
+
+func makeFakePullRequestEvent(action github.PullRequestEventAction) github.PullRequestEvent {
+	return github.PullRequestEvent{
+		Action: action,
+		Number: 3,
+		Repo: github.Repo{
+			Owner: github.User{
+				Login: "k",
+			},
+			Name: "k",
+		},
+	}
+}
+
+func TestHandlePullRequest(t *testing.T) {
+	var testcases = []struct {
+		name string
+
+		// PR settings
+		action                       github.PullRequestEventAction
+		commits                      []github.RepositoryCommit
+		hasInvalidCommitMessageLabel bool
+
+		// expectations
+		addedLabel   string
+		removedLabel string
+		addedComment string
+	}{
+		{
+			name:   "unsupported PR action -> no-op",
+			action: github.PullRequestActionEdited,
+		},
+		{
+			name:   "contains valid message -> no-op",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "fixing k/k#9999"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "not a @ mention"}},
+			},
+			hasInvalidCommitMessageLabel: false,
+		},
+		{
+			name:   "msg contains invalid keywords -> add label and comment",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
+				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
+				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+			},
+			hasInvalidCommitMessageLabel: false,
+
+			addedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			addedComment: `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+
+**The list of commits with invalid commit messages**:
+
+- [sha1](https://github.com/k/k/commits/sha1) this is a @mention
+- [sha2](https://github.com/k/k/commits/sha2) this @menti-on has a hyphen
+- [sha3](https://github.com/k/k/commits/sha3) this @Menti-On has mixed case letters
+- [sha4](https://github.com/k/k/commits/sha4) fixes k/k#9999
+- [sha5](https://github.com/k/k/commits/sha5) Close k/k#9999
+- [sha6](https://github.com/k/k/commits/sha6) resolved k/k#9999
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`,
+		},
+		{
+			name:   "msg does not contain invalid keywords but has label -> remove label",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			hasInvalidCommitMessageLabel: true,
+
+			removedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := makeFakePullRequestEvent(tc.action)
+			fc := &fakegithub.FakeClient{
+				PullRequests:  map[int]*github.PullRequest{event.Number: &event.PullRequest},
+				IssueComments: make(map[int][]github.IssueComment),
+				CommitMap: map[string][]github.RepositoryCommit{
+					"k/k#3": tc.commits,
+				},
+			}
+
+			if tc.hasInvalidCommitMessageLabel {
+				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel))
+			}
+			if err := handle(fc, logrus.WithField("plugin", pluginName), event, &fakePruner{}); err != nil {
+				t.Errorf("For case %s, didn't expect error from invalidcommitmsg plugin: %v", tc.name, err)
+			}
+
+			ok := tc.addedLabel == ""
+			if !ok {
+				for _, label := range fc.IssueLabelsAdded {
+					if reflect.DeepEqual(tc.addedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to add: %#v, Got %#v in case %s.", tc.addedLabel, fc.IssueLabelsAdded, tc.name)
+			}
+
+			ok = tc.removedLabel == ""
+			if !ok {
+				for _, label := range fc.IssueLabelsRemoved {
+					if reflect.DeepEqual(tc.removedLabel, label) {
+						ok = true
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected to remove: %#v, Got %#v in case %s.", tc.removedLabel, fc.IssueLabelsRemoved, tc.name)
+			}
+
+			comments := fc.IssueCommentsAdded
+			if len(comments) == 0 && tc.addedComment != "" {
+				t.Errorf("Expected comment with body %q to be added, but it was not", tc.addedComment)
+				return
+			}
+			if len(comments) > 1 {
+				t.Errorf("did not expect more than one comment to be created")
+			}
+			if len(comments) != 0 && comments[0] != tc.addedComment {
+				t.Errorf("expected comment to be \n%q\n but it was \n%q\n", tc.addedComment, comments[0])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/9360

This PR introduces a "invalidcommitmsg" plugin that adds the `do-not-merge/invalid-commit-message` label on PRs which have commit messages containing `@mentions` and keywords that automatically close issues.

Adding an explicit hold because this adds a new label and this should go through some other channels first.
/hold

This needs follow-ups:

- [ ] Communicate about the label in appropriate channels.
- [ ] Update the labels in `label_sync`.
- [ ] Add the plugin to the hook binary.
- [ ] Bump prow.
- [ ] Enable the plugin in `plugins.yaml`.
- [ ] Add info about this in the contributor guide.