### PR TITLE
enable welcome plugin for the contributor playground

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -501,6 +501,7 @@ plugins:
 
   kubernetes-sigs/contributor-playground:
   - require-sig
+  - welcome
 
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - trigger


### PR DESCRIPTION
/assign @jberkus @guineveresaenger 

I would like to enable this to soak test the functionality. I think the existing message is already reasonably welcoming (`Welcome @{{.AuthorLogin}}! It looks like this is your first PR to {{.Org}}/{{.Repo}} 🎉`) and we'll improve it in https://github.com/kubernetes/test-infra/issues/9367