### PR TITLE
Support gubernator.k8s.io domain GitHub OAuth.

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -21,7 +21,7 @@ import google.appengine.ext.ndb as ndb
 import models
 
 
-XREF_RE = re.compile(r'k8s-gubernator.appspot.com/build(/[^])\s]+/\d+)')
+XREF_RE = re.compile(r'(?:k8s-gubernator\.appspot\.com|gubernator\.k8s\.io)/build(/[^])\s]+/\d+)')
 APPROVERS_RE = re.compile(r'<!-- META={"?approvers"?:\[([^]]*)\]} -->')
 
 

--- a/gubernator/github_auth.py
+++ b/gubernator/github_auth.py
@@ -40,15 +40,20 @@ import view_base
 
 class Endpoint(view_base.BaseHandler):
     def github_client(self):
-        if not self.app.config['github_client']:
+        client_key = 'github_client'
+        if '.appspot.com:' not in self.request.host and \
+            not self.request.host.startswith('localhost:'):
+            client_key = 'github_client_' + self.request.host
+        if not self.app.config.get(client_key):
             try:
-                self.app.config['github_client'] = secrets.get('github_client')
+                self.app.config[client_key] = secrets.get(client_key)
             except KeyError:
                 self.abort(500,
                            body_template=(
                            'An admin must <a href="/config">'
-                           'configure Github secrets</a> first.'))
-        client = self.app.config['github_client']
+                           'configure Github secrets</a> for %r first.'
+                           % self.request.host))
+        client = self.app.config[client_key]
         return client['id'], client['secret']
 
     def maybe_redirect(self, target):

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -76,10 +76,16 @@ class ConfigHandler(view_base.BaseHandler):
             github_id = self.request.get('github_id')
             github_secret = self.request.get('github_secret')
             github_token = self.request.get('github_token')
+            github_client_key = 'github_client'
+            if self.request.get('github_client_host'):
+                # enable custom domains pointed at the same app to have their
+                # own github oauth config.
+                github_client_key = 'github_client_%s' % \
+                    self.request.get('github_client_host')
             if github_id and github_secret:
                 value = {'id': github_id, 'secret': github_secret}
-                secrets.put('github_client', value)
-                app.config['github_client'] = value
+                secrets.put(github_client_key, value)
+                app.config[github_client_key] = value
                 oauth_set = True
             github_webhook_secret = self.request.get('github_webhook_secret')
             if github_webhook_secret:

--- a/gubernator/templates/config.html
+++ b/gubernator/templates/config.html
@@ -8,6 +8,7 @@
 <p>New apps should be registered with "Homepage URL" set to https://{{hostname}} and "Authorization callback URL" set to https://{{hostname}}/github_auth.
 <p>GitHub OAuth Client Id: <input type="text" name="github_id"><br>
 GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
+Alternate OAuth Host (optional, for custom domains, like "g8r.k8s.io:443"): <input type="text" name="github_client_host"><br>
 <hr>
 <p>This value must match whatever is entered on GitHub when registering hooks to receive.
 <p>GitHub Webhook Secret: <input type="text" name="github_webhook_secret"><br>


### PR DESCRIPTION
gubernator.k8s.io uses the same instance as k8s-gubernator.appspot.com,
but GitHub OAuth apps are bound to a single host. This change allows the
alternate domain to be handled properly.