### PR TITLE
support Report from periodic & postsubmit jobs

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -93,7 +93,7 @@ type Presubmit struct {
 	Context string `json:"context"`
 	// Optional indicates that the job's status context should not be required for merge.
 	Optional bool `json:"optional,omitempty"`
-	// SkipReport skips commenting and setting status on GitHub.
+	// SkipReport skips commenting and setting status on target git provider.
 	SkipReport bool `json:"skip_report,omitempty"`
 
 	// Trigger is the regular expression to trigger the job.
@@ -145,6 +145,8 @@ type Postsubmit struct {
 	Spec *v1.PodSpec `json:"spec,omitempty"`
 	// Maximum number of this job running concurrently, 0 implies no limit.
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
+	// Report is whether the job need to report through crier
+	Report bool `json:"report,omitempty"`
 
 	Brancher
 
@@ -176,6 +178,8 @@ type Periodic struct {
 	Tags []string `json:"tags,omitempty"`
 	// Run these jobs after successfully running this one.
 	RunAfterSuccess []Periodic `json:"run_after_success,omitempty"`
+	// Report is whether the job need to report through crier
+	Report bool `json:"report,omitempty"`
 
 	UtilityConfig
 

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -138,6 +138,7 @@ func PostsubmitSpec(p config.Postsubmit, refs kube.Refs) kube.ProwJobSpec {
 		Job:       p.Name,
 		Refs:      &refs,
 		ExtraRefs: p.ExtraRefs,
+		Report:    p.Report,
 
 		MaxConcurrency: p.MaxConcurrency,
 
@@ -163,6 +164,7 @@ func PeriodicSpec(p config.Periodic) kube.ProwJobSpec {
 		Type:      kube.PeriodicJob,
 		Job:       p.Name,
 		ExtraRefs: p.ExtraRefs,
+		Report:    p.Report,
 
 		DecorationConfig: p.DecorationConfig,
 	}

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -86,10 +86,61 @@ func TestPostsubmitSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "can report",
+			p: config.Postsubmit{
+				UtilityConfig: config.UtilityConfig{
+					PathAlias: "foo",
+					CloneURI:  "bar",
+				},
+				Report: true,
+			},
+			expected: kube.ProwJobSpec{
+				Type: kube.PostsubmitJob,
+				Refs: &kube.Refs{
+					PathAlias: "foo",
+					CloneURI:  "bar",
+				},
+				Report: true,
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		actual := PostsubmitSpec(tc.p, tc.refs)
+		if expected := tc.expected; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: actual %#v != expected %#v", tc.name, actual, expected)
+		}
+	}
+}
+
+func TestPeriodicSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		p        config.Periodic
+		expected kube.ProwJobSpec
+	}{
+		{
+			name: "default perioidc job",
+			p:    config.Periodic{},
+			expected: kube.ProwJobSpec{
+				Type: kube.PeriodicJob,
+			},
+		},
+		{
+			name: "can report",
+			p: config.Periodic{
+				Report: true,
+			},
+			expected: kube.ProwJobSpec{
+				Type:   kube.PeriodicJob,
+				Report: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		actual := PeriodicSpec(tc.p)
 		if expected := tc.expected; !reflect.DeepEqual(actual, expected) {
 			t.Errorf("%s: actual %#v != expected %#v", tc.name, actual, expected)
 		}

--- a/prow/pjutil/tot.go
+++ b/prow/pjutil/tot.go
@@ -33,7 +33,8 @@ import (
 )
 
 var (
-	node *snowflake.Node
+	node  *snowflake.Node
+	sleep = time.Sleep
 )
 
 func init() {
@@ -86,11 +87,11 @@ func GetBuildID(name, totURL string) (string, error) {
 		return "", fmt.Errorf("invalid tot url: %v", err)
 	}
 	url.Path = path.Join(url.Path, "vend", name)
-	sleep := 100 * time.Millisecond
+	sleepDuration := 100 * time.Millisecond
 	for retries := 0; retries < 10; retries++ {
 		if retries > 0 {
-			time.Sleep(sleep)
-			sleep = sleep * 2
+			sleep(sleepDuration)
+			sleepDuration = sleepDuration * 2
 		}
 		var resp *http.Response
 		resp, err = http.Get(url.String())

--- a/prow/pjutil/tot_test.go
+++ b/prow/pjutil/tot_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 type responseVendor struct {
@@ -56,6 +57,10 @@ func parrotServer(codes []int, data []string) *httptest.Server {
 }
 
 func TestGetBuildID(t *testing.T) {
+	oldSleep := sleep
+	sleep = func(time.Duration) { return }
+	defer func() { sleep = oldSleep }()
+
 	var testCases = []struct {
 		name        string
 		codes       []int


### PR DESCRIPTION
Periodic jobs can also report via pubsub, but there's no upstream way of doing that except for... manually edit the mkpj output. We should support this.

also... fixes https://github.com/kubernetes/test-infra/issues/9056 or local test takes forever :-\
/shrug

/assign @cjwagner @stevekuznetsov @BenTheElder @fejta 
cc @Katharine @yutongz 
