### PR TITLE
fix podutilies image symlinks

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -15,9 +15,16 @@ go_library(
     ],
 )
 
-go_image(
-    name = "clonerefs-go_image",
-    base = "@git-base//image",
+go_binary(
+    name = "clonerefs",
+    embed = [":go_default_library"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+# same as binary above, but with goarch and goos for placing in the docker image
+go_binary(
+    name = "clonerefs-linux-amd64",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -25,19 +32,19 @@ go_image(
     visibility = ["//visibility:public"],
 )
 
+go_image(
+    name = "clonerefs-go_image",
+    base = "@git-base//image",
+    binary = ":clonerefs-linux-amd64",
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "image",
     base = ":clonerefs-go_image",
     symlinks = {
-        "/clonerefs": "/app/prow/cmd/clonerefs",
+        "/clonerefs": "/app/prow/cmd/clonerefs/clonerefs-linux-amd64",
     },
-    visibility = ["//visibility:public"],
-)
-
-go_binary(
-    name = "clonerefs",
-    embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -15,6 +15,39 @@ go_library(
     ],
 )
 
+go_binary(
+    name = "entrypoint",
+    embed = [":go_default_library"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+# same as binary above, but with goarch and goos for placing in the docker image
+go_binary(
+    name = "entrypoint-linux-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "entrypoint-go_image",
+    base = "@git-base//image",
+    binary = ":entrypoint-linux-amd64",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":entrypoint-go_image",
+    symlinks = {
+        "/entrypoint": "/app/prow/cmd/entrypoint/entrypoint-linux-amd64",
+    },
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -26,31 +59,5 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
-    visibility = ["//visibility:public"],
-)
-
-go_image(
-    name = "entrypoint-go_image",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "image",
-    base = ":entrypoint-go_image",
-    symlinks = {
-        "/entrypoint": "/app/prow/cmd/entrypoint",
-    },
-    visibility = ["//visibility:public"],
-)
-
-go_binary(
-    name = "entrypoint",
-    embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -2,25 +2,6 @@ load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_image(
-    name = "initupload-go_image",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "image",
-    base = ":initupload-go_image",
-    symlinks = {
-        "/initupload": "/app/prow/cmd/initupload",
-    },
-    visibility = ["//visibility:public"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
@@ -38,6 +19,32 @@ go_binary(
     name = "initupload",
     embed = [":go_default_library"],
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+# same as binary above, but with goarch and goos for placing in the docker image
+go_binary(
+    name = "initupload-linux-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "initupload-go_image",
+    base = "@alpine-base//image",
+    binary = ":initupload-linux-amd64",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":initupload-go_image",
+    symlinks = {
+        "/initupload": "/app/prow/cmd/initupload/initupload-linux-amd64",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -2,25 +2,6 @@ load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_image(
-    name = "sidecar-go_image",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "image",
-    base = ":sidecar-go_image",
-    symlinks = {
-        "/sidecar": "/app/prow/cmd/sidecar",
-    },
-    visibility = ["//visibility:public"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
@@ -38,6 +19,32 @@ go_binary(
     name = "sidecar",
     embed = [":go_default_library"],
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+# same as binary above, but with goarch and goos for placing in the docker image
+go_binary(
+    name = "sidecar-linux-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "sidecar-go_image",
+    base = "@git-base//image",
+    binary = ":sidecar-linux-amd64",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":sidecar-go_image",
+    symlinks = {
+        "/sidecar": "/app/prow/cmd/sidecar/sidecar-linux-amd64",
+    },
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
see: https://github.com/kubernetes/test-infra/pull/9237/files#r217923570

- normalize layout of pod-utilities BUILD files
- add to a go_binary rule for linux-amd64 for each of these so we can control the name of the in-image binary while enforcing goarch / goos
- update the `go_image` layers to use these binaries
- update the `container_image` layers to symlink to these

/assign @fejta @munnerz  