### PR TITLE
improve Spyglass buildlog viewer UI

### DIFF
--- a/prow/spyglass/viewers/buildlog/buildlog_template.go
+++ b/prow/spyglass/viewers/buildlog/buildlog_template.go
@@ -28,8 +28,11 @@ var buildLogTemplateText = `<style>
 	line-height:1.2;
 	color:black;
 }
-.highlighted {
-  background-color: rgba(255, 224, 0, .5);
+.line-highlighted {
+  background-color: rgba(255, 224, 0, .4);
+}
+.match-highlighted {
+  font-weight: bold;
 }
 .skipped {
   display: none;
@@ -68,7 +71,9 @@ tr {
         {{range $line := $g.LogLines}}
         <tr>
           <td class="linenum">{{$line.Number}}</td>
-          <td><span {{if $line.Highlighted}}class="highlighted"{{end}}>{{$line.Text}}</span></td>
+          <td>
+            <span {{if $line.Highlighted}}class="line-highlighted"{{end}}>{{range $s := $line.SubLines}}<span {{if $s.Highlighted}}class="match-highlighted"{{end}}>{{$s.Text}}</span>{{end}}</span>
+          </td>
         </tr>
         {{end}}
       </tbody>

--- a/prow/spyglass/viewers/buildlog/buildlog_viewer_test.go
+++ b/prow/spyglass/viewers/buildlog/buildlog_viewer_test.go
@@ -109,7 +109,7 @@ func TestGroupLines(t *testing.T) {
 				"a", "b", "c",
 				"don't panic",
 				"a", "b", "c",
-				"I'm panicking!",
+				"don't panic",
 				"a", "b", "c",
 			},
 			groups: []LineGroup{
@@ -128,7 +128,7 @@ func TestGroupLines(t *testing.T) {
 				"a", "b", "c", "d", "e",
 				"a", "b", "c",
 				"a", "b", "c", "d", "e",
-				"I'm panicking!",
+				"don't panic",
 				"a", "b", "c",
 			},
 			groups: []LineGroup{


### PR DESCRIPTION
1. The highlighting regex is made more selective, so things like directory names containing "error" won't get matched.
2. The matches themselves are bolded, making them easier to locate within the line.

/cc @BenTheElder @krzyzacy 

![screenshot from 2018-09-21 11-01-34](https://user-images.githubusercontent.com/16039734/45898174-00ba1180-bd8e-11e8-81b1-139dc0c34827.png)
