### PR TITLE
add scenarios into bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -124,4 +124,10 @@ COPY ["barnacle/barnacle", "/usr/local/bin/"]
 COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
         "/usr/local/bin/"]
 
+# TODO(krzyzacy): Move the scenario scripts to kubekins v2
+# The bundled scenarios are for podutil jobs, bootstrap jobs will still use
+# scenario scripts from cloned test-infra
+RUN mkdir /workspace/scenarios
+COPY ["./scenarios", "/workspace/scenarios"]
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -20,8 +20,10 @@ all: build
 build:
 	bazel build //images/bootstrap/barnacle:barnacle --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
 	cp ./../../bazel-bin/images/bootstrap/barnacle/linux_amd64_pure_stripped/barnacle ./barnacle/barnacle
+	cp -r ../../scenarios ./scenarios
 	docker build --pull --build-arg IMAGE_ARG=$(IMG):$(TAG) -t $(IMG):$(TAG) .
 	rm -f ./barnacle/barnacle
+	rm -r ./scenarios
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -1,3 +1,11 @@
+# DEPRECATION NOTICE
+
+*October 9, 2018* `scenarios/*.py` will be moved to become part of kubetest v2, so we are
+not taking PRs except for urgent bug fixes.
+
+Also please bump [bootstrap image](/images/bootstrap) and 
+[kubekins image](/images/kubekins-e2e) to take in any future changes.
+
 # Test scenarios
 
 Place scripts to run test scenarios inside this location.


### PR DESCRIPTION
so jobs like [podutil-canary](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml#L136-L152) won't need to specify test-infra as an extra_ref

/assign @BenTheElder @cjwagner 