### PR TITLE
Remove deprecated buildId env var

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -30,6 +30,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *October 12, 2018* Removed deprecated `buildId` environment variable from prow jobs. Use `BUILD_ID.`
  - *October 3, 2018* `-github-token-file` replaced with
     `-github-token-path` for consistency with `branchprotector` and
     `peribolos` which were already using `-github-token-path`.

--- a/prow/README.md
+++ b/prow/README.md
@@ -208,7 +208,6 @@ Variable | Periodic | Postsubmit | Batch | Presubmit | Description | Example
 `JOB_SPEC` | ✓ | ✓ | ✓ | ✓ | JSON-encoded job specification. | see below
 `BUILD_ID` | ✓ | ✓ | ✓ | ✓ | Unique build number for each run. | `12345`
 `PROW_JOB_ID` | ✓ | ✓ | ✓ | ✓ | Unique identifier for the owning Prow Job. | `1ce07fa2-0831-11e8-b07e-0a58ac101036`
-`BUILD_ID` | ✓ | ✓ | ✓ | ✓ | Unique build number for each run. | `12345`
 `REPO_OWNER` | | ✓ | ✓ | ✓ | GitHub org that triggered the job. | `kubernetes`
 `REPO_NAME` | | ✓ | ✓ | ✓ | GitHub repo that triggered the job. | `test-infra`
 `PULL_BASE_REF` | | ✓ | ✓ | ✓ | Ref name of the base branch. | `master`

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -85,9 +85,8 @@ const (
 	jobTypeEnv   = "JOB_TYPE"
 	prowJobIDEnv = "PROW_JOB_ID"
 
-	buildIDEnv        = "BUILD_ID"
-	prowBuildIDEnv    = "BUILD_NUMBER" // Deprecated, will be removed in the future.
-	jenkinsBuildIDEnv = "buildId"      // Deprecated, will be removed in the future.
+	buildIDEnv     = "BUILD_ID"
+	prowBuildIDEnv = "BUILD_NUMBER" // Deprecated, will be removed in the future.
 
 	repoOwnerEnv   = "REPO_OWNER"
 	repoNameEnv    = "REPO_NAME"
@@ -113,8 +112,6 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 	// and in both $buildId and $BUILD_NUMBER for Jenkins
 	if spec.agent == kube.KubernetesAgent {
 		env[prowBuildIDEnv] = spec.BuildID
-	} else if spec.agent == kube.JenkinsAgent {
-		env[jenkinsBuildIDEnv] = spec.BuildID
 	}
 
 	raw, err := json.Marshal(spec)
@@ -142,7 +139,7 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 
 // EnvForType returns the slice of environment variables to export for jobType
 func EnvForType(jobType kube.ProwJobType) []string {
-	baseEnv := []string{jobNameEnv, JobSpecEnv, jobTypeEnv, prowJobIDEnv, buildIDEnv, prowBuildIDEnv, jenkinsBuildIDEnv}
+	baseEnv := []string{jobNameEnv, JobSpecEnv, jobTypeEnv, prowJobIDEnv, buildIDEnv, prowBuildIDEnv}
 	refsEnv := []string{repoOwnerEnv, repoNameEnv, pullBaseRefEnv, pullBaseShaEnv, pullRefsEnv}
 	pullEnv := []string{pullNumberEnv, pullPullShaEnv}
 

--- a/prow/pod-utils/downwardapi/jobspec_test.go
+++ b/prow/pod-utils/downwardapi/jobspec_test.go
@@ -173,7 +173,6 @@ func TestEnvironmentForSpec(t *testing.T) {
 				"JOB_NAME":    "job-name",
 				"BUILD_ID":    "0",
 				"PROW_JOB_ID": "prowjob",
-				"buildId":     "0",
 				"JOB_TYPE":    "periodic",
 				"JOB_SPEC":    `{"type":"periodic","job":"job-name","buildid":"0","prowjobid":"prowjob","refs":{}}`,
 			},


### PR DESCRIPTION
/assign @kargakis @stevekuznetsov @cjwagner 

Looks like some things still use BUILD_NUMBER :-/ so going to fix that first in separate PRs before I remove BUILD_NUMBER too

Also remove duplicated BUILD_ID line in README.md