### PR TITLE
Remove invalid reference to cloud-controller-manager.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -80,11 +80,6 @@ branch-protection:
             users: []
             teams:
             - stage-bots
-        cloud-controller-manager:
-          restrictions:
-            users: []
-            teams:
-            - stage-bots
         cloud-provider:
           restrictions:
             users: []


### PR DESCRIPTION
Branch protector is failing on the cloud-controller-manager repo.
It was removed according to https://github.com/kubernetes/org/issues/56#issuecomment-419984595

/cc @spiffxp @fejta 