### PR TITLE
Update vendored graphql library to include shurcooL/graphql#30.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -727,7 +727,7 @@
     "ident",
     "internal/jsonutil",
   ]
-  revision = "62c9ce094e75302d560f7adcdf16c06d05aaa958"
+  revision = "e4a3a37e6d42afa87afee2edeeced52300b63893"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/shurcooL/graphql/query.go
+++ b/vendor/github.com/shurcooL/graphql/query.go
@@ -12,7 +12,7 @@ import (
 
 func constructQuery(v interface{}, variables map[string]interface{}) string {
 	query := query(v)
-	if variables != nil {
+	if len(variables) > 0 {
 		return "query(" + queryArguments(variables) + ")" + query
 	}
 	return query
@@ -20,7 +20,7 @@ func constructQuery(v interface{}, variables map[string]interface{}) string {
 
 func constructMutation(v interface{}, variables map[string]interface{}) string {
 	query := query(v)
-	if variables != nil {
+	if len(variables) > 0 {
 		return "mutation(" + queryArguments(variables) + ")" + query
 	}
 	return "mutation" + query


### PR DESCRIPTION
Hopefully we can get some more useful error messages from GitHub's v4 API with this change.
ref: shurcooL/graphql#30

/cc @BenTheElder @stevekuznetsov @fejta 