### PR TITLE
Use etcd 3.2.24 in kops-canary test

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -233,7 +233,7 @@ periodics:
       - --env=KUBE_SSH_USER=admin
       - --extract=ci/latest
       - --ginkgo-parallel
-      - --kops-etcd-version=3.1.10
+      - --kops-etcd-version=3.2.24
       - --kops-master-count=3
       - --kops-multiple-zones
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt


### PR DESCRIPTION
Our new way of running etcd, etcd-manager, doesn't (yet) support
arbitrary etcd versions, and we're sticking with the recommended
versions for now.