### PR TITLE
kubernetes-anywhere: make sure GCP project is allocated

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -938,12 +938,19 @@ func prepare(o *options) error {
 	}
 
 	switch o.provider {
-	case "gce", "gke", "kubernetes-anywhere", "node":
+	case "gce", "gke", "node":
 		if err := prepareGcp(o); err != nil {
 			return err
 		}
 	case "aws":
 		if err := prepareAws(o); err != nil {
+			return err
+		}
+	}
+	// For kubernetes-anywhere as the deployer, call prepareGcp()
+	// independent of the specified provider.
+	if o.deployment == "kubernetes-anywhere" {
+		if err := prepareGcp(o); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
With moving k-a to "--provider=local", the kubetest
function prepareGcp() is never called. Fix that by
handling "local" in prepare().

previous PR:
ref https://github.com/kubernetes/test-infra/pull/9884
failing test:
ref https://github.com/kubernetes/kubernetes/issues/70058

/area kubetest
/kind bug
/assign @BenTheElder @timothysc 
cc @jberkus 
