### PR TITLE
Enable skip_collaborators for kubernetes-sigs/contributor-playground

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -33,6 +33,8 @@ triggers:
 owners:
   mdyamlrepos:
   - kubernetes/website
+  skip_collaborators:
+  - kubernetes-sigs/contributor-playground
 
 approve:
 - repos:


### PR DESCRIPTION
I think this might do what we want, and allow all lgtm/approve actions to be taken without being a collab on the repo.