### PR TITLE
Allow cookiefile_secret to specify the basename

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,21 +37,21 @@ import (
 )
 
 const (
-	logMountName              = "logs"
-	logMountPath              = "/logs"
-	artifactsEnv              = "ARTIFACTS"
-	artifactsPath             = logMountPath + "/artifacts"
-	codeMountName             = "code"
-	codeMountPath             = "/home/prow/go"
-	gopathEnv                 = "GOPATH"
-	toolsMountName            = "tools"
-	toolsMountPath            = "/tools"
-	gcsCredentialsMountName   = "gcs-credentials"
-	gcsCredentialsMountPath   = "/secrets/gcs"
-	sshKeysMountNamePrefix    = "ssh-keys"
-	sshKeysMountPathPrefix    = "/secrets/ssh"
-	cookiefileMountNamePrefix = "cookiefile"
-	cookiefileMountPathPrefix = "/secrets/cookiefile"
+	logMountName            = "logs"
+	logMountPath            = "/logs"
+	artifactsEnv            = "ARTIFACTS"
+	artifactsPath           = logMountPath + "/artifacts"
+	codeMountName           = "code"
+	codeMountPath           = "/home/prow/go"
+	gopathEnv               = "GOPATH"
+	toolsMountName          = "tools"
+	toolsMountPath          = "/tools"
+	gcsCredentialsMountName = "gcs-credentials"
+	gcsCredentialsMountPath = "/secrets/gcs"
+	sshKeysMountNamePrefix  = "ssh-keys"
+	sshKeysMountPathPrefix  = "/secrets/ssh"
+	cookiefileMountName     = "cookiefile"
+	cookiefileMountPath     = "/secrets/cookiefile"
 )
 
 // Labels returns a string slice with label consts from kube.
@@ -194,24 +195,32 @@ func decorate(spec *kube.PodSpec, pj *kube.ProwJob, rawEnv map[string]string) er
 		var cloneArgs []string
 
 		if cp := pj.Spec.DecorationConfig.CookiefileSecret; cp != "" {
+			// my-cookie/.gitcookies => find my-cookie secret at /secrets/cookiefile/.gitcookies
+			// my-cookie => find my-cookie secret at /secrets/cookiefile/my-cookie
+			parts := strings.SplitN(cp, "/", 2)
+			cookieSecret := parts[0]
+			var base string
+			if len(parts) == 1 {
+				base = parts[0]
+			} else {
+				base = parts[1]
+			}
 			var cookiefileMode int32 = 0400 // u+r
-			name := fmt.Sprintf("%s-%s", cookiefileMountNamePrefix, cp)
-			keyPath := path.Join(cookiefileMountPathPrefix, cp)
 			cloneMounts = append(cloneMounts, kube.VolumeMount{
-				Name:      name,
-				MountPath: keyPath,
+				Name:      cookiefileMountName,
+				MountPath: cookiefileMountPath, // append base to flag
 				ReadOnly:  true,
 			})
 			cloneVolumes = append(cloneVolumes, kube.Volume{
-				Name: name,
+				Name: cookiefileMountName,
 				VolumeSource: kube.VolumeSource{
 					Secret: &kube.SecretSource{
-						SecretName:  cp,
+						SecretName:  cookieSecret,
 						DefaultMode: &cookiefileMode,
 					},
 				},
 			})
-			cloneArgs = append(cloneArgs, "--cookiefile="+keyPath)
+			cloneArgs = append(cloneArgs, "--cookiefile="+path.Join(cookiefileMountPath, base))
 		}
 
 		cloneLog = fmt.Sprintf("%s/clone.json", logMountPath)

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -132,7 +132,7 @@ func TestProwJobToPod(t *testing.T) {
 						DefaultRepo:  "kubernetes",
 					},
 					GCSCredentialsSecret: "secret-name",
-					CookiefileSecret:     "yummy",
+					CookiefileSecret:     "yummy/.gitcookies",
 				},
 				Agent: kube.KubernetesAgent,
 				Refs: &kube.Refs{
@@ -181,7 +181,7 @@ func TestProwJobToPod(t *testing.T) {
 							Name:    "clonerefs",
 							Image:   "clonerefs:tag",
 							Command: []string{"/clonerefs"},
-							Args:    []string{"--cookiefile=" + cookiefileMountPathPrefix + "/yummy"},
+							Args:    []string{"--cookiefile=" + cookiefileMountPath + "/.gitcookies"},
 							Env: []v1.EnvVar{
 								{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}]}`},
 							},
@@ -195,8 +195,8 @@ func TestProwJobToPod(t *testing.T) {
 									MountPath: "/home/prow/go",
 								},
 								{
-									Name:      cookiefileMountNamePrefix + "-yummy",
-									MountPath: cookiefileMountPathPrefix + "/yummy",
+									Name:      cookiefileMountName,
+									MountPath: cookiefileMountPath,
 									ReadOnly:  true,
 								},
 							},
@@ -319,7 +319,235 @@ func TestProwJobToPod(t *testing.T) {
 							},
 						},
 						{
-							Name: cookiefileMountNamePrefix + "-yummy",
+							Name: cookiefileMountName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName:  "yummy",
+									DefaultMode: &sshKeyMode,
+								},
+							},
+						},
+						{
+							Name: "code",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			podName: "pod",
+			buildID: "blabla",
+			labels:  map[string]string{"needstobe": "inherited"},
+			pjSpec: kube.ProwJobSpec{
+				Type: kube.PresubmitJob,
+				Job:  "job-name",
+				DecorationConfig: &kube.DecorationConfig{
+					Timeout:     120 * time.Minute,
+					GracePeriod: 10 * time.Second,
+					UtilityImages: &kube.UtilityImages{
+						CloneRefs:  "clonerefs:tag",
+						InitUpload: "initupload:tag",
+						Entrypoint: "entrypoint:tag",
+						Sidecar:    "sidecar:tag",
+					},
+					GCSConfiguration: &kube.GCSConfiguration{
+						Bucket:       "my-bucket",
+						PathStrategy: "legacy",
+						DefaultOrg:   "kubernetes",
+						DefaultRepo:  "kubernetes",
+					},
+					GCSCredentialsSecret: "secret-name",
+					CookiefileSecret:     "yummy",
+				},
+				Agent: kube.KubernetesAgent,
+				Refs: &kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []kube.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}},
+					PathAlias: "somewhere/else",
+				},
+				ExtraRefs: []*kube.Refs{},
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image:   "tester",
+							Command: []string{"/bin/thing"},
+							Args:    []string{"some", "args"},
+							Env: []v1.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+					Labels: map[string]string{
+						kube.CreatedByProw:    "true",
+						kube.ProwJobTypeLabel: "presubmit",
+						kube.ProwJobIDLabel:   "pod",
+						"needstobe":           "inherited",
+					},
+					Annotations: map[string]string{
+						kube.ProwJobAnnotation: "job-name",
+					},
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: "Never",
+					InitContainers: []v1.Container{
+						{
+							Name:    "clonerefs",
+							Image:   "clonerefs:tag",
+							Command: []string{"/clonerefs"},
+							Args:    []string{"--cookiefile=" + cookiefileMountPath + "/yummy"},
+							Env: []v1.EnvVar{
+								{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}]}`},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+								{
+									Name:      cookiefileMountName,
+									MountPath: cookiefileMountPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+						{
+							Name:    "initupload",
+							Image:   "initupload:tag",
+							Command: []string{"/initupload"},
+							Env: []v1.EnvVar{
+								{Name: "INITUPLOAD_OPTIONS", Value: `{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}`},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+							},
+							VolumeMounts: []kube.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+						{
+							Name:    "place-tools",
+							Image:   "entrypoint:tag",
+							Command: []string{"/bin/cp"},
+							Args: []string{
+								"/entrypoint",
+								"/tools/entrypoint",
+							},
+							VolumeMounts: []kube.VolumeMount{
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:       "test",
+							Image:      "tester",
+							Command:    []string{"/tools/entrypoint"},
+							Args:       []string{},
+							WorkingDir: "/home/prow/go/src/somewhere/else",
+							Env: []v1.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+								{Name: "ARTIFACTS", Value: "/logs/artifacts"},
+								{Name: "BUILD_ID", Value: "blabla"},
+								{Name: "BUILD_NUMBER", Value: "blabla"},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"args":["/bin/thing","some","args"],"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt"}`},
+								{Name: "GOPATH", Value: "/home/prow/go"},
+								{Name: "JOB_NAME", Value: "job-name"},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+								{Name: "JOB_TYPE", Value: "presubmit"},
+								{Name: "PROW_JOB_ID", Value: "pod"},
+								{Name: "PULL_BASE_REF", Value: "base-ref"},
+								{Name: "PULL_BASE_SHA", Value: "base-sha"},
+								{Name: "PULL_NUMBER", Value: "1"},
+								{Name: "PULL_PULL_SHA", Value: "pull-sha"},
+								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
+								{Name: "REPO_NAME", Value: "repo-name"},
+								{Name: "REPO_OWNER", Value: "org-name"},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+							},
+						},
+						{
+							Name:    "sidecar",
+							Image:   "sidecar:tag",
+							Command: []string{"/sidecar"},
+							Env: []v1.EnvVar{
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"wrapper_options":{"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt"}}`},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "logs",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "tools",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "gcs-credentials",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "secret-name",
+								},
+							},
+						},
+						{
+							Name: cookiefileMountName,
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName:  "yummy",


### PR DESCRIPTION
Also since there's only one cookiefile secret we don't need a prefix.

/assign @stevekuznetsov @krzyzacy 
/cc @BenTheElder 

Added unit test to cover `yummy/.gitcookies` in addition to `yummy`