### PR TITLE
Fix the Golint minimum confidence loading rules

### DIFF
--- a/prow/plugins/golint/BUILD.bazel
+++ b/prow/plugins/golint/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
-        "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -70,17 +70,8 @@ type githubClient interface {
 	ListPullRequestComments(org, repo string, number int) ([]github.ReviewComment, error)
 }
 
-const defaultConfidence = 0.8
-
-func minConfidence(g *plugins.Golint) float64 {
-	if g == nil || g.MinimumConfidence == nil {
-		return defaultConfidence
-	}
-	return *g.MinimumConfidence
-}
-
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
-	return handle(minConfidence(pc.PluginConfig.Golint), pc.GitHubClient, pc.GitClient, pc.Logger, &e)
+	return handle(*pc.PluginConfig.Golint.MinimumConfidence, pc.GitHubClient, pc.GitClient, pc.Logger, &e)
 }
 
 // modifiedGoFiles returns a map from filename to patch string for all go files

--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -26,7 +26,6 @@ import (
 
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 var initialFiles = map[string][]byte{
@@ -96,44 +95,6 @@ var e = &github.GenericCommentEvent{
 		Name:     "bar",
 		FullName: "foo/bar",
 	},
-}
-
-func TestMinConfidence(t *testing.T) {
-	zero := float64(0)
-	half := 0.5
-	cases := []struct {
-		name     string
-		golint   *plugins.Golint
-		expected float64
-	}{
-		{
-			name:     "nothing set",
-			expected: defaultConfidence,
-		},
-		{
-			name:     "no confidence set",
-			golint:   &plugins.Golint{},
-			expected: defaultConfidence,
-		},
-		{
-			name:     "confidence set to zero",
-			golint:   &plugins.Golint{MinimumConfidence: &zero},
-			expected: zero,
-		},
-		{
-			name:     "confidence set positive",
-			golint:   &plugins.Golint{MinimumConfidence: &half},
-			expected: half,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := minConfidence(tc.golint)
-			if actual != tc.expected {
-				t.Errorf("minimum confidence %f != expected %f", actual, tc.expected)
-			}
-		})
-	}
 }
 
 func TestLint(t *testing.T) {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -665,6 +665,11 @@ The list of patch release managers for each release can be found [here](https://
 			c.RequireMatchingLabel[i].GracePeriod = "5s"
 		}
 	}
+
+	if c.Golint != nil && c.Golint.MinimumConfidence == nil {
+		defaultConfidence := 0.8
+		c.Golint.MinimumConfidence = &defaultConfidence
+	}
 }
 
 // Load attempts to load config from the path. It returns an error if either

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -666,7 +666,10 @@ The list of patch release managers for each release can be found [here](https://
 		}
 	}
 
-	if c.Golint != nil && c.Golint.MinimumConfidence == nil {
+	if c.Golint == nil {
+		c.Golint = &Golint{}
+	}
+	if c.Golint.MinimumConfidence == nil {
 		defaultConfidence := 0.8
 		c.Golint.MinimumConfidence = &defaultConfidence
 	}
@@ -713,6 +716,9 @@ func (pa *PluginAgent) Load(path string) error {
 	if err := validateRequireMatchingLabel(np.RequireMatchingLabel); err != nil {
 		return err
 	}
+	if err := validateGolint(np.Golint); err != nil {
+		return err
+	}
 	pa.Set(np)
 	return nil
 }
@@ -721,6 +727,14 @@ func (pa *PluginAgent) Config() *Configuration {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 	return pa.configuration
+}
+
+// validateGolint will ensure the provided minimum confidence is valid
+func validateGolint(config *Golint) error {
+	if *config.MinimumConfidence <= 0 || *config.MinimumConfidence > 1 {
+		return fmt.Errorf("golint minimum confidence must be in (0,1], not %f", *config.MinimumConfidence)
+	}
+	return nil
 }
 
 // validatePlugins will return error if


### PR DESCRIPTION
Revert "Merge pull request #9454 from fejta/golint"

This reverts commit 8a2266b969ee50df3c6907dad18537a75e1760f4, reversing
changes made to 9fc51e109dc018a88a32ed437b4ccc6777fb1097.

---

Fix the Golint minimum confidence loading rules

The logic to default the Golint minimum confidence was incorrect; the
value that was exposed through configuration was furthermore not
validated to be an appropriate value for the minimum confidence.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/cc @BenTheElder 
/assign @fejta @cjwagner 
/kind bug

I do not think the approach by @fejta  was incorrect, but it would be the one odd man out from all the other defaulting and validation we do for plugin configuration, so I don't want to take that step right now.