### PR TITLE
Add area/prow/pubsub label

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -192,6 +192,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/prow/phony" href="#area/prow/phony">`area/prow/phony`</a> | Issues or PRs related to prow's phony component| label | |
 | <a id="area/prow/plank" href="#area/prow/plank">`area/prow/plank`</a> | Issues or PRs related to prow's plank component| label | |
 | <a id="area/prow/pod-utilities" href="#area/prow/pod-utilities">`area/prow/pod-utilities`</a> | Issues or PRs related to prow's pod-utilities component| label | |
+| <a id="area/prow/pubsub" href="#area/prow/pubsub">`area/prow/pubsub`</a> | Issues or PRs related to prow's pubsub reporter component| label | |
 | <a id="area/prow/sidecar" href="#area/prow/sidecar">`area/prow/sidecar`</a> | Issues or PRs related to prow's sidecar component| label | |
 | <a id="area/prow/sinker" href="#area/prow/sinker">`area/prow/sinker`</a> | Issues or PRs related to prow's sinker component| label | |
 | <a id="area/prow/splice" href="#area/prow/splice">`area/prow/splice`</a> | Issues or PRs related to prow's splice component| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -830,6 +830,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to prow's pubsub reporter component
+        name: area/prow/pubsub
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to prow's sidecar component
         name: area/prow/sidecar
         target: both

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -653,6 +653,11 @@
     color: #ffffff;
 }
 
+.areax00002fprowx00002fpubsub {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fprowx00002fsidecar {
     background-color: #0052cc;
     color: #ffffff;


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/pull/9262

Add label `area/prow/pubsub` for tracking progress on the pubsub reporter.