### PR TITLE
set repo path_alias

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-test
     always_run: false
     decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
path_alias is needed, otherwise, it pulls code to local path
at "github.com/cluster-api-provider-vsphere", this will not
satisfy the dependency on path
"sigs.k8s.io/cluster-api-provider-vsphere"

/cc @akutz 