### PR TITLE
Add area/conformance to k/k, k/community, k/test-infra

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -8,6 +8,8 @@
 - [Labels that apply to all repos, for both issues and PRs](#labels-that-apply-to-all-repos-for-both-issues-and-prs)
 - [Labels that apply to all repos, only for issues](#labels-that-apply-to-all-repos-only-for-issues)
 - [Labels that apply to all repos, only for PRs](#labels-that-apply-to-all-repos-only-for-prs)
+- [Labels that apply to kubernetes/community, for both issues and PRs](#labels-that-apply-to-kubernetescommunity-for-both-issues-and-prs)
+- [Labels that apply to kubernetes/kubernetes, for both issues and PRs](#labels-that-apply-to-kuberneteskubernetes-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/kubernetes, only for issues](#labels-that-apply-to-kuberneteskubernetes-only-for-issues)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
 
@@ -155,6 +157,18 @@ larger set of contributors to apply/remove them.
 | <a id="size/XXL" href="#size/XXL">`size/XXL`</a> | Denotes a PR that changes 1000+ lines, ignoring generated files.| prow |  [size](https://git.k8s.io/test-infra/prow/plugins/size) |
 | <a id="tide/squash" href="#tide/squash">`tide/squash`</a> | Denotes a PR that should be squashed by tide when it merges.| humans | |
 
+## Labels that apply to kubernetes/community, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+
+## Labels that apply to kubernetes/kubernetes, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+
 ## Labels that apply to kubernetes/kubernetes, only for issues
 
 | Name | Description | Added By | Prow Plugin |
@@ -168,6 +182,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/boskos" href="#area/boskos">`area/boskos`</a> | Issues or PRs related to code in /boskos| label | |
 | <a id="area/config" href="#area/config">`area/config`</a> | Issues or PRs related to code in /config| label | |
+| <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/ghproxy" href="#area/ghproxy">`area/ghproxy`</a> | Issues or PRs related to code in /ghproxy| label | |
 | <a id="area/greenhouse" href="#area/greenhouse">`area/greenhouse`</a> | Issues or PRs related to code in /greenhouse (our remote bazel cache)| label | |
 | <a id="area/gubernator" href="#area/gubernator">`area/gubernator`</a> | Issues or PRs related to code in /gubernator| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -675,6 +675,13 @@ default:
       prowPlugin: shrug
       addedBy: humans
 repos:
+  kubernetes/community:
+    labels:
+      - color: 0052cc
+        description: Issues or PRs related to kubernetes conformance tests
+        name: area/conformance
+        target: both
+        addedBy: label
   kubernetes/kubernetes:
     labels:
       - color: 0052cc
@@ -687,6 +694,11 @@ repos:
         name: area/api
         target: issues
         addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to kubernetes conformance tests
+        name: area/conformance
+        target: both
+        addedBy: label
   kubernetes/test-infra:
     labels:
       - color: 0052cc
@@ -697,6 +709,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to code in /config
         name: area/config
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to kubernetes conformance tests
+        name: area/conformance
         target: both
         addedBy: label
       - color: 0052cc

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -513,12 +513,22 @@
     color: #000000;
 }
 
+.areax00002fconformance {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fboskos {
     background-color: #0052cc;
     color: #ffffff;
 }
 
 .areax00002fconfig {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
+.areax00002fconformance {
     background-color: #0052cc;
     color: #ffffff;
 }
@@ -684,6 +694,11 @@
 }
 
 .areax00002fprowx00002ftot {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
+.areax00002fconformance {
     background-color: #0052cc;
     color: #ffffff;
 }


### PR DESCRIPTION
I'd like to be able to consistently use `area/conformance` across repos
to denote issues that are relevant to kubernetes conformance. Thus far
these are the repos where I've run into issues/PRs I want to label