### PR TITLE
Implement Stringer for branch protection requests

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -18,6 +18,7 @@ package github
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -295,6 +296,14 @@ type BranchProtectionRequest struct {
 	EnforceAdmins              *bool                       `json:"enforce_admins"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
 	Restrictions               *Restrictions               `json:"restrictions"`
+}
+
+func (r BranchProtectionRequest) String() string {
+	bytes, err := json.Marshal(&r)
+	if err != nil {
+		return fmt.Sprintf("%#v", r)
+	}
+	return string(bytes)
 }
 
 // RequiredStatusChecks specifies which contexts must pass to merge.


### PR DESCRIPTION
In order to get well-formatted messages for client calls to update
branch protection, the Stringer interface is implemented with a simple
JSON serialization and a falback to Sprintf when that fails.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
/kind bug