### PR TITLE
Truncate update timestamp to second precision

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -148,7 +148,8 @@ func (c *Controller) SaveLastSync(lastSync time.Time) error {
 // Sync looks for newly made gerrit changes
 // and creates prowjobs according to presubmit specs
 func (c *Controller) Sync() error {
-	syncTime := time.Now()
+	// gerrit timestamp only has second precision
+	syncTime := time.Now().Truncate(time.Second)
 
 	for instance, changes := range c.gc.QueryChanges(c.lastUpdate, c.ca.Config().Gerrit.RateLimit) {
 		for _, change := range changes {

--- a/prow/gerrit/client/gerrit.go
+++ b/prow/gerrit/client/gerrit.go
@@ -245,7 +245,7 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 
 			// process if updated later than last updated
 			// stop if update was stale
-			if updated.After(lastUpdate) {
+			if !updated.Before(lastUpdate) {
 				// we need to make sure the change update is from a new commit change
 				rev, ok := change.Revisions[change.CurrentRevision]
 				if !ok {
@@ -259,7 +259,7 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 					continue
 				}
 
-				if !created.After(lastUpdate) {
+				if created.Before(lastUpdate) {
 					// stale commit
 					continue
 				}

--- a/prow/gerrit/client/gerrit_test.go
+++ b/prow/gerrit/client/gerrit_test.go
@@ -121,6 +121,28 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
+			name:       "one up-to-date change, same timestamp",
+			lastUpdate: now.Truncate(time.Second),
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						CurrentRevision: "1-1",
+						Updated:         now.Format(layout),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: now.Format(layout),
+							},
+						},
+					},
+				},
+			},
+			revisions: map[string][]string{
+				"foo": {"1-1"},
+			},
+		},
+		{
 			name:       "one up-to-date change but stale commit",
 			lastUpdate: now.Add(-time.Minute),
 			changes: map[string][]gerrit.ChangeInfo{


### PR DESCRIPTION
Their API claims to have nanosecond precision, but when I print out the timestamp I only got second precision :this-is-fine:

```
{"msg":"Change 21021, last updated 2018-09-24 14:21:38.000000000","level":"info","component":"gerrit"}
```

fixes https://github.com/kubernetes/test-infra/issues/9541