### PR TITLE
CRI-O: serve from OpenShift gubernator

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5348,9 +5348,17 @@ dashboards:
   dashboard_tab:
   - name: crio-e2e-fedora
     test_group_name: test_pull_request_crio_e2e_fedora
+    open_test_template:
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>.txt
+    results_url_template:
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10
   - name: crio-e2e-rhel
     test_group_name: test_pull_request_crio_e2e_rhel
+    open_test_template:
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<changelist>.txt
+    results_url_template:
+      url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: width=10
 
 - name: sig-node-containerd


### PR DESCRIPTION
Unfortunately we still need the custom urls because the upstream k8s gubernator shows wrong links, for instance:

https://k8s-gubernator.appspot.com/build/origin-federated-results/pr-logs/pull/kubernetes-sigs_cri-o/1772/test_pull_request_crio_e2e_fedora/1218

You can see in `refs`, it points to upstram kubernets commit/PR whereas using the OpenShift gubernator provides the correct link.

I believe this is gonna be the last PR to settle all this :)

@krzyzacy @BenTheElder PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>