### PR TITLE
label_sync: fix shrug's arm

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -111,7 +111,7 @@ larger set of contributors to apply/remove them.
 | <a id="wg/policy" href="#wg/policy">`wg/policy`</a> | Categorizes an issue or PR as relevant to wg-policy.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="wg/resource-management" href="#wg/resource-management">`wg/resource-management`</a> | Categorizes an issue or PR as relevant to wg-resource-management.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="wg/security-audit" href="#wg/security-audit">`wg/security-audit`</a> | Categorizes an issue or PR as relevant to wg-security-audit.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="¯\_(ツ)_/¯" href="#¯\_(ツ)_/¯">`¯\_(ツ)_/¯`</a> | ¯\_(ツ)_/¯| humans |  [shrug](https://git.k8s.io/test-infra/prow/plugins/shrug) |
+| <a id="¯\_(ツ)_/¯" href="#¯\_(ツ)_/¯">`¯\_(ツ)_/¯`</a> | ¯\\\_(ツ)_/¯| humans |  [shrug](https://git.k8s.io/test-infra/prow/plugins/shrug) |
 
 ## Labels that apply to all repos, only for issues
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -625,7 +625,7 @@ default:
       target: prs
       addedBy: humans
     - color: f9d0c4
-      description: "¯\\_(ツ)_/¯"
+      description: ¯\\\_(ツ)_/¯
       name: "¯\\_(ツ)_/¯"
       target: both
       prowPlugin: shrug


### PR DESCRIPTION
The shrug description doesn't have an arm right now: https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md :(

It's just really unsettling lol :woman_shrugging: 

/assign @cblecker 
/shrug

