### PR TITLE
fix kind e2e presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -62,8 +62,9 @@ presubmits:
         - "--"
         # the script must run from kubernetes, but we're checking out kind
         - "bash"
+        - "--"
         - "-c"
-        - "cd ./../../k8s.io.kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+        - "cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
fixes:
```
I0927 03:13:35.334] Call:  /workspace/./test-infra/jenkins/../scenarios/execute.py bash -c 'cd ./../../k8s.io.kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh'
W0927 03:13:35.357] usage: execute.py [-h] [--env ENV] cmd [args [args ...]]
```

🤦‍♂️ 

also bikeshed the config filename, and fix the cd path...