### PR TITLE
Enable verify-owners prow plugin for kubernetes-sigs/cluster-api-provider-aws

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -493,6 +493,7 @@ plugins:
 
   kubernetes-sigs/cluster-api-provider-aws:
   - trigger
+  - verify-owners
 
   kubernetes-sigs/cluster-api-provider-gcp:
   - trigger


### PR DESCRIPTION
@roberthbailey I think it would be good to add this plugin to all of the `cluster-api` related repos. I didn't include the other repos in this PR initially because I didn't want to be presumptive. I'm happy to update with other repos if there is agreement. 