### PR TITLE
Pass page arguments to the title expansion

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -23,7 +23,7 @@
     <div class="mdl-layout__header-row">
       <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow"
          class="logo"><img src="/static/{{or branding.Logo "logo.svg"}}" alt="kubernetes logo" class="logo"/></a>
-      <span class="mdl-layout-title header-title">{{template "title"}}</span>
+      <span class="mdl-layout-title header-title">{{template "title" .Arguments}}</span>
     </div>
   </header>
   <div class="mdl-layout__drawer">


### PR DESCRIPTION
Correctly pass the template arguments to the expansion of `title` in the page.

Fixes #9704.

/kind bug
/area prow/deck
/cc @ibzib 
/cc @amwat 