### PR TITLE
Add testgrid entry for periodic GCE PD CSI Driver Kubernetes integration runs

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -1,0 +1,22 @@
+periodics:
+- name: ci-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181001-df2f5324a-master
+      args:
+      - "--repo=sigs.k8s.io/$(REPO_NAME)"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--clean"
+      - "--timeout=60" # Minutes
+      - "--scenario=execute"
+      - "--" # end bootstrap args, scenario args below
+      - "test/run-k8s-integration.sh"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+    

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3226,6 +3226,10 @@ test_groups:
 - name: baiducloud-e2e-conformance-v1.11
   gcs_prefix: k8s-conformance-baiducloud/baiducloud-e2e-conformance-v1.11
 
+# GCP Compute Persistent Disk CSI Driver Test Groups
+- name: ci-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
+  gcs_prefix: kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
+
 #
 # Start dashboards
 #
@@ -5816,6 +5820,12 @@ dashboards:
   - name: pr-test
     test_group_name: pull-cluster-api-provider-gcp-test
 
+- name: sig-gcp-compute-persistent-disk-csi-driver
+  dashboard_tab:
+  - name: Kubernetes Master Driver Master
+    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
+    description: 'Kubernetes Integration tests for Kubernetes Master branch and Driver Master branch'
+
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
   dashboard_tab:
   - name: pr-make
@@ -7425,6 +7435,7 @@ dashboard_groups:
   - sig-gcp-master
   - sig-gcp-release-1.11
   - sig-gcp-release-1.10
+  - sig-gcp-compute-persistent-disk-csi-driver
 
 - name: sig-autoscaling
   dashboard_names:


### PR DESCRIPTION
/assign @msau42 
/cc @krzyzacy 

We eventually want to run a different periodic integration test for each version skew, for example:
HEAD of Driver and Kubernetes
Latest stable version of Driver/Kubernetes
etc.