### PR TITLE
kubernetes_e2e.py: don't exclude provider 'local' from gce_ssh

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -586,7 +586,7 @@ def main(args):
         set_up_kops_aws(mode.workspace, args, mode, cluster, runner_args)
     elif args.deployment == 'kops' and args.provider == 'gce':
         set_up_kops_gce(mode.workspace, args, mode, cluster, runner_args)
-    elif args.gce_ssh and args.provider != 'local':
+    elif args.gce_ssh:
         mode.add_gce_ssh(args.gce_ssh, args.gce_pub)
 
     # TODO(fejta): delete this?


### PR DESCRIPTION
the latest runs of k-a jobs are failing with:
```
Something went wrong: failed to prepare test environment: stat /workspace/.ssh/google_compute_engine: no such file or directory
```
https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/584

add a solution in kubernetest_e2e.py as suggested by @krzyzacy on slack:
> would say for the actual local provider job, we won't mount the gce ssh key, so we are fine there.

/assign @krzyzacy @BenTheElder 
/kind failing-test
/area kubetest
