### PR TITLE
Make config validation check that 'command' or 'args' is specified for decorated jobs.

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -913,6 +913,22 @@ periodics:
 				},
 			},
 		},
+		{
+			name:       "decorated periodic missing `command`",
+			prowConfig: ``,
+			jobConfigs: []string{
+				`
+periodics:
+- interval: 10m
+  agent: kubernetes
+  name: foo
+  decorate: true
+  spec:
+    containers:
+    - image: alpine`,
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I think this is one of the most common configuration mistakes for the pod-utils and it is something that we could be detecting when loading the config.

/cc @stevekuznetsov @BenTheElder @spiffxp @fejta 