### PR TITLE
label_sync: fix usage of flags in docs

### DIFF
--- a/label_sync/README.md
+++ b/label_sync/README.md
@@ -57,7 +57,6 @@ bazel run //label_sync -- \
 bazel run //label_sync -- \
   --config $(pwd)/label_sync/labels.yaml \
   --token /path/to/github_oauth_token \
-  --orgs kubernetes \
   --only kubernetes/community,kubernetes/steering
   # see above
 


### PR DESCRIPTION
For label_sync, one of `--only` and `--org` can be set. In this case, _only_ `--only` should be used.

Ref:

https://github.com/kubernetes/test-infra/blob/2e10a0bbe9b34737fa022d71187528b4c4721322/label_sync/main.go#L683-L685