### PR TITLE
Increase staleness period for vSphere conformance

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3103,43 +3103,43 @@ test_groups:
 # cloud-provider-vsphere e2e conformance tests
 - name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance
   gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/ci/latest
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
   gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.12
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.11
   gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.11
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.10
   gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.10
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 # vsphere e2e conformance tests
 - name: ci-periodic-vsphere-test-e2e-conformance
   gcs_prefix: k8s-conformance-vsphere/head/ci/latest
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.12
   gcs_prefix: k8s-conformance-vsphere/head/release/v1.12
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.11
   gcs_prefix: k8s-conformance-vsphere/head/release/v1.11
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 - name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.10
   gcs_prefix: k8s-conformance-vsphere/head/release/v1.10
-  alert_stale_results_hours: 24
+  alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
 # Gardener Test Groups


### PR DESCRIPTION
This patch increases the periodic staleness check for vSphere e2e conformance tests from 24 hours to 32 hours due to the current inability to control the start time of the Travis-CI-based, daily cron job to ensure test results no older than 24 hours.

cc @figo 