### PR TITLE
Add Tide support for negative repo matching.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,8 @@
 # Announcements
 
 New features added to each component:
+ - *October 10, 2018* `tide` now supports the `-repo:foo/bar` tag in queries via
+   the `excludedRepos` YAML field.
  - *October 3, 2018* `welcome` now supports a configurable message on a per-org,
    or per-repo basis. Please note that this includes a config schema change that
    will break previous deployments of this plugin.

--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -63,4 +63,5 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )

--- a/prow/cmd/deck/static/api/tide.ts
+++ b/prow/cmd/deck/static/api/tide.ts
@@ -3,6 +3,7 @@ import {Commit, PullRequest as BasePullRequest} from "./github";
 export interface TideQuery {
   orgs?: string[];
   repos?: string[];
+  excludedRepos?: string[];
   excludedBranches?: string[];
   includedBranches?: string[];
   labels?: string[];

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -40,8 +40,9 @@ interface ProcessedQuery {
  * A Tide Query helper class that checks whether a pr is covered by the query.
  */
 class TideQuery {
-    repos?: string[];
     orgs?: string[];
+    repos?: string[];
+    excludedRepos?: string[];
     labels?: string[];
     missingLabels?: string[];
     excludedBranches?: string[];
@@ -49,8 +50,9 @@ class TideQuery {
     milestone?: string;
 
     constructor(query: ITideQuery) {
-        this.repos = query.repos;
         this.orgs = query.orgs;
+        this.repos = query.repos;
+        this.excludedRepos = query.excludedRepos;
         this.labels = query.labels;
         this.missingLabels = query.missingLabels;
         this.excludedBranches = query.excludedBranches;
@@ -64,7 +66,8 @@ class TideQuery {
     matchPr(pr: PullRequest): boolean {
         const isMatched =
             (this.repos && this.repos.indexOf(pr.Repository.NameWithOwner) !== -1) ||
-            (this.orgs && this.orgs.indexOf(pr.Repository.Owner.Login) !== -1);
+            ((this.orgs && this.orgs.indexOf(pr.Repository.Owner.Login) !== -1) &&
+            (this.excludedRepos && this.excludedRepos.indexOf(pr.Repository.NameWithOwner) === -1));
 
         if (!isMatched) {
             return false;

--- a/prow/cmd/deck/static/tide/tide.ts
+++ b/prow/cmd/deck/static/tide/tide.ts
@@ -126,37 +126,57 @@ function redrawQueries(): void {
             "GitHub Search Link"
         );
         li.appendChild(a);
+        li.appendChild(document.createTextNode(" - Meaning: Is an open Pull Request"));
 
         // build the description
         // all queries should implicitly mean this
-        const ul = document.createElement("ul");
-        const innerLi = document.createElement("li");
         // add the list of repos, defaulting to an empty array if no repos have been provided.
+        const orgs = tideQuery["orgs"] || [];
         const repos = tideQuery["repos"] || [];
+        const excludedRepos = tideQuery["excludedRepos"] || [];
+        if (orgs.length > 0) {
+            li.appendChild(document.createTextNode(" in one of the following orgs: "));
+            const ul = document.createElement("ul");
+            const innerLi = document.createElement("li");
+            for (let i = 0; i < orgs.length; i++) {
+                innerLi.appendChild(createLink("https://github.com/" + orgs[i], orgs[i]));
+                if (i + 1 < repos.length) {
+                    innerLi.appendChild(document.createTextNode(", "));
+                }
+            }
+            ul.appendChild(innerLi);
+            li.appendChild(ul);
+        }
         if (repos.length > 0) {
-            const explanationPrefix = " - Meaning: Is an open Pull Request " +
-                "in one of the following repos: ";
-            li.appendChild(document.createTextNode(explanationPrefix));
+            let reposText = " in one of the following repos: ";
+            if (orgs.length > 0) {
+                reposText = " or " + reposText;
+            }
+            li.appendChild(document.createTextNode(reposText));
+            const ul = document.createElement("ul");
+            const innerLi = document.createElement("li");
             for (let j = 0; j < repos.length; j++) {
                 innerLi.appendChild(createLink("https://github.com/" + repos[j], repos[j]));
                 if (j + 1 < repos.length) {
                     innerLi.appendChild(document.createTextNode(", "));
                 }
             }
-        } else if (tideQuery.orgs && tideQuery.orgs.length > 0) {
-            const explanationPrefix = " - Meaning: Is an open Pull Request " +
-                "in one of the following orgs: ";
-            li.appendChild(document.createTextNode(explanationPrefix));
-            for (let i = 0; i < tideQuery.orgs.length; i++) {
-                const org = tideQuery.orgs[i];
-                innerLi.appendChild(createLink("https://github.com/" + org, org));
-                if (i + 1 < repos.length) {
+            ul.appendChild(innerLi);
+            li.appendChild(ul);
+        }
+        if (excludedRepos.length > 0) {
+            li.appendChild(document.createTextNode(" but NOT in any of the following excluded repos: "));
+            const ul = document.createElement("ul");
+            const innerLi = document.createElement("li");
+            for (let j = 0; j < excludedRepos.length; j++) {
+                innerLi.appendChild(createLink("https://github.com/" + excludedRepos[j], excludedRepos[j]));
+                if (j + 1 < excludedRepos.length) {
                     innerLi.appendChild(document.createTextNode(", "));
                 }
             }
+            ul.appendChild(innerLi);
+            li.appendChild(ul);
         }
-        ul.appendChild(innerLi);
-        li.appendChild(ul);
         // required labels
         fillDetail(tideQuery.labels, "labels", "with ", li, function(data) {
           return createLabelEl(data);

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -17,8 +17,10 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -70,10 +72,8 @@ type Tide struct {
 	// StatusUpdatePeriod specifies how often Tide will update Github status contexts.
 	// Defaults to the value of SyncPeriod.
 	StatusUpdatePeriod time.Duration `json:"-"`
-	// Queries must not overlap. It must be impossible for any two queries to
-	// ever return the same PR.
-	// TODO: This will only be possible when we allow specifying orgs. At that
-	//       point, verify the above condition.
+	// Queries represents a list of GitHub search queries that collectively
+	// specify the set of PRs that meet merge requirements.
 	Queries TideQueries `json:"queries,omitempty"`
 
 	// A key/value pair of an org/repo as the key and merge method to override
@@ -132,8 +132,9 @@ func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
 // TideQuery is turned into a GitHub search query. See the docs for details:
 // https://help.github.com/articles/searching-issues-and-pull-requests/
 type TideQuery struct {
-	Orgs  []string `json:"orgs,omitempty"`
-	Repos []string `json:"repos,omitempty"`
+	Orgs          []string `json:"orgs,omitempty"`
+	Repos         []string `json:"repos,omitempty"`
+	ExcludedRepos []string `json:"excludedRepos,omitempty"`
 
 	ExcludedBranches []string `json:"excludedBranches,omitempty"`
 	IncludedBranches []string `json:"includedBranches,omitempty"`
@@ -154,6 +155,9 @@ func (tq *TideQuery) Query() string {
 	}
 	for _, r := range tq.Repos {
 		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
+	}
+	for _, r := range tq.ExcludedRepos {
+		toks = append(toks, fmt.Sprintf("-repo:\"%s\"", r))
 	}
 	for _, b := range tq.ExcludedBranches {
 		toks = append(toks, fmt.Sprintf("-base:\"%s\"", b))
@@ -176,41 +180,108 @@ func (tq *TideQuery) Query() string {
 	return strings.Join(toks, " ")
 }
 
-// OrgsAndRepos returns the set of orgs and repos present in any query.
-func (tqs TideQueries) OrgsAndRepos() (sets.String, sets.String) {
-	orgs := sets.NewString()
-	repos := sets.NewString()
-	for i := range tqs {
-		orgs.Insert(tqs[i].Orgs...)
-		repos.Insert(tqs[i].Repos...)
+// ForRepo indicates if the tide query applies to the specified repo.
+func (tq TideQuery) ForRepo(org, repo string) bool {
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+	for _, queryOrg := range tq.Orgs {
+		if queryOrg != org {
+			continue
+		}
+		// Check for repos excluded from the org.
+		for _, excludedRepo := range tq.ExcludedRepos {
+			if excludedRepo == fullName {
+				return false
+			}
+		}
+		return true
 	}
-	return orgs, repos
+	for _, queryRepo := range tq.Repos {
+		if queryRepo == fullName {
+			return true
+		}
+	}
+	return false
 }
 
-// QueryMap is a mapping from ("org/repo" or "org") -> TideQueries that
-// apply to that org or repo.
-type QueryMap map[string]TideQueries
-
-// QueryMap creates a QueryMap from TideQueries
-func (tqs TideQueries) QueryMap() QueryMap {
-	res := make(map[string]TideQueries)
-	for _, tq := range tqs {
-		for _, org := range tq.Orgs {
-			res[org] = append(res[org], tq)
-		}
-		for _, repo := range tq.Repos {
-			res[repo] = append(res[repo], tq)
+func reposInOrg(org string, repos []string) []string {
+	prefix := org + "/"
+	var res []string
+	for _, repo := range repos {
+		if strings.HasPrefix(repo, prefix) {
+			res = append(res, repo)
 		}
 	}
 	return res
 }
 
+// OrgExceptionsAndRepos determines which orgs and repos a set of queries cover.
+// Output is returned as a mapping from 'included org'->'repos excluded in the org'
+// and a set of included repos.
+func (tqs TideQueries) OrgExceptionsAndRepos() (map[string]sets.String, sets.String) {
+	orgs := make(map[string]sets.String)
+	for i := range tqs {
+		for _, org := range tqs[i].Orgs {
+			applicableRepos := sets.NewString(reposInOrg(org, tqs[i].ExcludedRepos)...)
+			if excepts, ok := orgs[org]; !ok {
+				// We have not seen this org so the exceptions are just applicable
+				// members of 'excludedRepos'.
+				orgs[org] = applicableRepos
+			} else {
+				// We have seen this org so the exceptions are the applicable
+				// members of 'excludedRepos' intersected with existing exceptions.
+				orgs[org] = excepts.Intersection(applicableRepos)
+			}
+		}
+	}
+	repos := sets.NewString()
+	for i := range tqs {
+		repos.Insert(tqs[i].Repos...)
+	}
+	// Remove any org exceptions that are explicitly included in a different query.
+	reposList := repos.UnsortedList()
+	for _, excepts := range orgs {
+		excepts.Delete(reposList...)
+	}
+	return orgs, repos
+}
+
+// QueryMap is a struct mapping from "org/repo" -> TideQueries that
+// apply to that org or repo. It is lazily populated, but threadsafe.
+type QueryMap struct {
+	queries TideQueries
+
+	cache map[string]TideQueries
+	sync.Mutex
+}
+
+// QueryMap creates a QueryMap from TideQueries
+func (tqs TideQueries) QueryMap() *QueryMap {
+	return &QueryMap{
+		queries: tqs,
+		cache:   make(map[string]TideQueries),
+	}
+}
+
 // ForRepo returns the tide queries that apply to a repo.
-func (qm QueryMap) ForRepo(org, repo string) TideQueries {
-	qs := TideQueries(nil)
-	qs = append(qs, qm[org]...)
-	qs = append(qs, qm[fmt.Sprintf("%s/%s", org, repo)]...)
-	return qs
+func (qm *QueryMap) ForRepo(org, repo string) TideQueries {
+	res := TideQueries(nil)
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+
+	qm.Lock()
+	defer qm.Unlock()
+
+	if qs, ok := qm.cache[fullName]; ok {
+		return append(res, qs...) // Return a copy.
+	}
+	// Cache miss. Need to determine relevant queries.
+
+	for _, query := range qm.queries {
+		if query.ForRepo(org, repo) {
+			res = append(res, query)
+		}
+	}
+	qm.cache[fullName] = res
+	return res
 }
 
 // Validate returns an error if the query has any errors.
@@ -221,6 +292,7 @@ func (qm QueryMap) ForRepo(org, repo string) TideQueries {
 // * a label that is in both the labels and missing_labels section
 // * a branch that is in both included and excluded branch set.
 func (tq *TideQuery) Validate() error {
+	orgs, repos, excludedRepos := sets.NewString(), sets.NewString(), sets.NewString()
 	for o := range tq.Orgs {
 		if strings.Contains(tq.Orgs[o], "/") {
 			return fmt.Errorf("orgs[%d]: %q contains a '/' which is not valid", o, tq.Orgs[o])
@@ -228,6 +300,10 @@ func (tq *TideQuery) Validate() error {
 		if len(tq.Orgs[o]) == 0 {
 			return fmt.Errorf("orgs[%d]: is an empty string", o)
 		}
+		orgs.Insert(tq.Orgs[o])
+	}
+	if dups := len(tq.Orgs) - orgs.Len(); dups != 0 {
+		return fmt.Errorf("'orgs' contains %d duplicate entries", dups)
 	}
 
 	for r := range tq.Repos {
@@ -235,20 +311,40 @@ func (tq *TideQuery) Validate() error {
 		if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
 			return fmt.Errorf("repos[%d]: %q is not of the form \"org/repo\"", r, tq.Repos[r])
 		}
-		for o := range tq.Orgs {
-			if tq.Orgs[o] == parts[0] {
-				return fmt.Errorf("repos[%d]: %q is already included via orgs[%d]: %q", r, tq.Repos[r], o, tq.Orgs[o])
-			}
+		if orgs.Has(parts[0]) {
+			return fmt.Errorf("repos[%d]: %q is already included via org: %q", r, tq.Repos[r], parts[0])
 		}
+		repos.Insert(tq.Repos[r])
+	}
+	if dups := len(tq.Repos) - repos.Len(); dups != 0 {
+		return fmt.Errorf("'repos' contains %d duplicate entries", dups)
+	}
+
+	if len(tq.Orgs) == 0 && len(tq.Repos) == 0 {
+		return errors.New("'orgs' and 'repos' cannot both be empty")
+	}
+
+	for er := range tq.ExcludedRepos {
+		parts := strings.Split(tq.ExcludedRepos[er], "/")
+		if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+			return fmt.Errorf("excludedRepos[%d]: %q is not of the form \"org/repo\"", er, tq.ExcludedRepos[er])
+		}
+		if !orgs.Has(parts[0]) {
+			return fmt.Errorf("excludedRepos[%d]: %q has no effect because org %q is not included", er, tq.ExcludedRepos[er], parts[0])
+		}
+		// Note: At this point we also know that this excludedRepo is not found in 'repos'.
+		excludedRepos.Insert(tq.ExcludedRepos[er])
+	}
+	if dups := len(tq.ExcludedRepos) - excludedRepos.Len(); dups != 0 {
+		return fmt.Errorf("'excludedRepos' contains %d duplicate entries", dups)
 	}
 
 	if invalids := sets.NewString(tq.Labels...).Intersection(sets.NewString(tq.MissingLabels...)); len(invalids) > 0 {
 		return fmt.Errorf("the labels: %q are both required and forbidden", invalids.List())
 	}
 
-	// Warnings
 	if len(tq.ExcludedBranches) > 0 && len(tq.IncludedBranches) > 0 {
-		logrus.Warning("Smell: Both included and excluded branches are specified (excluded branches have no effect).")
+		return errors.New("both 'includedBranches' and 'excludedBranches' are specified ('excludedBranches' have no effect)")
 	}
 
 	return nil

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -54,6 +54,49 @@ func TestTideQuery(t *testing.T) {
 	checkTok("review:approved")
 }
 
+func TestOrgExceptionsAndRepos(t *testing.T) {
+	queries := TideQueries{
+		{
+			Orgs:          []string{"k8s"},
+			ExcludedRepos: []string{"k8s/k8s"},
+		},
+		{
+			Orgs:          []string{"kuber"},
+			Repos:         []string{"foo/bar", "baz/bar"},
+			ExcludedRepos: []string{"kuber/netes"},
+		},
+		{
+			Orgs:          []string{"k8s"},
+			ExcludedRepos: []string{"k8s/k8s", "k8s/t-i"},
+		},
+		{
+			Orgs:          []string{"org", "org2"},
+			ExcludedRepos: []string{"org2/repo", "org2/repo2", "org2/repo3"},
+		},
+		{
+			Orgs:  []string{"foo"},
+			Repos: []string{"org2/repo3"},
+		},
+	}
+
+	expectedOrgs := map[string]sets.String{
+		"foo":   sets.NewString(),
+		"k8s":   sets.NewString("k8s/k8s"),
+		"kuber": sets.NewString("kuber/netes"),
+		"org":   sets.NewString(),
+		"org2":  sets.NewString("org2/repo", "org2/repo2"),
+	}
+	expectedRepos := sets.NewString("foo/bar", "baz/bar", "org2/repo3")
+
+	orgs, repos := queries.OrgExceptionsAndRepos()
+	if !reflect.DeepEqual(orgs, expectedOrgs) {
+		t.Errorf("Expected org map %v, but got %v.", expectedOrgs, orgs)
+	}
+	if !repos.Equal(expectedRepos) {
+		t.Errorf("Expected repo set %v, but got %v.", expectedRepos, repos)
+	}
+}
+
 func TestMergeMethod(t *testing.T) {
 	ti := &Tide{
 		MergeType: map[string]github.PullRequestMergeType{
@@ -494,6 +537,167 @@ func TestMergeTideContextPolicyConfig(t *testing.T) {
 
 func TestTideQuery_Validate(t *testing.T) {
 	testCases := []struct {
+		name        string
+		query       TideQuery
+		expectError bool
+	}{
+		{
+			name: "good query",
+			query: TideQuery{
+				Orgs:                   []string{"kuber"},
+				Repos:                  []string{"foo/bar", "baz/bar"},
+				ExcludedRepos:          []string{"kuber/netes"},
+				IncludedBranches:       []string{"master"},
+				Milestone:              "backlog-forever",
+				Labels:                 []string{"lgtm", "approve"},
+				MissingLabels:          []string{"do-not-merge/evil-code"},
+				ReviewApprovedRequired: true,
+			},
+			expectError: false,
+		},
+		{
+			name: "simple org query is valid",
+			query: TideQuery{
+				Orgs: []string{"kuber"},
+			},
+			expectError: false,
+		},
+		{
+			name: "org with slash is invalid",
+			query: TideQuery{
+				Orgs: []string{"kube/r"},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty org is invalid",
+			query: TideQuery{
+				Orgs: []string{""},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate org is invalid",
+			query: TideQuery{
+				Orgs: []string{"kuber", "kuber"},
+			},
+			expectError: true,
+		},
+		{
+			name: "simple repo query is valid",
+			query: TideQuery{
+				Repos: []string{"kuber/netes"},
+			},
+			expectError: false,
+		},
+		{
+			name: "repo without slash is invalid",
+			query: TideQuery{
+				Repos: []string{"foobar", "baz/bar"},
+			},
+			expectError: true,
+		},
+		{
+			name: "repo included with parent org is invalid",
+			query: TideQuery{
+				Orgs:  []string{"kuber"},
+				Repos: []string{"foo/bar", "kuber/netes"},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate repo is invalid",
+			query: TideQuery{
+				Repos: []string{"baz/bar", "foo/bar", "baz/bar"},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty orgs and repos is invalid",
+			query: TideQuery{
+				IncludedBranches:       []string{"master"},
+				Milestone:              "backlog-forever",
+				Labels:                 []string{"lgtm", "approve"},
+				MissingLabels:          []string{"do-not-merge/evil-code"},
+				ReviewApprovedRequired: true,
+			},
+			expectError: true,
+		},
+		{
+			name: "simple excluded repo query is valid",
+			query: TideQuery{
+				Orgs:          []string{"kuber"},
+				ExcludedRepos: []string{"kuber/netes"},
+			},
+			expectError: false,
+		},
+		{
+			name: "excluded repo without slash is invalid",
+			query: TideQuery{
+				Orgs:          []string{"kuber"},
+				ExcludedRepos: []string{"kubernetes"},
+			},
+			expectError: true,
+		},
+		{
+			name: "excluded repo included without parent org is invalid",
+			query: TideQuery{
+				Repos:         []string{"foo/bar", "baz/bar"},
+				ExcludedRepos: []string{"kuber/netes"},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate excluded repo is invalid",
+			query: TideQuery{
+				Orgs:                   []string{"kuber"},
+				ExcludedRepos:          []string{"kuber/netes", "kuber/netes"},
+				ReviewApprovedRequired: true,
+			},
+			expectError: true,
+		},
+		{
+			name: "label cannot be required and forbidden",
+			query: TideQuery{
+				Orgs:          []string{"kuber"},
+				Labels:        []string{"lgtm", "approve"},
+				MissingLabels: []string{"do-not-merge/evil-code", "lgtm"},
+			},
+			expectError: true,
+		},
+		{
+			name: "simple excluded branches query is valid",
+			query: TideQuery{
+				Orgs:             []string{"kuber"},
+				ExcludedBranches: []string{"dev"},
+			},
+			expectError: false,
+		},
+		{
+			name: "specifying both included and excluded branches is invalid",
+			query: TideQuery{
+				Orgs:             []string{"kuber"},
+				IncludedBranches: []string{"master"},
+				ExcludedBranches: []string{"dev"},
+			},
+			expectError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.query.Validate()
+			if err != nil && !tc.expectError {
+				t.Errorf("Unexpected error: %v.", err)
+			} else if err == nil && tc.expectError {
+				t.Error("Expected a validation error, but didn't get one.")
+			}
+		})
+
+	}
+}
+
+func TestTideContextPolicy_Validate(t *testing.T) {
+	testCases := []struct {
 		name   string
 		t      TideContextPolicy
 		failed bool
@@ -506,7 +710,7 @@ func TestTideQuery_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "good policy",
+			name: "optional contexts must differ from required contexts",
 			t: TideContextPolicy{
 				OptionalContexts: []string{"c1"},
 				RequiredContexts: []string{"c1"},
@@ -514,7 +718,7 @@ func TestTideQuery_Validate(t *testing.T) {
 			failed: true,
 		},
 		{
-			name: "good policy",
+			name: "individual contexts cannot be both optional and required",
 			t: TideContextPolicy{
 				OptionalContexts: []string{"c1", "c2", "c3", "c4"},
 				RequiredContexts: []string{"c1", "c4"},

--- a/prow/tide/blockers/BUILD.bazel
+++ b/prow/tide/blockers/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/tide/blockers/blockers_test.go
+++ b/prow/tide/blockers/blockers_test.go
@@ -71,11 +71,11 @@ func TestParseBranches(t *testing.T) {
 
 func TestBlockerQuery(t *testing.T) {
 	tcs := []struct {
-		orgs, repos sets.String
-		expected    sets.String
+		orgRepoQuery string
+		expected     sets.String
 	}{
 		{
-			orgs: sets.NewString("k8s"),
+			orgRepoQuery: "org:\"k8s\"",
 			expected: sets.NewString(
 				"is:issue",
 				"state:open",
@@ -84,7 +84,7 @@ func TestBlockerQuery(t *testing.T) {
 			),
 		},
 		{
-			repos: sets.NewString("k8s/t-i"),
+			orgRepoQuery: "repo:\"k8s/t-i\"",
 			expected: sets.NewString(
 				"is:issue",
 				"state:open",
@@ -93,7 +93,7 @@ func TestBlockerQuery(t *testing.T) {
 			),
 		},
 		{
-			orgs: sets.NewString("k8s", "kuber"),
+			orgRepoQuery: "org:\"k8s\" org:\"kuber\"",
 			expected: sets.NewString(
 				"is:issue",
 				"state:open",
@@ -103,7 +103,7 @@ func TestBlockerQuery(t *testing.T) {
 			),
 		},
 		{
-			repos: sets.NewString("k8s/t-i", "k8s/k8s"),
+			orgRepoQuery: "repo:\"k8s/t-i\" repo:\"k8s/k8s\"",
 			expected: sets.NewString(
 				"is:issue",
 				"state:open",
@@ -113,24 +113,23 @@ func TestBlockerQuery(t *testing.T) {
 			),
 		},
 		{
-			orgs:  sets.NewString("kuber", "netes"),
-			repos: sets.NewString("k8s/t-i", "k8s/k8s"),
+			orgRepoQuery: "org:\"k8s\" org:\"kuber\" repo:\"k8s/t-i\" repo:\"k8s/k8s\"",
 			expected: sets.NewString(
 				"is:issue",
 				"state:open",
 				"label:\"blocker\"",
 				"repo:\"k8s/t-i\"",
 				"repo:\"k8s/k8s\"",
-				"org:\"netes\"",
+				"org:\"k8s\"",
 				"org:\"kuber\"",
 			),
 		},
 	}
 
 	for _, tc := range tcs {
-		got := sets.NewString(strings.Split(blockerQuery("blocker", tc.orgs, tc.repos), " ")...)
+		got := sets.NewString(strings.Split(blockerQuery("blocker", tc.orgRepoQuery), " ")...)
 		if !reflect.DeepEqual(got, tc.expected) {
-			t.Errorf("Expected blockerQuery(\"blocker\", %v, %v)==%v, but got %v.", tc.orgs, tc.repos, tc.expected, got)
+			t.Errorf("Expected blockerQuery(\"blocker\", %q)==%q, but got %q.", tc.orgRepoQuery, tc.expected, got)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for the `-repo:foo` GitHub search query tag. So that we can specify repos that should be excluded from searches that include an org.

fixes #9451 

/cc @spiffxp @stevekuznetsov @amwat 