### PR TITLE
Thaw 1.12 code freeze.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -372,14 +372,9 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
-    milestone: v1.12
-    includedBranches:
-    - master
-    - release-1.12
     labels:
     - lgtm
     - approved
-    - priority/critical-urgent
     - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
@@ -392,24 +387,6 @@ tide:
     - needs-kind
     - needs-rebase
     - needs-sig
-  - repos:
-    - kubernetes/kubernetes
-    excludedBranches:
-    - master
-    - release-1.12
-    labels:
-    - lgtm
-    - approved
-    - "cncf-cla: yes"
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/blocked-paths
-    - do-not-merge/cherry-pick-not-approved
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
   merge_method:
     helm/charts: squash
     kubeflow: squash


### PR DESCRIPTION
- Removes `v1.12` milestone requirement from `release-1.12` and `master` branches.
- Removes `priority/critical-urgent` label requirement from `release-1.12` and `master` branches.
- Adds `needs-kind` and `needs-sig` as forbidden labels for the rest of the branches in `kubernetes/kubernetes`. (We should be blocking on these labels all the time.)


Tide won't update status contexts on PRs that have not changed. I'll restart the `tide` pod to force an update of all status contexts after I've confirmed that the config update is having the expected effect.

This is safe to merge/deploy as soon as the PR looks good.
/cc @tpepper @amwat @spiffxp 