### PR TITLE
use podutil for all our canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -87,15 +87,15 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --bare
-      - --timeout=85
-      - --scenario=kubernetes_e2e
-      - --
       - --check-leaked-resources
       - --cluster=canary-e2e-prow
       - --extract=ci/latest
@@ -110,13 +110,13 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
   spec:
     containers:
-    - args:
-      - --timeout=60
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --check-leaked-resources
       - --check-version-skew=false
       - --cluster=canary-e2e
@@ -132,46 +132,20 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
-# TODO(krzyzacy): get rid once this is working
-- interval: 30m
-  name: ci-kubernetes-e2e-gce-podutil-canary
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-scalability-canary
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 6500000000000 # 1h + 5m
+    timeout: 14000000000000 # 140m
   spec:
     containers:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --check-leaked-resources
-      - --cluster=podutil-canary-e2e
-      - --extract=ci/latest
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-nodes=2
-      - --gcp-zone=us-central1-f
-      - --ginkgo-parallel
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gce-scalability-canary
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
       - --cluster=e2e-big-canary
       - --env-file=jobs/env/ci-kubernetes-e2e-scalability-common.env
       - --env-file=jobs/env/ci-kubernetes-e2e-gci-gce-scalability.env
@@ -191,13 +165,13 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
   spec:
     containers:
-    - args:
-      - --timeout=70
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
@@ -218,13 +192,15 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 14000000000000 # 140m
   spec:
     containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --cluster=e2e-kops-aws-canary.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
@@ -245,13 +221,15 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 14000000000000 # 140m
   spec:
     containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --cluster=e2e-kops-gce-canary.k8s.local
       - --deployment=kops
       - --extract=ci/latest
@@ -269,16 +247,20 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --repo=k8s.io/kubernetes=master
-      - --timeout=110
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
       - --deployment=node
       - --gcp-zone=us-central1-f
       - --node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud
@@ -297,15 +279,17 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 26000000000000 # 260m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --bare
-      - --timeout=260
-      - --scenario=kubernetes_e2e
-      - --
       - --cluster=kubemark-100-canary
       - --env-file=jobs/env/ci-kubernetes-e2e-kubemark-common.env
       - --extract=ci/latest

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -269,8 +269,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-ha
 - name: ci-kubernetes-e2e-gce-canary
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary
-- name: ci-kubernetes-e2e-gce-podutil-canary
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-podutil-canary
 - name: ci-kubernetes-coverage-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-conformance
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
@@ -6578,10 +6576,6 @@ dashboards:
   dashboard_tab:
   - name: gce-canary
     test_group_name: ci-kubernetes-e2e-gce-canary
-    code_search_url_template:
-      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
-  - name: gce-podutil-canary
-    test_group_name: ci-kubernetes-e2e-gce-podutil-canary
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: gke-canary


### PR DESCRIPTION
https://prow.k8s.io/?type=periodic&job=ci-kubernetes-e2e-gce-podutil-canary is pretty green now, let's see how it works with other kind of jobs (or not)

/area jobs
/assign @BenTheElder @cjwagner @amwat @fejta 