### PR TITLE
Remove language-specific repos from Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -347,9 +347,6 @@ tide:
     - kubernetes/kubeadm
     - kubernetes/kubectl
     - kubernetes/kubernetes-anywhere
-    - kubernetes/kubernetes-docs-ja
-    - kubernetes/kubernetes-docs-ko
-    - kubernetes/kubernetes-docs-zh
     - kubernetes/kubernetes-template-project
     - kubernetes/minikube
     - kubernetes/node-problem-detector
@@ -408,8 +405,6 @@ tide:
     kubernetes-sigs/cluster-api: squash
     kubernetes/dashboard: squash
     kubernetes/kube-deploy: squash
-    kubernetes/kubernetes-docs-ja: squash
-    kubernetes/kubernetes-docs-ko: squash
     kubernetes/website: squash
   pr_status_base_url: https://prow.k8s.io/pr
   blocker_label: merge-blocker


### PR DESCRIPTION
🍏 This PR is clear to merge. 🍏 

This PR removes language-specific repositories from Prow configuration.

## Context
This PR is dependent on https://github.com/kubernetes/website/pull/10485. Specifically, it depends on the archival of language-specific repos (`k/kubernetes-docs-*`). Please wait to merge this PR until #10485 receives adequate discussion or achieves lazy consensus by Friday, October 11. 

This PR goes stale on **Friday, October 19th**. Please feel free to close this PR if it's still open after that date.

/area prow
/sig docs

/assign @spiffxp 

/cc @chenopis @Bradamant3 

