### PR TITLE
Adding a periodic job to run conformance tests.

### DIFF
--- a/config/jobs/kubernetes/conformance/conformance.yaml
+++ b/config/jobs/kubernetes/conformance/conformance.yaml
@@ -1,0 +1,33 @@
+periodics:
+- name: kubernetes-conformance-image
+  interval: 60m
+  always_run: false
+  skip_report: false
+  optional: true
+  run_if_changed: '(hyperkube|local-up-cluster)'
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/kubernetes-ci-images/conformance:v1.13.0-alpha.1.100_feb6475a3097cf
+      env:
+      - name: E2E_FOCUS
+        value: "Conformance"
+      - name: E2E_SKIP
+        value: "Alpha|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"
+      cmd:
+      - /run_e2e.sh
+      args:
+      - "--timeout=140"
+      - --
+      - --ginkgo-parallel=1
+      - --provider=local
+      - --test
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
+      - --timeout=120m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3056,6 +3056,11 @@ test_groups:
   num_columns_recent: 3
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
+- name: kubernetes-conformance-image
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-conformance-image
+  num_columns_recent: 3
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
 # sigs.k8s.io/kind jobs
 - name: ci-kubernetes-kind-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-kind-conformance
@@ -3289,7 +3294,7 @@ dashboards:
     test_group_name: ci-kubernetes-kind-conformance
   - name: kind, master (dev) [non-serial]
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel
+    test_group_name: kubernetes-conformance-image
   - name: kind, v1.12 (dev)
     description: Runs conformance tests using kubetest against latest kubernetes relase-1.12 with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance-latest-1-12
@@ -3447,6 +3452,9 @@ dashboards:
   - name: local-up-cluster-containerized, master (dev)
     description: Runs conformance tests using kubetest with local-up-cluster (containerized kubelet)
     test_group_name: ci-kubernetes-local-e2e-containerized
+  - name: kubernetes-conformance-image, master (dev)
+    description: Runs conformance tests using conformace release image locally using ginkgo
+    test_group_name: kubernetes-conformance-image
 
 - name: conformance-vsphere
   dashboard_tab:


### PR DESCRIPTION
Attempting this in response to https://github.com/kubernetes/kubernetes/issues/69777. I would like to add a periodic job that runs the conformance tests using the conformance image that is built as part of release-images target.

WIP : Need a image reference and how to test this job.

@dims Please let me know how to proceed.