### PR TITLE
Gopherage CLI UX cleanup

### DIFF
--- a/gopherage/cmd/aggregate/aggregate.go
+++ b/gopherage/cmd/aggregate/aggregate.go
@@ -17,7 +17,8 @@ limitations under the License.
 package aggregate
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/cover"
@@ -48,24 +49,29 @@ that counts how many of those coverage profiles hit a block at least once.`,
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		log.Fatalf("expected at least one file")
+		fmt.Println("Expected at least one file.")
+		cmd.Usage()
+		os.Exit(2)
 	}
 
 	profiles := make([][]*cover.Profile, 0, len(args))
 	for _, path := range args {
 		profile, err := cover.ParseProfiles(path)
 		if err != nil {
-			log.Fatalf("failed to open %s: %v", path, err)
+			fmt.Fprintf(os.Stderr, "failed to open %s: %v", path, err)
+			os.Exit(1)
 		}
 		profiles = append(profiles, profile)
 	}
 
 	aggregated, err := cov.AggregateProfiles(profiles)
 	if err != nil {
-		log.Fatalf("failed to aggregate files: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to aggregate files: %v", err)
+		os.Exit(1)
 	}
 
 	if err := util.DumpProfile(flags.OutputFile, aggregated); err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/gopherage/cmd/aggregate/aggregate.go
+++ b/gopherage/cmd/aggregate/aggregate.go
@@ -42,7 +42,7 @@ that counts how many of those coverage profiles hit a block at least once.`,
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.OutputFile, "o", "-", "output file")
+	cmd.Flags().StringVarP(&flags.OutputFile, "output", "o", "-", "output file")
 	return cmd
 }
 

--- a/gopherage/cmd/diff/diff.go
+++ b/gopherage/cmd/diff/diff.go
@@ -45,7 +45,7 @@ at least equal to those in the first file.`,
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.OutputFile, "o", "-", "output file")
+	cmd.Flags().StringVarP(&flags.OutputFile, "output", "o", "-", "output file")
 	return cmd
 }
 

--- a/gopherage/cmd/diff/diff.go
+++ b/gopherage/cmd/diff/diff.go
@@ -17,11 +17,12 @@ limitations under the License.
 package diff
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/cover"
 	"k8s.io/test-infra/gopherage/pkg/cov"
 	"k8s.io/test-infra/gopherage/pkg/util"
-	"log"
 )
 
 type flags struct {

--- a/gopherage/cmd/diff/diff.go
+++ b/gopherage/cmd/diff/diff.go
@@ -17,7 +17,8 @@ limitations under the License.
 package diff
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/cover"
@@ -51,25 +52,31 @@ at least equal to those in the first file.`,
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		log.Fatal("Expected exactly two arguments.")
+		fmt.Fprintln(os.Stderr, "Expected two files.")
+		cmd.Usage()
+		os.Exit(2)
 	}
 
 	before, err := cover.ParseProfiles(args[0])
 	if err != nil {
-		log.Fatalf("couldn't load %s: %v", args[0], err)
+		fmt.Fprintf(os.Stderr, "Couldn't load %s: %v.", args[0], err)
+		os.Exit(1)
 	}
 
 	after, err := cover.ParseProfiles(args[1])
 	if err != nil {
-		log.Fatalf("couldn't load %s: %v", args[0], err)
+		fmt.Fprintf(os.Stderr, "Couldn't load %s: %v.", args[0], err)
+		os.Exit(1)
 	}
 
 	diff, err := cov.DiffProfiles(before, after)
 	if err != nil {
-		log.Fatalf("failed to diff profiles: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to diff profiles: %v", err)
+		os.Exit(1)
 	}
 
 	if err := util.DumpProfile(flags.OutputFile, diff); err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -41,7 +41,7 @@ func MakeCommand() *cobra.Command {
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.OutputFile, "o", "-", "output file")
+	cmd.Flags().StringVarP(&flags.OutputFile, "output", "o", "-", "output file")
 	return cmd
 }
 

--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -35,8 +35,17 @@ type flags struct {
 func MakeCommand() *cobra.Command {
 	flags := &flags{}
 	cmd := &cobra.Command{
-		Use:   "html [coverage]",
-		Short: "Emits an HTML file to browse a coverage file.",
+		Use:   "html [coverage...]",
+		Short: "Emits an HTML file to browse coverage files.",
+		Long: `Produces a self-contained HTML file that enables browsing the provided
+coverage files by directory. The resulting file can be distributed alone to
+produce the same rendering (but does currently require gstatic.com to be
+accessible).
+
+If multiple files are provided, they will all be
+shown in the generated HTML file, with the columns in the same order the files
+were listed. When there are multiples columns, each column will have an arrow
+indicating the change from the column immediately to its right.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			run(flags, cmd, args)
 		},
@@ -52,6 +61,7 @@ type coverageFile struct {
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
+		cmd.Usage()
 		log.Fatalln("Usage: gopherage html [coverage...]")
 	}
 

--- a/gopherage/cmd/merge/merge.go
+++ b/gopherage/cmd/merge/merge.go
@@ -45,7 +45,7 @@ Merging a single file is a no-op, but is supported for convenience when shell sc
 			run(flags, cmd, args)
 		},
 	}
-	cmd.Flags().StringVar(&flags.OutputFile, "o", "-", "output file")
+	cmd.Flags().StringVarP(&flags.OutputFile, "output", "o", "-", "output file")
 	return cmd
 }
 

--- a/gopherage/cmd/merge/merge.go
+++ b/gopherage/cmd/merge/merge.go
@@ -17,7 +17,8 @@ limitations under the License.
 package merge
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/cover"
@@ -51,24 +52,29 @@ Merging a single file is a no-op, but is supported for convenience when shell sc
 
 func run(flags *flags, cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		log.Fatalf("expected at least one file")
+		fmt.Fprintln(os.Stderr, "Expected at least one coverage file.")
+		cmd.Usage()
+		os.Exit(2)
 	}
 
 	profiles := make([][]*cover.Profile, len(args))
 	for _, path := range args {
 		profile, err := cover.ParseProfiles(path)
 		if err != nil {
-			log.Fatalf("failed to open %s: %v", path, err)
+			fmt.Fprintf(os.Stderr, "failed to open %s: %v", path, err)
+			os.Exit(1)
 		}
 		profiles = append(profiles, profile)
 	}
 
 	merged, err := cov.MergeMultipleProfiles(profiles)
 	if err != nil {
-		log.Fatalf("failed to merge files: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to merge files: %v", err)
+		os.Exit(1)
 	}
 
 	if err := util.DumpProfile(flags.OutputFile, merged); err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/gopherage/cmd/merge/merge.go
+++ b/gopherage/cmd/merge/merge.go
@@ -17,11 +17,12 @@ limitations under the License.
 package merge
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/cover"
 	"k8s.io/test-infra/gopherage/pkg/cov"
 	"k8s.io/test-infra/gopherage/pkg/util"
-	"log"
 )
 
 type flags struct {


### PR DESCRIPTION
Assorted changes to gopherage's CLI:

- Now uses `-o` to indicate an output file instead of `--o` (which was in error)
  - Also accepts `--output` as an alias
- Always prints the usage when used incorrectly.
- Doesn't print timestamps when emitting errors (due to not abusing `log`).
- Avoid failing silently if the HTML template is invalid.

/kind cleanup
/cc @BenTheElder 