### PR TITLE
use dnsConfig on kind jobs to reduce ndots

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -10,3 +10,10 @@ postsubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180924-8e8468033-experimental
         command:
         - "./hack/ci/build-all.sh"
+      # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+      # so use ndots 1 to improve dns performance
+      # TODO(bentheelder): consider setting this at the cluster level instead
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmit.yaml
@@ -10,6 +10,13 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180924-8e8468033-experimental
         command:
         - "./hack/ci/build-all.sh"
+      # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+      # so use ndots 1 to improve dns performance
+      # TODO(bentheelder): consider setting this at the cluster level instead
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
   - name: pull-kind-verify
     decorate: true
     path_alias: sigs.k8s.io/kind
@@ -19,3 +26,10 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180924-8e8468033-experimental
         command:
         - "./hack/verify-all.sh"
+      # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+      # so use ndots 1 to improve dns performance
+      # TODO(bentheelder): consider setting this at the cluster level instead
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -62,6 +62,13 @@ periodics:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+    # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+    # so use ndots 1 to improve dns performance
+    # TODO(bentheelder): consider setting this at the cluster level instead
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
 # conformance test against kubernetes master branch with `kind`, skipping
 # serial tests so it runs in ~20m
 - interval: 20m
@@ -114,3 +121,10 @@ periodics:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+    # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+    # so use ndots 1 to improve dns performance
+    # TODO(bentheelder): consider setting this at the cluster level instead
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"


### PR DESCRIPTION
this may help with https://github.com/kubernetes/test-infra/issues/9555

if it does we should look at doing this more widely

/area kind
/area jobs