### PR TITLE
Add language labels for k/website repo

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -14,6 +14,7 @@
 - [Labels that apply to kubernetes/kubernetes, only for issues](#labels-that-apply-to-kuberneteskubernetes-only-for-issues)
 - [Labels that apply to kubernetes/org, only for issues](#labels-that-apply-to-kubernetesorg-only-for-issues)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
+- [Labels that apply to kubernetes/website, for both issues and PRs](#labels-that-apply-to-kuberneteswebsite-for-both-issues-and-prs)
 
 
 ## Intro
@@ -225,5 +226,15 @@ larger set of contributors to apply/remove them.
 | <a id="area/prow/spyglass" href="#area/prow/spyglass">`area/prow/spyglass`</a> | Issues or PRs related to prow's spyglass UI| label | |
 | <a id="area/prow/tide" href="#area/prow/tide">`area/prow/tide`</a> | Issues or PRs related to prow's tide component| label | |
 | <a id="area/prow/tot" href="#area/prow/tot">`area/prow/tot`</a> | Issues or PRs related to prow's tot component| label | |
+
+## Labels that apply to kubernetes/website, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="language/en" href="#language/en">`language/en`</a> | Issues or PRs related to English language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/ja" href="#language/ja">`language/ja`</a> | Issues or PRs related to Japanese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/ko" href="#language/ko">`language/ko`</a> | Issues or PRs related to Korean language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/no" href="#language/no">`language/no`</a> | Issues or PRs related to Norwegian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -868,3 +868,37 @@ repos:
         name: area/prow/pod-utilities
         target: both
         addedBy: label
+  kubernetes/website:
+    labels:
+      - color: e9b3f9
+        description: Issues or PRs related to English language
+        name: language/en
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
+        description: Issues or PRs related to Japanese language
+        name: language/ja
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
+        description: Issues or PRs related to Korean language
+        name: language/ko
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
+        description: Issues or PRs related to Norwegian language
+        name: language/no
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
+        description: Issues or PRs related to Chinese language
+        name: language/zh
+        previously:
+          - name: language/cn
+        target: both
+        prowPlugin: label
+        addedBy: anyone

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -323,6 +323,31 @@
     color: #000000;
 }
 
+.languagex00002fen {
+    background-color: #e9b3f9;
+    color: #000000;
+}
+
+.languagex00002fja {
+    background-color: #e9b3f9;
+    color: #000000;
+}
+
+.languagex00002fko {
+    background-color: #e9b3f9;
+    color: #000000;
+}
+
+.languagex00002fno {
+    background-color: #e9b3f9;
+    color: #000000;
+}
+
+.languagex00002fzh {
+    background-color: #e9b3f9;
+    color: #000000;
+}
+
 .lgtm {
     background-color: #15dd18;
     color: #000000;


### PR DESCRIPTION
Allow anyone to add l10n labels for the issues or PRs in the k/website repo using `label` prow.

/cc @zacharysarah @tengqm @cstoku 