### PR TITLE
Ignore push events for deleted branches

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -490,6 +490,8 @@ type PushEvent struct {
 	// Sender contains more information that Pusher about the user.
 	Sender User `json:"sender"`
 	Repo   Repo `json:"repository"`
+	// Deleted is set when a branch is deleted
+	Deleted bool `json:"deleted"`
 
 	// GUID is included in the header of the request received by Github.
 	GUID string


### PR DESCRIPTION
When a branch is deleted, GitHub sends both a `delete` event
as well as a `push` event updating the branch to an invalid
commit SHA. No consumer of push events is expecting an invalid
commit at the HEAD; we should allow plugins to subscribe to
the `delete` event if they want to handle that case. So, if
we can detect that this is the weird `push` event before the
imminent branch deletion, we don't handle it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 
/cc @BenTheElder @fejta @smarterclayton 