### PR TITLE
add some more logs for grandmatriarch

### DIFF
--- a/prow/cmd/grandmatriarch/bake.sh
+++ b/prow/cmd/grandmatriarch/bake.sh
@@ -71,8 +71,11 @@ print-cookie() {
 while true; do
   token=$(print-token)
   expire=$(expr 60 \* 60 + $(date +%s))
+  echo "token expires at"
+  date -d "@$expire"
   print-cookie .googlesource.com TRUE "$expire" "$token" > cookies
   print-cookie source.developers.google.com FALSE "$expire" "$token" >> cookies
+  md5sum cookies
 
   kubectl create secret generic "$name" --from-file=cookies --dry-run -o yaml > secret.yaml
   if ! kubectl get -f secret.yaml; then
@@ -81,6 +84,6 @@ while true; do
     verb=replace
   fi
   kubectl "$verb" -f secret.yaml
-  echo "successfully updated token, sleeping for 30m..."
-  sleep 30m
+  echo "successfully updated token, sleeping for 20m..."
+  sleep 20m
 done


### PR DESCRIPTION
- print token expire stamp
- print a md5sum of the cookies file see if it can somehow generate a dup data?
- made it run a bit more often, so that it can try more than once in the 60min window.

in order to investigate https://github.com/kubernetes/test-infra/issues/9652

/area prow/grandmatriarch
/assign @amwat @fejta 