### PR TITLE
Migrate PR Dashboard JavaScript to TypeScript

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -43,13 +43,19 @@ rollup_bundle(
     ],
 )
 
-rollup_bundle(
+ts_library(
     name = "pr",
-    srcs = [
-        "pr-script.js",
-    ],
-    entry_point = "prow/cmd/deck/static/pr-script.js",
+    srcs = glob(["pr/*.ts"]),
     deps = [
+        ":api",
+    ],
+)
+
+rollup_bundle(
+    name = "pr_bundle",
+    entry_point = "prow/cmd/deck/static/pr/pr",
+    deps = [
+        ":pr",
         "@npm//:dialog-polyfill",
     ],
 )
@@ -113,7 +119,7 @@ filegroup(
     srcs = [
         ":command_help_bundle",
         ":plugin_help_bundle",
-        ":pr",
+        ":pr_bundle",
         ":prow_bundle",
         ":spyglass_bundle",
         ":tide_bundle",

--- a/prow/cmd/deck/template/pr.html
+++ b/prow/cmd/deck/template/pr.html
@@ -2,7 +2,7 @@
 {{define "scripts"}}
     <link rel="stylesheet" href="/static/labels.css">
     <link rel="stylesheet" href="/static/dialog-polyfill.css">
-    <script type="text/javascript" src="/static/pr.min.js"></script>
+    <script type="text/javascript" src="/static/pr_bundle.min.js"></script>
     <script type="text/javascript" src="data.js?var=allBuilds"></script>
     <script type="text/javascript" src="tide.js?var=tideData"></script>
 {{end}}


### PR DESCRIPTION
This PR performs a minimal migration of the prow status page from JavaScript to TypeScript, in that the TypeScript type checks correctly and doesn't use `any`.

This PR depends on #9622, which depends on #9543. Only the last commit is interesting.

/area prow/deck
/kind cleanup
/cc @BenTheElder 