### PR TITLE
Trim unused dashboards

### DIFF
--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -10,10 +10,6 @@
 gs://kubernetes-jenkins/logs/:
   contact: "fejta"
   prefix: ""
-gs://kopeio-kubernetes-e2e/logs/:
-  contact: "justinsb"
-  prefix: "kopeio:"
-  sequential: false
 gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -43,7 +43,6 @@ var (
 		"istio",
 		"google",
 		"kopeio",
-		"tectonic",
 		"redhat",
 		"vmware",
 	}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2117,13 +2117,6 @@ test_groups:
   - configuration_value: Commit
   - configuration_value: infra-commit
 
-# kopeio (contact: @justinsb on github)
-- name: kopeio-kubernetes-e2e-aws
-  gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-aws
-- name: kopeio-kubernetes-e2e-upup-aws-ha
-  gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-upup-aws-ha
-- name: kopeio-kubernetes-e2e-upup-aws
-  gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-upup-aws
 # @luxas' multiarch e2e results
 - name: periodic-multi-platform-kubeadm-gce-amd64
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-gce-amd64
@@ -4084,15 +4077,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos2-k8sstable3-slow
   - name: gke-cos2-k8sstable3-updown
     test_group_name: ci-kubernetes-e2e-gke-cos2-k8sstable3-updown
-
-- name: kopeio
-  dashboard_tab:
-  - name: kopeio-aws
-    test_group_name: kopeio-kubernetes-e2e-aws
-  - name: kopeio-upup-aws-ha
-    test_group_name: kopeio-kubernetes-e2e-upup-aws-ha
-  - name: kopeio-upup-aws
-    test_group_name: kopeio-kubernetes-e2e-upup-aws
 
 - name: google-aws
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6619,14 +6619,6 @@ dashboards:
     description: Runs conformance tests using kubetest against latest kubernetes relase-1.12 with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance-latest-1-11
 
-- name: sig-ui
-  dashboard_tab:
-  - name: TODO
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow  # TODO(fejta): fix
-  notifications:
-  - summary: Please configure this skeleton dashboard and remove this notification
-    context_link: https://github.com/kubernetes/test-infra/tree/master/testgrid/config
-
 - name: sig-gcp-master
   dashboard_tab:
   - name: gci-gke

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -795,15 +795,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1-12
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
-# Tectonic (contact: @ethernetdan on GitHub)
-- name: ci-tectonic-e2e-aws
-  gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-aws
-- name: ci-tectonic-e2e-etcd
-  gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-etcd
-- name: ci-tectonic-e2e-aws-serial
-  gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-aws-serial
-- name: ci-tectonic-e2e-etcd-serial
-  gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-etcd-serial
 # Ubuntu node e2e tests (contact: @kubernetes/ubuntu-image on github)
 - name: ci-kubernetes-e2enode-ubuntu1-k8sbeta-gkespec
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2enode-ubuntu1-k8sbeta-gkespec
@@ -4102,17 +4093,6 @@ dashboards:
     test_group_name: kopeio-kubernetes-e2e-upup-aws-ha
   - name: kopeio-upup-aws
     test_group_name: kopeio-kubernetes-e2e-upup-aws
-
-- name: tectonic
-  dashboard_tab:
-  - name: e2e
-    test_group_name: ci-tectonic-e2e-aws
-  - name: e2e-etcd
-    test_group_name: ci-tectonic-e2e-etcd
-  - name: e2e-serial
-    test_group_name: ci-tectonic-e2e-aws-serial
-  - name: e2e-etcd-serial
-    test_group_name: ci-tectonic-e2e-etcd-serial
 
 - name: google-aws
   dashboard_tab:


### PR DESCRIPTION
There were two top-level dashboards driven by buckets with no results 
since 2017, and one dashboard that had no jobs in it.

I tried looking at other jobs that were listed as STALE according to
testgrid, but there were too many, and some were likely stale due to
just not being that high-traffic.

Leaving individual commits incase one of them needs to be reverted

/kind cleanup