### PR TITLE
Update plugins for k/features and k/sig-release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -332,7 +332,10 @@ plugins:
   - trigger
 
   kubernetes/features:
+  - blockade
   - milestone
+  - owners-label
+  - require-sig
   - stage
 
   kubernetes/ingress-gce:
@@ -365,6 +368,8 @@ plugins:
   - trigger
 
   kubernetes/sig-release:
+  - blockade
+  - owners-label
   - stage
 
   kubernetes/test-infra:


### PR DESCRIPTION
/sig pm release
/assign @idvoretskyi @calebamiles @jdumars 

(some of these are plugins I'd like to have active prior to https://github.com/kubernetes/community/pull/2655 flipping to `implementable`)

Signed-off-by: Stephen Augustus <foo@agst.us>