### PR TITLE
Add logging, stop looking at previous clusters

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -17,6 +17,8 @@
 set -exu
 cd $(dirname $0)
 
+start=$(date +%s)
+
 if [[ -e ${GOOGLE_APPLICATION_CREDENTIALS-} ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
   gcloud config set project k8s-gubernator
@@ -25,46 +27,46 @@ fi
 
 date
 
-table_mtime=$(bq --format=json show 'k8s-gubernator:build.week' | jq -r '(.lastModifiedTime|tonumber)/1000|floor' )
-if [[ ! -e triage_builds.json ]] || [ $(stat -c%Y triage_builds.json) -lt ${table_mtime} ]; then
-  echo "UPDATING" $table_mtime
-  bq --headless --format=json query -n 1000000 \
-    "select
-      path,
-      timestamp_to_sec(started) started,
-      elapsed,
-      tests_run,
-      tests_failed,
-      result,
-      executor,
-      job,
-      number
-    from
-      [k8s-gubernator:build.week]" > triage_builds.json
+bq --headless --format=json query -n 1000000 \
+  "select
+    path,
+    timestamp_to_sec(started) started,
+    elapsed,
+    tests_run,
+    tests_failed,
+    result,
+    executor,
+    job,
+    number
+  from
+    [k8s-gubernator:build.week]" > triage_builds.json
 
-  bq query --allow_large_results --headless -n0 --replace --destination_table k8s-gubernator:temp.triage \
-    "select
-      path build,
-      test.name name,
-      test.failure_text failure_text
-    from
-      [k8s-gubernator:build.week]
-    where
-      test.failed
-      and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -7, 'DAY'))"
-  bq extract --compression GZIP --destination_format NEWLINE_DELIMITED_JSON 'k8s-gubernator:temp.triage' gs://k8s-gubernator/triage_tests.json.gz
-  gsutil cp gs://k8s-gubernator/triage-latest.json.gz triage_tests.json.gz
-  gzip -d triage_tests.json.gz
-fi
+bq query --allow_large_results --headless -n0 --replace --destination_table k8s-gubernator:temp.triage \
+  "select
+    timestamp_to_sec(started) started,
+    path build,
+    test.name name,
+    test.failure_text failure_text
+  from
+    [k8s-gubernator:build.week]
+  where
+    test.failed
+    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -7, 'DAY'))"
+bq extract --compression GZIP --destination_format NEWLINE_DELIMITED_JSON 'k8s-gubernator:temp.triage' gs://k8s-gubernator/triage_tests.json.gz
+gsutil cp gs://k8s-gubernator/triage_tests.json.gz triage_tests.json.gz
+gzip -df triage_tests.json.gz
 
-gsutil cp gs://k8s-gubernator/triage/failure_data.json failure_data_previous.json
+# gsutil cp gs://k8s-gubernator/triage/failure_data.json failure_data_previous.json
 curl -sO --retry 6 https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/test_owners.json
 
 mkdir -p slices
 
-pypy summarize.py triage_builds.json triage_tests.json \
-  --previous failure_data_previous.json --owners test_owners.json \
-  --output failure_data.json --output_slices slices/failure_data_PREFIX.json
+pypy summarize.py \
+  triage_builds.json \
+  triage_tests.json \
+  --owners test_owners.json \
+  --output failure_data.json \
+  --output_slices slices/failure_data_PREFIX.json
 
 gsutil_cp() {
   gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"
@@ -73,3 +75,7 @@ gsutil_cp() {
 gsutil_cp failure_data.json gs://k8s-gubernator/triage/
 gsutil_cp slices/*.json gs://k8s-gubernator/triage/slices/
 gsutil_cp failure_data.json "gs://k8s-gubernator/triage/history/$(date -u +%Y%m%d).json"
+
+stop=$(date +%s)
+elapsed=$(( ${stop} - ${start} ))
+echo "Finished in $(( ${elapsed} / 60))m$(( ${elapsed} % 60))s"


### PR DESCRIPTION
Most of the slowdown appears to come from scanning through previous
failure clusters. So, let's ignore them and do a fresh scan each
time.

Add some comments and logging

Also fix the super embarassing typo in copying test failures down

Locally this was taking ~40min, now it's taking ~4min

ref: https://github.com/kubernetes/test-infra/issues/9271