### PR TITLE
Fix boskos format strings to keep go 1.11 happy

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/crds"
 	"k8s.io/test-infra/boskos/ranch"
-	"strings"
 )
 
 var (
@@ -160,7 +160,7 @@ func handleAcquire(r *ranch.Ranch) http.HandlerFunc {
 			// release the resource, though this is not expected to happen.
 			err = r.Release(resource.Name, state, owner)
 			if err != nil {
-				logrus.WithError(err).Warning("unable to release resource %s", resource.Name)
+				logrus.WithError(err).Warningf("unable to release resource %s", resource.Name)
 			}
 			return
 		}
@@ -220,7 +220,7 @@ func handleAcquireByState(r *ranch.Ranch) http.HandlerFunc {
 			for _, resource := range resources {
 				err := r.Release(resource.Name, state, owner)
 				if err != nil {
-					logrus.WithError(err).Warning("unable to release resource %s", resource.Name)
+					logrus.WithError(err).Warningf("unable to release resource %s", resource.Name)
 				}
 			}
 			return
@@ -383,7 +383,7 @@ func handleMetric(r *ranch.Ranch) http.HandlerFunc {
 		logrus.WithField("handler", "handleMetric").Infof("From %v", req.RemoteAddr)
 
 		if req.Method != http.MethodGet {
-			logrus.Warning("[BadRequest]method %v, expect GET", req.Method)
+			logrus.Warningf("[BadRequest]method %v, expect GET", req.Method)
 			http.Error(res, "/metric only accepts GET", http.StatusMethodNotAllowed)
 			return
 		}

--- a/boskos/mason/client.go
+++ b/boskos/mason/client.go
@@ -47,7 +47,7 @@ func (c *Client) Acquire(rtype, state, dest string) (*common.Resource, error) {
 	releaseOnFailure := func() {
 		for _, r := range resourcesToRelease {
 			if err := c.basic.ReleaseOne(r.Name, common.Dirty); err != nil {
-				logrus.WithError(err).Warning("failed to release resource %s", r.Name)
+				logrus.WithError(err).Warningf("failed to release resource %s", r.Name)
 			}
 		}
 	}
@@ -87,7 +87,7 @@ func (c *Client) ReleaseOne(name, dest string) (allErrors error) {
 			logrus.WithError(err).Errorf("cannot parse %s from User Data", LeasedResources)
 			allErrors = multierror.Append(allErrors, err)
 			if err := c.basic.ReleaseOne(name, dest); err != nil {
-				logrus.WithError(err).Warning("failed to release resource %s", name)
+				logrus.WithError(err).Warningf("failed to release resource %s", name)
 				allErrors = multierror.Append(allErrors, err)
 			}
 			return
@@ -96,7 +96,7 @@ func (c *Client) ReleaseOne(name, dest string) (allErrors error) {
 	resourceNames = append(resourceNames, leasedResources...)
 	for _, n := range resourceNames {
 		if err := c.basic.ReleaseOne(n, dest); err != nil {
-			logrus.WithError(err).Warning("failed to release resource %s", n)
+			logrus.WithError(err).Warningf("failed to release resource %s", n)
 			allErrors = multierror.Append(allErrors, err)
 		}
 	}

--- a/boskos/metrics/metrics.go
+++ b/boskos/metrics/metrics.go
@@ -146,7 +146,7 @@ func handleMetric(boskos *client.Client) http.HandlerFunc {
 		log.Infof("From %v", req.RemoteAddr)
 
 		if req.Method != "GET" {
-			log.Warning("[BadRequest]method %v, expect GET", req.Method)
+			log.Warningf("[BadRequest]method %v, expect GET", req.Method)
 			http.Error(res, "only accepts GET request", http.StatusMethodNotAllowed)
 			return
 		}


### PR DESCRIPTION
Fix format calls that go test 1.11 detects as incorrect.

(Going to take a break from doing these now!)