### PR TITLE
Enable distinct tab/header titles in deck templates

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -23,7 +23,7 @@
     <div class="mdl-layout__header-row">
       <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow"
          class="logo"><img src="/static/{{or branding.Logo "logo.svg"}}" alt="kubernetes logo" class="logo"/></a>
-      <span class="mdl-layout-title header-title">{{template "title" .Arguments}}</span>
+      <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
     </div>
   </header>
   <div class="mdl-layout__drawer">


### PR DESCRIPTION
Enable deck templates to have distinct values for the title in the window/tab title versus the page header by defining a `pageTitle`. If `pageTitle` is not defined, default to `title` as we do now.

/area prow/deck
/kind feature
/cc @amwat 
cc @ibzib 