### PR TITLE
PR Dashboard: Nullable pools data was uhandled

### DIFF
--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -418,15 +418,13 @@ function loadPrStatus(prData: UserData): void {
         }
         const githubContexts = prWithContext.Contexts;
         const contexts = getFullPRContext(builds, githubContexts);
-        // Initialises an empty pool when Pools from TideData is null.
-        const pools = tideData.Pools || [];
         const validQueries: TideQuery[] = [];
         for (let query of tideQueries) {
             if (query.matchPr(pr)) {
                 validQueries.push(query);
             }
         }
-        container.appendChild(createPRCard(pr, contexts, closestMatchingQueries(pr, validQueries), pools));
+        container.appendChild(createPRCard(pr, contexts, closestMatchingQueries(pr, validQueries), tideData.Pools));
     }
 }
 

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -418,13 +418,15 @@ function loadPrStatus(prData: UserData): void {
         }
         const githubContexts = prWithContext.Contexts;
         const contexts = getFullPRContext(builds, githubContexts);
+        // Initialises an empty pool when Pools from TideData is null.
+        const pools = tideData.Pools || [];
         const validQueries: TideQuery[] = [];
         for (let query of tideQueries) {
             if (query.matchPr(pr)) {
                 validQueries.push(query);
             }
         }
-        container.appendChild(createPRCard(pr, contexts, closestMatchingQueries(pr, validQueries), tideData.Pools));
+        container.appendChild(createPRCard(pr, contexts, closestMatchingQueries(pr, validQueries), pools));
     }
 }
 

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -101,7 +101,7 @@ func (ta *tideAgent) filterHidden(tideQueries []config.TideQuery, pools []tide.P
 		return tideQueries, pools
 	}
 
-	var filteredTideQueries []config.TideQuery
+	filteredTideQueries := make([]config.TideQuery, 0, len(tideQueries))
 	for _, qc := range tideQueries {
 		includesHidden := false
 		// This will exclude the query even if a single
@@ -120,7 +120,7 @@ func (ta *tideAgent) filterHidden(tideQueries []config.TideQuery, pools []tide.P
 		}
 	}
 
-	var filteredPools []tide.Pool
+	filteredPools := make([]tide.Pool, 0, len(pools))
 	for _, pool := range pools {
 		needsHide := matches(pool.Org+"/"+pool.Repo, ta.hiddenRepos)
 		if (needsHide && ta.hiddenOnly) ||


### PR DESCRIPTION
Default parameters in Javascript did not catch `null` values so it left the null pool unhandled. The check that handles the null was removed from recent refactoring. 

This PR forces the Deck returns an empty slice instead of nil ptr which is later marshalled to a null value.

/cc @BenTheElder 
/cc @cjwagner 