### PR TITLE
prow/flagutil/config: Add ConfigOptions

### DIFF
--- a/experiment/ci-janitor/BUILD.bazel
+++ b/experiment/ci-janitor/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/experiment/ci-janitor",
     visibility = ["//visibility:private"],
     deps = [
-        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/branchprotector",
     visibility = ["//visibility:public"],
     deps = [
+        "//flagutil:go_default_library",
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
@@ -46,7 +47,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
-        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -28,51 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 
 	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 )
-
-func TestOptions_Validate(t *testing.T) {
-	var testCases = []struct {
-		name        string
-		opt         options
-		expectedErr bool
-	}{
-		{
-			name: "all ok",
-			opt: options{
-				config: "dummy",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
-			},
-			expectedErr: false,
-		},
-		{
-			name: "no config",
-			opt: options{
-				config: "",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
-			},
-			expectedErr: true,
-		},
-		{
-			name: "no token, allow",
-			opt: options{
-				config: "dummy",
-			},
-			expectedErr: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		err := testCase.opt.Validate()
-		if testCase.expectedErr && err == nil {
-			t.Errorf("%s: expected an error but got none", testCase.name)
-		}
-		if !testCase.expectedErr && err != nil {
-			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
-		}
-	}
-}
 
 type fakeClient struct {
 	repos    map[string][]github.Repo

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/tide:go_default_library",
@@ -72,6 +73,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/deck/jobs:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/githuboauth:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/tide"
@@ -49,7 +50,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "minimal set ok",
 			input: options{
-				configPath: "test",
+				config: flagutil.ConfigOptions{ConfigPath: "test"},
 			},
 			expectedErr: false,
 		},
@@ -61,7 +62,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "ok with oauth",
 			input: options{
-				configPath:            "test",
+				config:                flagutil.ConfigOptions{ConfigPath: "test"},
 				oauthURL:              "website",
 				githubOAuthConfigFile: "something",
 				cookieSecretFile:      "yum",
@@ -71,7 +72,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "missing github config with oauth",
 			input: options{
-				configPath:       "test",
+				config:           flagutil.ConfigOptions{ConfigPath: "test"},
 				oauthURL:         "website",
 				cookieSecretFile: "yum",
 			},
@@ -80,7 +81,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "missing cookie with oauth",
 			input: options{
-				configPath:            "test",
+				config:                flagutil.ConfigOptions{ConfigPath: "test"},
 				oauthURL:              "website",
 				githubOAuthConfigFile: "something",
 			},

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/gerrit",
     visibility = ["//visibility:private"],
     deps = [
-        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/gerrit/adapter:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/cron:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -45,10 +45,9 @@ import (
 )
 
 type options struct {
-	configPath    string
-	jobConfigPath string
-	selector      string
-	totURL        string
+	config   prowflagutil.ConfigOptions
+	selector string
+	totURL   string
 
 	jenkinsURL             string
 	jenkinsUserName        string
@@ -65,7 +64,7 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+	for _, group := range []flagutil.OptionGroup{&o.config, &o.kubernetes, &o.github} {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err
 		}
@@ -100,8 +99,6 @@ func (o *options) Validate() error {
 func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
-	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.selector, "label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 	fs.StringVar(&o.totURL, "tot-url", "", "Tot URL")
 
@@ -115,7 +112,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.csrfProtect, "csrf-protect", false, "Request a CSRF protection token from Jenkins that will be used in all subsequent requests to Jenkins.")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub/Kubernetes/Jenkins.")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+	for _, group := range []flagutil.OptionGroup{&o.config, &o.kubernetes, &o.github} {
 		group.AddFlags(fs)
 	}
 	fs.Parse(os.Args[1:])
@@ -135,8 +132,8 @@ func main() {
 		logrus.WithError(err).Fatal("Error parsing label selector.")
 	}
 
-	configAgent := &config.Agent{}
-	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
+	configAgent, err := o.config.Agent()
+	if err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "k8s.io/test-infra/prow/cmd/mkpj",
     deps = [
-        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
@@ -37,6 +37,7 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/flagutil:go_default_library"],
 )
 
 go_binary(

--- a/prow/cmd/mkpj/main_test.go
+++ b/prow/cmd/mkpj/main_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"k8s.io/test-infra/prow/flagutil"
+)
 
 func TestOptions_Validate(t *testing.T) {
 	var testCases = []struct {
@@ -27,22 +31,15 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "all ok",
 			input: options{
-				jobName:    "job",
-				configPath: "somewhere",
+				jobName: "job",
+				config:  flagutil.ConfigOptions{ConfigPath: "somewhere"},
 			},
 			expectedErr: false,
 		},
 		{
-			name: "missing config",
-			input: options{
-				jobName: "job",
-			},
-			expectedErr: true,
-		},
-		{
 			name: "missing job",
 			input: options{
-				configPath: "somewhere",
+				config: flagutil.ConfigOptions{ConfigPath: "somewhere"},
 			},
 			expectedErr: true,
 		},

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/peribolos",
     visibility = ["//visibility:private"],
     deps = [
+        "//flagutil:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/org:go_default_library",
         "//prow/flagutil:go_default_library",

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -40,7 +40,7 @@ func TestOptions(t *testing.T) {
 	}{
 		{
 			name: "missing --config",
-			args: []string{},
+			args: []string{"--config-path="},
 		},
 		{
 			name: "bad --github-endpoint",
@@ -62,7 +62,7 @@ func TestOptions(t *testing.T) {
 			name: "maximal delta",
 			args: []string{"--config-path=foo", "--maximum-removal-delta=1"},
 			expected: &options{
-				config:        "foo",
+				config:        flagutil.ConfigOptions{ConfigPath: "foo"},
 				minAdmins:     defaultMinAdmins,
 				requireSelf:   true,
 				maximumDelta:  1,
@@ -74,7 +74,7 @@ func TestOptions(t *testing.T) {
 			name: "minimal delta",
 			args: []string{"--config-path=foo", "--maximum-removal-delta=0"},
 			expected: &options{
-				config:        "foo",
+				config:        flagutil.ConfigOptions{ConfigPath: "foo"},
 				minAdmins:     defaultMinAdmins,
 				requireSelf:   true,
 				maximumDelta:  0,
@@ -86,7 +86,7 @@ func TestOptions(t *testing.T) {
 			name: "minimal admins",
 			args: []string{"--config-path=foo", "--min-admins=2"},
 			expected: &options{
-				config:        "foo",
+				config:        flagutil.ConfigOptions{ConfigPath: "foo"},
 				minAdmins:     2,
 				requireSelf:   true,
 				maximumDelta:  defaultDelta,
@@ -114,7 +114,7 @@ func TestOptions(t *testing.T) {
 			name: "allow disabled throttle",
 			args: []string{"--config-path=foo", "--tokens=0"},
 			expected: &options{
-				config:        "foo",
+				config:        flagutil.ConfigOptions{ConfigPath: "foo"},
 				minAdmins:     defaultMinAdmins,
 				requireSelf:   true,
 				maximumDelta:  defaultDelta,
@@ -124,7 +124,7 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name: "allow dump without config",
-			args: []string{"--dump=frogger"},
+			args: []string{"--config-path=", "--dump=frogger"},
 			expected: &options{
 				minAdmins:     defaultMinAdmins,
 				requireSelf:   true,
@@ -138,7 +138,7 @@ func TestOptions(t *testing.T) {
 			name: "minimal",
 			args: []string{"--config-path=foo"},
 			expected: &options{
-				config:        "foo",
+				config:        flagutil.ConfigOptions{ConfigPath: "foo"},
 				minAdmins:     defaultMinAdmins,
 				requireSelf:   true,
 				maximumDelta:  defaultDelta,
@@ -150,7 +150,7 @@ func TestOptions(t *testing.T) {
 			name: "full",
 			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--tokens=5", "--token-burst=2", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members"},
 			expected: &options{
-				config:         "foo",
+				config:         flagutil.ConfigOptions{ConfigPath: "foo"},
 				confirm:        true,
 				requireSelf:    false,
 				minAdmins:      defaultMinAdmins,

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -41,13 +41,12 @@ import (
 type options struct {
 	totURL string
 
-	configPath    string
-	jobConfigPath string
-	buildCluster  string
-	selector      string
-	skipReport    bool
+	buildCluster string
+	selector     string
+	skipReport   bool
 
 	dryRun     bool
+	config     prowflagutil.ConfigOptions
 	kubernetes prowflagutil.KubernetesOptions
 	github     prowflagutil.GitHubOptions
 }
@@ -57,15 +56,12 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	fs.StringVar(&o.totURL, "tot-url", "", "Tot URL")
-
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
-	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.buildCluster, "build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	fs.StringVar(&o.selector, "label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 	fs.BoolVar(&o.skipReport, "skip-report", false, "Whether or not to ignore report with githubClient")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+	for _, group := range []flagutil.OptionGroup{&o.config, &o.kubernetes, &o.github} {
 		group.AddFlags(fs)
 	}
 
@@ -74,7 +70,7 @@ func gatherOptions() options {
 }
 
 func (o *options) Validate() error {
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+	for _, group := range []flagutil.OptionGroup{&o.config, &o.kubernetes, &o.github} {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err
 		}
@@ -97,8 +93,8 @@ func main() {
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "plank"}),
 	)
 
-	configAgent := &config.Agent{}
-	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
+	configAgent, err := o.config.Agent()
+	if err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/tot",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",

--- a/prow/config/agent.go
+++ b/prow/config/agent.go
@@ -35,11 +35,6 @@ type Agent struct {
 // fails, Start with return the error and abort. Future load failures will log
 // the failure message but continue attempting to load.
 func (ca *Agent) Start(prowConfig, jobConfig string) error {
-	c, err := Load(prowConfig, jobConfig)
-	if err != nil {
-		return err
-	}
-	ca.c = c
 	go func() {
 		var lastModTime time.Time
 		// Rarely, if two changes happen in the same second, mtime will

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "config.go",
         "doc.go",
         "github.go",
         "kubernetes.go",

--- a/prow/flagutil/config.go
+++ b/prow/flagutil/config.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+// ConfigOptions holds options for interacting with Configs.
+type ConfigOptions struct {
+	ConfigPath    string
+	jobConfigPath string
+}
+
+// AddFlags injects config options into the given FlagSet.
+func (o *ConfigOptions) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&o.ConfigPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+}
+
+// Validate validates config options.
+func (o *ConfigOptions) Validate(dryRun bool) error {
+	return nil
+}
+
+// Agent returns a started config agent.
+func (o *ConfigOptions) Agent() (agent *config.Agent, err error) {
+	agent = &config.Agent{}
+	config, err := config.Load(o.ConfigPath, o.jobConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	agent.Set(config)
+
+	err = agent.Start(o.ConfigPath, o.jobConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return agent, err
+}


### PR DESCRIPTION
To centralize handling for `-config-path` and `-job-config-path`.

Two of these commands (`gerrit` and `refresh`) previously had no `-job-config-path` and hard-coded an empty string.  We could add a `ConfigOptions.SkipJobConfigPath` boolean to turn off the flag injection for those commands, but I don't think it's worth it.

This is the next stage of the `OptionGroup` refactor, following on the heels of #9503 (which seems to be in it's final descent towards landing).  Only the last two commits are unique to this PR, and after #9503 lands I can rebase to make GitHub's full-PR diff smaller.