### PR TITLE
Fix high-density kubemark job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -532,8 +532,8 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8
       - --gcp-nodes=8
-      - --gcp-project=k8s-jenkins-kubemark
-      - --gcp-zone=us-central1-f
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
       - --kubemark
       - --kubemark-master-size=n1-standard-32
       - --kubemark-nodes=600


### PR DESCRIPTION
This job is currently failing all the time, because its project was used in boskos and other jobs were running in this project and then janitor was cleaning this up during the test.