### PR TITLE
Add cluster-api-provider-vsphere test job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - sig-cluster-lifecycle-leads
+  - sig-vmware-leads
+  - cluster-api-admins
+  - cluster-api-vsphere-maintainers
+  - figo
+  - akutz

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -1,0 +1,15 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-vsphere:
+  - name: pull-cluster-api-provider-vsphere-test
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181010-2672d9494-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -346,6 +346,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/cluster-api",
 		"kubernetes-sigs/cluster-api-provider-aws",
 		"kubernetes-sigs/cluster-api-provider-gcp",
+		"kubernetes-sigs/cluster-api-provider-vsphere",
 		"kubernetes-sigs/cluster-api-provider-openstack",
 		"kubernetes-sigs/poseidon",
 		"kubernetes-sigs/structured-merge-diff",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2448,6 +2448,9 @@ test_groups:
 - name: pull-cluster-api-provider-gcp-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-gcp-test
   num_columns_recent: 20
+- name: pull-cluster-api-provider-vsphere-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-vsphere-test
+  num_columns_recent: 20
 - name: pull-cluster-api-provider-openstack-make
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-openstack-make
   num_columns_recent: 20
@@ -3551,6 +3554,14 @@ dashboards:
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
+
+- name: vmware-cluster-api-provider-vsphere
+  dashboard_tab:
+  - name: pr-test
+    description: Runs unit tests
+    test_group_name: pull-cluster-api-provider-vsphere-test
+    alert_options:
+      alert_mail_to_addresses: cnx+clusterapi@vmware.com
 
 # Alibaba Cloud Provider Dashboard
 - name: conformance-alibaba-cloud-provider
@@ -5815,6 +5826,11 @@ dashboards:
     test_group_name: ci-gcp-compute-persistent-disk-csi-driver-kubernetes-integration
     description: 'Kubernetes Integration tests for Kubernetes Master branch and Driver Master branch'
 
+- name: sig-cluster-lifecycle-cluster-api-provider-vsphere
+  dashboard_tab:
+  - name: pr-test
+    test_group_name: pull-cluster-api-provider-vsphere-test
+
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
   dashboard_tab:
   - name: pr-make
@@ -7362,6 +7378,7 @@ dashboard_groups:
   - sig-cluster-lifecycle-multi-platform
   - sig-cluster-lifecycle-cluster-api
   - sig-cluster-lifecycle-cluster-api-provider-aws
+  - sig-cluster-lifecycle-cluster-api-provider-vsphere
   - sig-cluster-lifecycle-cluster-api-provider-gcp
   - sig-cluster-lifecycle-cluster-api-provider-openstack
   - sig-cluster-lifecycle-kops
@@ -7450,3 +7467,4 @@ dashboard_groups:
   - vmware-presubmits-cloud-provider-vsphere
   - vmware-conformance
   - vmware-conformance-cloud-provider
+  - vmware-cluster-api-provider-vsphere


### PR DESCRIPTION
the ci job going to run `make test` which invoke all unit tests
in the repo.

it reports result to testgrid at both:
sig-cluster-lifecycle
vmware

/cc @krzyzacy @BenTheElder @akutz @sflxn