### PR TITLE
allow overwrite env vars in presets

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1042,8 +1042,9 @@ func validateDecoration(name string, spec *v1.PodSpec, config *kube.DecorationCo
 }
 
 func resolvePresets(name string, labels map[string]string, spec *v1.PodSpec, presets []Preset) error {
-	for _, preset := range presets {
-		if err := mergePreset(preset, labels, spec); err != nil {
+	// resolve presets backwards so envs can be resolved properly
+	for i := len(presets) - 1; i >= 0; i-- {
+		if err := mergePreset(presets[i], labels, spec); err != nil {
 			return fmt.Errorf("job %s failed to merge presets: %v", name, err)
 		}
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1061,12 +1061,12 @@ periodics:
 			expectEnv: map[string][]v1.EnvVar{
 				"foo": {
 					{
-						Name:  "baz",
-						Value: "fejtaverse",
-					},
-					{
 						Name:  "k8s",
 						Value: "kubernetes",
+					},
+					{
+						Name:  "baz",
+						Value: "fejtaverse",
 					},
 				},
 				"bar": {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -45,16 +45,23 @@ func mergePreset(preset Preset, labels map[string]string, pod *v1.PodSpec) error
 			return nil
 		}
 	}
-	for _, e1 := range preset.Env {
+
+	for _, presetEnv := range preset.Env {
 		for i := range pod.Containers {
-			for _, e2 := range pod.Containers[i].Env {
-				if e1.Name == e2.Name {
-					return fmt.Errorf("env var duplicated in pod spec: %s", e1.Name)
+			// container envs will overwrite preset envs
+			exist := false
+			for _, containerEnv := range pod.Containers[i].Env {
+				if containerEnv.Name == presetEnv.Name {
+					exist = true
 				}
 			}
-			pod.Containers[i].Env = append(pod.Containers[i].Env, e1)
+
+			if !exist {
+				pod.Containers[i].Env = append(pod.Containers[i].Env, presetEnv)
+			}
 		}
 	}
+
 	for _, v1 := range preset.Volumes {
 		for _, v2 := range pod.Volumes {
 			if v1.Name == v2.Name {


### PR DESCRIPTION
In order to support https://github.com/kubernetes/test-infra/pull/9860

presets is a list so this should be reasonable?

/area prow
/assign @cjwagner @BenTheElder @stevekuznetsov 