### PR TITLE
[Approve plugin] Set state fields from PR when handling a review

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -243,9 +243,10 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, config *
 		&state{
 			org:       re.Repo.Owner.Login,
 			repo:      re.Repo.Name,
+			branch:    pr.Base.Ref,
 			number:    re.PullRequest.Number,
-			body:      re.Review.Body,
-			author:    re.Review.User.Login,
+			body:      re.PullRequest.Body,
+			author:    re.PullRequest.User.Login,
 			assignees: re.PullRequest.Assignees,
 			htmlURL:   re.PullRequest.HTMLURL,
 		},

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -19,6 +19,7 @@ package approve
 import (
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1142,20 +1143,13 @@ func (fro fakeRepoOwners) RequiredReviewers(path string) sets.String {
 	return sets.NewString()
 }
 
-// func (fro fakeRepoOwners) FindReviewersOwners
-
-func getTestHandleFunc() func(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, opts *plugins.Approve, pr *state) error {
-	return func(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, opts *plugins.Approve, pr *state) error {
-		return nil
-	}
-}
-
 func TestHandleGenericComment(t *testing.T) {
 	tests := []struct {
 		name              string
 		commentEvent      github.GenericCommentEvent
 		lgtmActsAsApprove bool
 		expectHandle      bool
+		expectState       *state
 	}{
 		{
 			name: "valid approve command",
@@ -1167,8 +1161,22 @@ func TestHandleGenericComment(t *testing.T) {
 				User: github.User{
 					Login: "author",
 				},
+				IssueBody: "Fix everything",
+				IssueAuthor: github.User{
+					Login: "P.R. Author",
+				},
 			},
 			expectHandle: true,
+			expectState: &state{
+				org:       "org",
+				repo:      "repo",
+				branch:    "branch",
+				number:    1,
+				body:      "Fix everything",
+				author:    "P.R. Author",
+				assignees: nil,
+				htmlURL:   "",
+			},
 		},
 		{
 			name: "not comment created",
@@ -1253,7 +1261,9 @@ func TestHandleGenericComment(t *testing.T) {
 	}
 
 	var handled bool
+	var gotState *state
 	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, opts *plugins.Approve, pr *state) error {
+		gotState = pr
 		handled = true
 		return nil
 	}
@@ -1300,6 +1310,10 @@ func TestHandleGenericComment(t *testing.T) {
 			t.Errorf("%s: expected no call to handleFunc, but it was called", test.name)
 		}
 
+		if test.expectState != nil && !reflect.DeepEqual(test.expectState, gotState) {
+			t.Errorf("%s: expected PR state to equal: %#v, but got: %#v", test.name, test.expectState, gotState)
+		}
+
 		if err != nil {
 			t.Errorf("%s: error calling handleGenericComment: %v", test.name, err)
 		}
@@ -1312,13 +1326,14 @@ func stateToLower(s github.ReviewState) github.ReviewState {
 	return github.ReviewState(strings.ToLower(string(s)))
 }
 
-func TestHandleReviewEvent(t *testing.T) {
+func TestHandleReview(t *testing.T) {
 	tests := []struct {
 		name                string
 		reviewEvent         github.ReviewEvent
 		lgtmActsAsApprove   bool
 		reviewActsAsApprove bool
 		expectHandle        bool
+		expectState         *state
 	}{
 		{
 			name: "approved state",
@@ -1334,6 +1349,16 @@ func TestHandleReviewEvent(t *testing.T) {
 			},
 			reviewActsAsApprove: true,
 			expectHandle:        true,
+			expectState: &state{
+				org:       "org",
+				repo:      "repo",
+				branch:    "branch",
+				number:    1,
+				body:      "Fix everything",
+				author:    "P.R. Author",
+				assignees: nil,
+				htmlURL:   "",
+			},
 		},
 		{
 			name: "changes requested state",
@@ -1351,7 +1376,7 @@ func TestHandleReviewEvent(t *testing.T) {
 			expectHandle:        true,
 		},
 		{
-			name: "pending state",
+			name: "pending review state",
 			reviewEvent: github.ReviewEvent{
 				Action: github.ReviewActionSubmitted,
 				Review: github.Review{
@@ -1444,7 +1469,9 @@ func TestHandleReviewEvent(t *testing.T) {
 	}
 
 	var handled bool
+	var gotState *state
 	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, opts *plugins.Approve, pr *state) error {
+		gotState = pr
 		handled = true
 		return nil
 	}
@@ -1459,10 +1486,14 @@ func TestHandleReviewEvent(t *testing.T) {
 		Name: "repo",
 	}
 	pr := github.PullRequest{
+		User: github.User{
+			Login: "P.R. Author",
+		},
 		Base: github.PullRequestBranch{
 			Ref: "branch",
 		},
 		Number: 1,
+		Body:   "Fix everything",
 	}
 	fghc := &fakegithub.FakeClient{
 		PullRequests: map[int]*github.PullRequest{1: &pr},
@@ -1493,25 +1524,50 @@ func TestHandleReviewEvent(t *testing.T) {
 			t.Errorf("%s: expected no call to handleFunc, but it was called", test.name)
 		}
 
+		if test.expectState != nil && !reflect.DeepEqual(test.expectState, gotState) {
+			t.Errorf("%s: expected PR state to equal: %#v, but got: %#v", test.name, test.expectState, gotState)
+		}
+
 		if err != nil {
-			t.Errorf("%s: error calling handleGenericComment: %v", test.name, err)
+			t.Errorf("%s: error calling handleReview: %v", test.name, err)
 		}
 		handled = false
 	}
 }
 
-func TestHandlePullRequestEvent(t *testing.T) {
+func TestHandlePullRequest(t *testing.T) {
 	tests := []struct {
 		name         string
 		prEvent      github.PullRequestEvent
 		expectHandle bool
+		expectState  *state
 	}{
 		{
 			name: "pr opened",
 			prEvent: github.PullRequestEvent{
 				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					User: github.User{
+						Login: "P.R. Author",
+					},
+					Base: github.PullRequestBranch{
+						Ref: "branch",
+					},
+					Body: "Fix everything",
+				},
+				Number: 1,
 			},
 			expectHandle: true,
+			expectState: &state{
+				org:       "org",
+				repo:      "repo",
+				branch:    "branch",
+				number:    1,
+				body:      "Fix everything",
+				author:    "P.R. Author",
+				assignees: nil,
+				htmlURL:   "",
+			},
 		},
 		{
 			name: "pr reopened",
@@ -1570,7 +1626,9 @@ func TestHandlePullRequestEvent(t *testing.T) {
 	}
 
 	var handled bool
+	var gotState *state
 	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, opts *plugins.Approve, pr *state) error {
+		gotState = pr
 		handled = true
 		return nil
 	}
@@ -1604,8 +1662,12 @@ func TestHandlePullRequestEvent(t *testing.T) {
 			t.Errorf("%s: expected no call to handleFunc, but it was called", test.name)
 		}
 
+		if test.expectState != nil && !reflect.DeepEqual(test.expectState, gotState) {
+			t.Errorf("%s: expected PR state to equal: %#v, but got: %#v", test.name, test.expectState, gotState)
+		}
+
 		if err != nil {
-			t.Errorf("%s: error calling handleGenericComment: %v", test.name, err)
+			t.Errorf("%s: error calling handlePullRequest: %v", test.name, err)
 		}
 		handled = false
 	}


### PR DESCRIPTION
Branch, body, and author fields were previously unset or incorrectly sourced from the review instead of the PR. This removed the ability for authors to implicitly self-approve because their authorship was replaced by the author of the currently handled review.

One test for each of `handleGenericComment`, `handleReview`, and `handlePullRequest` now verifies that the state given to `handleFunc` is correct.

Fixes #9609.

/cc @fejta @cjwagner @guineveresaenger @stevekuznetsov 