### PR TITLE
Correctly quote/escape [Conformance] in the coverage job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -33,7 +33,7 @@ periodics:
         ../test-infra/scenarios/kubernetes_e2e.py --build=quick --dump-before-and-after --extract=local \
                                                   --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-conformance-coverage \
                                                   --gcp-zone=us-central1-f --provider=gce --timeout=120m \
-                                                  --test_args=--ginkgo.focus=\[Conformance\]
+                                                  --test_args="--ginkgo.focus=\[Conformance\]"
         cd ../test-infra
         bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
         bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"


### PR DESCRIPTION
I am relatively confident that this is the correct combination of quotes and backslashes to do the right thing.

/cc @BenTheElder @spiffxp 