### PR TITLE
Add prow config for kubeadm-dind based IPv6-only CI

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -289,3 +289,42 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
+
+- interval: 6h
+  name: ci-kubernetes-e2e-kubeadm-dind-ipv6
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+    # TODO(leblancd) SSH preset shouldn't be required for provider=local.
+    # This can be removed if PR #9915 is ever reverted.
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --tmpfs=/docker-graph:exec
+      - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+      # TODO(leblancd) The following repo should be switched to
+      # github.com/kubernetes-sigs/kubeadm-dind-cluster=stable when K-D-C
+      # PR #247 is merged and stable branch is bumped to include this fix.
+      - --repo=github.com/leblancd/kubeadm-dind-cluster=k8s_bin_dir_stable
+      - --timeout=80
+      - --clean
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --deployment=kubeadm-dind
+      - --extract=ci/latest
+      - --kubeadm-dind-ip-mode=ipv6
+      # TODO(leblancd) The following path should switch to use
+      # kubernetes-sigs/kubeadm-dind-cluster when K-D-C PR #247 is merged
+      # and K-D-C stable branch is bumped to include this fix.
+      - --kubeadm-dind-k8s-tar-file=/workspace/github.com/leblancd/kubeadm-dind-cluster/kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+      - --provider=local
+      - --ginkgo-parallel=30
+      - --test_args=--ginkgo.focus=Networking|Services --ginkgo.skip=IPv4|DNS|Networking-Performance|Federation|functioning\sNodePort|preserve\ssource\spod|affinity\swork|affinity\sfor --minStartupPods=8
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
+      # Privileged mode required to enable IPv6 and Docker-in-Docker mode
+      securityContext:
+        privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -380,6 +380,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-coredns
 - name: ci-kubernetes-e2e-gci-gce-kube-dns
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-kube-dns
+- name: ci-kubernetes-e2e-kubeadm-dind-ipv6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-dind-ipv6
 - name: ci-kubernetes-e2e-gce-alpha-api
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
@@ -6006,6 +6008,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-kube-dns
     base_options: include-filter-by-regex=\[sig-network\]
     description: network gci-gce tests with kube-dns
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
+  - name: kubeadm-dind-ipv6
+    test_group_name: ci-kubernetes-e2e-kubeadm-dind-ipv6
+    base_options: include-filter-by-regex=\[sig-network\]
+    description: network Kubeadm-DinD-Cluster based IPv6 tests
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gce-alpha-api


### PR DESCRIPTION
This change adds prow config for a CI test job for testing Kubernetes
IPv6-only functionality. This config uses the Kubeadm-DinD-Cluster (K-D-C)
kubetest deployer that was added via PR #7529.

The K-D-C scripts provide some built-in functionality that is important for
testing IPv6-only support:

    Bridge CNI and host local IPAM plugins are loaded (both plugins support IPv6)
    Static routes are provided from each node to pod networks on other nodes.
    When the scripts are run in IPv6 mode, the following is configured for the cluster:
        IPv6 node addresses and service subnets
        IPv6 CNI configuration for pods
        IPv6 DNS nameserver in kubelet startup config
        Bind9 container for DNS64 functionality
        Tayga container for NAT64 functionality

The End-to-End test suite that is used to test functionality is described here:
https://github.com/leblancd/kube-v6-test

I've tested this CI by running its Prow container locally
(via 'docker run ...'), sample results and logs can be found here:
    https://k8s-gubernator.appspot.com/builds/my-kubernetes-jenkins/pull/65951/pull-kubernetes-e2e-kubeadm-dind-ipv6/