### PR TITLE
Fix typos issues in prow files

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -157,13 +157,13 @@ const (
 	PullRequestActionReviewRequested = "review_requested"
 	// PullRequestActionReviewRequestRemoved means review requests were removed.
 	PullRequestActionReviewRequestRemoved = "review_request_removed"
-	// PullRequestActionLabeled means means labels were added.
+	// PullRequestActionLabeled means labels were added.
 	PullRequestActionLabeled = "labeled"
 	// PullRequestActionUnlabeled means labels were removed
 	PullRequestActionUnlabeled = "unlabeled"
 	// PullRequestActionOpened means the PR was created
 	PullRequestActionOpened = "opened"
-	// PullRequestActionEdited means means the PR body changed.
+	// PullRequestActionEdited means the PR body changed.
 	PullRequestActionEdited = "edited"
 	// PullRequestActionClosed means the PR was closed (or was merged).
 	PullRequestActionClosed = "closed"

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -44,7 +44,7 @@ func NewDefaultFieldsFormatter(
 	return res
 }
 
-// Format implements logrus.Formatter's Format. We allocate a a new Fields
+// Format implements logrus.Formatter's Format. We allocate a new Fields
 // map in order to not modify the caller's Entry, as that is not a thread
 // safe operation.
 func (d *DefaultFieldsFormatter) Format(entry *logrus.Entry) ([]byte, error) {

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -83,7 +83,7 @@ func (sc *statusController) shutdown() {
 // For instance, we need to convey that a PR is open against a forbidden branch
 // more than we need to detail which status contexts are failed against the PR.
 // Note: an empty diff can be returned if the reason that the PR does not match
-// the TideQuery is unknown. This can happen happen if this function's logic
+// the TideQuery is unknown. This can happen if this function's logic
 // does not match GitHub's and does not indicate that the PR matches the query.
 func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (string, int) {
 	const maxLabelChars = 50


### PR DESCRIPTION
Fix typos issues in below files:
prow/github/types.go
prow/logrusutil/logrusutil.go
prow/tide/status.go