### PR TITLE
Check effect of flakeAttempts=1 in ci-kubernetes-e2e-gci-gce-flaky job

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -233,7 +233,28 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-f
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
+      - --timeout=180m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180924-8e8468033-master
+
+- interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=200
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-f
+      - --provider=gce
+      - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20180924-8e8468033-master
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -351,6 +351,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-etcd3
 - name: ci-kubernetes-e2e-gci-gce-flaky
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-flaky
+- name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-single-flake-attempt
 - name: ci-kubernetes-e2e-gci-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce
 - name: ci-kubernetes-e2e-gci-gce-scalability
@@ -4134,6 +4136,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-etcd3
   - name: gci-gce-flaky
     test_group_name: ci-kubernetes-e2e-gci-gce-flaky
+  - name: gci-gce-single-flake-attempt
+    test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
   - name: gci-gce-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
   - name: gce-multizone
@@ -5368,6 +5372,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-flaky
     base_options: include-filter-by-regex=sig-api-machinery
     description: apimachinery gce flaky e2e tests for master branch
+  - name: gce-single-flake-attempt
+    test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
+    base_options: include-filter-by-regex=sig-api-machinery
+    description: apimachinery gce e2e tests for master branch with reduced flake attempt
   - name: gke-flaky
     test_group_name: ci-kubernetes-e2e-gci-gke-flaky
     base_options: include-filter-by-regex=sig-api-machinery
@@ -6361,6 +6369,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-flaky
     base_options: include-filter-by-regex=Volume%7Cstorage
     description: storage gce flaky e2e tests for master branch
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
+  - name: gce-single-flake-attempt
+    test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
+    base_options: include-filter-by-regex=Volume%7Cstorage
+    description: storage gce e2e tests for master branch with reduced flake attempt
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
   - name: gke-flaky


### PR DESCRIPTION
So, we need to measure the effect of the default flakeAttempts=2 in our
CI.

We already have a ci-kubernetes-e2e-gci-gce-flaky which runs just tests
with "Flaky" tags. So let's set flakeAttempts=1 for that.

Let's add a ci-kubernetes-e2e-gci-gce-single-flake-attempt that runs all
the tests including the Flaky ones (see above).

We run this experiment for say a month to see:
- Are the Flaky tests really flaky?
- Does flakeAttempts hide failures and contribute to increasing the
  flakiness overall over time
- How worse off would we be if we set flakeAttempts=1 for all the jobs
  and may be even get rid of ginkgo eventually.

Change-Id: Ifa9b1ba24b126b0f670bc4382ee666241230475d