### PR TITLE
Create utility to label trusted PRs lacking ok-to-test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -94,6 +94,7 @@ filegroup(
         "//queue_health/graph:all-srcs",
         "//robots/commenter:all-srcs",
         "//robots/issue-creator:all-srcs",
+        "//robots/pr-labeler:all-srcs",
         "//scenarios:all-srcs",
         "//testgrid:all-srcs",
         "//triage:all-srcs",

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -864,6 +864,32 @@ func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment
 	return comments, nil
 }
 
+// GetPullRequests get all pull requests.
+//
+// See https://developer.github.com/v3/pulls/#get-a-single-pull-request
+func (c *Client) GetPullRequests(org, repo string) ([]PullRequest, error) {
+	c.log("GetPullRequests", org, repo)
+	var prs []PullRequest
+	if c.fake {
+		return prs, nil
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls", org, repo)
+	err := c.readPaginatedResults(
+		path,
+		"application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
+		func() interface{} {
+			return &[]PullRequest{}
+		},
+		func(obj interface{}) {
+			prs = append(prs, *(obj.(*[]PullRequest))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return prs, err
+}
+
 // GetPullRequest gets a pull request.
 //
 // See https://developer.github.com/v3/pulls/#get-a-single-pull-request

--- a/robots/pr-labeler/BUILD.bazel
+++ b/robots/pr-labeler/BUILD.bazel
@@ -1,0 +1,59 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+docker_bundle(
+    name = "bundle",
+    images = {
+        "{STABLE_DOCKER_REPO}/pr-labeler:{DOCKER_TAG}": ":pr-labeler-image",
+        "{STABLE_DOCKER_REPO}/pr-labeler:latest": ":pr-labeler-image",
+        "{STABLE_DOCKER_REPO}/pr-labeler:latest-{BUILD_USER}": ":pr-labeler-image",
+    },
+    stamp = True,
+)
+
+docker_push(
+    name = "push",
+    bundle = ":bundle",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_image(
+    name = "pr-labeler-image",
+    base = "@distroless-base//image",
+    embed = [":go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/robots/pr-labeler",
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+# Delete after gazelle stops forcing its creation
+go_binary(
+    name = "pr-labeler",
+    embed = [":go_default_library"],
+)

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// PR labeler provides a way to add a missing ok-to-test label on trusted PRs.
+//
+// The --token-path determines who interacts with github.
+// By default PR labeler runs in dry mode, add --confirm to make it leave comments.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
+)
+
+const (
+	needsOkToTest = "needs-ok-to-test"
+	okToTest      = "ok-to-test"
+)
+
+type client interface {
+	AddLabel(org, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	GetPullRequests(org, repo string) ([]github.PullRequest, error)
+	ListCollaborators(org, repo string) ([]github.User, error)
+	ListOrgMembers(org, role string) ([]github.TeamMember, error)
+}
+
+type options struct {
+	confirm            bool
+	endpoint           flagutil.Strings
+	org                string
+	repo               string
+	tokenPath          string
+	trustCollaborators bool
+}
+
+func flagOptions() options {
+	o := options{
+		endpoint: flagutil.NewStrings("https://api.github.com"),
+	}
+	flag.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
+	flag.StringVar(&o.org, "org", "", "github org")
+	flag.StringVar(&o.repo, "repo", "", "github repo")
+	flag.StringVar(&o.tokenPath, "token-path", "", "Path to github token")
+	flag.BoolVar(&o.trustCollaborators, "trust-collaborators", false, "Also trust PRs from collaborators")
+	flag.Parse()
+	return o
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	o := flagOptions()
+
+	if o.org == "" {
+		log.Fatal("empty --org")
+	}
+	if o.repo == "" {
+		log.Fatal("empty --repo")
+	}
+	if o.tokenPath == "" {
+		log.Fatal("empty --token-path")
+	}
+
+	secretAgent := &config.SecretAgent{}
+	if err := secretAgent.Start([]string{o.tokenPath}); err != nil {
+		log.Fatalf("Error starting secrets agent: %v", err)
+	}
+
+	var err error
+	for _, ep := range o.endpoint.Strings() {
+		_, err = url.ParseRequestURI(ep)
+		if err != nil {
+			log.Fatalf("Invalid --endpoint URL %q: %v.", ep, err)
+		}
+	}
+
+	var c client
+	if o.confirm {
+		c = github.NewClient(secretAgent.GetTokenGenerator(o.tokenPath), o.endpoint.Strings()...)
+	} else {
+		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.tokenPath), o.endpoint.Strings()...)
+	}
+
+	// get all open PRs
+	prs, err := c.GetPullRequests(o.org, o.repo)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get the list of members once and use a set for lookups
+	mem, err := c.ListOrgMembers(o.org, "member")
+	if err != nil {
+		log.Fatal(err)
+	}
+	members := sets.NewString()
+	for _, member := range mem {
+		members.Insert(member.Login)
+	}
+
+	// get the list of collaborators once and use a set for lookups
+	col, err := c.ListCollaborators(o.org, o.repo)
+	if err != nil {
+		log.Fatal(err)
+	}
+	collaborators := sets.NewString()
+	for _, collaborator := range col {
+		collaborators.Insert(collaborator.Login)
+	}
+
+	for _, pr := range prs {
+		// skip PRs from members
+		if members.Has(pr.User.Login) {
+			continue
+		}
+		// eventually skip PRs from collaborators
+		if o.trustCollaborators && collaborators.Has(pr.User.Login) {
+			continue
+		}
+		// skip PRs with *ok-to-test labels
+		labels, err := c.GetIssueLabels(o.org, o.repo, pr.Number)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if github.HasLabel(okToTest, labels) || github.HasLabel(needsOkToTest, labels) {
+			continue
+		}
+		// only add ok-to-test with --confirm
+		if !o.confirm {
+			log.Println("Use --confirm to add", okToTest, "to", pr.HTMLURL)
+			continue
+		}
+		if err := c.AddLabel(o.org, o.repo, pr.Number, okToTest); err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This implements a tool to label trusted PRs with the new label introduced in #9754