### PR TITLE
Add some area/github-* labels for kubernetes/org

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -12,6 +12,7 @@
 - [Labels that apply to kubernetes/features, for both issues and PRs](#labels-that-apply-to-kubernetesfeatures-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/kubernetes, for both issues and PRs](#labels-that-apply-to-kuberneteskubernetes-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/kubernetes, only for issues](#labels-that-apply-to-kuberneteskubernetes-only-for-issues)
+- [Labels that apply to kubernetes/org, only for issues](#labels-that-apply-to-kubernetesorg-only-for-issues)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
 
 
@@ -173,6 +174,14 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/admin" href="#area/admin">`area/admin`</a> | Indicates an issue on admin area.| label | |
 | <a id="area/api" href="#area/api">`area/api`</a> | Indicates an issue on api area.| label | |
+
+## Labels that apply to kubernetes/org, only for issues
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/github-integration" href="#area/github-integration">`area/github-integration`</a> | Third-party integrations, webhooks, or GitHub Apps| label | |
+| <a id="area/github-membership" href="#area/github-membership">`area/github-membership`</a> | Requesting membership in a Kubernetes GitHub Organization or Team| label | |
+| <a id="area/github-repo" href="#area/github-repo">`area/github-repo`</a> | Creating, migrating or deleting a Kubernetes GitHub Repository| label | |
 
 ## Labels that apply to kubernetes/test-infra, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -657,6 +657,23 @@ repos:
         name: area/conformance
         target: both
         addedBy: label
+  kubernetes/org:
+    labels:
+      - color: 0052cc
+        description: Third-party integrations, webhooks, or GitHub Apps
+        name: area/github-integration
+        target: issues
+        addedBy: label
+      - color: 0052cc
+        description: Requesting membership in a Kubernetes GitHub Organization or Team
+        name: area/github-membership
+        target: issues
+        addedBy: label
+      - color: 0052cc
+        description: Creating, migrating or deleting a Kubernetes GitHub Repository
+        name: area/github-repo
+        target: issues
+        addedBy: label
   kubernetes/test-infra:
     labels:
       - color: 0052cc

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -33,6 +33,21 @@
     color: #ffffff;
 }
 
+.areax00002fgithubx00002dintegration {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
+.areax00002fgithubx00002dmembership {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
+.areax00002fgithubx00002drepo {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fgreenhouse {
     background-color: #0052cc;
     color: #ffffff;


### PR DESCRIPTION
Would like to add these to the kubernetes/org issue templates to
auto-label incoming requests

/cc @fejta @cblecker