### PR TITLE
testgrid: add kubeadm stable-on-master job to master-blocking

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4616,6 +4616,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
   - name: kubeadm-gce-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
+  - name: kubeadm-gce-stable-on-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
   - name: packages-pushed-master
     test_group_name: periodic-kubernetes-e2e-packages-pushed
 


### PR DESCRIPTION
the release-1.12-blocking dashboard has a 1.11-on-1.12 kubeadm job, while the release-master-blocking doesn't have the analogous.

this is done as requested in this issue:
https://github.com/kubernetes/test-infra/issues/9363#issuecomment-429962773

/assign @krzyzacy @timothysc 
/cc @jberkus 
/area testgrid
/kind cleanup
