### PR TITLE
prow/flagutil/github: Add deprecatedStringSentinal

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -59,7 +59,6 @@ func TestOptions_Validate(t *testing.T) {
 			opt: options{
 				config: "dummy",
 			},
-			expectedErr: true,
 		},
 	}
 

--- a/prow/flagutil/doc.go
+++ b/prow/flagutil/doc.go
@@ -17,3 +17,7 @@ limitations under the License.
 // Package flagutil contains utilities and interfaces shared between
 // several Prow commands.
 package flagutil
+
+// deprecatedStringSentinal is a sentinal value so we can detect users
+// explicitly setting an empty-string value for a deprecated option.
+var deprecatedStringSentinal string = "don't use this option, it is deprecated"


### PR DESCRIPTION
Before 8e5893b5 (#9503), only `branchprotector` and `peribolos` explicitly required non-empty GitHub tokens.  And @krzyzacy has [a plank use-case which doesn't need a GitHub token][1] (see also [the plank code calling `secretAgent.Start` if and only if `TokenPath` is empty][2]).  ~~This pull request adds a new `TokenPathRequired` which commands can use to explicitly opt into the check~~.  And it adds a sentinal value so folks using the deprecated `--github-token-file=` to explicitly clear the setting will still be respected.

[edit: I've dropped `TokenPathRequired`, see [here][3]].

[1]: https://github.com/kubernetes/test-infra/pull/9503/#discussion_r227979933
[2]: https://github.com/kubernetes/test-infra/blob/761277f59c4568298cd696a2a20339879d235566/prow/cmd/plank/main.go#L104-L108
[3]: https://github.com/kubernetes/test-infra/pull/9913#issuecomment-432861235