### PR TITLE
Bump coverage job timeout

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -19,6 +19,8 @@ periodics:
     repo: release
     base_ref: master
     path_alias: k8s.io/release
+  decoration_config:
+    timeout: 10800000000000 # 3 hours
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20181002-3e479534e-master


### PR DESCRIPTION
Two hours isn't quite long enough to bring up a cluster, run conformance tests in serial, and tear it down again.

Make it three.

/cc @BenTheElder 

(I'm not at all certain this is the correct way to bump the timeout.)