### PR TITLE
Move structured-merge-diff dashboard to sig-apimachinery tab

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -7243,7 +7243,7 @@ dashboards:
   - name: pr-test
     test_group_name: pull-kube-storage-version-migrator-test
 
-- name: sig-apimachinery-structured-merge-diff
+- name: sig-api-machinery-structured-merge-diff
   dashboard_tab:
   - name: pr-test
     test_group_name: pull-structured-merge-diff-test
@@ -7317,6 +7317,7 @@ dashboard_groups:
   dashboard_names:
   - sig-api-machinery-gce-gke
   - sig-api-machinery-kube-storage-version-migrator
+  - sig-api-machinery-structured-merge-diff
 
 - name: sig-cli
   dashboard_names:


### PR DESCRIPTION
Continuation of #9710 

I think I need to put the `sig-apimachinery-structured-merge-diff` dashboard in the `sig-apimachinery` menu

https://k8s-testgrid.appspot.com/ right now is like this:

<img width="710" alt="screenshot 2018-10-06 at 7 45 10" src="https://user-images.githubusercontent.com/33343952/46567461-e2324980-c93b-11e8-975f-b5ba1d79c917.png">

/assign @BenTheElder 
