### PR TITLE
fail back on artifacts env gracefully

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -807,6 +807,12 @@ def setup_logging(path):
     return build_log
 
 
+def get_artifacts_dir():
+    if JOB_ARTIFACTS_ENV in os.environ:
+        return JOB_ARTIFACTS_ENV
+    return os.path.join(os.getenv(WORKSPACE_ENV, os.getcwd()), '_artifacts')
+
+
 def setup_magic_environment(job, call):
     """Set magic environment variables scripts currently expect."""
     home = os.environ[HOME_ENV]
@@ -864,11 +870,12 @@ def setup_magic_environment(job, call):
         os.getenv(WORKSPACE_ENV, os.getcwd()), '_artifacts')
 
     # also make the artifacts dir if it doesn't exist yet
-    if not os.path.isdir(os.environ[JOB_ARTIFACTS_ENV]):
+    if not os.path.isdir(get_artifacts_dir()):
         try:
-            os.makedirs(os.environ[JOB_ARTIFACTS_ENV])
+            os.makedirs(get_artifacts_dir())
         except OSError as exc:
-            logging.info('cannot create $WORKSPACE/_artifacts, continue : %s', exc)
+            logging.info(
+                'cannot create %s, continue : %s', get_artifacts_dir(), exc)
 
     # Try to set SOURCE_DATE_EPOCH based on the commit date of the tip of the
     # tree.
@@ -1121,7 +1128,7 @@ def bootstrap(args):
         logging.info('Gubernator results at %s', gubernator_uri(paths))
         try:
             finish(
-                gsutil, paths, success, os.environ[JOB_ARTIFACTS_ENV],
+                gsutil, paths, success, get_artifacts_dir(),
                 build, version, repos, call
             )
         except subprocess.CalledProcessError:  # Still try to upload build log


### PR DESCRIPTION
probably fixes:
```
I1004 22:09:26.098] process 61 exited with code 1 after 0.0m
E1004 22:09:26.098] unexpected error
Traceback (most recent call last):
  File "./test-infra/jenkins/bootstrap.py", line 1097, in bootstrap
  File "./test-infra/jenkins/bootstrap.py", line 985, in setup_root
  File "./test-infra/jenkins/bootstrap.py", line 307, in checkout
  File "./test-infra/jenkins/bootstrap.py", line 1058, in <lambda>
  File "./test-infra/jenkins/bootstrap.py", line 149, in _call
CalledProcessError: Command '['git', 'merge', '--no-ff', '-m', 'Merge +refs/pull/9626/head:refs/pr/9626', '0705242bdb142941133cf4e78faec4e7ff6e9755']' returned non-zero exit status 1
I1004 22:09:26.098] Call:  gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
W1004 22:09:26.520] Activated service account credentials for: [pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com]
I1004 22:09:26.903] process 62 exited with code 0 after 0.0m
I1004 22:09:26.903] Call:  gcloud config get-value account
W1004 22:09:27.172] Your active configuration is: [default]
W1004 22:09:27.172] 
I1004 22:09:27.541] process 74 exited with code 0 after 0.0m
I1004 22:09:27.541] Will upload results to gs://kubernetes-jenkins/pr-logs using pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
I1004 22:09:27.541] Upload result and artifacts...
I1004 22:09:27.542] Gubernator results at https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/9626/pull-test-infra-verify-bazel/17702
Traceback (most recent call last):
  File "./test-infra/jenkins/bootstrap.py", line 1198, in <module>
    bootstrap(ARGS)
  File "./test-infra/jenkins/bootstrap.py", line 1124, in bootstrap
    gsutil, paths, success, os.environ[JOB_ARTIFACTS_ENV],
  File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
    raise KeyError(key)
KeyError: 'ARTIFACTS'
```
/shrug