### PR TITLE
Get rid of /spyglass.js.

### DIFF
--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -5,7 +5,9 @@
 <script type="text/javascript" src="/static/moment.min.js"></script>
 <script type="text/javascript" src="/static/script.js"></script>
 <script type="text/javascript" src="data.js?var=allBuilds"></script>
-<script type="text/javascript" src="spyglass.js?var=spyglass"></script>
+<script type="text/javascript">
+  var spyglass = {{.SpyglassEnabled}};
+</script>
 {{end}}
 
 {{define "content"}}

--- a/prow/cmd/deck/templates.go
+++ b/prow/cmd/deck/templates.go
@@ -54,7 +54,7 @@ func prepareBaseTemplate(templateRoot string, ca jobs.ConfigAgent, t *template.T
 	}).ParseFiles(path.Join(templateRoot, "base.html"))
 }
 
-func handleSimpleTemplate(templateRoot string, ca jobs.ConfigAgent, templateName string) http.HandlerFunc {
+func handleSimpleTemplate(templateRoot string, ca jobs.ConfigAgent, templateName string, param interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		t := template.New(templateName) // the name matters, and must match the filename.
 		if _, err := prepareBaseTemplate(templateRoot, ca, t); err != nil {
@@ -68,7 +68,7 @@ func handleSimpleTemplate(templateRoot string, ca jobs.ConfigAgent, templateName
 			http.Error(w, "error parsing template", http.StatusInternalServerError)
 			return
 		}
-		if err := t.Execute(w, nil); err != nil {
+		if err := t.Execute(w, param); err != nil {
 			logrus.WithError(err).Error("error executing template " + templateName)
 			http.Error(w, "error executing template", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Remove the extra pageload of /spyglass.js in favour of just embedding the boolean value directly.

Also adjusts `handleSimpleTemplate` so you can pass it a value for `.` in the templates it executes.

/area prow/deck
/kind cleanup
