### PR TITLE
Create ConfigMaps when they don't already exist

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -32,6 +32,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 15, 2018* the `hook` service account now requires RBAC privileges
+   to create `ConfigMaps` to support new functionality in the `updateconfig` plugin.
  - *November 9, 2018* Prow gerrit client label/annotations now have a `prow.k8s.io/` namespace
     prefix, if you have a gerrit deployment, please bump both cmd/gerrit and cmd/crier.
  - *October 16, 2018* Prow tls-cert management has been migrated from kube-lego to cert-manager.

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -22,6 +22,7 @@ rules:
     resources:
       - configmaps
     verbs:
+      - create
       - update
 ---
 kind: RoleBinding


### PR DESCRIPTION
When `updateconfig` is configured to watch a directory or file, but the
target `ConfigMap` does not yet exist, it should create it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
fixes https://github.com/kubernetes/test-infra/issues/8940
/assign @krzyzacy 
/cc @BenTheElder @cjwagner 