### PR TITLE
Remove etcd2 upgrade/downgrade jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
@@ -204,34 +204,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181002-3e479534e-master
 
 - interval: 2h
-  name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=110
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --env=STORAGE_BACKEND=etcd2
-      - --env=ETCD_VERSION=2.2.1
-      - --env=ETCD_IMAGE=2.2.1
-      - --env=STORAGE_MEDIA_TYPE=application/json
-      - --extract=ci/latest
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test=false
-      - --timeout=60m
-      - --upgrade_args=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181002-3e479534e-master
-
-- interval: 2h
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
@@ -1,29 +1,4 @@
 periodics:
-- interval: 2h
-  name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=110
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --env-file=jobs/env/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env
-      - --extract=ci/latest
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test=false
-      - --timeout=60m
-      - --upgrade_args=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181002-3e479534e-master
-
 - interval: 30m
   name: ci-kubernetes-e2e-gce-ha-master
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2170,9 +2170,6 @@ test_groups:
 # packages tests
 - name: periodic-kubernetes-e2e-packages-pushed
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-packages-pushed
-# etcd tests
-- name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
 
 # charts tests
 - name: ci-kubernetes-charts-gce
@@ -4539,11 +4536,6 @@ dashboards:
   - name: gke-gci-new-gci-master-upgrade-cluster-new
     test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
     description: Upgrade master and node, in gke(gci), from 1.10 to master, and run skewed e2e tests
-
-- name: sig-release-etcd-upgrades
-  dashboard_tab:
-  - name: gce-latest
-    test_group_name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
 
 # These are the master *blocking* tests.  These provide a valid binary signal
 # to gate releases (alpha, beta, official).
@@ -7371,7 +7363,6 @@ dashboard_groups:
   - sig-release-1.11-blocking
   - sig-release-1.10-all
   - sig-release-1.10-blocking
-  - sig-release-etcd-upgrades
   - sig-release-1.9-all
   - sig-release-1.9-blocking
   - sig-release-misc

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2173,8 +2173,6 @@ test_groups:
 # etcd tests
 - name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
-- name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
 
 # charts tests
 - name: ci-kubernetes-charts-gce
@@ -4546,8 +4544,6 @@ dashboards:
   dashboard_tab:
   - name: gce-latest
     test_group_name: ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd
-  - name: gce-rollback-latest
-    test_group_name: ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
 
 # These are the master *blocking* tests.  These provide a valid binary signal
 # to gate releases (alpha, beta, official).


### PR DESCRIPTION
ref: #7602
ref: kubernetes/features#622
ref: kubernetes/kubernetes#69310

Followup to #9672

As we are no longer supporting etcd2 in v1.13, we no longer need
these jobs