### PR TITLE
switch kind to track k/k master e2e images

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
         command:
         - "./hack/ci/build-all.sh"
       # trialing this on kind jobs, we are using FQDN for in-cluster services, now

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
         command:
         - "./hack/ci/build-all.sh"
       # trialing this on kind jobs, we are using FQDN for in-cluster services, now
@@ -46,7 +46,7 @@ presubmits:
     optional: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -12,7 +12,7 @@ periodics:
   always_run: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
       command:
       - "./hack/ci/build-all.sh"
 # conformance test against kubernetes master branch with `kind`
@@ -25,7 +25,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -80,7 +80,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"


### PR DESCRIPTION
we don't need it that badly and we're hitting caching flakes on -experimental. 

realistically kind _should_ be tracking the same tools as k8s master for building k8s master..

I'm leaving the verify job on -experimental so we don't regress in gofmt