### PR TITLE
Fix plugin catalog repo dropdown

### DIFF
--- a/prow/cmd/deck/static/plugin-help/plugin-help.ts
+++ b/prow/cmd/deck/static/plugin-help/plugin-help.ts
@@ -37,6 +37,8 @@ window.onload = function (): void {
     dialog.querySelector('.close')!.addEventListener('click', () => {
         dialog.close();
     });
+    // Set up dropdown
+    document.querySelector<HTMLSelectElement>('#repo')!.onchange = redraw;
 };
 
 function selectionText(sel: HTMLSelectElement): string {

--- a/prow/cmd/deck/template/plugins.html
+++ b/prow/cmd/deck/template/plugins.html
@@ -11,7 +11,7 @@
   <div class="card-box">
     <ul class="noBullets">
       <li>Plugin help for</li>
-      <li><select id="repo" onchange="redraw();">
+      <li><select id="repo">
         <option>All plugins</option>
       </select></li>
     </ul>


### PR DESCRIPTION
The HTML was directly referencing a function that was no longer exposed to it. Move the reference to be the other way around.

/area prow/deck
/kind bug