### PR TITLE
tide: Add merge_github_approve_tag config setting

### DIFF
--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -15,6 +15,17 @@ The following configuration fields are available:
 * `merge_method`: A key/value pair of an `org/repo` as the key and merge method to override
    the default method of merge as value. Valid options are `squash`, `rebase`, and `merge`.
    Defaults to `merge`.
+* `merge_github_approve_tag`: The tag appended to the automatic commit
+   message for each approver.  A recommended value (if you want this
+   feature at all) is `GitHub-approved-by` to make it clear that
+   entries correspond to GitHub review approval, which is distinct
+   from approval via the [`lgtm`](/prow/plugins/lgtm) and
+   [`approve`](/prow/plugins/approve) plugins.  If you set this
+   property, you probably want to [enable *Dismiss stale pull request
+   approvals when new commits are
+   pushed*][pull-request-required-reviews] for your repository to
+   avoid having tags entered for stale reviews.  Leaving the property
+   unset or setting it to an empty string will disable commit tagging.
 * `target_url`: URL for tide status contexts.
 * `pr_status_base_url`: The base URL for the PR status page. If specified, this URL is used to construct
    a link that will be used for the tide status context. It is mutually exclusive with the `target_url` field.
@@ -136,3 +147,5 @@ All commits in PRs from `github.com/kubeflow/community` repository are squashed 
 Before a PR is merged, Tide ensures that all jobs configured as required in the `presubmits` part of the `config.yaml` file are passing against the latest base branch commit, rerunning the jobs if necessary. **No job is required to be configured** in which case it's enough if a PR meets all GitHub search criteria.
 
 Semantic of individual fields of the `presubmits` is described in [prow/README.md#how-to-add-new-jobs](/prow/README.md#how-to-add-new-jobs).
+
+[pull-request-required-reviews]: https://help.github.com/articles/enabling-required-reviews-for-pull-requests/

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -80,6 +80,15 @@ type Tide struct {
 	// the default method of merge. Valid options are squash, rebase, and merge.
 	MergeType map[string]github.PullRequestMergeType `json:"merge_method,omitempty"`
 
+	// MergeGitHubApproveTag is the tag appended to the automatic commit
+	// message for each approver.  A recommended value (if you want this
+	// feature at all) is GitHub-approved-by to make it clear that entries
+	// correspond to GitHub review approval, which is distinct from
+	// approval via the 'lgtm' and 'approve' plugins.  Leaving the
+	// property unset or setting it to an empty string will disable
+	// commit tagging.
+	MergeGitHubApproveTag string `json:"merge_github_approve_tag,omitempty"`
+
 	// URL for tide status contexts.
 	// We can consider allowing this to be set separately for separate repos, or
 	// allowing it to be a template.

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1909,7 +1909,7 @@ func (c *Client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 type MergeDetails struct {
 	// CommitTitle defaults to the automatic message.
 	CommitTitle string `json:"commit_title,omitempty"`
-	// CommitMessage defaults to the automatic message.
+	// Extra detail to append to automatic commit message.
 	CommitMessage string `json:"commit_message,omitempty"`
 	// The PR HEAD must match this to prevent races.
 	SHA string `json:"sha,omitempty"`

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1964,3 +1964,28 @@ func TestPresubmitsByPull(t *testing.T) {
 		}
 	}
 }
+
+func TestApproverTags(t *testing.T) {
+	pr := &PullRequest{
+		Reviews: struct {
+			Nodes []Review
+		}{
+			Nodes: []Review{
+				{Author: Author{Login: "alice"}},
+				{Author: Author{Login: "bob", User: User{Name: "Bob"}}},
+				{Author: Author{Login: "carol", User: User{Name: "Carol", Email: "c@example.com"}}},
+				{Author: Author{Login: "dan", User: User{Email: "d@example.com"}}},
+			},
+		},
+	}
+	fmt.Printf("%v\n", pr)
+	actual := approverTags(pr, "Reviewed-by")
+	expected := `Reviewed-by: Bob <bob@users.noreply.github.com>
+Reviewed-by: Carol <c@example.com>
+Reviewed-by: alice <alice@users.noreply.github.com>
+Reviewed-by: dan <d@example.com>
+`
+	if actual != expected {
+		t.Fatalf("%s!=\n%s", actual, expected)
+	}
+}


### PR DESCRIPTION
Make it easier to find out who approved a given commit/merge by appending that information to the commit message.  Homu has something similar [to append `Approved by`][1] when it merges a pull request.  And [Git][2] and [Linux][3] both define a `Reviewed-by` tag with similar semantics to GitHub approval.  I think this would be a useful addition to Tide (obviously Homu, Git, Linux, and others think this information is worth preserving in commit messages), but it's not strictly necessary for a functioning merge queue, so I'll understand if this gets closed "we're not interested" ;).

This is pulling approvers from GitHub because we can do that with straightforward GraphQL.  Pulling approver information from comments (e.g. as processed by the `approve` plugin) would be more complicated, but I may take a stab at that later.

Another potential wrinkle is that I'm currently configuring this per-Tide.  If folks want per-repo granularity, I'm happy to update to follow the `MergeMethod`/`MergeType` approach.

I've added unit tests for the rendering code.  Testing the GraphQL structure itself seemed hard to do except with a possibly unreliable mock.  So I wrote a one-off script for testing the GraphQL pull:

```go
package main

import (
  "context"
  "fmt"
  "log"
  "os"

  githubql "github.com/shurcooL/githubv4"
  "golang.org/x/oauth2"
  "k8s.io/test-infra/prow/tide"
)

func main() {
  ctx := context.Background()
  src := oauth2.StaticTokenSource(
    &oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
  )
  httpClient := oauth2.NewClient(ctx, src)
  client := githubql.NewClient(httpClient)

  var query struct {
    Repository struct {
      PullRequest tide.PullRequest `graphql:"pullRequest(number: 46669)"`
    } `graphql:"repository(owner: \"kubernetes\", name: \"kubernetes\")"`
  }
  err := client.Query(ctx, &query, nil)
  if err != nil {
    log.Fatal(err)
  }

  fmt.Print(tide.ApproverTags(&query.Repository.PullRequest, "Reviewed-by"))
}
```

To get that script running, I temporarily patched my function to be the public `ApproverTags` instead of the private `approverTags`.  Then:

[EDIT: I've updated this output to keep up with 182510 -> 765a4dbf]

```console
$ GITHUB_TOKEN=... go run main.go
Reviewed-by: Janet Kuo <janetkuo@users.noreply.github.com>
Reviewed-by: krmayankk <krmayankk@users.noreply.github.com>
```

If anyone has suggestions for exercising the GraphQL structure in unit tests, I'm all ears.

My initial intention was to inline the structure definitions, but I ended up creating named types for most of them to make it easier to write the compound literal for the test.  The new types are added in roughly alphabetical order after the existing `PullRequest` type.

I have not used my new `User` type for `PullRequest.Author`.  The existing code was fine getting only the `Login` there, so I'd only waste some bandwidth transferring names and email addresses as well if I used `User` there.

The updated `CommitMessage` comment is from [GitHub's docs for the associated property][4].  The previous wording sounded (at least to me) like our string was the entire commit message, when in fact it's just a footer on GitHub's automatic message.

Thoughts?

[1]: https://github.com/servo/homu/blob/461e9acbef5e984d18e0342b679ee424a945cfaf/homu/main.py#L722
[2]: https://github.com/git/git/blob/v2.19.0/Documentation/SubmittingPatches#L358-L361
[3]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst?h=v4.18#n565
[4]: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button