### PR TITLE
Update istio testgrid config

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6831,7 +6831,7 @@ dashboards:
 
 - name: istio-postsubmits
   dashboard_tab:
-  - name: postsubmit
+  - name: unit-tests
     test_group_name: istio-istio-postsubmit
     alert_options:
       alert_mail_to_addresses: istio-oncall@googlegroups.com

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6820,7 +6820,7 @@ dashboards:
     test_group_name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-presubmit
   - name: circleci-e2e-pilot-noauth-v1alpha3-v2
     test_group_name: istio-circleci-e2e-pilot-noauth-v1alpha3-v2-presubmit
-  - name: circleci-test
+  - name: circleci-unit-tests
     test_group_name: istio-circleci-test-presubmit
   - name: circleci-racetest
     test_group_name: istio-circleci-racetest-presubmit

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2821,13 +2821,9 @@ test_groups:
 - name: test_pull_request_crio_e2e_rhel
   gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel
 # Istio Prow Presubmits
-- name: istio-presubmit
-  gcs_prefix: istio-prow/directory/istio-presubmit
 - name: istio-unit-tests-presubmit
   gcs_prefix: istio-prow/directory/istio-unit-tests
   days_of_results: 7
-- name: istio-pilot-e2e-presubmit
-  gcs_prefix: istio-prow/directory/istio-pilot-e2e
 - name: istio-pilot-e2e-envoyv2-v1alpha3-presubmit
   gcs_prefix: istio-prow/directory/istio-pilot-e2e-envoyv2-v1alpha3
 - name: istio-e2e-mixer-no_auth-presubmit
@@ -2836,8 +2832,6 @@ test_groups:
   gcs_prefix: istio-prow/directory/e2e-dashboard
 - name: istio-e2e-simpleTests-presubmit
   gcs_prefix: istio-prow/directory/e2e-simpleTests
-- name: istio-e2e-bookInfoTests-presubmit
-  gcs_prefix: istio-prow/directory/e2e-bookInfoTests
 - name: istio-e2e-bookInfoTests-envoyv2-v1alpha3-presubmit
   gcs_prefix: istio-prow/directory/e2e-bookInfoTests-envoyv2-v1alpha3
 # Istio Prow Postsubmits
@@ -2870,7 +2864,7 @@ test_groups:
 - name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-presubmit
   gcs_prefix: istio-circleci/presubmit/e2e-mixer-noauth-v1alpha3-v2
 - name: istio-circleci-e2e-galley-presubmit
-  gcs_prefix: istio-circleci/e2e-galley
+  gcs_prefix: istio-circleci/presubmit/e2e-galley
 - name: istio-circleci-e2e-pilot-cloudfoundry-v1alpha3-v2-presubmit
   gcs_prefix: istio-circleci/presubmit/e2e-pilot-cloudfoundry-v1alpha3-v2
 - name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-presubmit
@@ -2883,9 +2877,9 @@ test_groups:
 - name: istio-circleci-racetest-presubmit
   gcs_prefix: istio-circleci/presubmit/racetest
 - name: istio-circleci-test-integration-local-presubmit
-  gcs_prefix: istio-circleci/test-integration-local
+  gcs_prefix: istio-circleci/presubmit/test-integration-local
 - name: istio-circleci-test-integration-kubernetes-presubmit
-  gcs_prefix: istio-circleci/test-integration-kubernetes
+  gcs_prefix: istio-circleci/presubmit/test-integration-kubernetes
 # Istio CircleCI Postsubmits
 - name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2
   gcs_prefix: istio-circleci/e2e-mixer-noauth-v1alpha3-v2
@@ -6800,12 +6794,8 @@ dashboards:
 
 - name: istio-presubmits
   dashboard_tab:
-  - name: presubmit
-    test_group_name: istio-presubmit
   - name: unit-tests
     test_group_name: istio-unit-tests-presubmit
-  - name: pilot-e2e
-    test_group_name: istio-pilot-e2e-presubmit
   - name: pilot-e2e-envoyv2-v1alpha3
     test_group_name: istio-pilot-e2e-envoyv2-v1alpha3-presubmit
   - name: e2e-mixer-no_auth
@@ -6814,8 +6804,6 @@ dashboards:
     test_group_name: istio-e2e-dashboard-presubmit
   - name: e2e-simpleTests
     test_group_name: istio-e2e-simpleTests-presubmit
-  - name: e2e-bookInfoTests
-    test_group_name: istio-e2e-bookInfoTests-presubmit
   - name: e2e-bookInfoTests-envoyv2-v1alpha3
     test_group_name: istio-e2e-bookInfoTests-envoyv2-v1alpha3-presubmit
   - name: circleci-e2e-simple
@@ -6836,9 +6824,9 @@ dashboards:
     test_group_name: istio-circleci-test-presubmit
   - name: circleci-racetest
     test_group_name: istio-circleci-racetest-presubmit
-  - name: test-integration-local
+  - name: circleci-integration-local
     test_group_name: istio-circleci-test-integration-local-presubmit
-  - name: test-integration-kubernetes
+  - name: circleci-integration-kubernetes
     test_group_name: istio-circleci-test-integration-kubernetes-presubmit
 
 - name: istio-postsubmits


### PR DESCRIPTION
1. Remove state jobs.
2. Renamed test-integration-XXX to circle-integration-XXX to be more
consistent.
3. Updated circle presubmit jobs to use "presubmit" in the path.
4. Updated circle unit tests job name to "circle-unit-tests" to be more descriptive.
5. Updated prow postsubmit job name to "unit-tests" to be more descriptive.