### PR TITLE
label_sync: don't warn that repo isn't inside orgs if --only is used

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -65,7 +65,7 @@ type Label struct {
 	// Color is rrggbb or color
 	Color string `json:"color"`
 	// Description is brief text explaining its meaning, who can apply it
-	Description string `json:"description"` // What does this label mean, who can apply it
+	Description string `json:"description"`
 	// Target specifies whether it targets PRs, issues or both
 	Target LabelTarget `json:"target"`
 	// ProwPlugin specifies which prow plugin add/removes this label
@@ -217,7 +217,7 @@ func stringInSortedSlice(a string, list []string) bool {
 	return false
 }
 
-// Returns a sorted list of labels unique by name
+// Labels returns a sorted list of labels unique by name
 func (c Configuration) Labels() []Label {
 	var labelarrays [][]Label
 	labelarrays = append(labelarrays, c.Default.Labels)
@@ -246,6 +246,10 @@ func (c Configuration) Labels() []Label {
 // TODO(spiffxp): needs to validate labels duped across repos are identical
 // Ensures the config does not duplicate label names between default and repo
 func (c Configuration) validate(orgs string) error {
+	if len(orgs) == 0 {
+		return nil
+	}
+
 	// Generate list of orgs
 	sortedOrgs := strings.Split(orgs, ",")
 	sort.Strings(sortedOrgs)
@@ -260,7 +264,7 @@ func (c Configuration) validate(orgs string) error {
 		if _, err := validate(repoconfig.Labels, repo, seen); err != nil {
 			return fmt.Errorf("invalid config: %v", err)
 		}
-		// Warn if repo isn't under org
+		// Warn if repo isn't under orgs
 		data := strings.Split(repo, "/")
 		if len(data) == 2 {
 			if !stringInSortedSlice(data[0], sortedOrgs) {


### PR DESCRIPTION
When `--only` is used, `--orgs` cannot be used and it will be an empty string. So in this case, the warning will always occur.

Ref: https://github.com/kubernetes/test-infra/pull/9801, https://github.com/kubernetes/test-infra/pull/9880

For example, if `--only kubernetes/community,kubernetes/steering` is used, it shows the following warning:

```
WARN[0000] Repo isn't inside orgs                        org=kubernetes orgs= repo=kubernetes/features
WARN[0000] Repo isn't inside orgs                        org=kubernetes orgs= repo=kubernetes/kubernetes
WARN[0000] Repo isn't inside orgs                        org=kubernetes orgs= repo=kubernetes/org
WARN[0000] Repo isn't inside orgs                        org=kubernetes orgs= repo=kubernetes/test-infra
WARN[0000] Repo isn't inside orgs                        org=kubernetes orgs= repo=kubernetes/community
```

If `--orgs kubernetes` is used, it doesn't show the warning anymore.