### PR TITLE
Add e2e tests for kube-dns for comparison with CoreDNS

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -217,6 +217,53 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181019-3f9819d46-master
 
+- interval: 60m
+  name: ci-kubernetes-e2e-gci-gce-kube-dns
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --env=CLUSTER_DNS_CORE_DNS=false
+      - --extract=ci/latest
+      - --gcp-zone=us-central1-f
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=150m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20181019-3f9819d46-master
+
+- interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=520
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=NODE_LOCAL_SSDS_EXT=1,scsi,fs
+      - --env=CLUSTER_DNS_CORE_DNS=false,
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-f
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=500m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20181019-3f9819d46-master
+
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -358,10 +358,14 @@ test_groups:
   num_failures_to_alert: 6 # Runs every 1h. Alert when it's been failing for 6 hours.
 - name: ci-kubernetes-e2e-gci-gce-coredns
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-coredns
+- name: ci-kubernetes-e2e-gci-gce-kube-dns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-kube-dns
 - name: ci-kubernetes-e2e-gce-alpha-api
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
+- name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-kube-dns
 - name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
 - name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
@@ -6000,6 +6004,12 @@ dashboards:
     description: network gci-gce tests with CoreDNS
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
+  - name: gci-gce-kube-dns
+    test_group_name: ci-kubernetes-e2e-gci-gce-kube-dns
+    base_options: include-filter-by-regex=\[sig-network\]
+    description: network gci-gce tests with kube-dns
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gce-alpha-api
     test_group_name: ci-kubernetes-e2e-gce-alpha-api
     alert_options:
@@ -6020,6 +6030,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-serial
     base_options: include-filter-by-regex=\[sig-network\]
     description: network gci-gce serial e2e tests for master branch
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
+  - name: gci-gce-serial-kube-dns
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
+    base_options: include-filter-by-regex=\[sig-network\]
+    description: network gci-gce with kube-dns serial e2e tests for master branch
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gci-gce-alpha-features


### PR DESCRIPTION
This PR achieves the same goals as https://github.com/kubernetes/test-infra/pull/7838

### Ability to verify tests results of CoreDNS against kube-dns
CoreDNS is expected to replace kube-dns. See KEP : kubernetes/community#1956

One of the graduation criteria is to be able to:

>Validate all e2e conformance and DNS related tests (xxx-kubernetes-e2e-gce, ci-kubernetes-e2e-gce-gci-ci-master and filtered by --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]) for CoreDNS. None of the tests successful with Kube-DNS should be failing with CoreDNS.

I propose here these 2 extra tests that will run always with kube-dns, whatever the default DNS service defined for K8s:

- the test for graduation criteria
- another test to validate the [Serial], [Slow] (but not Flaky). These tests includes some other DNS - specifics (like updating the DNS configuration by configMap).


/assign @fejta @MrHohn  