### PR TITLE
upgrade experimental kubekins-e2e to go 1.11

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -89,7 +89,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -7,6 +7,6 @@ postsubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         command:
         - "./hack/ci/build-all.sh"

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmit.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         command:
         - "./hack/ci/build-all.sh"
   - name: pull-kind-verify
@@ -16,6 +16,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         command:
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -12,7 +12,7 @@ periodics:
   always_run: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       command:
       - "./hack/ci/build-all.sh"
 # conformance test against kubernetes master branch with `kind`
@@ -25,7 +25,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -73,7 +73,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -52,7 +52,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -68,7 +68,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       args:
       - --repo=github.com/containerd/containerd=release/1.1
       - --repo=github.com/containerd/cri=release/1.0
@@ -280,7 +280,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/test-infra=master"

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -64,7 +64,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -53,7 +53,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -99,7 +99,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -126,7 +126,7 @@ presubmits:
       - name: test
         command:
         - ./hack/verify-config.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         env:
         - name: TEST_TMPDIR
           value: /bazel-scratch/.cache/bazel
@@ -151,7 +151,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -175,7 +175,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         command:
         - ./hack/verify-codegen.sh
         resources:
@@ -225,7 +225,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --root=/go/src

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -25,7 +25,7 @@ CFSSL ?= R1.2
 
 # config for testing prior to rolling out to master / ongoing release
 ifeq ($(K8S), experimental)
-	GO = 1.10.4
+	GO = 1.11
 	BAZEL = 0.16.1
 	CFSSL = R1.2
 	UPGRADE_DOCKER = true


### PR DESCRIPTION
the second commit is from:
```console
$ K8S=experimental make -C "${TREE}/images/kubekins-e2e" push

$ TAG="v20180919-d79396d82-experimental"

$ find "./config/jobs/" -type f -name \*.yaml -exec sed -i "s/\\/kubekins-e2e:v.*-\\(experimental\)$/\\/kubekins-e2e:${TAG}-\\1/" {} \;
```