### PR TITLE
kubetest e2e runner: automatically populate --host from kubeconfig

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -85,6 +85,7 @@ filegroup(
         "//kubetest/dind:all-srcs",
         "//kubetest/e2e:all-srcs",
         "//kubetest/kubeadmdind:all-srcs",
+        "//kubetest/kubectl:all-srcs",
         "//kubetest/process:all-srcs",
         "//kubetest/util:all-srcs",
     ],

--- a/kubetest/kubectl/BUILD.bazel
+++ b/kubetest/kubectl/BUILD.bazel
@@ -1,17 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "interfaces.go",
-        "runner.go",
-    ],
-    importpath = "k8s.io/test-infra/kubetest/e2e",
+    srcs = ["config.go"],
+    importpath = "k8s.io/test-infra/kubetest/kubectl",
     visibility = ["//visibility:public"],
-    deps = [
-        "//kubetest/kubectl:go_default_library",
-        "//kubetest/process:go_default_library",
-    ],
+    deps = ["//kubetest/process:go_default_library"],
 )
 
 filegroup(
@@ -26,4 +20,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
 )

--- a/kubetest/kubectl/config.go
+++ b/kubetest/kubectl/config.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+
+	"k8s.io/test-infra/kubetest/process"
+)
+
+// GetConfig gets the current kubectl configuration, parsing the output into a kubeconfig object
+func GetConfig(control *process.Control, kubeconfig string) (*Config, error) {
+	cmd := "kubectl"
+	args := []string{}
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig="+kubeconfig)
+	}
+	args = append(args, "config", "view", "--flatten", "-ojson")
+
+	o, err := control.Output(exec.Command(cmd, args...))
+	if err != nil {
+		log.Printf("kubectl config view failed: %s\n%s", err, string(o))
+		return nil, err
+	}
+
+	return parseConfig(o)
+}
+
+func parseConfig(b []byte) (*Config, error) {
+	k := &Config{}
+	if err := json.Unmarshal(b, k); err != nil {
+		// The config usually contains credentials, so we don't print it
+		return nil, fmt.Errorf("error parsing kubectl config view output: %v", err)
+	}
+
+	return k, nil
+}
+
+// Config is a simplified version of the v1.Config type
+type Config struct {
+	Clusters       []ConfigCluster `json:"clusters,omitempty"`
+	Contexts       []ConfigContext `json:"contexts,omitempty"`
+	CurrentContext string          `json:"current-context"`
+	// And more fields that we haven't needed yet
+}
+
+// ConfigCluster holds information on a single cluster
+type ConfigCluster struct {
+	Name string            `json:"name"`
+	Info ConfigClusterInfo `json:"cluster"`
+}
+
+// ConfigClusterInfo holds detailed information on a cluster
+type ConfigClusterInfo struct {
+	Server string `json:"server"`
+	// And more fields that we haven't needed yet
+}
+
+// ConfigContext holds information on a single context
+type ConfigContext struct {
+	Name string            `json:"name"`
+	Info ConfigContextInfo `json:"context"`
+}
+
+// ConfigContextInfo holds detailed information on a context
+type ConfigContextInfo struct {
+	Cluster   string `json:"cluster"`
+	User      string `json:"user"`
+	Namespace string `json:"namespace"`
+}
+
+// CurrentServer returns the server URL from the current context, of (false, nil) if it isn't configured
+func (k *Config) CurrentServer() (string, bool) {
+	context, found := k.Context(k.CurrentContext)
+	if !found {
+		return "", false
+	}
+
+	cluster, found := k.Cluster(context.Info.Cluster)
+	if !found {
+		return "", false
+	}
+
+	if cluster.Info.Server == "" {
+		return "", false
+	}
+
+	return cluster.Info.Server, true
+}
+
+// Context returns the context with the matching name, or (nil,false) if not found
+func (k *Config) Context(name string) (*ConfigContext, bool) {
+	for i := range k.Contexts {
+		if k.Contexts[i].Name == name {
+			return &k.Contexts[i], true
+		}
+	}
+	return nil, false
+}
+
+// Cluster returns the cluster with the matching name, or (nil,false) if not found
+func (k *Config) Cluster(name string) (*ConfigCluster, bool) {
+	for i := range k.Clusters {
+		if k.Clusters[i].Name == name {
+			return &k.Clusters[i], true
+		}
+	}
+	return nil, false
+}

--- a/kubetest/kubectl/config_test.go
+++ b/kubetest/kubectl/config_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"testing"
+)
+
+func TestParseKubeconfig(t *testing.T) {
+	output := `
+{
+    "kind": "Config",
+    "apiVersion": "v1",
+    "preferences": {},
+    "clusters": [
+        {
+            "name": "gke_testproject_us-central1-a_testcluster",
+            "cluster": {
+                "server": "https://10.10.10.10",
+                "certificate-authority-data": "LS0t...removed..."
+            }
+        }
+    ],
+    "users": [
+        {
+            "name": "gke_testproject_us-central1-a_testcluster",
+            "user": {
+                "auth-provider": {
+                    "name": "gcp",
+                    "config": {
+                        "access-token": "ya29.foo",
+                        "cmd-args": "config config-helper --format=json",
+                        "cmd-path": "/usr/lib/google-cloud-sdk/bin/gcloud",
+                        "expiry": "2018-10-03T18:42:11Z",
+                        "expiry-key": "{.credential.token_expiry}",
+                        "token-key": "{.credential.access_token}"
+                    }
+                }
+            }
+        }
+    ],
+    "contexts": [
+        {
+            "name": "gke_testproject_us-central1-a_testcluster",
+            "context": {
+                "cluster": "gke_testproject_us-central1-a_testcluster",
+                "user": "gke_testproject_us-central1-a_testcluster",
+                "namespace": "default"
+            }
+        }
+    ],
+    "current-context": "gke_testproject_us-central1-a_testcluster"
+}
+`
+
+	config, err := parseConfig([]byte(output))
+	if err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	t.Logf("parsed as %+v", config)
+
+	actual, found := config.CurrentServer()
+	if !found {
+		t.Fatalf("server was not found")
+	}
+
+	expected := "https://10.10.10.10"
+	if actual != expected {
+		t.Fatalf("server was not as expected.  actual=%q, expected=%q", actual, expected)
+	}
+}


### PR DESCRIPTION
The docs say that e2e doesn't need the --host variable, but
test/e2e/kubectl/kubectl.go checks that it is set.

We can move this logic into the test suite once verified here, but
starting here because we need to work with older test suites.