### PR TITLE
Add --pull --list options to bump.sh

### DIFF
--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -20,6 +20,10 @@
 # * update all the cluster/*.yaml files to use the new image tags
 
 set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(fejta): rewrite this in a better language REAL SOON
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 
@@ -49,17 +53,77 @@ if ! ($SED --version 2>&1 | grep -q GNU); then
   exit 1
 fi
 
-new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
-echo -e "version: $(color-version ${new_version})" >&2
-if [[ "${new_version}" == *-dirty ]]; then
-  echo -e "$(color-error ERROR): uncommitted changes to repo" >&2
-  echo "  Fix with git commit" >&2
-  exit 1
-fi
-
 cd "$(dirname "${BASH_SOURCE}")"
 
-# Determine what images we need to update
+usage() {
+  echo "Usage: "$(basename "$0")" [--push || --list || vYYYYMMDD-deadbeef] [image subset...]" >&2
+  exit 1
+}
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
+  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+  gcloud auth configure-docker
+  cmd="--push"
+elif [[ $# == 0 ]]; then
+  usage
+else
+  cmd="$1"
+  shift
+fi
+
+if [[ "$cmd" == "--push" ]]; then
+  new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
+  echo -e "version: $(color-version ${new_version})" >&2
+  if [[ "${new_version}" == *-dirty ]]; then
+    echo -e "$(color-error ERROR): uncommitted changes to repo" >&2
+    echo "  Fix with git commit" >&2
+    exit 1
+  fi
+  echo -e "Pushing $(color-version ${new_version}) via $(color-target //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64) ..." >&2
+  bazel run //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+elif [[ "$cmd" == "--list" ]]; then
+  # TODO(fejta): figure out why the timestamp on all these image is 1969...
+  # Then we'll be able to just sort them.
+  options=(
+    $(gcloud container images list-tags gcr.io/k8s-prow/plank --filter="tags ~ ^v|,v" --format='value(tags)' \
+      | grep -o -E 'v\d{8}-(\d|[da-f]){6,9}' | sort -u | tail -n 10)
+  )
+  echo "Recent versions of prow:" >&2
+  new_version=
+  for o in "${options[@]}"; do
+    def_opt="$o"
+    echo -e "  $(color-version $o)"
+  done
+  read -p "select version [$def_opt]: " new_version
+  if [[ -z "${new_version:-}" ]]; then
+    new_version="$def_opt"
+  else
+    found=
+    for o in "${options[@]}"; do
+      if [[ "$o" == "$new_version" ]]; then
+        found=yes
+        break
+      fi
+    done
+    if [[ -z "$found" ]]; then
+      echo "Invalid version: $new_version" >&2
+      exit 1
+    fi
+  fi
+elif [[ "$cmd" =~ v[0-9]{8}-[a-f0-9]{6,9} ]]; then
+  new_version="$cmd"
+else
+  usage
+fi
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  # TODO(fejta): consider making this publish to a recent-releases.json or something
+  exit 0
+fi
+
+
+# Determine what deployment images we need to update
 echo -n "images: " >&2
 images=("$@")
 if [[ "${#images[@]}" == 0 ]]; then
@@ -68,15 +132,6 @@ if [[ "${#images[@]}" == 0 ]]; then
   echo -n "images: " >&2
 fi
 echo -e "$(color-image ${images[@]})" >&2
-
-if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
-  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
-  gcloud auth configure-docker
-fi
-
-echo -e "Pushing $(color-version ${new_version}) via $(color-target //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64) ..." >&2
-bazel run //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
 
 echo -e "Bumping: $(color-image ${images[@]}) to $(color-version ${new_version}) ..." >&2
 


### PR DESCRIPTION
/assign @BenTheElder @krzyzacy @stevekuznetsov 

Since we now [auto-publish every prow commit](https://k8s-testgrid.appspot.com/sig-testing-misc#push-prow), update `bump.sh` to ask the user to select one of them: 

`prow/bump.sh --list` will list some recent builds, defaulting to the latest* build.
`prow/bump.sh --push` does the same behavior as today

Also change bump.sh to skip updating the config.yaml files when the bot is pushing images (we just throw away this change anyway)


 🚨 🚨 🚨 warning!! excessive bash ahead 🚨 🚨 🚨  