### PR TITLE
Remove stray branding script reference

### DIFF
--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -222,29 +222,6 @@ window.onload = function () {
     redraw(fz);
 };
 
-document.addEventListener("DOMContentLoaded", function (event) {
-    configure();
-});
-
-function configure() {
-    if (!branding) {
-        return;
-    }
-    if (branding.logo) {
-        document.getElementById('img').src = branding.logo;
-    }
-    if (branding.favicon) {
-        document.getElementById('favicon').href = branding.favicon;
-    }
-    if (branding.background_color) {
-        document.body.style.background = branding.background_color;
-    }
-    if (branding.header_color) {
-        document.getElementsByTagName(
-            'header')[0].style.backgroundColor = branding.header_color;
-    }
-}
-
 function displayFuzzySearchResult(el, inputContainer) {
     el.classList.add("active-fuzzy-search");
     el.style.top = inputContainer.height - 1 + "px";


### PR DESCRIPTION
Whoops, I missed one of these! This should've been removed in #9465 (as several other copies of the same code were).

No functional impact because it's asynchronous, but leaves a spurious error message in the JS console for those happening to look.

/kind bug
/area prow/deck