### PR TITLE
Add Tide to starter.yaml

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -279,6 +279,55 @@ spec:
           name: config
 ---
 apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tide
+  labels:
+    app: tide
+spec:
+  replicas: 1 # Do not scale up.
+  template:
+    metadata:
+      labels:
+        app: tide
+    spec:
+      serviceAccountName: "tide"
+      containers:
+      - name: tide
+        image: gcr.io/k8s-prow/tide:v20180928-46ab7c3d9
+        args:
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tide
+spec:
+  selector:
+    app: tide
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: ing
@@ -472,3 +521,33 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "hook"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "tide"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "tide"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "tide"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "tide"
+subjects:
+- kind: ServiceAccount
+  name: "tide"

--- a/prow/cmd/checkconfig/README.md
+++ b/prow/cmd/checkconfig/README.md
@@ -1,4 +1,6 @@
 # `checkconfig`
 
-`checkconfig` loads the Prow configuration given with `--config-path` and `--job-config-path` in order to validate it. Use
-`checkconfig` as a pre-submit for any repository holding Prow configuration to ensure that check-ins do not break anything.
+`checkconfig` loads the Prow configuration given with `--config-path`,
+`--job-config-path` and `--plugin-config` in order to validate it.
+Use `checkconfig` as a pre-submit for any repository holding Prow
+configuration to ensure that check-ins do not break anything.

--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -4,6 +4,8 @@ Configuration of Tide is located under the [prow/config.yaml](/prow/config.yaml)
 
 This document will describe the fields of the `tide` configuration and how to populate them, but you can also check out the [GoDocs](https://godoc.org/github.com/kubernetes/test-infra/prow/config#Tide) for the most up to date configuration specification.
 
+To deploy Tide for your organization or repository, please see [how to get started with prow](/prow/getting_started.md).
+
 ### General configuration
 
 The following configuration fields are available:

--- a/prow/getting_started.md
+++ b/prow/getting_started.md
@@ -88,7 +88,7 @@ being ignored unjustly.
 Run the following command to start up a basic set of prow components.
 
 ```sh
-kubectl apply -f cluster/starter.yaml
+kubectl apply -f prow/cluster/starter.yaml
 ```
 
 After a moment, the cluster components will be running.
@@ -101,6 +101,7 @@ hook         2         2         2            2           1m
 horologium   1         1         1            1           1m
 plank        1         1         1            1           1m
 sinker       1         1         1            1           1m
+tide         1         1         1            1           1m
 ```
 
 Find out your external address. It might take a couple minutes for the IP to
@@ -350,6 +351,14 @@ This results in:
 
 See [mkbuild-cluster][5] for more details about how to create/update `cluster.yaml`.
 
+## Enable merge automation using Tide
+
+PRs satisfying a set of predefined criteria can be configured to be
+automatically merged by [Tide][6].
+
+Tide can be enabled by modifying `config.yaml`.
+See [how to configure tide][7] for more details.
+
 ## Configure SSL
 
 Use [kube-lego][3] for automatic LetsEncrypt integration. If you
@@ -371,3 +380,5 @@ a separate namespace.
 [3]: https://github.com/jetstack/kube-lego
 [4]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
 [5]: /prow/cmd/mkbuild-cluster/
+[6]: /prow/cmd/tide/README.md
+[7]: /prow/cmd/tide/config.md


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/blob/master/prow/getting_started.md shows how to deploy prow and enable plugins. This means that we can apply lgtm+approved labels to PRs, but those labels don't really _do_ anything. There is also no guide on how to deploy Tide.

This PR adds Tide manifests to starter.yaml so that deploying starter.yaml also deploys Tide.

Also, enabling Tide specifically requires it to be enabled in `config.yaml`. So if anyone doesn't want to use merge automation, they can simply leave it out of `config.yaml`.
