### PR TITLE
Add missing labels for CI coverage job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -2,6 +2,9 @@ periodics:
 - interval: 1h
   name: ci-kubernetes-coverage-conformance
   decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
     repo: kubernetes


### PR DESCRIPTION
Apparently I was supposed to guess that these were necessary.

/cc @BenTheElder 