### PR TITLE
fix prow image push override

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -30,6 +30,8 @@ CLUSTER       ?= prow
 REGISTRY ?= gcr.io
 PUSH     ?= docker push
 
+export PROW_REPO_OVERRIDE ?= $(REGISTRY)/$(PROJECT)
+
 DOCKER_LABELS:=--label io.k8s.prow.git-describe="$(shell git describe --tags --always --dirty)"
 
 update-config: get-cluster-credentials
@@ -72,7 +74,6 @@ bazel-release-push:
 	@echo See https://bazel.build/ for install options.
 	@echo Be sure to setup authentication: https://github.com/bazelbuild/rules_docker#authentication
 	@echo Also run gcloud auth application-default login
-	export STABLE_PROW_REPO=$(REGISTRY)/$(PROJECT)
 	bazel run //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
 
 .PHONY: bazel-release-push

--- a/prow/README.md
+++ b/prow/README.md
@@ -70,7 +70,7 @@ Assuming your prow components have multiple replicas, this will result in no dow
 
 Update your deployment (optionally build/pushing the image) to a new image with:
 ```shell
-# export STABLE_PROW_REPO=gcr.io/k8s-prow  # optionally override project
+# export PROW_REPO_OVERRIDE=gcr.io/k8s-prow  # optionally override project
 bump.sh --list  # Choose a recent published version
 bump.sh --push  # Build and push the current repo state (and use this version).
 bump.sh v20181002-deadbeef # Use a specific version


### PR DESCRIPTION
unfortunately it takes the override env in https://github.com/kubernetes/test-infra/blob/master/hack/print-workspace-status.sh#L26 :-\ so whatever we doc'd doesn't really work.

/area prow
/assign @ixdy @fejta @BenTheElder 
cc @ibzib 