### PR TITLE
Remove etcd2 from non-upgrade CI tests

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -55,7 +55,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env-file=jobs/env/ci-kubernetes-e2e-gci-gce-sig-cli.env
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci

--- a/jobs/env/ci-kubernetes-e2e-gce-alpha-api.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-alpha-api.env
@@ -1,9 +1,4 @@
 ### job-env
 
-# For now explicitly test etcd v2 mode in this suite.
-STORAGE_BACKEND=etcd2
-TEST_ETCD_IMAGE=2.2.1
-TEST_ETCD_VERSION=2.2.1
-
 # List GCE Alpha features we want to enable, separated by commas.
 GCE_ALPHA_FEATURES=NetworkTiers

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-ip-alias.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-ip-alias.env
@@ -1,8 +1,3 @@
 ### job-env
 
-# For now explicitly test etcd v2 mode in this suite.
-STORAGE_BACKEND=etcd2
-TEST_ETCD_IMAGE=2.2.1
-TEST_ETCD_VERSION=2.2.1
-
 KUBE_GCE_ENABLE_IP_ALIASES=true

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-sig-cli.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-sig-cli.env
@@ -1,6 +1,0 @@
-### job-env
-# For now explicitly test etcd v2 mode in this suite.
-STORAGE_BACKEND=etcd2
-TEST_ETCD_IMAGE=2.2.1
-TEST_ETCD_VERSION=2.2.1
-

--- a/jobs/env/ci-kubernetes-e2e-gci-gce.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce.env
@@ -1,8 +1,4 @@
 ### job-env
-# For now explicitly test etcd v2 mode in this suite.
-STORAGE_BACKEND=etcd2
-TEST_ETCD_IMAGE=2.2.1
-TEST_ETCD_VERSION=2.2.1
 
 # Enable the PodSecurityPolicy in tests.
 ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/7602
ref: https://github.com/kubernetes/features/issues/622
ref: https://github.com/kubernetes/kubernetes/pull/69310

I would like to address the upgrade tests in a later PR.

I've broken into commit-per-env-file, with a list of jobs
that could be impacted for each commit

/hold
I would like to get a gut check on how green these jobs are today before
we go flipping this on them.  But the idea would be to merge all at once,
and then revert whichever commit(s) are necessary if jobs start failing.