### PR TITLE
podutils: add missing ssh_config file to clonerefs image

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -42,8 +42,10 @@ go_image(
 container_image(
     name = "image",
     base = ":clonerefs-go_image",
+    files = ["ssh_config"],
     symlinks = {
         "/clonerefs": "/app/prow/cmd/clonerefs/clonerefs-linux-amd64",
+        "/etc/ssh/ssh_config": "/ssh_config",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The Bazel build rules for clonerefs do not include the ssh_config file like the Dockerfile does.

This causes clonerefs to fail when closing from GitHub using SSH as it expects a tty in order to ask whether to accept the host key.

This PR adds the ssh_config file at the appropriate path. I have tested this locally and clonerefs is able to clone the repo successfully 😄 