### PR TITLE
enable trigger for k/release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -369,6 +369,9 @@ plugins:
   kubernetes/perf-tests:
   - trigger
 
+  kubernetes/release:
+  - trigger
+
   kubernetes/sig-release:
   - blockade
   - owners-label


### PR DESCRIPTION
/priority critical-urgent

this should not have been disabled, will investigate how it was disabled later