### PR TITLE
kubernetes-anywhere: use 'local' as provider

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1827,7 +1827,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -1924,7 +1924,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -2018,7 +2018,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
@@ -25,7 +25,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
       - --timeout=300m
@@ -56,7 +56,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
@@ -87,7 +87,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
@@ -118,7 +118,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-version=stable
       - --kubernetes-anywhere-kubernetes-version=stable
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
@@ -22,7 +22,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -48,7 +48,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -74,6 +74,6 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-version=stable
       - --kubernetes-anywhere-kubernetes-version=stable
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -22,7 +22,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
       - --timeout=300m
 
@@ -48,7 +48,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -75,7 +75,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.12
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.12
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -102,7 +102,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
       - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=kubernetes-anywhere
+      - --provider=local
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -55,7 +55,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -115,7 +115,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -174,7 +174,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=local
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel


### PR DESCRIPTION
post the e2e refactor --provider=kubernetes-anywhere is no longer a valid provider.
we don't want to add "kubernetes-anywhere" to the framework as a NULL provider, thus the alternative is to modify all the jobs to use "local".

ref: https://github.com/kubernetes/kubernetes/pull/70059#issuecomment-431950601

fixes kubernetes/kubernetes#70058

/area config
/kind bug
/assign @BenTheElder @timothysc 
/cc @pohly 
