### PR TITLE
Require travis-ci status for kubernetes/k8s.io repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,6 +112,10 @@ branch-protection:
           restrictions: # only allow admins
             users: []
             teams: []
+        k8s.io:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
         kompose:
           required_status_checks:
             contexts:


### PR DESCRIPTION
This commit adds requirement for travis-ci to pass before merging in https://github.com/kubernetes/k8s.io.

/hold
until https://github.com/kubernetes/k8s.io/pull/142 is merged