### PR TITLE
testgrid: add email notifications when kubeadm tests fail

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5721,8 +5721,16 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11
   - name: kubeadm-gce-1.12
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-12
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
   - name: kubeadm-gce-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for 24 hours
 # kubeadm x-on-y tests
   - name: kubeadm-gce-1.10-on-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
@@ -5730,6 +5738,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   - name: kubeadm-gce-stable-on-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for 24 hours
 # kubeadm upgrade tests
   - name: kubeadm-gce-upgrade-1.9-1.10
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10


### PR DESCRIPTION
added notifications for the following tests:
- kubeadm-gce-master
- kubeadm-gce-1.12
- kubeadm-gce-stable-on-master

1) do we need more tests to have notifications?
2) is kubernetes-sig-cluster-lifecycle ... the right email address for this?

/assign @timothysc @BenTheElder 
/cc @kubernetes/sig-cluster-lifecycle 
/kind cleanup
/area testgrid
/hold
