### PR TITLE
Fix spyglass CSS

### DIFF
--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -88,15 +88,17 @@
 {{end}}
 
 {{define "content"}}
-{{range .Views}}
-<div class="mdl-card mdl-shadow--2dp lens-card">
-<div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{.Title}}</h3></div>
-<div id="{{.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
-  <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{.Name}}-loading"></div>
-    <div id="{{.Name}}-view"></div>
+<div id="lens-container">
+  {{range .Views}}
+  <div class="mdl-card mdl-shadow--2dp lens-card">
+  <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{.Title}}</h3></div>
+  <div id="{{.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
+    <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{.Name}}-loading"></div>
+      <div id="{{.Name}}-view"></div>
+    </div>
   </div>
+  {{end}}
 </div>
-{{end}}
 {{end}}
 
 {{template "page" (settings mobileUnfriendly "spyglass" .)}}


### PR DESCRIPTION
The spyglass CSS wants everything to live in `#lens-container`, so make it so.

Fixes #9531.

Review tip: [ignore whitespace changes](https://github.com/kubernetes/test-infra/pull/9532/files?w=1)

(I'm having a great day!)



/kind bug
/area prow/deck
/cc @BenTheElder 