### PR TITLE
Update instructions for adding new labels via `label_sync`

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -28,7 +28,9 @@ larger set of contributors to apply/remove them.
 ### How do I add a new label?
 
 - Add automation that consumes/produces the label
-- Open a PR against [labels.yaml](https://git.k8s.io/test-infra/label_sync/labels.yaml)
+- Open a PR, _with a single commit_, that:
+  - updates [labels.yaml](https://git.k8s.io/test-infra/label_sync/labels.yaml) with the new label(s)
+  - runs `hack/update-labels.sh` (to regenerate the label descriptions and associated CSS)
 - Involve [sig-contributor-experience](https://git.k8s.io/community/sig-contributor-experience) in the change, eg: chat about it in slack, mention @kubernetes/sig-contributor-experience-pr-reviews in the PR, etc.
 - After the PR is merged, a kubernetes CronJob is responsible for syncing labels daily
 

--- a/label_sync/labels.md.tmpl
+++ b/label_sync/labels.md.tmpl
@@ -25,7 +25,9 @@ larger set of contributors to apply/remove them.
 ### How do I add a new label?
 
 - Add automation that consumes/produces the label
-- Open a PR against [labels.yaml](https://git.k8s.io/test-infra/label_sync/labels.yaml)
+- Open a PR, _with a single commit_, that:
+  - updates [labels.yaml](https://git.k8s.io/test-infra/label_sync/labels.yaml) with the new label(s)
+  - runs `hack/update-labels.sh` (to regenerate the label descriptions and associated CSS)
 - Involve [sig-contributor-experience](https://git.k8s.io/community/sig-contributor-experience) in the change, eg: chat about it in slack, mention @kubernetes/sig-contributor-experience-pr-reviews in the PR, etc.
 - After the PR is merged, a kubernetes CronJob is responsible for syncing labels daily
 


### PR DESCRIPTION
`pull-test-infra-verify-labels` [fails](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/9437/pull-test-infra-verify-labels/204/) when the `labels.yaml` is updated, but `hack/update-labels.sh` is run and committed separately.

This updates the instructions to note update and script run need to be committed together.

ref: https://github.com/kubernetes/test-infra/pull/9437

Signed-off-by: Stephen Augustus <foo@agst.us>