### PR TITLE
Revert "kubernetes-anywhere: use 'local' as provider"

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1827,7 +1827,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -1924,7 +1924,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -2018,7 +2018,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
@@ -25,7 +25,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
       - --timeout=300m
@@ -56,7 +56,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
@@ -87,7 +87,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
@@ -118,7 +118,7 @@ periodics:
       - --kubernetes-anywhere-kubelet-version=stable
       - --kubernetes-anywhere-kubernetes-version=stable
       - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --skew
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
@@ -22,7 +22,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -48,7 +48,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -74,6 +74,6 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-version=stable
       - --kubernetes-anywhere-kubernetes-version=stable
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -22,7 +22,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
       - --timeout=300m
 
@@ -48,7 +48,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.11
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.11
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -75,7 +75,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.12
       - --kubernetes-anywhere-kubernetes-version=ci/latest-1.12
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 
@@ -102,7 +102,7 @@ periodics:
       - --kubeadm=ci
       - --kubernetes-anywhere-kubelet-ci-version=latest-bazel
       - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=local
+      - --provider=kubernetes-anywhere
       - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
       - --timeout=300m
 

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -55,7 +55,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -115,7 +115,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -174,7 +174,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=local
+          - --provider=kubernetes-anywhere
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel


### PR DESCRIPTION
Reverts kubernetes/test-infra#9884

just an experiment at this point.

i'm out of ideas how to fix https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-12/100

```
W1025 10:06:57.292] 2018/10/25 10:06:57 main.go:314: Something went wrong: encountered 1 errors: [error during ./cluster/log-dump/log-dump.sh /workspace/_artifacts: exit status 1]
```
similar failures for all k-a jobs.

my suspicion is that "local" is still handled in a non-compliant way to kubernetes-anywhere somewhere, but no idea where.

if you agree, we can just apply this, if it doesn't help, we can revert this revert.
the e2e framework would treat "kubernetes-anywhere" as a NULL provider and just throw a warning after this PR:
https://github.com/kubernetes/kubernetes/pull/70141

/assign @krzyzacy @BenTheElder 
/kind failing-test
/priority critical-urgent
