### PR TITLE
Include the month in gubernator shorttimestamp filters

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -45,7 +45,7 @@ def do_dt_to_epoch(dt):
 def do_shorttimestamp(unix_time):
     t = datetime.datetime.utcfromtimestamp(unix_time)
     return jinja2.Markup('<span class="shorttimestamp" data-epoch="%s">%s</span>' %
-                         (unix_time, t.strftime('%d %H:%M')))
+                         (unix_time, t.strftime('%m-%d %H:%M')))
 
 
 def do_duration(seconds):

--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -31,7 +31,7 @@ function fix_timestamps() {
 		}
 	}
 	replace('timestamp', 'YYYY-MM-DD HH:mm z')
-	replace('shorttimestamp', 'DD HH:mm')
+	replace('shorttimestamp', 'MM-DD HH:mm')
 	replace('humantimestamp', function(t) {
 		var fmt = 'MMM D, Y';
 		if (t.isAfter(moment().startOf('day'))) {


### PR DESCRIPTION
Maybe it's just me, but the current shorttimestamp format is
not something I'm used to seeing. Including the month would
make it easier for me to quickly parse as a human

/kind cleanup