### PR TITLE
Rename PR Status Tidepool label

### DIFF
--- a/prow/cmd/deck/static/pr-script.js
+++ b/prow/cmd/deck/static/pr-script.js
@@ -430,8 +430,8 @@ function createTidePoolLabel(pr, tidePool) {
     }
     const labelTitle = ["Merging", "In Batch & Test Pending",
         "Test Passing & Merge Pending", "Test Pending",
-        "Test failed/Missing Labels"];
-    const labelStyle = ["merging", "batching", "passing", "pending", "failed"];
+        "Queued for retest"];
+    const labelStyle = ["merging", "batching", "passing", "pending", "pending"];
     label.textContent = "In Pool - " + labelTitle[inPoolId];
     label.classList.add("title-label", "mdl-shadow--2dp", labelStyle[inPoolId]);
 


### PR DESCRIPTION
`MissingPrs` pool cat was named inappropriately in PR Status page. Renamed it to `In pool - Queued for retest`

Fixes #9413

/cc @cjwagner 
/assign @cjwagner 