### PR TITLE
Fix kubeflow periodic jobs

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: kubeflow-periodic
+- name: kubeflow-periodic-release-branch
   interval: 8h
   labels:
     preset-service-account: "true"
@@ -7,3 +7,10 @@ periodics:
     containers:
     - image: gcr.io/kubeflow-ci/test-worker:latest
       imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.3-branch

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2319,8 +2319,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
 - name: ci-kubernetes-multicluster-ingress-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-multicluster-ingress-test
-- name: kubeflow-periodic
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic
+- name: kubeflow-periodic-release-branch
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic-release-branch
 - name: kubeflow-presubmit
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-presubmit
   num_columns_recent: 30
@@ -5418,9 +5418,9 @@ dashboards:
 
 - name: sig-big-data
   dashboard_tab:
-  - name: kubeflow-periodic
-    description: Periodic testing of Kubeflow.
-    test_group_name: kubeflow-periodic
+  - name: kubeflow-periodic-release-branch
+    description: Periodic testing of Kubeflow on the latest release branch.
+    test_group_name: kubeflow-periodic-release-branch
   - name: kubeflow-postsubmit
     description: Postsubmit tests for Kubeflow.
     test_group_name: kubeflow-postsubmit


### PR DESCRIPTION
- Create a periodic Prow job for Kubeflow release branch.
- Sets environment variables for REPO_OWNER, REPO_NAME, and BRANCH_NAME