### PR TITLE
Expose the Tide status in Deck in starter.yaml

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -226,6 +226,7 @@ spec:
       - name: deck
         image: gcr.io/k8s-prow/deck:v20181019-08e9d55c9
         args:
+        - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         ports:
           - name: http


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/9768 added Tide to starter.yaml but it was never exposed in Deck.

