### PR TITLE
[WIP] implement TBR: third time's the charm

### DIFF
--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -269,7 +269,7 @@ func TestLGTMComment(t *testing.T) {
 			pc.Owners.SkipCollaborators = []string{"org/repo"}
 		}
 		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", PluginName), *e); err != nil {
-			t.Errorf("didn't expect error from lgtmComment: %v", err)
+			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 			continue
 		}
 		if tc.shouldAssign {
@@ -281,34 +281,34 @@ func TestLGTMComment(t *testing.T) {
 				}
 			}
 			if !found || len(fc.AssigneesAdded) != 1 {
-				t.Errorf("should have assigned %s but added assignees are %s", tc.commenter, fc.AssigneesAdded)
+				t.Errorf("For case %s, should have assigned %s but added assignees are %s", tc.name, tc.commenter, fc.AssigneesAdded)
 			}
 		} else if len(fc.AssigneesAdded) != 0 {
-			t.Errorf("should not have assigned anyone but assigned %s", fc.AssigneesAdded)
+			t.Errorf("For case %s, should not have assigned anyone but assigned %s", tc.name, fc.AssigneesAdded)
 		}
 		if tc.shouldToggle {
 			if tc.hasLGTM {
 				if len(fc.LabelsRemoved) == 0 {
-					t.Errorf("should have removed LGTM.")
+					t.Errorf("For case %s, should have removed LGTM.", tc.name)
 				} else if len(fc.LabelsAdded) > 1 {
-					t.Errorf("should not have added LGTM.")
+					t.Errorf("For case %s, should not have added LGTM.", tc.name)
 				}
 			} else {
 				if len(fc.LabelsAdded) == 0 {
-					t.Errorf("should have added LGTM.")
+					t.Errorf("For case %s, should have added LGTM.", tc.name)
 				} else if len(fc.LabelsRemoved) > 0 {
-					t.Errorf("should not have removed LGTM.")
+					t.Errorf("For case %s, should not have removed LGTM.", tc.name)
 				}
 			}
 		} else if len(fc.LabelsRemoved) > 0 {
-			t.Errorf("should not have removed LGTM.")
+			t.Errorf("For case %s, should not have removed LGTM.", tc.name)
 		} else if (tc.hasLGTM && len(fc.LabelsAdded) > 1) || (!tc.hasLGTM && len(fc.LabelsAdded) > 0) {
-			t.Errorf("should not have added LGTM.")
+			t.Errorf("For case %s, should not have added LGTM.", tc.name)
 		}
 		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
-			t.Errorf("should have commented.")
+			t.Errorf("For case %s, should have commented.", tc.name)
 		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
-			t.Errorf("should not have commented.")
+			t.Errorf("For case %s, should not have commented.", tc.name)
 		}
 	}
 }
@@ -705,30 +705,30 @@ func TestHandlePullRequest(t *testing.T) {
 			err := handlePullRequest(fakeGitHub, c.event, logrus.WithField("plugin", PluginName))
 
 			if err != nil && c.err == nil {
-				t.Fatalf("handlePullRequest error: %v", err)
+				t.Fatalf("For case %s, handlePullRequest error: %v", c.name, err)
 			}
 
 			if err == nil && c.err != nil {
-				t.Fatalf("handlePullRequest wanted error: %v, got nil", c.err)
+				t.Fatalf("For case %s, handlePullRequest wanted error: %v, got nil", c.name, c.err)
 			}
 
 			if got, want := err, c.err; !equality.Semantic.DeepEqual(got, want) {
-				t.Fatalf("handlePullRequest error mismatch: got %v, want %v", got, want)
+				t.Fatalf("For case %s, handlePullRequest error mismatch: got %v, want %v", c.name, got, want)
 			}
 
 			if got, want := len(fakeGitHub.labelsRemoved), len(c.labelsRemoved); got != want {
 				t.Logf("labelsRemoved: got %v, want: %v", fakeGitHub.labelsRemoved, c.labelsRemoved)
-				t.Fatalf("labelsRemoved length mismatch: got %d, want %d", got, want)
+				t.Fatalf("For case %s, labelsRemoved length mismatch: got %d, want %d", c.name, got, want)
 			}
 
 			if got, want := fakeGitHub.issueComments, c.issueComments; !equality.Semantic.DeepEqual(got, want) {
-				t.Fatalf("LGTM revmoved notifications mismatch: got %v, want %v", got, want)
+				t.Fatalf("For case %s, LGTM revmoved notifications mismatch: got %v, want %v", c.name, got, want)
 			}
 			if c.expectNoComments && len(fakeGitHub.issueComments) > 0 {
-				t.Fatalf("expected no comments but got %v", fakeGitHub.issueComments)
+				t.Fatalf("For case %s, expected no comments but got %v", c.name, fakeGitHub.issueComments)
 			}
 			if !c.expectNoComments && len(fakeGitHub.issueComments) == 0 {
-				t.Fatalf("expected comments but got none")
+				t.Fatalf("For case %s, expected comments but got none", c.name)
 			}
 		})
 	}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -366,6 +366,9 @@ type Lgtm struct {
 	// ReviewActsAsLgtm indicates that a Github review of "approve" or "request changes"
 	// acts as adding or removing the lgtm label
 	ReviewActsAsLgtm bool `json:"review_acts_as_lgtm,omitempty"`
+	// ToBeReviewedEnabled enables the `/tbr` command if true, which allows
+	// authors to self-lgtm PRs to code they can approve
+	ToBeReviewedEnabled bool `json:"to_be_reviewed_enabled,omitempty"`
 }
 
 type Cat struct {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/test-infra/issues/7899
Supersedes:  https://github.com/kubernetes/test-infra/pull/9423, https://github.com/kubernetes/test-infra/pull/9424

This PR adds a new config-gated `/tbr` command to the LGTM plugin which, **if enabled** for the repo, allows the PR author to self-`lgtm` while adding a `to-be-reviewed` label flagging the PR for future review. 

This can be used for quickly merging fixes where the author can otherwise approve the changes themselves, as an alternative to clicking merge. 

It will be useful in test-infra for the occasional "quick I need to fix this and I'm an `OWNER`" (the original motivation) and generally for allowing maintainers of smaller projects / projects with fewer reviewers to merge fix PRs without write-access or waiting for someone to `/lgtm`.

This plugs a small hole in our "in the future we won't need GitHub's rather limited ACLs".

Changes include...
- make sure lgtm test cases log the test case name to make debugging easier...
- break out the "should we allow the comment author manipulate LGTM" into a separate func

Actual TBR implementation:
- add an option to `lgtm` plugin config for allowing `/tbr` usage
- implement `/tbr` command

TODO: test-caes for `/tbr`
