### PR TITLE
Update jobs to point to pr-logs directory

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2822,22 +2822,22 @@ test_groups:
   gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel
 # Istio Prow Presubmits
 - name: istio-unit-tests-presubmit
-  gcs_prefix: istio-prow/directory/istio-unit-tests
+  gcs_prefix: istio-prow/pr-logs/directory/istio-unit-tests
   days_of_results: 7
 - name: istio-pilot-e2e-envoyv2-v1alpha3-presubmit
-  gcs_prefix: istio-prow/directory/istio-pilot-e2e-envoyv2-v1alpha3
+  gcs_prefix: istio-prow/pr-logs/directory/istio-pilot-e2e-envoyv2-v1alpha3
 - name: istio-e2e-mixer-no_auth-presubmit
-  gcs_prefix: istio-prow/directory/e2e-mixer-no_auth
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-mixer-no_auth
 - name: istio-e2e-dashboard-presubmit
-  gcs_prefix: istio-prow/directory/e2e-dashboard
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-dashboard
 - name: istio-e2e-simpleTests-presubmit
-  gcs_prefix: istio-prow/directory/e2e-simpleTests
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-simpleTests
 - name: istio-e2e-bookInfoTests-envoyv2-v1alpha3-presubmit
-  gcs_prefix: istio-prow/directory/e2e-bookInfoTests-envoyv2-v1alpha3
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-bookInfoTests-envoyv2-v1alpha3
 - name: istio-pilot-e2e-envoyv2-v1alpha3-mcp-presubmit
-  gcs_prefix: istio-prow/directory/istio-pilot-e2e-envoyv2-v1alpha3-mcp
+  gcs_prefix: istio-prow/pr-logs/directory/istio-pilot-e2e-envoyv2-v1alpha3-mcp
 - name: istio-e2e-mixer-no_auth-mcp-presubmit
-  gcs_prefix: istio-prow/directory/e2e-mixer-no_auth-mcp
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-mixer-no_auth-mcp
 # Istio Prow Postsubmits
 - name: istio-istio-postsubmit
   gcs_prefix: istio-prow/istio-postsubmit


### PR DESCRIPTION
Updated to pod-utils and the path is different. 