### PR TITLE
clean up explicit etcd3 CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -21,28 +21,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
 
 - interval: 2h
-  name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
-
-- interval: 2h
   name: ci-kubernetes-e2e-gci-gce-sig-cli
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -195,28 +195,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
 
 - interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-etcd3
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
-
-- interval: 30m
   name: ci-kubernetes-e2e-gci-gce-flaky
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -434,29 +434,6 @@ periodics:
       - --timeout=90m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
 
-- interval: 1h
-  name: ci-cri-containerd-e2e-gci-gce-etcd3
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/cri=master
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env-file=jobs/env/ci-cri-containerd-e2e-gce.env
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
-
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-flaky
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -109,8 +109,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-ubuntu-gce
 - name: ci-cri-containerd-e2e-gci-gce-reboot
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-reboot
-- name: ci-cri-containerd-e2e-gci-gce-etcd3
-  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-etcd3
 - name: ci-cri-containerd-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce-serial
 - name: ci-cri-containerd-e2e-gci-gce-slow
@@ -347,8 +345,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-es-logging
 - name: ci-kubernetes-e2e-gci-gce-sd-logging
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-sd-logging
-- name: ci-kubernetes-e2e-gci-gce-etcd3
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-etcd3
 - name: ci-kubernetes-e2e-gci-gce-flaky
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-flaky
 - name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
@@ -374,8 +370,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
 - name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-serial-sig-cli
-- name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
 - name: ci-kubernetes-e2e-gci-gce-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow
 - name: ci-kubernetes-e2e-gci-gce-sig-cli
@@ -4154,8 +4148,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-es-logging
   - name: gci-gce-sd-logging
     test_group_name: ci-kubernetes-e2e-gci-gce-sd-logging
-  - name: gci-gce-etcd3
-    test_group_name: ci-kubernetes-e2e-gci-gce-etcd3
   - name: gci-gce-flaky
     test_group_name: ci-kubernetes-e2e-gci-gce-flaky
   - name: gci-gce-single-flake-attempt
@@ -5681,11 +5673,6 @@ dashboards:
     description: kubectl gke serial e2e tests for master branch
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
-  - name: gce-etcd3
-    test_group_name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
-    description: e2e tests run against a cluster with an etcd3 instance
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws-sig-cli
     alert_options:
@@ -6178,8 +6165,6 @@ dashboards:
     test_group_name: ci-containerd-e2e-gci-gce-1-1
   - name: containerd-e2e-ubuntu
     test_group_name: ci-containerd-e2e-ubuntu-gce
-  - name: e2e-gci-etcd3
-    test_group_name: ci-cri-containerd-e2e-gci-gce-etcd3
   - name: e2e-gci-reboot
     test_group_name: ci-cri-containerd-e2e-gci-gce-reboot
   - name: e2e-gci-serial


### PR DESCRIPTION
with https://github.com/kubernetes/test-infra/pull/9672 etcd3 is default now, and we don't need to have a duplicated version of etcd3 CI job.

/area jobs
/assign @spiffxp @BenTheElder 