### PR TITLE
Do not use experimental image in containerd.

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -89,7 +89,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -52,7 +52,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-master
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -68,7 +68,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-master
       args:
       - --repo=github.com/containerd/containerd=release/1.1
       - --repo=github.com/containerd/cri=release/1.0
@@ -280,7 +280,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180919-d79396d82-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180918-762ed5b64-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src


### PR DESCRIPTION
Containerd community is still using 1.10, gofmt in 1.11 is not backward compatible with 1.10.

So keep using 1.10 in containerd presubmit test.

Signed-off-by: Lantao Liu <lantaol@google.com>