### PR TITLE
Add Docker 18.06 to the CI tests

### DIFF
--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -5,8 +5,8 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+  coreos-beta:
+    image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:


### PR DESCRIPTION
Looks like the @kubernetes/sig-cluster-lifecycle folks are adding support for 18.06 in kubeadm in https://github.com/kubernetes/kubernetes/pull/68495. However we do not have any CI jobs that use 18.06, So let's please add one.

1883.1.0 from https://coreos.com/releases/#beta
Release Date: September 11, 2018
kernel: 4.14.69
rkt: 1.30.0
docker: 18.06.1
etcd: 3.3.9
systemd: 238
Ignition: 0.28.0

Confirmed that the image is available using:
gcloud compute images list | grep coreos

Change-Id: If1a694ad67ed3daa105093e52c1515053c78a532