### PR TITLE
Add aggregation command to gopherage

### DIFF
--- a/gopherage/BUILD.bazel
+++ b/gopherage/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/gopherage",
     visibility = ["//visibility:private"],
     deps = [
+        "//gopherage/cmd/aggregate:go_default_library",
         "//gopherage/cmd/diff:go_default_library",
         "//gopherage/cmd/html:go_default_library",
         "//gopherage/cmd/merge:go_default_library",
@@ -30,6 +31,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//gopherage/cmd/aggregate:all-srcs",
         "//gopherage/cmd/diff:all-srcs",
         "//gopherage/cmd/html:all-srcs",
         "//gopherage/cmd/merge:all-srcs",

--- a/gopherage/cmd/aggregate/BUILD.bazel
+++ b/gopherage/cmd/aggregate/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["aggregate.go"],
+    importpath = "k8s.io/test-infra/gopherage/cmd/aggregate",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gopherage/pkg/cov:go_default_library",
+        "//gopherage/pkg/util:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/golang.org/x/tools/cover:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/gopherage/cmd/aggregate/aggregate.go
+++ b/gopherage/cmd/aggregate/aggregate.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregate
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/tools/cover"
+	"k8s.io/test-infra/gopherage/pkg/cov"
+	"k8s.io/test-infra/gopherage/pkg/util"
+)
+
+type flags struct {
+	OutputFile string
+}
+
+// MakeCommand returns an `aggregate` command.
+func MakeCommand() *cobra.Command {
+	flags := &flags{}
+	cmd := &cobra.Command{
+		Use:   "aggregate [files...]",
+		Short: "Aggregates multiple Go coverage files.",
+		Long: `Given multiple Go coverage files from identical binaries recorded in
+"count" or "atomic" mode, produces a new Go coverage file in the same mode
+that counts how many of those coverage profiles hit a block at least once.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			run(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(&flags.OutputFile, "o", "-", "output file")
+	return cmd
+}
+
+func run(flags *flags, cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		log.Fatalf("expected at least one file")
+	}
+
+	profiles := make([][]*cover.Profile, 0, len(args))
+	for _, path := range args {
+		profile, err := cover.ParseProfiles(path)
+		if err != nil {
+			log.Fatalf("failed to open %s: %v", path, err)
+		}
+		profiles = append(profiles, profile)
+	}
+
+	aggregated, err := cov.AggregateProfiles(profiles)
+	if err != nil {
+		log.Fatalf("failed to aggregate files: %v", err)
+	}
+
+	if err := util.DumpProfile(flags.OutputFile, aggregated); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/gopherage/main.go
+++ b/gopherage/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"k8s.io/test-infra/gopherage/cmd/aggregate"
 	"k8s.io/test-infra/gopherage/cmd/diff"
 	"k8s.io/test-infra/gopherage/cmd/html"
 	"k8s.io/test-infra/gopherage/cmd/merge"
@@ -34,6 +35,7 @@ func run() error {
 	rootCommand.AddCommand(diff.MakeCommand())
 	rootCommand.AddCommand(merge.MakeCommand())
 	rootCommand.AddCommand(html.MakeCommand())
+	rootCommand.AddCommand(aggregate.MakeCommand())
 	return rootCommand.Execute()
 }
 

--- a/gopherage/pkg/cov/BUILD.bazel
+++ b/gopherage/pkg/cov/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "aggregate.go",
         "diff.go",
         "merge.go",
         "util.go",
@@ -15,6 +16,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "aggregate_test.go",
         "diff_test.go",
         "equality_test.go",
         "merge_test.go",

--- a/gopherage/pkg/cov/aggregate.go
+++ b/gopherage/pkg/cov/aggregate.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cov
+
+import (
+	"golang.org/x/tools/cover"
+)
+
+// AggregateProfiles takes multiple coverage profiles and produces a new
+// coverage profile that counts the number of profiles that hit a block at least
+// once.
+func AggregateProfiles(profiles [][]*cover.Profile) ([]*cover.Profile, error) {
+	setProfiles := make([][]*cover.Profile, 0, len(profiles))
+	for _, p := range profiles {
+		c := countToBoolean(p)
+		setProfiles = append(setProfiles, c)
+	}
+	aggregateProfiles, err := MergeMultipleProfiles(setProfiles)
+	if err != nil {
+		return nil, err
+	}
+	return aggregateProfiles, nil
+}
+
+// countToBoolean converts a profile containing hit counts to instead contain
+// only 1s or 0s.
+func countToBoolean(profile []*cover.Profile) []*cover.Profile {
+	setProfile := make([]*cover.Profile, 0, len(profile))
+	for _, p := range profile {
+		pc := deepCopyProfile(*p)
+		for i := range pc.Blocks {
+			if pc.Blocks[i].Count > 0 {
+				pc.Blocks[i].Count = 1
+			}
+		}
+		setProfile = append(setProfile, &pc)
+	}
+	return setProfile
+}

--- a/gopherage/pkg/cov/aggregate_test.go
+++ b/gopherage/pkg/cov/aggregate_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cov_test
+
+import (
+	"reflect"
+	"testing"
+
+	"golang.org/x/tools/cover"
+	"k8s.io/test-infra/gopherage/pkg/cov"
+)
+
+func TestAggregateProfilesSingleProfile(t *testing.T) {
+	p := [][]*cover.Profile{
+		{
+			{
+				FileName: "a.go",
+				Mode:     "count",
+				Blocks: []cover.ProfileBlock{
+					{StartLine: 1, StartCol: 14, EndLine: 5, EndCol: 13, NumStmt: 4, Count: 3},
+					{StartLine: 7, StartCol: 4, EndLine: 12, EndCol: 4, NumStmt: 3, Count: 0},
+				},
+			},
+			{
+				FileName: "b.go",
+				Mode:     "count",
+				Blocks: []cover.ProfileBlock{
+					{StartLine: 3, StartCol: 2, EndLine: 7, EndCol: 2, NumStmt: 3, Count: 1},
+				},
+			},
+		},
+	}
+
+	aggregate, err := cov.AggregateProfiles(p)
+	if err != nil {
+		t.Fatalf("AggregateProfiles failed: %v", err)
+	}
+
+	expected := []*cover.Profile{
+		{
+			FileName: "a.go",
+			Mode:     "count",
+			Blocks: []cover.ProfileBlock{
+				{StartLine: 1, StartCol: 14, EndLine: 5, EndCol: 13, NumStmt: 4, Count: 1},
+				{StartLine: 7, StartCol: 4, EndLine: 12, EndCol: 4, NumStmt: 3, Count: 0},
+			},
+		},
+		{
+			FileName: "b.go",
+			Mode:     "count",
+			Blocks: []cover.ProfileBlock{
+				{StartLine: 3, StartCol: 2, EndLine: 7, EndCol: 2, NumStmt: 3, Count: 1},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(aggregate, expected) {
+		t.Fatal("aggregate profile incorrect")
+	}
+}
+
+func TestAggregateProfilesOverlapping(t *testing.T) {
+	p := [][]*cover.Profile{
+		{
+			{
+				FileName: "a.go",
+				Mode:     "count",
+				Blocks: []cover.ProfileBlock{
+					{StartLine: 1, StartCol: 14, EndLine: 5, EndCol: 13, NumStmt: 4, Count: 3},
+					{StartLine: 7, StartCol: 4, EndLine: 12, EndCol: 4, NumStmt: 3, Count: 0},
+					{StartLine: 14, StartCol: 3, EndLine: 19, EndCol: 4, NumStmt: 6, Count: 0},
+				},
+			},
+		},
+		{
+			{
+				FileName: "a.go",
+				Mode:     "count",
+				Blocks: []cover.ProfileBlock{
+					{StartLine: 1, StartCol: 14, EndLine: 5, EndCol: 13, NumStmt: 4, Count: 0},
+					{StartLine: 7, StartCol: 4, EndLine: 12, EndCol: 4, NumStmt: 3, Count: 4},
+					{StartLine: 14, StartCol: 3, EndLine: 19, EndCol: 4, NumStmt: 6, Count: 0},
+				},
+			},
+		},
+	}
+
+	aggregate, err := cov.AggregateProfiles(p)
+	if err != nil {
+		t.Fatalf("AggregateProfiles failed: %v", err)
+	}
+
+	expected := []*cover.Profile{
+		{
+			FileName: "a.go",
+			Mode:     "count",
+			Blocks: []cover.ProfileBlock{
+				{StartLine: 1, StartCol: 14, EndLine: 5, EndCol: 13, NumStmt: 4, Count: 1},
+				{StartLine: 7, StartCol: 4, EndLine: 12, EndCol: 4, NumStmt: 3, Count: 1},
+				{StartLine: 14, StartCol: 3, EndLine: 19, EndCol: 4, NumStmt: 6, Count: 0},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(aggregate, expected) {
+		t.Fatal("aggregate profile incorrect")
+	}
+}


### PR DESCRIPTION
Add an `aggregate` command to gopherage. This command takes multiple coverage files for the same binary, and produces a coverage file indicating in how many of those files a given block was hit. The intent is to use this on multiple e2e coverage files generated by running the same tests on the same binaries, to help mitigate the impact of sporadic background operations.

/kind feature
/cc @BenTheElder @spiffxp 
/area gopherage!