### PR TITLE
kubeadm: remove 1.9-on-1.10 job

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
@@ -1,31 +1,5 @@
 # kubeadm x-on-y tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180924-6f4c8e719
-      args:
-      - --repo=k8s.io/kubernetes=release-1.10
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.9
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
-      - --timeout=300m
-
 - name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
   interval: 6h
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2148,8 +2148,6 @@ test_groups:
 - name: ci-kubernetes-e2e-kubeadm-gce-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master
 # kubeadm x-on-y tests
-- name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
 - name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
@@ -4967,8 +4965,6 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-test-1-10
   - name: kubeadm-gce-1-10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  - name: kubeadm-gce-1-9-on-1-10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
   - name: kubeadm-gce-upgrade-1-9-1-10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
   - name: periodic-kubernetes-packages-pushed
@@ -5681,8 +5677,6 @@ dashboards:
   - name: kubeadm-gce-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
 # kubeadm x-on-y tests
-  - name: kubeadm-gce-1.9-on-1.10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9-on-1-10
   - name: gce-kubeadm-1.10-on-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
   - name: kubeadm-gce-1.11-on-1.12


### PR DESCRIPTION
this PR removes the old 1.9-on-1.10 job for kubeadm as requested by @timothysc on slack.
this leaves only the 1.9->1.10 upgrade jobs in terms of 1.9.

a similar amend has been made to the recently added kubeadm-e2e docs:
https://github.com/kubernetes/kubeadm/pull/1148

/area testgrid
/area config
/kind cleanup
/assign @timothysc 
