### PR TITLE
Make sure the PR dashboard styling affects nothing else.

### DIFF
--- a/prow/cmd/deck/static/pr-script.js
+++ b/prow/cmd/deck/static/pr-script.js
@@ -102,7 +102,7 @@ function getPRQuery(q) {
  * @param {Object} prData
  */
 function redraw(prData) {
-    const mainContainer = document.querySelector("#main-container");
+    const mainContainer = document.querySelector("#pr-container");
     while (mainContainer.firstChild) {
         mainContainer.removeChild(mainContainer.firstChild);
     }
@@ -225,7 +225,7 @@ window.onload = () => {
         loadProgress(false);
     }, () => {
         loadProgress(false);
-        const mainContainer = document.querySelector("#main-container");
+        const mainContainer = document.querySelector("#pr-container");
         mainContainer.appendChild(createMessage("Something wrongs! We could not fulfill your request"));
     });
     showAlerts();
@@ -359,7 +359,7 @@ function loadPrStatus(prData) {
         tideQueries.push(new TideQuery(query));
     }
 
-    const container = document.querySelector("#main-container");
+    const container = document.querySelector("#pr-container");
     container.appendChild(createSearchCard());
     if (!prData.PullRequestsWithContexts || prData.PullRequestsWithContexts.length === 0) {
         const msg = createMessage("No open PRs found", "");

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -482,12 +482,12 @@ Plugin Help style
     width: calc(100% - 16px);
 }
 
-#main-container {
+#pr-container {
     display: flex;
     flex-direction: column;
 }
 
-#main-container .message {
+#pr-container .message {
     padding-top: 72px;
     text-align: center;
 }

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -37,7 +37,7 @@
     </nav>
   </div>
   <div id="loading-progress" class="mdl-progress mdl-js-progress mdl-progress__indeterminate hidden"></div>
-  <main id="main-container" class="mdl-layout__content">
+  <main class="mdl-layout__content">
     {{block "content" .Arguments}}{{end}}
   </main>
 </div>

--- a/prow/cmd/deck/template/pr.html
+++ b/prow/cmd/deck/template/pr.html
@@ -7,6 +7,11 @@
     <script type="text/javascript" src="data.js?var=allBuilds"></script>
     <script type="text/javascript" src="tide.js?var=tideData"></script>
 {{end}}
+{{define "content"}}
+<div id="pr-container">
+
+</div>
+{{end}}
 {{define "extra content"}}
 <dialog id="search-dialog" class="pr-status-dialog mdl-dialog">
   <h4 class="mdl-dialog__title">Github search query</h4>


### PR DESCRIPTION
The PR dashboard used `#main-container` as a container, which was inadvertently lifted into the base template.

Rename it to `#pr-container` to reduce confusion (especially in the shared stylesheet) and move it back down to the PR dashboard template.

Fixes #9538.

/kind bug
/cc @cjwagner @BenTheElder 
