### PR TITLE
Initialize submodules by default but allow an opt-out

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -308,6 +308,9 @@ type Refs struct {
 	// repository. If unset, will default to
 	// `https://github.com/org/repo.git`.
 	CloneURI string `json:"clone_uri,omitempty"`
+	// SkipSubmodules determines if submodules should be
+	// cloned when the job is run. Defaults to true.
+	SkipSubmodules bool `json:"skip_submodules,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/prow/cmd/clonerefs/README.md
+++ b/prow/cmd/clonerefs/README.md
@@ -59,7 +59,8 @@ as JSON in the `$CLONEREFS_OPTIONS` environment variable, which has the form:
                     "author": "smarterclayton",
                     "sha": "2b58234a8aee0d55918b158a3b38c292d6a95ef7"
                 }
-            ]
+            ],
+            "skip_submodules": true
         }
     ]
 }

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -322,6 +322,9 @@ type UtilityConfig struct {
 	// repository. If unset, will default to
 	// `https://github.com/org/repo.git`.
 	CloneURI string `json:"clone_uri,omitempty"`
+	// SkipSubmodules determines if submodules should be
+	// cloned when the job is run. Defaults to true.
+	SkipSubmodules bool `json:"skip_submodules,omitempty"`
 
 	// ExtraRefs are auxiliary repositories that
 	// need to be cloned, determined from config

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -144,6 +144,7 @@ func PresubmitSpec(p config.Presubmit, refs kube.Refs) kube.ProwJobSpec {
 	if p.CloneURI != "" {
 		refs.CloneURI = p.CloneURI
 	}
+	refs.SkipSubmodules = p.SkipSubmodules
 	pjs := kube.ProwJobSpec{
 		Type:      kube.PresubmitJob,
 		Job:       p.Name,
@@ -179,6 +180,7 @@ func PostsubmitSpec(p config.Postsubmit, refs kube.Refs) kube.ProwJobSpec {
 	if p.CloneURI != "" {
 		refs.CloneURI = p.CloneURI
 	}
+	refs.SkipSubmodules = p.SkipSubmodules
 	pjs := kube.ProwJobSpec{
 		Type:      kube.PostsubmitJob,
 		Job:       p.Name,
@@ -234,6 +236,7 @@ func BatchSpec(p config.Presubmit, refs kube.Refs) kube.ProwJobSpec {
 	if p.CloneURI != "" {
 		refs.CloneURI = p.CloneURI
 	}
+	refs.SkipSubmodules = p.SkipSubmodules
 	pjs := kube.ProwJobSpec{
 		Type:      kube.BatchJob,
 		Job:       p.Name,

--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -78,6 +78,7 @@ Additional fields may be required for some use cases:
 to clone the repo to a path different than the default of `/go/src/github.com/org/repo/` (e.g. `/go/src/k8s.io/kubernetes/kubernetes`).
 - Jobs that require additional repos to be checked out can arrange for that with
 the `exta_refs` field.
+- Jobs that do not want submodules to be cloned should set `skip_submodules` to `true`
 
 ```yaml
 - name: post-job
@@ -90,6 +91,7 @@ the `exta_refs` field.
   - org: kubernetes
     repo: other-repo
     base_ref: master
+  skip_submodules: true
   spec:
     containers:
     - image: alpine

--- a/prow/pod-utils/clone/BUILD.bazel
+++ b/prow/pod-utils/clone/BUILD.bazel
@@ -33,5 +33,8 @@ go_test(
     name = "go_default_test",
     srcs = ["clone_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/kube:go_default_library"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -19,7 +19,6 @@ package clone
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -32,69 +31,8 @@ import (
 func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail, cookiePath string, env []string) Record {
 	logrus.WithFields(logrus.Fields{"refs": refs}).Info("Cloning refs")
 	record := Record{Refs: refs}
-	repositoryURI := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
-	if refs.CloneURI != "" {
-		repositoryURI = refs.CloneURI
-	}
-	cloneDir := PathForRefs(dir, refs)
-
-	commands := []cloneCommand{
-		func() (string, string, error) {
-			return fmt.Sprintf("os.MkdirAll(%s, 0755)", cloneDir), "", os.MkdirAll(cloneDir, 0755)
-		},
-	}
-
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "init"))
-	if gitUserName != "" {
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "config", "user.name", gitUserName))
-	}
-	if gitUserEmail != "" {
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "config", "user.email", gitUserEmail))
-	}
-	if cookiePath != "" {
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "config", "http.cookiefile", cookiePath))
-	}
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, "--tags", "--prune"))
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, refs.BaseRef))
-
-	// unless the user specifically asks us not to, init submodules
-	if !refs.SkipSubmodules {
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "submodule", "update", "--init", "--recursive"))
-	}
-
-	var target string
-	if refs.BaseSHA != "" {
-		target = refs.BaseSHA
-	} else {
-		target = "FETCH_HEAD"
-	}
-	// we need to be "on" the target branch after the sync
-	// so we need to set the branch to point to the base ref,
-	// but we cannot update a branch we are on, so in case we
-	// are on the branch we are syncing, we check out the SHA
-	// first and reset the branch second, then check out the
-	// branch we just reset to be in the correct final state
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "checkout", target))
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "branch", "--force", refs.BaseRef, target))
-	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "checkout", refs.BaseRef))
-
-	for _, prRef := range refs.Pulls {
-		ref := fmt.Sprintf("pull/%d/head", prRef.Number)
-		if prRef.Ref != "" {
-			ref = prRef.Ref
-		}
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, ref))
-		var prCheckout string
-		if prRef.SHA != "" {
-			prCheckout = prRef.SHA
-		} else {
-			prCheckout = "FETCH_HEAD"
-		}
-		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "merge", prCheckout))
-	}
-
-	for _, command := range commands {
-		formattedCommand, output, err := command()
+	for _, command := range commandsForRefs(refs, dir, gitUserName, gitUserEmail, cookiePath, env) {
+		formattedCommand, output, err := command.run()
 		logrus.WithFields(logrus.Fields{"command": formattedCommand, "output": output, "error": err}).Info("Ran command")
 		message := ""
 		if err != nil {
@@ -122,18 +60,87 @@ func PathForRefs(baseDir string, refs *kube.Refs) string {
 	return fmt.Sprintf("%s/src/%s", baseDir, clonePath)
 }
 
-type cloneCommand func() (string, string, error)
+func commandsForRefs(refs *kube.Refs, dir, gitUserName, gitUserEmail, cookiePath string, env []string) []cloneCommand {
+	repositoryURI := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
+	if refs.CloneURI != "" {
+		repositoryURI = refs.CloneURI
+	}
+	cloneDir := PathForRefs(dir, refs)
 
-func shellCloneCommand(dir string, env []string, command string, args ...string) cloneCommand {
+	commands := []cloneCommand{{"/", env, "mkdir", []string{"-p", cloneDir}}}
+
+	gitCommand := func(args ...string) cloneCommand {
+		return cloneCommand{dir: cloneDir, env: env, command: "git", args: args}
+	}
+	commands = append(commands, gitCommand("init"))
+	if gitUserName != "" {
+		commands = append(commands, gitCommand("config", "user.name", gitUserName))
+	}
+	if gitUserEmail != "" {
+		commands = append(commands, gitCommand("config", "user.email", gitUserEmail))
+	}
+	if cookiePath != "" {
+		commands = append(commands, gitCommand("config", "http.cookiefile", cookiePath))
+	}
+	commands = append(commands, gitCommand("fetch", repositoryURI, "--tags", "--prune"))
+	commands = append(commands, gitCommand("fetch", repositoryURI, refs.BaseRef))
+
+	// unless the user specifically asks us not to, init submodules
+	if !refs.SkipSubmodules {
+		commands = append(commands, gitCommand("submodule", "update", "--init", "--recursive"))
+	}
+
+	var target string
+	if refs.BaseSHA != "" {
+		target = refs.BaseSHA
+	} else {
+		target = "FETCH_HEAD"
+	}
+	// we need to be "on" the target branch after the sync
+	// so we need to set the branch to point to the base ref,
+	// but we cannot update a branch we are on, so in case we
+	// are on the branch we are syncing, we check out the SHA
+	// first and reset the branch second, then check out the
+	// branch we just reset to be in the correct final state
+	commands = append(commands, gitCommand("checkout", target))
+	commands = append(commands, gitCommand("branch", "--force", refs.BaseRef, target))
+	commands = append(commands, gitCommand("checkout", refs.BaseRef))
+
+	for _, prRef := range refs.Pulls {
+		ref := fmt.Sprintf("pull/%d/head", prRef.Number)
+		if prRef.Ref != "" {
+			ref = prRef.Ref
+		}
+		commands = append(commands, gitCommand("fetch", repositoryURI, ref))
+		var prCheckout string
+		if prRef.SHA != "" {
+			prCheckout = prRef.SHA
+		} else {
+			prCheckout = "FETCH_HEAD"
+		}
+		commands = append(commands, gitCommand("merge", prCheckout))
+	}
+	return commands
+}
+
+type cloneCommand struct {
+	dir     string
+	env     []string
+	command string
+	args    []string
+}
+
+func (c *cloneCommand) run() (string, string, error) {
 	output := bytes.Buffer{}
-	cmd := exec.Command(command, args...)
-	cmd.Dir = dir
-	cmd.Env = append(cmd.Env, env...)
+	cmd := exec.Command(c.command, c.args...)
+	cmd.Dir = c.dir
+	cmd.Env = append(cmd.Env, c.env...)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
+	err := cmd.Run()
+	return strings.Join(append([]string{c.command}, c.args...), " "), output.String(), err
+}
 
-	return func() (string, string, error) {
-		err := cmd.Run()
-		return strings.Join(append([]string{command}, args...), " "), output.String(), err
-	}
+func (c *cloneCommand) String() string {
+	return fmt.Sprintf("PWD=%s %s %s %s", c.dir, strings.Join(c.env, " "), c.command, strings.Join(c.env, " "))
 }

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -57,6 +57,11 @@ func Run(refs *kube.Refs, dir, gitUserName, gitUserEmail, cookiePath string, env
 	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, "--tags", "--prune"))
 	commands = append(commands, shellCloneCommand(cloneDir, env, "git", "fetch", repositoryURI, refs.BaseRef))
 
+	// unless the user specifically asks us not to, init submodules
+	if !refs.SkipSubmodules {
+		commands = append(commands, shellCloneCommand(cloneDir, env, "git", "submodule", "update", "--init", "--recursive"))
+	}
+
 	var target string
 	if refs.BaseSHA != "" {
 		target = refs.BaseSHA

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package clone
 
 import (
+	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -48,6 +50,283 @@ func TestPathForRefs(t *testing.T) {
 	for _, testCase := range testCases {
 		if actual, expected := PathForRefs("base", testCase.refs), testCase.expected; actual != expected {
 			t.Errorf("%s: expected path %q, got %q", testCase.name, expected, actual)
+		}
+	}
+}
+
+func TestCommandsForRefs(t *testing.T) {
+	var testCases = []struct {
+		name                                       string
+		refs                                       *kube.Refs
+		dir, gitUserName, gitUserEmail, cookiePath string
+		env                                        []string
+		expected                                   []cloneCommand
+	}{
+		{
+			name: "simplest case, minimal refs",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "minimal refs with git user name",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+			},
+			gitUserName: "user",
+			dir:         "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"config", "user.name", "user"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "minimal refs with git user email",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+			},
+			gitUserEmail: "user@go.com",
+			dir:          "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"config", "user.email", "user@go.com"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "minimal refs with http cookie file",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+			},
+			cookiePath: "/cookie.txt",
+			dir:        "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"config", "http.cookiefile", "/cookie.txt"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "minimal refs with no submodules",
+			refs: &kube.Refs{
+				Org:            "org",
+				Repo:           "repo",
+				BaseRef:        "master",
+				SkipSubmodules: true,
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "refs with clone URI override",
+			refs: &kube.Refs{
+				Org:      "org",
+				Repo:     "repo",
+				BaseRef:  "master",
+				CloneURI: "internet.com",
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "internet.com", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "internet.com", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "refs with path alias",
+			refs: &kube.Refs{
+				Org:       "org",
+				Repo:      "repo",
+				BaseRef:   "master",
+				PathAlias: "my/favorite/dir",
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/my/favorite/dir"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"init"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/my/favorite/dir", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "refs with specific base sha",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				BaseSHA: "abcdef",
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "abcdef"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "abcdef"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+		},
+		{
+			name: "refs with simple pr ref",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []kube.Pull{
+					{Number: 1},
+				},
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "pull/1/head"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"merge", "FETCH_HEAD"}},
+			},
+		},
+		{
+			name: "refs with pr ref override",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []kube.Pull{
+					{Number: 1, Ref: "pull-me"},
+				},
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "pull-me"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"merge", "FETCH_HEAD"}},
+			},
+		},
+		{
+			name: "refs with pr ref with specific sha",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []kube.Pull{
+					{Number: 1, SHA: "abcdef"},
+				},
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "pull/1/head"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"merge", "abcdef"}},
+			},
+		},
+		{
+			name: "refs with multiple simple pr refs",
+			refs: &kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []kube.Pull{
+					{Number: 1},
+					{Number: 2},
+				},
+			},
+			dir: "/go",
+			expected: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "pull/1/head"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"merge", "FETCH_HEAD"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "pull/2/head"}},
+				{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"merge", "FETCH_HEAD"}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := commandsForRefs(testCase.refs, testCase.dir, testCase.gitUserName, testCase.gitUserEmail, testCase.cookiePath, testCase.env), testCase.expected; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: generated incorrect commands: %v", testCase.name, diff.ObjectGoPrintDiff(expected, actual))
 		}
 	}
 }


### PR DESCRIPTION
Currently, `clonerefs` does nothing for `git` repositories that use
submodules, which leads their clone process to be incomplete. As it is
generally assumed that repositories with submodules will want them
cloned, we should do that by default but allow users to opt-out if they
so wish.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/cc @BenTheElder @fejta @smarterclayton 
/assign @cjwagner 