### PR TITLE
Migrate spyglass JavaScript to TypeScript

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -87,6 +87,19 @@ rollup_bundle(
     ],
 )
 
+ts_library(
+    name = "spyglass",
+    srcs = glob(["spyglass/*.ts"]),
+)
+
+rollup_bundle(
+    name = "spyglass_bundle",
+    entry_point = "prow/cmd/deck/static/spyglass/spyglass",
+    deps = [
+        ":spyglass",
+    ],
+)
+
 filegroup(
     name = "resources",
     srcs = glob(
@@ -102,6 +115,7 @@ filegroup(
         ":plugin_help_bundle",
         ":pr",
         ":prow_bundle",
+        ":spyglass_bundle",
         ":tide_bundle",
     ],
 )

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,0 +1,105 @@
+interface Lens {
+  Name: string;
+  Title: string;
+  HTMLView: string;
+  Priority: number;
+}
+
+declare const src: string;
+declare const viewerCache: {[key: string]: string[]};
+declare const views: Lens[];
+
+// Loads views for this job
+function loadViews(): void {
+  for (let view of views) {
+    refreshView(view.Name, '{}');
+  }
+}
+
+// refreshView refreshes a single view. Use this function to to communicate with your viewer backend.
+function refreshView(viewName: string, viewData: string): void {
+  requestReload(viewName, createBody(viewName, viewData))
+}
+
+// Add a function here with a standard body response (list of matching artifacts, etc)
+function createBody(viewName: string, viewData: string): string {
+  return JSON.stringify({
+    name: viewName,
+    viewMatches: viewerCache[viewName],
+    viewData: viewData
+  });
+}
+
+// asynchronously requests a reloaded view of the provided viewer given a body request
+function requestReload(name: string, body: string): void {
+  insertLoading(name);
+  const url = "/view/render?src="+encodeURIComponent(src)+"&name="+encodeURIComponent(name);
+  const req = new XMLHttpRequest();
+  req.open('POST', url, true);
+  req.setRequestHeader('Content-Type', 'application/json');
+  req.onreadystatechange = function() {
+    if (req.readyState === 4 && req.status === 200) {
+      const lensJson = JSON.parse(req.responseText) as Lens;
+      insertView(name, lensJson.HTMLView);
+    } else if (req.readyState === 4 && !(req.status === 200)) {
+      insertView(name, "<div>Error: " + req.status +"</div>");
+    }
+  };
+  req.send(body);
+}
+
+// Insert rendered view into page and remove loading wheel
+function insertView(name: string, content: string): void {
+  document.getElementById(name + "-loading")!.style.display = "none";
+  document.getElementById(name + "-view")!.innerHTML = content;
+}
+
+// Show loading wheel over view
+function insertLoading(name: string): void {
+  document.getElementById(name + "-loading")!.style.display = "block";
+}
+
+window.onload = loadViews;
+
+// Show all lines in specified log
+function showAllLines(logID: string): void {
+  document.getElementById(logID + "-show-all")!.style.display = "none";
+  const log = document.getElementById(logID)!;
+  const skipped = log.querySelectorAll<HTMLElement>(".skipped");
+  for (let i = 0; i < skipped.length; i++) {
+    skipped[i].classList.remove("skipped");
+  }
+  // hide any remaining "show hidden lines" buttons
+  const showSkipped = log.querySelectorAll<HTMLElement>(".show-skipped");
+  for (let i = 0; i < showSkipped.length; i++) {
+    showSkipped[i].style.display = "none";
+  }
+}
+
+function showLines(linesID: string, skipID: string): void {
+  // show a single group of hidden lines
+  document.getElementById(linesID)!.classList.remove("skipped");
+  // hide the corresponding button
+  document.getElementById(skipID)!.style.display = "none";
+}
+
+function toggleExpansion(bodyId: string, expanderId: string): void {
+  const body = document.getElementById(bodyId)!;
+  body.classList.toggle('hidden-tests');
+  if (body.classList.contains('hidden-tests')) {
+    document.getElementById(expanderId)!.innerHTML = 'expand_more';
+  } else {
+    document.getElementById(expanderId)!.innerHTML = 'expand_less';
+  }
+}
+
+// The following form the "public API" and so are exposed until we do something
+// better.
+
+// Actual public API:
+(window as any).refreshView = refreshView;
+
+// Just for the build log:
+(window as any).showAllLines = showAllLines;
+(window as any).showLines = showLines;
+(window as any).toggleExpansion = toggleExpansion;

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -1,100 +1,12 @@
 {{define "title"}}Job View {{.Source}}{{end}}
 
 {{define "scripts"}}
-<script type="text/javascript" src="/static/prow_bundle.min.js"></script>
 <script type="text/javascript">
-  var pageUrl = window.location.href;
-  var urlObj = new URL(pageUrl);
-  var src = {{.Source}}
+  var src = {{.Source}};
   var viewerCache = {{ .ViewerCache}};
-
-  // Loads views for this job
-  function loadViews() {
-    {{.Views}}.map(view => {
-      refreshView(view.Name, '{}')
-    });
-  }
-
-  // refreshView refreshes a single view. Use this function to to communicate with your viewer backend.
-  function refreshView(viewName, viewData) {
-    requestReload(viewName, createBody(viewName, viewData))
-  }
-
-  // Add a function here with a standard body response (list of matching artifacts, etc)
-  function createBody(viewName, viewData) {
-    var body = new Object();
-    body.name = viewName;
-    body.viewMatches = viewerCache[viewName];
-    body.viewData = viewData;
-    return JSON.stringify(body);
-  }
-
-  // asynchronously requests a reloaded view of the provided viewer given a body request
-  function requestReload(name, body) {
-    insertLoading(name);
-    const url = "/view/render?src="+encodeURIComponent(src)+"&name="+encodeURIComponent(name);
-    var req = new XMLHttpRequest();
-    req.open('POST', url, true);
-    req.setRequestHeader('Content-Type', 'application/json')
-    req.onreadystatechange = function() {
-      if (req.readyState === 4 && req.status === 200) {
-        var lensJson = JSON.parse(req.responseText);
-        insertView(name, lensJson.HTMLView);
-      } else if (req.readyState === 4 && !(req.status === 200)) {
-       insertView(name, "<div>Error: " + req.status +"</div>");
-      }
-
-    }
-    req.send(body);
-  }
-
-  // Insert rendered view into page and remove loading wheel
-  function insertView(name, content) {
-    document.getElementById(name + "-loading").style.display = "none";
-    document.getElementById(name + "-view").innerHTML = content;
-  }
-
-  // Show loading wheel over view
-  function insertLoading(name) {
-    document.getElementById(name + "-loading").style.display = "block";
-  }
-
-  window.onload = loadViews;
-
-  // Show all lines in specified log
-  function showAllLines(logID) {
-    document.getElementById(logID + "-show-all").style.display = "none";
-    var log = document.getElementById(logID);
-    var skipped = log.querySelectorAll(".skipped");
-    for (var i = 0; i < skipped.length; i++) {
-      skipped[i].classList.remove("skipped");
-    }
-    // hide any remaining "show hidden lines" buttons
-    var showSkipped = log.querySelectorAll(".show-skipped");
-    for (var i = 0; i < showSkipped.length; i++) {
-      showSkipped[i].style.display = "none";
-    }
-  }
-
-  function showLines(linesID, skipID) {
-    // show a single group of hidden lines
-    document.getElementById(linesID).classList.remove("skipped");
-    // hide the corresponding button
-    document.getElementById(skipID).style.display = "none";
-  }
-
-  function toggleExpansion(bodyId, expanderId) {
-    var body = document.getElementById(bodyId);
-    body.classList.toggle('hidden-tests');
-    if (body.classList.contains('hidden-tests')) {
-      document.getElementById(expanderId).innerHTML = 'expand_more';
-    } else {
-      document.getElementById(expanderId).innerHTML = 'expand_less';
-    }
-  }
-
-  window.onload = loadViews;
+  var views = {{ .Views }};
 </script>
+<script type="text/javascript" src="/static/spyglass_bundle.min.js"></script>
 {{end}}
 
 {{define "content"}}


### PR DESCRIPTION
This one is kinda silly because literally all the types are apparently `string`, but it lays the foundation for future work.

As with the others, depends on #9622, which depends on #9543. Only the last commit is interesting.

/area prow/deck
/kind cleanup
/cc @BenTheElder 