### PR TITLE
Increase timeout for gke upgrade test: 15h -> 20h

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
@@ -35,7 +35,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=920
+      - --timeout=1220
       - --bare
       - --scenario=kubernetes_e2e
       - --
@@ -50,7 +50,7 @@ periodics:
       - --gke-environment=test
       - --provider=gke
       - --skew
-      - --timeout=900m
+      - --timeout=1200m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
 


### PR DESCRIPTION
It looks like the tests are legitimately taking >15h to run, raising
timeout to confirm.

I _think_ the issue here is some of the new subpath tests, but I
figured it would be a good idea to get a green run simply by
increasing the timeout to confirm that.

cc @AishSundar