### PR TITLE
Add area/gopherage to kubernetes/test-infra

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -193,6 +193,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/config" href="#area/config">`area/config`</a> | Issues or PRs related to code in /config| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/ghproxy" href="#area/ghproxy">`area/ghproxy`</a> | Issues or PRs related to code in /ghproxy| label | |
+| <a id="area/gopherage" href="#area/gopherage">`area/gopherage`</a> | Issues or PRs related to code in /gopherage| humans | |
 | <a id="area/greenhouse" href="#area/greenhouse">`area/greenhouse`</a> | Issues or PRs related to code in /greenhouse (our remote bazel cache)| label | |
 | <a id="area/gubernator" href="#area/gubernator">`area/gubernator`</a> | Issues or PRs related to code in /gubernator| label | |
 | <a id="area/kind" href="#area/kind">`area/kind`</a> | Issues or PRs related to code in /kind| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -709,6 +709,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to code in /gopherage
+        name: area/gopherage
+        target: both
+        addedBy: humans
+      - color: 0052cc
         description: Issues or PRs related to code in /greenhouse (our remote bazel cache)
         name: area/greenhouse
         target: both

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -48,6 +48,11 @@
     color: #ffffff;
 }
 
+.areax00002fgopherage {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fgreenhouse {
     background-color: #0052cc;
     color: #ffffff;


### PR DESCRIPTION
Gopherage label for the gopherage party.

(also the label actually already exists.)

/cc @BenTheElder 