### PR TITLE
update kustomize repo to sigs.k8s.io/kustomize

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -10,7 +10,7 @@ periodics:
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
-      - "--repo=github.com/kubernetes-sigs/kustomize"
+      - "--repo=sigs.k8s.io/kustomize"
       - "--upload=gs://kubernetes-jenkins/logs/"
       - "--timeout=150"
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Fix the failure in ci-kustomize-periodic-default-gke https://k8s-testgrid.appspot.com/sig-cli-misc#kustomize-periodic-default-gke
Recently we changed the import paths in kustomize from `github.com/kubernetes-sigs/kustomize` to `sigs.k8s.io/kustomize`.
So the repo need to be checked out to `go/src/sigs.k8s.io/kustomize`.