### PR TITLE
Run triage more frequently as a decorated prowjob

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -27,7 +27,8 @@ periodics:
           memory: "2Gi"
 
 - name: ci-test-infra-triage
-  interval: 1h
+  decorate: true
+  interval: 20m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/triage:latest
@@ -35,6 +36,12 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
+      command:
+        - "timeout"
+      args:
+        - "-t"
+        - "10800"
+        - "/update_summaries.sh"
       volumeMounts:
       - name: service
         mountPath: /etc/service-account

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6262,7 +6262,7 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: gke-kubernetes-engprod+alerts@google.com
   - name: triage
-    description: College results for triage page
+    description: Runs BigQuery queries, summarizes results into clusters, and uploads to GCS for go.k8s.io/triage
     test_group_name: ci-test-infra-triage
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>

--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -20,4 +20,4 @@ RUN curl -o installer https://sdk.cloud.google.com && bash installer --disable-p
 ADD *.py update_summaries.sh /
 
 # Point GOOGLE_APPLICATION_CREDENTIALS at a serviceaccount.json with the necessary permissions.
-CMD ["timeout", "-t", "10800", "/update_summaries.sh"]
+ENTRYPOINT ["timeout", "-t", "10800", "/update_summaries.sh"]


### PR DESCRIPTION
Now that triage is running and taking much less time than before, let's run the job more frequently.

Let's also try using pod utilities to get logs uploaded to GCS and results to show in testgrid.

/area testgrid
/kind cleanup

ref: https://github.com/kubernetes/test-infra/issues/9271