### PR TITLE
implement Spyglass build log highlighting and collapsing/expanding

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -466,7 +466,8 @@ Plugin Help style
 }
 
 #lens-container .lens-view-content {
-  width: calc(100% - 32px);
+  width: calc(100% - 16px);
+  padding: 8px;
 }
 
 .lens-card-loading {

--- a/prow/cmd/deck/static/template/spyglass-template.html
+++ b/prow/cmd/deck/static/template/spyglass-template.html
@@ -104,6 +104,28 @@
         document.getElementById(name + "-loading").style.display = "block";
       }
 
+      // Show all lines in specified log
+      function showAllLines(logId) {
+        document.getElementById(logId + "-show-all").style.display = "none";
+        var log = document.getElementById(logId);
+        var skipped = log.querySelectorAll(".skipped");
+        for (var i = 0; i < skipped.length; i++) {
+          skipped[i].style.display = "table-row-group";
+        }
+        // hide any remaining "show hidden lines" buttons
+        var showSkipped = log.querySelectorAll(".show-skipped");
+        for (var i = 0; i < showSkipped.length; i++) {
+          showSkipped[i].style.display = "none";
+        }
+      }
+
+      function showLines(linesId, skipId) {
+        // show a single group of hidden lines
+        document.getElementById(linesId).style.display = "table-row-group";
+        // hide the corresponding button
+        document.getElementById(skipId).style.display = "none";
+      }
+
     </script>
   </body>
 </html>

--- a/prow/cmd/deck/static/template/spyglass-template.html
+++ b/prow/cmd/deck/static/template/spyglass-template.html
@@ -105,12 +105,12 @@
       }
 
       // Show all lines in specified log
-      function showAllLines(logId) {
-        document.getElementById(logId + "-show-all").style.display = "none";
-        var log = document.getElementById(logId);
+      function showAllLines(logID) {
+        document.getElementById(logID + "-show-all").style.display = "none";
+        var log = document.getElementById(logID);
         var skipped = log.querySelectorAll(".skipped");
         for (var i = 0; i < skipped.length; i++) {
-          skipped[i].style.display = "table-row-group";
+          skipped[i].classList.remove("skipped");
         }
         // hide any remaining "show hidden lines" buttons
         var showSkipped = log.querySelectorAll(".show-skipped");
@@ -119,11 +119,11 @@
         }
       }
 
-      function showLines(linesId, skipId) {
+      function showLines(linesID, skipID) {
         // show a single group of hidden lines
-        document.getElementById(linesId).style.display = "table-row-group";
+        document.getElementById(linesID).classList.remove("skipped");
         // hide the corresponding button
-        document.getElementById(skipId).style.display = "none";
+        document.getElementById(skipID).style.display = "none";
       }
 
     </script>

--- a/prow/spyglass/viewers/buildlog/BUILD.bazel
+++ b/prow/spyglass/viewers/buildlog/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -26,4 +26,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["buildlog_viewer_test.go"],
+    embed = [":go_default_library"],
 )

--- a/prow/spyglass/viewers/buildlog/buildlog_template.go
+++ b/prow/spyglass/viewers/buildlog/buildlog_template.go
@@ -24,7 +24,7 @@ var buildLogTemplateText = `<style>
 .loglines {
 	list-style-type: none;
 	padding: 0;
-	margin:0;
+	margin: 0;
 	line-height:1.2;
 	color:black;
 }

--- a/prow/spyglass/viewers/buildlog/buildlog_viewer_test.go
+++ b/prow/spyglass/viewers/buildlog/buildlog_viewer_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildlog
+
+import (
+	"testing"
+)
+
+func TestGroupLines(t *testing.T) {
+	lorem := []string{
+		"Lorem ipsum dolor sit amet",
+		"consectetur adipiscing elit",
+		"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+		"Ut enim ad minim veniam",
+		"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+		"Excepteur sint occaecat cupidatat non proident",
+		"sunt in culpa qui officia deserunt mollit anim id est laborum",
+	}
+	tests := []struct {
+		name   string
+		lines  []string
+		groups []LineGroup
+	}{
+		{
+			name:   "Test empty log",
+			lines:  []string{},
+			groups: []LineGroup{},
+		},
+		{
+			name:  "Test error highlighting",
+			lines: []string{"This is an ErRoR message"},
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   1,
+					Skip:  false,
+				},
+			},
+		},
+		{
+			name:  "Test skip all",
+			lines: lorem,
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   8,
+					Skip:  true,
+				},
+			},
+		},
+		{
+			name: "Test skip none",
+			lines: []string{
+				"a", "b", "c", "d", "e",
+				"Failed to immanentize the eschaton.",
+				"a", "b", "c", "d", "e",
+			},
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   11,
+					Skip:  false,
+				},
+			},
+		},
+		{
+			name: "Test skip threshold",
+			lines: []string{
+				"a", "b", "c", "d", // skip threshold unmet
+				"a", "b", "c", "d", "e", "Failed to immanentize the eschaton.", "a", "b", "c", "d", "e",
+				"a", "b", "c", "d", "e", // skip threshold met
+			},
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   4,
+					Skip:  false,
+				},
+				{
+					Start: 4,
+					End:   15,
+					Skip:  false,
+				},
+				{
+					Start: 15,
+					End:   20,
+					Skip:  true,
+				},
+			},
+		},
+		{
+			name: "Test nearby errors",
+			lines: []string{
+				"a", "b", "c",
+				"don't panic",
+				"a", "b", "c",
+				"I'm panicking!",
+				"a", "b", "c",
+			},
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   11,
+					Skip:  false,
+				},
+			},
+		},
+		{
+			name: "Test separated errors",
+			lines: []string{
+				"a", "b", "c",
+				"don't panic",
+				"a", "b", "c", "d", "e",
+				"a", "b", "c",
+				"a", "b", "c", "d", "e",
+				"I'm panicking!",
+				"a", "b", "c",
+			},
+			groups: []LineGroup{
+				{
+					Start: 0,
+					End:   9,
+					Skip:  false,
+				},
+				{
+					Start: 9,
+					End:   12,
+					Skip:  false,
+				},
+				{
+					Start: 12,
+					End:   21,
+					Skip:  false,
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := groupLines(test.lines, i)
+			if len(got) != len(test.groups) {
+				t.Fatalf("Expected %d groups, got %d", len(test.groups), len(got))
+			}
+			for j, exp := range test.groups {
+				if got[j].Start != exp.Start || got[j].End != exp.End {
+					t.Fatalf("Group %d expected lines [%d, %d), got [%d, %d)", j, exp.Start, exp.End, got[j].Start, got[j].End)
+				}
+				if got[j].Skip != exp.Skip {
+					t.Errorf("Lines [%d, %d) expected Skip = %t", exp.Start, exp.End, exp.Skip)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
/cc @AishSundar @BenTheElder @krzyzacy @paulangton 
fixes #9340 

Error messages in build logs are highlighted. Blocks of log lines not containing error messages are collapsed by default and can be expanded by the user. (Emulates existing Gubernator functionality)

![screenshot from 2018-09-18 10-37-56](https://user-images.githubusercontent.com/16039734/45705655-0108a180-bb2f-11e8-9f14-4eb0b4fa8fd3.png)

