### PR TITLE
switch to look for authdaemon at root

### DIFF
--- a/prow/gerrit/client/gerrit.go
+++ b/prow/gerrit/client/gerrit.go
@@ -93,7 +93,13 @@ func auth(c *Client) {
 	logrus.Info("Starting auth loop...")
 	for {
 		// TODO(fejta): migrate this to the grandmatriarch
-		cmd := exec.Command("python", "./git-cookie-authdaemon")
+
+		// look for authdaemon under root dir
+		if _, err := os.Stat("/git-cookie-authdaemon"); os.IsNotExist(err) {
+			panic("cannot find /git-cookie-authdaemon")
+		}
+
+		cmd := exec.Command("/git-cookie-authdaemon")
 		if err := cmd.Run(); err != nil {
 			logrus.WithError(err).Error("Fail to authenticate to gerrit using git-cookie-authdaemon")
 		}


### PR DESCRIPTION
```
senlu-macbookpro:~ senlu$ kubectl exec -it gerrit-senlu-76b4897d8b-657mm -- /bin/sh
# ls
prow
# cd ..
# ls
app  boot  etc			  home	lib64  mnt  proc  run	srv  tmp  var
bin  dev   git-cookie-authdaemon  lib	media  opt  root  sbin	sys  usr
# ./git-cookie-authdaemon
git-cookie-authdaemon PID 53
```

/shrug
/hold
let me rebuild first
/assign @fejta @BenTheElder 