### PR TITLE
Fix label_sync description size limit.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -219,7 +219,7 @@ presubmits:
   - name: pull-test-infra-verify-labels
     branches:
     - master
-    run_if_changed: '^label_sync'
+    run_if_changed: '^label_sync/labels.yaml'
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -194,7 +194,7 @@ func validate(labels []Label, parent string, seen map[string]string) (map[string
 		if newSeen, err := validate(l.Previously, path, newSeen); err != nil {
 			return newSeen, err
 		}
-		if len(l.Description) > 99 { // github limits the description field to 100 chars
+		if len(l.Description) > 100 { // github limits the description field to 100 chars
 			return newSeen, fmt.Errorf("description for %s is too long", name)
 		}
 	}

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -518,6 +518,11 @@
     color: #ffffff;
 }
 
+.areax00002fconformance {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fboskos {
     background-color: #0052cc;
     color: #ffffff;
@@ -694,11 +699,6 @@
 }
 
 .areax00002fprowx00002ftot {
-    background-color: #0052cc;
-    color: #ffffff;
-}
-
-.areax00002fconformance {
     background-color: #0052cc;
     color: #ffffff;
 }


### PR DESCRIPTION
https://github.com/kubernetes/community/labels?utf8=%E2%9C%93&q=area%2Fmentorship-planning+
has exactly 100.
/shrug
/cc @krzyzacy @BenTheElder 