### PR TITLE
Handle unconfigured golint options

### DIFF
--- a/prow/plugins/golint/BUILD.bazel
+++ b/prow/plugins/golint/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -70,8 +70,17 @@ type githubClient interface {
 	ListPullRequestComments(org, repo string, number int) ([]github.ReviewComment, error)
 }
 
+const defaultConfidence = 0.8
+
+func minConfidence(g *plugins.Golint) float64 {
+	if g == nil || g.MinimumConfidence == nil {
+		return defaultConfidence
+	}
+	return *g.MinimumConfidence
+}
+
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
-	return handle(*pc.PluginConfig.Golint.MinimumConfidence, pc.GitHubClient, pc.GitClient, pc.Logger, &e)
+	return handle(minConfidence(pc.PluginConfig.Golint), pc.GitHubClient, pc.GitClient, pc.Logger, &e)
 }
 
 // modifiedGoFiles returns a map from filename to patch string for all go files

--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
 )
 
 var initialFiles = map[string][]byte{
@@ -95,6 +96,44 @@ var e = &github.GenericCommentEvent{
 		Name:     "bar",
 		FullName: "foo/bar",
 	},
+}
+
+func TestMinConfidence(t *testing.T) {
+	zero := float64(0)
+	half := 0.5
+	cases := []struct {
+		name     string
+		golint   *plugins.Golint
+		expected float64
+	}{
+		{
+			name:     "nothing set",
+			expected: defaultConfidence,
+		},
+		{
+			name:     "no confidence set",
+			golint:   &plugins.Golint{},
+			expected: defaultConfidence,
+		},
+		{
+			name:     "confidence set to zero",
+			golint:   &plugins.Golint{MinimumConfidence: &zero},
+			expected: zero,
+		},
+		{
+			name:     "confidence set positive",
+			golint:   &plugins.Golint{MinimumConfidence: &half},
+			expected: half,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := minConfidence(tc.golint)
+			if actual != tc.expected {
+				t.Errorf("minimum confidence %f != expected %f", actual, tc.expected)
+			}
+		})
+	}
 }
 
 func TestLint(t *testing.T) {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -665,11 +665,6 @@ The list of patch release managers for each release can be found [here](https://
 			c.RequireMatchingLabel[i].GracePeriod = "5s"
 		}
 	}
-
-	if c.Golint != nil && c.Golint.MinimumConfidence == nil {
-		defaultConfidence := 0.8
-		c.Golint.MinimumConfidence = &defaultConfidence
-	}
 }
 
 // Load attempts to load config from the path. It returns an error if either


### PR DESCRIPTION
/assign @stevekuznetsov @cjwagner 

When golint is undefined, plugins.go will not set this value to anything, which will cause hook to blow up.

Move this logic out plugins.go and into a function in golint plugin, which can handle all the scenarios (add unit tests for these scenarios)

ref https://github.com/kubernetes/test-infra/pull/9453 https://github.com/kubernetes/test-infra/pull/9397