### PR TITLE
Add a job to test large artifact uploads

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -46,3 +46,16 @@ periodics:
         value: "true"
       securityContext:
         privileged: true
+- interval: 1h
+  name: ci-can-we-upload-large-files
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181005-fd9cfb8b0-master
+      command:
+      - bash
+      args:
+      - -e
+      - -c
+      - |
+        dd if=/dev/zero of="${ARTIFACTS}/ten_megabytes_of_zeros" count=10240 bs=1024


### PR DESCRIPTION
We theorise that podutils fails if required to upload an artifact larger than eight megabytes (see e.g. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-coverage-conformance/161)

Test this by attempting to upload such an artifact in a trivial job that doesn't take two hours to run.

/cc @BenTheElder 
/area prow/pod-utilities