### PR TITLE
Don't build hyperkube or conformance images for conformance coverage test

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -44,5 +44,9 @@ periodics:
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
+      - name: KUBE_BUILD_HYPERKUBE
+        value: "n"
+      - name: KUBE_BUILD_CONFORMANCE
+        value: "n"
       securityContext:
         privileged: true


### PR DESCRIPTION
We don't need these and they waste time; avoid building them.

("don't build conformance testing image for conformance tests" sounds bizarre.)

/cc @BenTheElder 