### PR TITLE
Make Tide ignore pending batch jobs containing PRs that have left the pool of been updated.

### DIFF
--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -171,6 +171,19 @@ func TestAccumulateBatch(t *testing.T) {
 			pulls:   []pull{{1, "a"}, {2, "b"}},
 			pending: false,
 		},
+		{
+			name:       "pending batch with PR that left pool, successful previous run",
+			presubmits: map[int]sets.String{2: jobSet},
+			pulls:      []pull{{2, "b"}},
+			prowJobs: []prowjob{
+				{job: "foo", state: kube.PendingState, prs: []pull{{1, "a"}}},
+				{job: "foo", state: kube.SuccessState, prs: []pull{{2, "b"}}},
+				{job: "bar", state: kube.SuccessState, prs: []pull{{2, "b"}}},
+				{job: "baz", state: kube.SuccessState, prs: []pull{{2, "b"}}},
+			},
+			pending: false,
+			merges:  []int{2},
+		},
 	}
 	for _, test := range tests {
 		var pulls []PullRequest


### PR DESCRIPTION
fixes #9558 
I tried to make this a little more readable as well.

/cc @BenTheElder @stevekuznetsov 
/kind bug