### PR TITLE
implement tbr plugin

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//prow/plugins/skip:go_default_library",
         "//prow/plugins/slackevents:go_default_library",
         "//prow/plugins/stage:go_default_library",
+        "//prow/plugins/tbr:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "//prow/plugins/updateconfig:go_default_library",
         "//prow/plugins/verify-owners:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -49,6 +49,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/skip"
 	_ "k8s.io/test-infra/prow/plugins/slackevents"
 	_ "k8s.io/test-infra/prow/plugins/stage"
+	_ "k8s.io/test-infra/prow/plugins/tbr"
 	_ "k8s.io/test-infra/prow/plugins/trigger"
 	_ "k8s.io/test-infra/prow/plugins/updateconfig"
 	_ "k8s.io/test-infra/prow/plugins/verify-owners"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -79,6 +79,7 @@ filegroup(
         "//prow/plugins/skip:all-srcs",
         "//prow/plugins/slackevents:all-srcs",
         "//prow/plugins/stage:all-srcs",
+        "//prow/plugins/tbr:all-srcs",
         "//prow/plugins/trigger:all-srcs",
         "//prow/plugins/updateconfig:all-srcs",
         "//prow/plugins/verify-owners:all-srcs",

--- a/prow/plugins/tbr/BUILD.bazel
+++ b/prow/plugins/tbr/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tbr.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/tbr",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["tbr_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)

--- a/prow/plugins/tbr/tbr.go
+++ b/prow/plugins/tbr/tbr.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tbr
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const PluginName = "tbr"
+
+var (
+	// TODO(bentheelder,cjwagner): move label definitions to a common package
+	LGTMLabel     = "lgtm"
+	approvedLabel = "approved"
+	TBRLabel      = "to-be-reviewed"
+	tbrRE         = regexp.MustCompile(`(?mi)^/tbr\s*$`)
+)
+
+func init() {
+	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
+	//plugins.RegisterPullRequestHandler()
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The Config field is omitted because this plugin is not configurable.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/tbr",
+		Description: "Adds the 'lgtm' label which is typically used to gate merging and the 'to-be-reviewed' label.",
+		Featured:    false,
+		WhoCanUse:   "Pull Request Authors. See also the 'lgtm' plugin.",
+		Examples:    []string{"/tbr"},
+	})
+	return pluginHelp, nil
+}
+
+type githubClient interface {
+	AddLabel(owner, repo string, number int, label string) error
+	CreateComment(owner, repo string, number int, comment string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+func handleGenericCommentEvent(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.Logger, e)
+}
+
+func handleGenericComment(gc githubClient, config *plugins.Configuration, log *logrus.Entry, e github.GenericCommentEvent) error {
+	// Only consider open PRs and new comments.
+	if !e.IsPR || e.IssueState != "open" || e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	// ignore if the comment doesn't match the tbr command
+	if !tbrRE.MatchString(e.Body) {
+		return nil
+	}
+
+	// extract some information about the pull request
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+	body := e.Body
+	htmlURL := e.HTMLURL
+	author := e.User.Login
+	prAuthor := e.IssueAuthor.Login
+
+	// only the PR author can TBR
+	isAuthor := author == prAuthor
+	if !isAuthor {
+		resp := "/tbr is restricted to PR authors."
+		log.Infof("Reply to /tbr request with comment: \"%s\"", resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(body, htmlURL, author, resp))
+	}
+
+	// you can only TBR if the PR is already approved
+	approved, err := isApproved(gc, org, repo, number)
+	if err != nil {
+		return err
+	}
+	if !approved {
+		resp := "/tbr can only be used on approved PRs"
+		log.Infof("Reply to /tbr request with comment: \"%s\"", resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(body, htmlURL, author, resp))
+	}
+
+	// at this point we are actually going to TBR this PR
+	// add comment
+	resp := fmt.Sprintf(
+		"Adding %s and %s labels. This PR should be reviewed later.",
+		TBRLabel, LGTMLabel,
+	)
+	formattedResp := plugins.FormatResponseRaw(body, htmlURL, author, resp)
+	if err := gc.CreateComment(org, repo, number, formattedResp); err != nil {
+		return err
+	}
+	// add lgtm + tbr labels
+	if err := gc.AddLabel(org, repo, number, TBRLabel); err != nil {
+		return err
+	}
+	if err := gc.AddLabel(org, repo, number, LGTMLabel); err != nil {
+		return err
+	}
+	return nil
+}
+
+// isApproved checks if a PR has the approved label
+func isApproved(gc githubClient, org, repo string, number int) (bool, error) {
+	labels, err := gc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return false, err
+	}
+	for _, label := range labels {
+		if label.Name == approvedLabel {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/prow/plugins/tbr/tbr_test.go
+++ b/prow/plugins/tbr/tbr_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tbr
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func fakeLabels(fc *fakegithub.FakeClient, org, repo string, number int) []string {
+	githubLabels, _ := fc.GetIssueLabels(org, repo, number)
+	ret := []string{}
+	for _, label := range githubLabels {
+		ret = append(ret, label.Name)
+	}
+	return ret
+}
+
+func TestHandleGenericComment(t *testing.T) {
+	cases := []struct {
+		name        string
+		event       github.GenericCommentEvent
+		issueLabels []string
+
+		expectLabels     []string
+		expectNoComments bool
+	}{
+		{
+			name: "should tbr",
+			event: github.GenericCommentEvent{
+				Action:      github.GenericCommentActionCreated,
+				IssueState:  "open",
+				IsPR:        true,
+				Body:        "/tbr\n",
+				User:        github.User{Login: "author"},
+				IssueAuthor: github.User{Login: "author"},
+				Number:      5,
+				Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				HTMLURL:     "<url>",
+			},
+			issueLabels:      []string{"approved"},
+			expectLabels:     []string{"approved", LGTMLabel, TBRLabel},
+			expectNoComments: false,
+		},
+		{
+			name: "not approved",
+			event: github.GenericCommentEvent{
+				Action:      github.GenericCommentActionCreated,
+				IssueState:  "open",
+				IsPR:        true,
+				Body:        "/tbr\n",
+				User:        github.User{Login: "author"},
+				IssueAuthor: github.User{Login: "author"},
+				Number:      5,
+				Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				HTMLURL:     "<url>",
+			},
+			issueLabels:      []string{},
+			expectLabels:     []string{},
+			expectNoComments: false,
+		},
+		{
+			name: "not author",
+			event: github.GenericCommentEvent{
+				Action:      github.GenericCommentActionCreated,
+				IssueState:  "open",
+				IsPR:        true,
+				Body:        "/tbr\n",
+				User:        github.User{Login: "not-author"},
+				IssueAuthor: github.User{Login: "author"},
+				Number:      5,
+				Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				HTMLURL:     "<url>",
+			},
+			issueLabels:      []string{"approved"},
+			expectLabels:     []string{"approved"},
+			expectNoComments: false,
+		},
+		{
+			name: "not matching",
+			event: github.GenericCommentEvent{
+				Action:      github.GenericCommentActionCreated,
+				IssueState:  "open",
+				IsPR:        true,
+				Body:        "/tbr-not-matching\n",
+				User:        github.User{Login: "author"},
+				IssueAuthor: github.User{Login: "author"},
+				Number:      5,
+				Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				HTMLURL:     "<url>",
+			},
+			issueLabels:      []string{},
+			expectLabels:     []string{},
+			expectNoComments: true,
+		},
+	}
+	fpc := &plugins.Configuration{}
+	fle := logrus.WithField("plugin", PluginName)
+	for _, tc := range cases {
+		fgc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+		org := tc.event.Repo.Owner.Login
+		repo := tc.event.Repo.Name
+		number := tc.event.Number
+		for _, label := range tc.issueLabels {
+			fgc.AddLabel(org, repo, number, label)
+		}
+		err := handleGenericComment(fgc, fpc, fle, tc.event)
+		if err != nil {
+			t.Errorf("case: '%s' Unexpected error: %v", tc.name, err)
+		}
+		nComments := len(fgc.IssueCommentsAdded)
+		if nComments > 0 && tc.expectNoComments {
+			t.Errorf("case: '%s' Unexpected number of comments: %v != 0", tc.name, nComments)
+		} else if nComments == 0 && !tc.expectNoComments {
+			t.Errorf("case: '%s' Unexpected number of comments: %v > 0", tc.name, nComments)
+		}
+		labels := fakeLabels(fgc, org, repo, number)
+		// sort so we can compare ...
+		sort.Strings(labels)
+		sort.Strings(tc.expectLabels)
+		if !reflect.DeepEqual(labels, tc.expectLabels) {
+			t.Errorf(
+				"case: '%s' labels did not match expected: %v != %v",
+				tc.name, labels, tc.expectLabels,
+			)
+		}
+	}
+}


### PR DESCRIPTION
see: https://github.com/kubernetes/test-infra/issues/7899

This plugin adds `lgtm` and `to-be-reviewed` to PRs if enabled, when the author comments `/tbr` IFF the PR is already `approved`. It does not work for non-authors (they should use `/lgtm`) and it does not work if the PR is not already `approved` (get it approved first)

TBD is removing the `to-be-removed` label
  - we could just leave the label, forever noting that this PR was merged prior to `/lgtm`
  - we could allow `/lgtm` or `/approve` remove it later

Also TBD is adding the label to the label sync.
Ideally it wouldn't clutter repos that don't enable this, I think the default for repos should probably be to not support this (EG this is probably not a great idea for kubernetes/kubernetes), with smaller projects leveraging this. 
I'm also not sure what color to paint the label bikeshed etc :-) (yellow?)