### PR TITLE
approve: Drop state.repoOptions

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -85,8 +85,6 @@ type state struct {
 	author    string
 	assignees []github.User
 	htmlURL   string
-
-	repoOptions *plugins.Approve
 }
 
 func init() {


### PR DESCRIPTION
We've had this since ff0f5529 (#5115), but `handle` has taken `plugin.Approve` as a sibling of the `state` since that same commit.  So there have never been consumers of the embedded-in-the-`state` property.