### PR TITLE
fix openstack ci check/test job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -32,6 +32,12 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
         command:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "test"
   - name: pull-cluster-api-provider-openstack-check
@@ -45,5 +51,11 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
         command:
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "check"


### PR DESCRIPTION
The original job have some issues, result in ci not work.

CI link: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-openstack/36/pull-cluster-api-provider-openstack-check/3

error message: 
```
find: `/home/prow/go/src/sigs.k8s.io/cluster-api-provider-openstack': No such file or directory
Makefile:33: *** Please run 'make' from /home/prow/go/src/sigs.k8s.io/cluster-api-provider-openstack. Current directory is /home/prow/go/src/github.com/kubernetes-sigs/cluster-api-provider-openstack.  Stop.
```