### PR TITLE
Enable gopherage to generate comparison HTML files

### DIFF
--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -46,8 +46,8 @@ func MakeCommand() *cobra.Command {
 }
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		log.Fatalln("Usage: gopherage html [coverage]")
+	if len(args) < 1 {
+		log.Fatalln("Usage: gopherage html [coverage...]")
 	}
 
 	// This path assumes we're being run using bazel.
@@ -73,9 +73,13 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		}
 	}
 
-	coverage, err := ioutil.ReadFile(args[0])
-	if err != nil {
-		log.Fatalf("Couldn't read coverage file: %v", err)
+	coverageFiles := make(map[string]string, len(args))
+	for _, arg := range args {
+		content, err := ioutil.ReadFile(arg)
+		if err != nil {
+			log.Fatalf("Couldn't read coverage file: %v", err)
+		}
+		coverageFiles[arg] = string(content)
 	}
 
 	outputPath := flags.OutputFile
@@ -93,6 +97,6 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 
 	tpl.Execute(output, struct {
 		Script   template.JS
-		Coverage string
-	}{template.JS(script), string(coverage)})
+		Coverage map[string]string
+	}{template.JS(script), coverageFiles})
 }

--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -45,6 +45,11 @@ func MakeCommand() *cobra.Command {
 	return cmd
 }
 
+type coverageFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
 		log.Fatalln("Usage: gopherage html [coverage...]")
@@ -73,13 +78,13 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		}
 	}
 
-	coverageFiles := make(map[string]string, len(args))
+	var coverageFiles []coverageFile
 	for _, arg := range args {
 		content, err := ioutil.ReadFile(arg)
 		if err != nil {
 			log.Fatalf("Couldn't read coverage file: %v", err)
 		}
-		coverageFiles[arg] = string(content)
+		coverageFiles = append(coverageFiles, coverageFile{Path: arg, Content: string(content)})
 	}
 
 	outputPath := flags.OutputFile
@@ -97,6 +102,6 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 
 	tpl.Execute(output, struct {
 		Script   template.JS
-		Coverage map[string]string
+		Coverage []coverageFile
 	}{template.JS(script), coverageFiles})
 }

--- a/gopherage/cmd/html/static/browser.html
+++ b/gopherage/cmd/html/static/browser.html
@@ -5,7 +5,7 @@
   <title>Conformance Code Coverage</title>
   <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
-    var coverage = "{{ .Coverage }}";
+    var embeddedProfiles = {{ .Coverage }};
     {{ .Script }}
   </script>
   <style type="text/css">

--- a/gopherage/cmd/html/static/browser.ts
+++ b/gopherage/cmd/html/static/browser.ts
@@ -17,9 +17,9 @@ limitations under the License.
 import {Coverage, FileCoverage, parseCoverage} from './parser';
 import {enumerate, map} from './utils';
 
-declare const coverage: string;
+declare const embeddedProfiles: {[path: string]: string};
 
-let coverageFiles: Coverage[] = [];
+let coverageFiles: Array<{name: string, coverage: Coverage}> = [];
 let prefix = 'k8s.io/kubernetes/';
 
 function filterCoverage(coverage: Coverage): Coverage {
@@ -37,8 +37,23 @@ function filterCoverage(coverage: Coverage): Coverage {
   return coverage;
 }
 
-function loadEmbeddedProfile(): Coverage {
-  return filterCoverage(parseCoverage(coverage));
+function filenameForDisplay(path: string): string {
+  const basename = path.split('/').pop()!;
+  const withoutSuffix = basename.replace(/\.[^.]+$/, '');
+  return withoutSuffix;
+}
+
+function loadEmbeddedProfiles(): Array<{name: string, coverage: Coverage}> {
+  const results = [];
+  for (const path in embeddedProfiles) {
+    if (Object.prototype.hasOwnProperty.call(embeddedProfiles, path)) {
+      results.push({
+        name: filenameForDisplay(path),
+        coverage: filterCoverage(parseCoverage(embeddedProfiles[path]))
+      });
+    }
+  }
+  return results;
 }
 
 async function loadProfile(path: string): Promise<Coverage> {
@@ -52,7 +67,7 @@ async function init(): Promise<void> {
     prefix = location.hash.substring(1);
   }
   // TODO: this path shouldn't be hardcoded.
-  coverageFiles = [loadEmbeddedProfile()];
+  coverageFiles = loadEmbeddedProfiles();
   google.charts.load('current', {'packages': ['table']});
   google.charts.setOnLoadCallback(drawTable);
 }
@@ -130,18 +145,20 @@ function mergeMaps<T, U>(maps: Iterable<Map<T, U>>): Map<T, U[]> {
 }
 
 function drawTable(): void {
-  const rows = Array.from(coveragesForPrefix(coverageFiles, prefix));
+  const rows = Array.from(
+      coveragesForPrefix(coverageFiles.map((x) => x.coverage), prefix));
+  const cols = coverageFiles.map(
+      (x, i) => ({id: `file-${i}`, label: x.name, type: 'number'}));
   const dataTable = new google.visualization.DataTable({
     cols: [
       {id: 'child', label: 'File', type: 'string'},
-      {id: 'statement-coverage', label: 'Coverage', type: 'number'},
-    ],
+    ].concat(cols),
     rows
   });
 
   const colourFormatter = new google.visualization.ColorFormat();
   colourFormatter.addGradientRange(0, 1.0001, '#FFFFFF', '#DD0000', '#00DD00');
-  for (let i = 1; i < rows[0].c.length; ++i) {
+  for (let i = 1; i < cols.length + 1; ++i) {
     colourFormatter.format(dataTable, i);
   }
 

--- a/gopherage/cmd/html/static/browser.ts
+++ b/gopherage/cmd/html/static/browser.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import {Coverage, FileCoverage, parseCoverage} from './parser';
 import {enumerate, map} from './utils';
 
-declare const embeddedProfiles: {[path: string]: string};
+declare const embeddedProfiles: Array<{path: string, content: string}>;
 
 let coverageFiles: Array<{name: string, coverage: Coverage}> = [];
 let prefix = 'k8s.io/kubernetes/';
@@ -44,16 +44,10 @@ function filenameForDisplay(path: string): string {
 }
 
 function loadEmbeddedProfiles(): Array<{name: string, coverage: Coverage}> {
-  const results = [];
-  for (const path in embeddedProfiles) {
-    if (Object.prototype.hasOwnProperty.call(embeddedProfiles, path)) {
-      results.push({
-        name: filenameForDisplay(path),
-        coverage: filterCoverage(parseCoverage(embeddedProfiles[path]))
-      });
-    }
-  }
-  return results;
+  return embeddedProfiles.map(({path, content}) => ({
+                                name: filenameForDisplay(path),
+                                coverage: filterCoverage(parseCoverage(content))
+                              }));
 }
 
 async function loadProfile(path: string): Promise<Coverage> {
@@ -66,7 +60,7 @@ async function init(): Promise<void> {
   if (location.hash.length > 1) {
     prefix = location.hash.substring(1);
   }
-  // TODO: this path shouldn't be hardcoded.
+
   coverageFiles = loadEmbeddedProfiles();
   google.charts.load('current', {'packages': ['table']});
   google.charts.setOnLoadCallback(drawTable);


### PR DESCRIPTION
This PR enables `gopherage html` to generate comparative HTML files, given multiple files as input:

![image](https://user-images.githubusercontent.com/110792/47051640-e3445180-d159-11e8-869f-f171fb28bdc8.png)

/kind feature
/area gopherage???
/cc @BenTheElder 