### PR TITLE
make upload target handle slash in repos

### DIFF
--- a/prow/pod-utils/gcs/target.go
+++ b/prow/pod-utils/gcs/target.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -108,6 +109,8 @@ func NewLegacyRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBuilder {
 			}
 			return repo
 		}
+		// handle gerrit repo
+		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}
 }
@@ -119,6 +122,8 @@ func NewSingleDefaultRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBui
 		if org == defaultOrg && repo == defaultRepo {
 			return ""
 		}
+		// handle gerrit repo
+		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}
 }
@@ -127,6 +132,8 @@ func NewSingleDefaultRepoPathBuilder(defaultOrg, defaultRepo string) RepoPathBui
 // where a path will always have an explicit "org_repo" path segment
 func NewExplicitRepoPathBuilder() RepoPathBuilder {
 	return func(org, repo string) string {
+		// handle gerrit repo
+		repo = strings.Replace(repo, "/", "_", -1)
 		return fmt.Sprintf("%s_%s", org, repo)
 	}
 }

--- a/prow/pod-utils/gcs/target_test.go
+++ b/prow/pod-utils/gcs/target_test.go
@@ -318,6 +318,14 @@ func TestNewLegacyRepoPathBuilder(t *testing.T) {
 			repo:        "wild",
 			expected:    "other_wild",
 		},
+		{
+			name:        "gerrit",
+			defaultOrg:  "org",
+			defaultRepo: "repo",
+			org:         "gerrit",
+			repo:        "foo/bar",
+			expected:    "gerrit_foo_bar",
+		},
 	}
 
 	for _, test := range testCases {
@@ -369,6 +377,14 @@ func TestNewSingleDefaultRepoPathBuilder(t *testing.T) {
 			repo:        "wild",
 			expected:    "other_wild",
 		},
+		{
+			name:        "gerrit",
+			defaultOrg:  "org",
+			defaultRepo: "repo",
+			org:         "gerrit",
+			repo:        "foo/bar",
+			expected:    "gerrit_foo_bar",
+		},
 	}
 
 	for _, test := range testCases {
@@ -380,7 +396,29 @@ func TestNewSingleDefaultRepoPathBuilder(t *testing.T) {
 }
 
 func TestNewExplicitRepoPathBuilder(t *testing.T) {
-	if expected, actual := "a_b", NewExplicitRepoPathBuilder()("a", "b"); expected != actual {
-		t.Errorf("expected explicit repo path builder to create path segment %q but got %q", expected, actual)
+	testCases := []struct {
+		name     string
+		org      string
+		repo     string
+		expected string
+	}{
+		{
+			name:     "default org and repo",
+			org:      "org",
+			repo:     "repo",
+			expected: "org_repo",
+		},
+		{
+			name:     "gerrit",
+			org:      "gerrit",
+			repo:     "foo/bar",
+			expected: "gerrit_foo_bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		if expected, actual := tc.expected, NewExplicitRepoPathBuilder()(tc.org, tc.repo); expected != actual {
+			t.Errorf("tc %s: expected explicit repo path builder to create path segment %q but got %q", tc.name, expected, actual)
+		}
 	}
 }


### PR DESCRIPTION
this unifies upload logic for repo with slashes in bootstrap (https://github.com/kubernetes/test-infra/blob/87f78b890ecf6acc1f4acc289d6e5547a6b3706e/jenkins/bootstrap.py#L682)

should only affect gerrit repos which has slash in repos, and this makes more sense on gcs (instead of gerrit_foo/bar)

/area prow
/assign @cjwagner @BenTheElder @stevekuznetsov @fejta 