### PR TITLE
add an option for plank to skip report

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -55,11 +55,11 @@ func TestOptions_Validate(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "no token",
+			name: "no token, allow",
 			opt: options{
 				config: "dummy",
 			},
-			expectedErr: true,
+			expectedErr: false,
 		},
 	}
 

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -45,6 +45,7 @@ type options struct {
 	jobConfigPath string
 	buildCluster  string
 	selector      string
+	skipReport    bool
 
 	dryRun     bool
 	kubernetes prowflagutil.KubernetesOptions
@@ -61,6 +62,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.buildCluster, "build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	fs.StringVar(&o.selector, "label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
+	fs.BoolVar(&o.skipReport, "--skip-report", false, "Whether or not to ignore report with githubClient")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
@@ -135,7 +137,7 @@ func main() {
 		}
 	}
 
-	c, err := plank.NewController(kubeClient, pkcs, githubClient, nil, configAgent, o.totURL, o.selector)
+	c, err := plank.NewController(kubeClient, pkcs, githubClient, nil, configAgent, o.totURL, o.selector, o.skipReport)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating plank controller.")
 	}

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flagutil
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -57,7 +56,7 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 	}
 
 	if o.TokenPath == "" {
-		return errors.New("empty -github-token-path")
+		logrus.Warn("empty -github-token-path, will use anonymous github client")
 	}
 
 	return nil

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -618,6 +618,7 @@ func TestBatch(t *testing.T) {
 	defer totServ.Close()
 	c := Controller{
 		kc:          fc,
+		ghc:         &fghc{},
 		jc:          jc,
 		log:         logrus.NewEntry(logrus.StandardLogger()),
 		ca:          newFakeConfigAgent(t, 0, nil),

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1137,6 +1137,7 @@ func TestPeriodic(t *testing.T) {
 	}
 	c := Controller{
 		kc:          fc,
+		ghc:         &fghc{},
 		pkcs:        map[string]kubeClient{kube.DefaultClusterAlias: &fkc{}, "trusted": fc},
 		log:         logrus.NewEntry(logrus.StandardLogger()),
 		ca:          newFakeConfigAgent(t, 0),

--- a/prow/report/report.go
+++ b/prow/report/report.go
@@ -83,6 +83,9 @@ func reportStatus(ghc GithubClient, pj kube.ProwJob, childDescription string) er
 // Report is creating/updating/removing reports in Github based on the state of
 // the provided ProwJob.
 func Report(ghc GithubClient, reportTemplate *template.Template, pj kube.ProwJob) error {
+	if ghc == nil {
+		return fmt.Errorf("trying to report pj %s, but found empty github client", pj.ObjectMeta.Name)
+	}
 	if !pj.Spec.Report {
 		return nil
 	}


### PR DESCRIPTION
So https://github.com/kubernetes/test-infra/pull/9503 turned empty github auth token into an annoymous gh client. Besides #9913, let's also make the report gate more explicit so we are not only depend on ghc...

(And will clean everything up after I get https://github.com/kubernetes/test-infra/pull/9914 to work)

/area prow/plank
/assign @cjwagner @stevekuznetsov @BenTheElder 
cc @wking  