### PR TITLE
Add a skip regex to the coverage job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -35,7 +35,7 @@ periodics:
         ../test-infra/scenarios/kubernetes_e2e.py --build=quick --dump-before-and-after --extract=local \
                                                   --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-conformance-coverage \
                                                   --gcp-zone=us-central1-f --provider=gce --timeout=120m \
-                                                  --test_args="--ginkgo.focus=\[Conformance\]"
+                                                  --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
         cd ../test-infra
         bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
         bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"


### PR DESCRIPTION
`[Conformance]` is a lie; let's teach the coverage job about this harsh reality by skipping the 23 non-conformance [Conformance] tests.

/cc @BenTheElder @spiffxp 