### PR TITLE
prow/help: only consider open issues and new comments

### DIFF
--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -93,6 +93,11 @@ func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent)
 }
 
 func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.GenericCommentEvent) error {
+	// Only consider open issues and new comments.
+	if e.IsPR || e.IssueState != "open" || e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
 	org := e.Repo.Owner.Login
 	repo := e.Repo.Name
 	commentAuthor := e.User.Login


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/68954 for an example where:

- the main issue body contains a body of text + the `good-first-issue` command.
- the label is removed using the `/remove-good-first-issue` command later.
- the main issue body is edited and it adds back the `good-first-issue` label, because edit actions were also considered now.

/sig contributor-experience
/kind bug

/assign @BenTheElder @cblecker 