### PR TITLE
CRI-O: fix bucket suffix

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5345,17 +5345,9 @@ dashboards:
   dashboard_tab:
   - name: crio-e2e-fedora
     test_group_name: test_pull_request_crio_e2e_fedora
-    open_test_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10
   - name: crio-e2e-rhel
     test_group_name: test_pull_request_crio_e2e_rhel
-    open_test_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10
 
 - name: sig-node-containerd


### PR DESCRIPTION
We do have `.txt` suffixed gs links at https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel/ 
This PR fixes links retrieval by appending `.txt`.
You can see it's failing to use the correct link by going here https://k8s-testgrid.appspot.com/sig-node-cri-o#crio-e2e-rhel and clicking the red square for a build.
It should redirect (on click) to https://storage.googleapis.com/origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel/1352.txt instead and this PR does that.

@stevekuznetsov @mrunalp  @BenTheElder @krzyzacy PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>