### PR TITLE
Move kubernetes-incubator/kube-arbitrator to k-sigs/kube-batch

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -256,10 +256,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
-        kube-arbitrator:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
         node-feature-discovery:
           required_status_checks:
             contexts:
@@ -269,6 +265,11 @@ branch-protection:
       required_status_checks:
         contexts:
         - cla/linuxfoundation
+      repos:
+        kube-batch:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
 
 tide:
   queries:


### PR DESCRIPTION
I'm manually disabling the rest of the branch protection rules so that
tide will play nicely

ref: https://github.com/kubernetes/org/issues/112

/sig scheduling
/hold
until I've got the branch protection settings taken care of, and have moved
the repo over