### PR TITLE
kubetest log dump: capture full systemd journal

### DIFF
--- a/kubetest/dump.go
+++ b/kubetest/dump.go
@@ -229,6 +229,12 @@ func (n *logDumperNode) dump(ctx context.Context) []error {
 		errors = append(errors, err)
 	}
 
+	// Capture full journal - needed so we can see e.g. disk mounts
+	// This does duplicate the other files, but ensures we have all output
+	if err := n.shellToFile(ctx, "sudo journalctl --output=short-precise", filepath.Join(n.dir, "journal.log")); err != nil {
+		errors = append(errors, err)
+	}
+
 	// Capture logs from any systemd services in our list, that are registered
 	services, err := n.listSystemdUnits(ctx)
 	if err != nil {

--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -216,6 +216,9 @@ func Test_logDumperNode_dump(t *testing.T) {
 			command: "sudo journalctl --output=short-precise -k",
 		},
 		&mockCommand{
+			command: "sudo journalctl --output=short-precise",
+		},
+		&mockCommand{
 			command: "sudo systemctl list-units -t service --no-pager --no-legend --all",
 			stdout: []byte(
 				"kubelet.service                      loaded active running kubelet daemon\n" +
@@ -294,6 +297,7 @@ func Test_logDumperNode_dump(t *testing.T) {
 	expected := []string{
 		"nodename1/",
 		"nodename1/kern.log",
+		"nodename1/journal.log",
 		"nodename1/kubelet.log",
 		"nodename1/kube-controller-manager.log",
 		"nodename1/kube-controller-manager.log.1",


### PR DESCRIPTION
We're seeing occasional flakes where we fail to mount the disk, and we
need the full systemd logs to diagnose.

Example: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-channelalpha/6096/artifacts/18.185.111.25/etcd.log

```
I1009 10:36:13.764740       1 mount_linux.go:491] Attempting to mount disk:  /dev/xvdu /mnt/master-vol-06cc392317a8774fb
I1009 10:36:13.764761       1 nsenter_mount.go:81] nsenter mount /dev/xvdu /mnt/master-vol-06cc392317a8774fb  [defaults]
I1009 10:36:13.764777       1 nsenter.go:106] Running nsenter command: nsenter [--mount=/rootfs/proc/1/ns/mnt -- /usr/bin/systemd-run --description=Kubernetes transient mount for /mnt/master-vol-06cc392317a8774fb --scope -- /bin/mount -o defaults /dev/xvdu /mnt/master-vol-06cc392317a8774fb]
I1009 10:36:13.773849       1 nsenter_mount.go:85] Output of mounting /dev/xvdu to /mnt/master-vol-06cc392317a8774fb: Job for run-r470cb99ffa6441f1b8a9e2da9eace0ce.scope failed.
See "systemctl status run-r470cb99ffa6441f1b8a9e2da9eace0ce.scope" and "journalctl -xe" for details.
```