### PR TITLE
Ingnore archived repos in the branch protector

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -205,7 +205,9 @@ func (p *protector) UpdateOrg(orgName string, org config.Org, allRepos bool) err
 			return fmt.Errorf("GetRepos(%s) failed: %v", orgName, err)
 		}
 		for _, r := range rs {
-			repos = append(repos, r.Name)
+			if !r.Archived {
+				repos = append(repos, r.Name)
+			}
 		}
 	} else {
 		// Unopinionated org, just set explicitly defined repos

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -717,3 +717,61 @@ func fixup(r *requirements) {
 		sort.Strings(*restr.Users)
 	}
 }
+
+func TestIgnoreArchivedRepos(t *testing.T) {
+	repos := map[string]map[string]bool{}
+	branches := map[string][]github.Branch{}
+	org, repo, branch := "organization", "repository", "branch"
+	k := org + "/" + repo
+	branches[k] = append(branches[k], github.Branch{
+		Name: branch,
+	})
+	r := repos[org]
+	if r == nil {
+		repos[org] = make(map[string]bool)
+	}
+	repos[org][repo] = true
+	fc := fakeClient{
+		branches: branches,
+		repos:    map[string][]github.Repo{},
+	}
+	for org, r := range repos {
+		for rname := range r {
+			fc.repos[org] = append(fc.repos[org], github.Repo{Name: rname, FullName: org + "/" + rname, Archived: true})
+		}
+	}
+
+	var cfg config.Config
+	if err := yaml.Unmarshal([]byte(`
+branch-protection:
+  protect-by-default: true
+  orgs:
+    organization:
+`), &cfg); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+	p := protector{
+		client:         &fc,
+		cfg:            &cfg,
+		errors:         Errors{},
+		updates:        make(chan requirements),
+		done:           make(chan []error),
+		completedRepos: make(map[string]bool),
+	}
+	go func() {
+		p.protect()
+		close(p.updates)
+	}()
+
+	protectionErrors := p.errors.errs
+	if len(protectionErrors) != 0 {
+		t.Errorf("expected no errors, got %d errors: %v", len(protectionErrors), protectionErrors)
+	}
+	var actual []requirements
+	for r := range p.updates {
+		actual = append(actual, r)
+	}
+	if len(actual) != 0 {
+		t.Errorf("expected no updates, got: %v", actual)
+	}
+}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -271,6 +271,7 @@ type PullRequestChange struct {
 }
 
 // Repo contains general repository information.
+// See also https://developer.github.com/v3/repos/#get
 type Repo struct {
 	Owner         User   `json:"owner"`
 	Name          string `json:"name"`
@@ -278,6 +279,7 @@ type Repo struct {
 	HTMLURL       string `json:"html_url"`
 	Fork          bool   `json:"fork"`
 	DefaultBranch string `json:"default_branch"`
+	Archived      bool   `json:"archived"`
 }
 
 // Branch contains general branch information.


### PR DESCRIPTION
Archived repositories are read-only and cannot have any settings
updated, so we cannot protect their branches.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
fixes https://github.com/kubernetes/test-infra/issues/9752
/assign @fejta 
/cc @cjwagner 