### PR TITLE
Ensure all repos in kubernetes-incubator are automated

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -253,11 +253,31 @@ branch-protection:
         contexts:
         - cla/linuxfoundation
       repos:
+        apiserver-builder:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        bootkube:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        cluster-proportional-autoscaler:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        external-storage:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+        kube-aws:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
         kubespray:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
-        bootkube:
+        metrics-server:
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
@@ -309,13 +329,10 @@ tide:
   - orgs:
     - kubernetes-client
     - kubernetes-csi
+    - kubernetes-incubator
     - kubernetes-sigs
     repos:
     - client-go/unofficial-docs
-    - kubernetes-incubator/bootkube
-    - kubernetes-incubator/ip-masq-agent
-    - kubernetes-incubator/kubespray
-    - kubernetes-incubator/service-catalog
     - kubernetes/autoscaler
     - kubernetes/client-go
     - kubernetes/cloud-provider-aws

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -433,41 +433,30 @@ plugins:
   - yuks
 
   kubernetes-incubator:
+  - approve
   - assign
+  - blunderbuss
+  - cat
   - cla
+  - dog
+  - heart
+  - help
+  - hold
   - label
   - lgtm
   - lifecycle
+  - shrug
   - size
-
-  kubernetes-incubator/bootkube:
-  - approve
-  - blunderbuss
-  - hold
+  - skip
   - verify-owners
   - wip
-
-  kubernetes-incubator/kubespray:
-  - approve
-  - blunderbuss
-  - verify-owners
+  - yuks
 
   kubernetes-incubator/service-catalog:
-  - approve
-  - blunderbuss
-  - cat
-  - dog
-  - help
-  - hold
   - trigger
-  - verify-owners
-  - wip
 
   kubernetes-incubator/ip-masq-agent:
-  - approve
-  - hold
   - trigger
-  - verify-owners
 
   kubernetes-security/kubernetes:
   - trigger


### PR DESCRIPTION
This brings kubernetes-incubator up to the same level of automation as
kubernetes-sigs.

If I found a travis-ci context, I marked it as required for merge. This is
so tide doesn't surprise folks by merging before travis has had its say. If
repo owners need to manually merge despite travis failing, they still can.

Suggested lazy consensus deadline: 3pm PT 2018-10-08

WDYT @cblecker @cjwagner @fejta