### PR TITLE
Add a configuration option to go lint min confidence

### DIFF
--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -136,7 +136,7 @@ func TestLint(t *testing.T) {
 			},
 		},
 	}
-	if err := handle(gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
+	if err := handle(0, gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
 		t.Fatalf("Got error from handle: %v", err)
 	}
 	if len(gh.comment.Comments) != 2 {
@@ -150,7 +150,7 @@ func TestLint(t *testing.T) {
 			Body:     c.Body,
 		})
 	}
-	if err := handle(gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
+	if err := handle(0, gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
 		t.Fatalf("Got error from handle on second try: %v", err)
 	}
 	if len(gh.comment.Comments) != 0 {
@@ -170,7 +170,7 @@ func TestLint(t *testing.T) {
 		t.Fatalf("Adding PR commit: %v", err)
 	}
 	gh.oldComments = nil
-	if err := handle(gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
+	if err := handle(0, gh, c, logrus.NewEntry(logrus.New()), e); err != nil {
 		t.Fatalf("Got error from handle on third try: %v", err)
 	}
 	if len(gh.comment.Comments) != maxComments {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -167,6 +167,7 @@ type Configuration struct {
 	Cat                  Cat                    `json:"cat,omitempty"`
 	CherryPickUnapproved CherryPickUnapproved   `json:"cherry_pick_unapproved,omitempty"`
 	ConfigUpdater        ConfigUpdater          `json:"config_updater,omitempty"`
+	Golint               *Golint                `json:"golint,omitempty"`
 	Heart                Heart                  `json:"heart,omitempty"`
 	Label                *Label                 `json:"label,omitempty"`
 	Lgtm                 []Lgtm                 `json:"lgtm,omitempty"`
@@ -178,6 +179,14 @@ type Configuration struct {
 	Size                 *Size                  `json:"size,omitempty"`
 	Triggers             []Trigger              `json:"triggers,omitempty"`
 	Welcome              Welcome                `json:"welcome,omitempty"`
+}
+
+// Golint holds configuration for the golint plugin
+type Golint struct {
+	// MinimumConfidence is the smallest permissible confidence
+	// in (0,1] over which problems will be printed. Defaults to
+	// 0.8, as does the `go lint` tool.
+	MinimumConfidence *float64 `json:"minimum_confidence,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -655,6 +664,11 @@ The list of patch release managers for each release can be found [here](https://
 		if rml.GracePeriod == "" {
 			c.RequireMatchingLabel[i].GracePeriod = "5s"
 		}
+	}
+
+	if c.Golint != nil && c.Golint.MinimumConfidence == nil {
+		defaultConfidence := 0.8
+		c.Golint.MinimumConfidence = &defaultConfidence
 	}
 }
 


### PR DESCRIPTION
The `go lint` tool defaults to a minimum confidence level for printing
of 0.8. The `golint` plugin uses a condfidence level of 0, i.e. no
filtering whatsoever. We have found below confidence of 0.2 irritating
and incorrect messages (like that which complains for package comments)
begin to appear. We should expose the minimum confidence and set the
default as the upstream tool does.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner @fejta @BenTheElder 
/kind bug