### PR TITLE
Add a sticky LGTM option for collaborators

### DIFF
--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/trigger:go_default_library",
         "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -369,14 +369,15 @@ type Lgtm struct {
 	// StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
 	// squashed commits before removing lgtm labels
 	StoreTreeHash bool `json:"store_tree_hash,omitempty"`
-	// WARNING: Read below for potential risk before you enable this option.
-	// StickyForCollaborators indicates if LGTM is sticky for PRs authored by collaborators.
-	// This means that collaborators are trusted to not introduce bad code after the initial
-	// LGTM, and it eliminates the need to re-lgtm minor fixes/updates. If the PR is authored
-	// by non-collaborator, this option does not apply.
-	// This disables the security mechanism that prevents a malicious collaborator (or
-	// compromised collaborator GitHub account) from merging arbitrary code.
-	StickyForCollaborators bool `json:"sticky_for_collaborators,omitempty"`
+	// WARNING: This disables the security mechanism that prevents a malicious member (or
+	// compromised GitHub account) from merging arbitrary code. Use with caution.
+	//
+	// StickyForTrustedUsers indicates if LGTM is sticky for PRs authored by trusted users, and
+	// eliminates the need to re-lgtm minor fixes/updates. This does not apply if the author is
+	// not trusted. Trusted users are by default collaborators and org members, but can also be
+	// restricted to only org members using Trigger.OnlyOrgMembers. i.e. thr same set of users
+	// who can issue "/ok-to-test".
+	StickyForTrustedUsers bool `json:"sticky_for_collaborators,omitempty"`
 }
 
 type Cat struct {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -372,12 +372,12 @@ type Lgtm struct {
 	// WARNING: This disables the security mechanism that prevents a malicious member (or
 	// compromised GitHub account) from merging arbitrary code. Use with caution.
 	//
-	// StickyForTrustedUsers indicates if LGTM is sticky for PRs authored by trusted users, and
+	// StickyForTrustedAuthors indicates if LGTM is sticky for PRs authored by trusted users, and
 	// eliminates the need to re-lgtm minor fixes/updates. This does not apply if the author is
 	// not trusted. Trusted users are by default collaborators and org members, but can also be
-	// restricted to only org members using Trigger.OnlyOrgMembers. i.e. thr same set of users
+	// restricted to only org members using Trigger.OnlyOrgMembers. i.e. the same set of users
 	// who can issue "/ok-to-test".
-	StickyForTrustedUsers bool `json:"sticky_for_collaborators,omitempty"`
+	StickyForTrustedAuthors bool `json:"sticky_for_trusted_authors,omitempty"`
 }
 
 type Cat struct {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -369,6 +369,14 @@ type Lgtm struct {
 	// StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
 	// squashed commits before removing lgtm labels
 	StoreTreeHash bool `json:"store_tree_hash,omitempty"`
+	// WARNING: Read below for potential risk before you enable this option.
+	// StickyForCollaborators indicates if LGTM is sticky for PRs authored by collaborators.
+	// This means that collaborators are trusted to not introduce bad code after the initial
+	// LGTM, and it eliminates the need to re-lgtm minor fixes/updates. If the PR is authored
+	// by non-collaborator, this option does not apply.
+	// This disables the security mechanism that prevents a malicious collaborator (or
+	// compromised collaborator GitHub account) from merging arbitrary code.
+	StickyForCollaborators bool `json:"sticky_for_collaborators,omitempty"`
 }
 
 type Cat struct {

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -62,7 +62,7 @@ func handleIC(c client, trigger *plugins.Trigger, ic github.IssueCommentEvent) e
 		// Check for the presence of the needs-ok-to-test label and remove it
 		// if a trusted member has commented "/ok-to-test".
 		if okToTest && ic.Issue.HasLabel(NeedsOkToTest) {
-			trusted, err := trustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
+			trusted, err := TrustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func handleIC(c client, trigger *plugins.Trigger, ic github.IssueCommentEvent) e
 
 	var comments []github.IssueComment
 	// Skip untrusted users.
-	trusted, err := trustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
+	trusted, err := TrustedUser(c.GitHubClient, trigger, commentAuthor, org, repo)
 	if err != nil {
 		return fmt.Errorf("error checking trust of %s: %v", commentAuthor, err)
 	}

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -41,7 +41,7 @@ func handlePR(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) er
 		// When a PR is opened, if the author is in the org then build it.
 		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
 		// "/ok-to-test" comments since the PR was just opened!
-		member, err := trustedUser(c.GitHubClient, trigger, author, org, repo)
+		member, err := TrustedUser(c.GitHubClient, trigger, author, org, repo)
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
 		}
@@ -189,7 +189,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands)
 // comments by org members.
 func trustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org, repo string, comments []github.IssueComment) (bool, error) {
 	// First check if the author is a member of the org.
-	if orgMember, err := trustedUser(ghc, trigger, author, org, repo); err != nil {
+	if orgMember, err := TrustedUser(ghc, trigger, author, org, repo); err != nil {
 		return false, fmt.Errorf("error checking %s for trust: %v", author, err)
 	} else if orgMember {
 		return true, nil
@@ -206,7 +206,7 @@ func trustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 			continue
 		}
 		// Ensure that the commenter is in the org.
-		if commentAuthorMember, err := trustedUser(ghc, trigger, commentAuthor, org, repo); err != nil {
+		if commentAuthorMember, err := TrustedUser(ghc, trigger, commentAuthor, org, repo); err != nil {
 			return false, fmt.Errorf("error checking %s for trust: %v", commentAuthor, err)
 		} else if commentAuthorMember {
 			return true, nil

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -113,6 +113,11 @@ type client struct {
 	Logger       *logrus.Entry
 }
 
+type trustedUserClient interface {
+	IsCollaborator(org, repo, user string) (bool, error)
+	IsMember(org, user string) (bool, error)
+}
+
 func getClient(pc plugins.PluginClient) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
@@ -135,11 +140,11 @@ func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {
 	return handlePE(getClient(pc), pe)
 }
 
-// trustedUser returns true if user is trusted in repo.
+// TrustedUser returns true if user is trusted in repo.
 //
 // Trusted users are either repo collaborators, org members or trusted org members.
 // Whether repo collaborators and/or a second org is trusted is configured by trigger.
-func trustedUser(ghc githubClient, trigger *plugins.Trigger, user, org, repo string) (bool, error) {
+func TrustedUser(ghc trustedUserClient, trigger *plugins.Trigger, user, org, repo string) (bool, error) {
 	// First check if user is a collaborator, assuming this is allowed
 	allowCollaborators := trigger == nil || !trigger.OnlyOrgMembers
 	if allowCollaborators {


### PR DESCRIPTION
This adds a new option "StickyForCollaborators" in the LGTM plugin.

StickyForCollaborators indicates if LGTM is sticky for PRs authored by collaborators.
This means that collaborators are trusted to not introduce bad code after the initial
LGTM, and it eliminates the need to re-lgtm minor fixes/updates. If the PR is authored
by non-collaborator, this option does not apply.

Fixes https://github.com/kubernetes/test-infra/issues/9786