### PR TITLE
Add a testgrid OWNERS file

### DIFF
--- a/testgrid/OWNERS
+++ b/testgrid/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- michelle192837
+- spiffxp
+labels:
+- area/testgrid


### PR DESCRIPTION
This is mainly for the auto-labeling, so the approvers are made up
and the points don't matter

/area testgrid
/kind cleanup
/sig testing