### PR TITLE
Publish images with correct timestamp

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,39 +23,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_depen
 
 go_rules_dependencies()
 
-go_register_toolchains(
-    go_version = "1.11",
-)
-
-git_repository(
-    name = "io_bazel_rules_k8s",
-    commit = "3756369d4920033c32c12d16207e8ee14fee1b18",
-    remote = "https://github.com/bazelbuild/rules_k8s.git",
-)
+go_register_toolchains(go_version = "1.11")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "cef4e7adfc1df999891e086bf42bed9092cfdf374adb902f18de2c1d6e1e0197",
-    strip_prefix = "rules_docker-198367210c55fba5dded22274adde1a289801dc4",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/198367210c55fba5dded22274adde1a289801dc4.tar.gz"],
-)
-
-git_repository(
-    name = "io_kubernetes_build",
-    commit = "4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
-    remote = "https://github.com/kubernetes/repo-infra.git",
-)
-
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_pull", "docker_repositories")
-
-docker_repositories()
-
-docker_pull(
-    name = "distroless-base",
-    # latest circa 2017/11/29
-    digest = "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
-    registry = "gcr.io",
-    repository = "distroless/base",
+    sha256 = "5235045774d2f40f37331636378f21fe11f69906c0386a790c5987a09211c3c4",
+    strip_prefix = "rules_docker-8010a50ef03d1e13f1bebabfc625478da075fa60",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/8010a50ef03d1e13f1bebabfc625478da075fa60.tar.gz"],
 )
 
 load(
@@ -65,34 +39,60 @@ load(
 
 _go_repositories()
 
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_pull", "docker_repositories")
+
+docker_repositories()
+
+docker_pull(
+    name = "distroless-base",
+    digest = "sha256:472206d4c501691d9e72cafca4362f2adbc610fecff3dfa42e5b345f9b7d05e5",  # 2018/10/25
+    registry = "gcr.io",
+    repository = "distroless/base",
+    tag = "latest",
+)
+
 docker_pull(
     name = "alpine-base",
-    # 0.1 as of 2017/11/29
-    digest = "sha256:317d39ece9dd09992fa81236964be3f3919b940f42e3143379dd66e4af930f3a",
+    digest = "sha256:bd327018b3effc802514b63cc90102bfcd92765f4486fc5abc28abf7eb9f1e4d",  # 2018/09/20
     registry = "gcr.io",
     repository = "k8s-prow/alpine",
+    tag = "0.1",
 )
 
 docker_pull(
     name = "gcloud-base",
+    digest = "sha256:1dbdee42a553dd6a652d64df1902015ba36ef12d6c16df568a59843e410e270b",  # 2018/10/25
     registry = "gcr.io",
     repository = "cloud-builders/gcloud",
+    tag = "latest",
 )
 
 docker_pull(
     name = "git-base",
-    # 0.2 as of 2018/05/10
-    digest = "sha256:3eaeff9a2c35a50c3a0af7ef7cf26ea73e6fd966f54ef3dfe79d4ffb45805112",
+    digest = "sha256:01b0f83fe91b782ec7ddf1e742ab7cc9a2261894fd9ab0760ebfd39af2d6ab28",  # 2018/07/02
     registry = "gcr.io",
     repository = "k8s-prow/git",
+    tag = "0.2",
 )
 
 docker_pull(
     name = "python",
-    digest = "sha256:8bfeec8f8ba3aaeea918a0198f4b1c7c9b2b39e26f399a7173229dfcef76fc1f",
+    digest = "sha256:0888426cc407c5ce9f2d656d776757f8fdb31795e01f60df38a5bacb697a0db0",  # 2018/10/25
     registry = "index.docker.io",
     repository = "library/python",
-    tag = "2.7.14-jessie",
+    tag = "2",
+)
+
+git_repository(
+    name = "io_bazel_rules_k8s",
+    commit = "9d2f6e8e21f1b5e58e721fc29b806957d9931930",
+    remote = "https://github.com/bazelbuild/rules_k8s.git",
+)
+
+git_repository(
+    name = "io_kubernetes_build",
+    commit = "4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
+    remote = "https://github.com/kubernetes/repo-infra.git",
 )
 
 git_repository(

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -1,17 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("//prow:def.bzl", "prefix", "tags")
 load(
-    ":prow.bzl",
-    prow_docker_tags = "docker_tags",
-    prow_prefix = "prefix",
-    prow_tags = "tags",
+    "//:image.bzl",
+    image_tags = "tags",
 )
 
-docker_bundle(
+container_bundle(
     name = "release",
-    images = prow_tags(
+    images = tags(
         "branchprotector",
         "clonerefs",
         "deck",
@@ -28,8 +27,8 @@ docker_bundle(
         "sinker",
         "tide",
         "tot",
-    ) + prow_docker_tags(**{
-        prow_prefix("needs-rebase"): "//prow/external-plugins/needs-rebase:image",
+    ) + image_tags(**{
+        prefix("needs-rebase"): "//prow/external-plugins/needs-rebase:image",
     }),
     stamp = True,
 )

--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//prow:__subpackages__"])
 
-load("//prow:prow.bzl", "release", "component", "MULTI_KIND", "BUILD_CLUSTER")
+load("//prow:def.bzl", "release", "component", "MULTI_KIND", "BUILD_CLUSTER")
 
 # Usage:
 #   bazel run //prow/cluster:foo.apply

--- a/prow/cmd/artifact-uploader/BUILD.bazel
+++ b/prow/cmd/artifact-uploader/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -20,20 +19,9 @@ go_library(
     ],
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/artifact-uploader/BUILD.bazel
+++ b/prow/cmd/artifact-uploader/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -18,15 +20,20 @@ go_library(
     ],
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -1,9 +1,8 @@
 # Usage:
 #   bazel run :dev-job.{create,delete,describe}
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
+load("//prow:def.bzl", "prow_image")
 
 k8s_object(
     name = "oneshot",
@@ -14,20 +13,9 @@ k8s_object(
     template = ":oneshot-job.yaml",
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -1,10 +1,9 @@
 # Usage:
 #   bazel run :dev-job.{create,delete,describe}
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
-load(
-    "//prow:prow.bzl",
-    prow_tags = "tags",
-)
 
 k8s_object(
     name = "oneshot",
@@ -15,10 +14,8 @@ k8s_object(
     template = ":oneshot-job.yaml",
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
@@ -27,7 +24,12 @@ go_image(
     visibility = ["//visibility:public"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/prow/cmd/build/BUILD.bazel
+++ b/prow/cmd/build/BUILD.bazel
@@ -1,7 +1,6 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
+load("//prow:def.bzl", "prow_image")
 
 k8s_object(
     name = "dev",
@@ -11,20 +10,9 @@ k8s_object(
     template = ":dev.yaml",
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/build/BUILD.bazel
+++ b/prow/cmd/build/BUILD.bazel
@@ -1,8 +1,7 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
-load(
-    "//prow:prow.bzl",
-    prow_tags = "tags",
-)
 
 k8s_object(
     name = "dev",
@@ -12,10 +11,8 @@ k8s_object(
     template = ":dev.yaml",
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
@@ -24,7 +21,12 @@ go_image(
     visibility = ["//visibility:public"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -22,23 +21,12 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
+    base = "@git-base//image",
     files = ["ssh_config"],
-    stamp = True,
     symlinks = {
-        "/clonerefs": "/app/prow/cmd/clonerefs/clonerefs-linux-amd64",
+        "/clonerefs": "/app/prow/cmd/clonerefs/app.binary",
         "/etc/ssh/ssh_config": "/ssh_config",
     },
     visibility = ["//visibility:public"],

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -22,9 +22,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-# same as binary above, but with goarch and goos for placing in the docker image
-go_binary(
-    name = "clonerefs-linux-amd64",
+go_image(
+    name = "app",
+    base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -32,17 +32,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "clonerefs-go_image",
-    base = "@git-base//image",
-    binary = ":clonerefs-linux-amd64",
-    visibility = ["//visibility:public"],
-)
-
 container_image(
     name = "image",
-    base = ":clonerefs-go_image",
+    base = ":app",
     files = ["ssh_config"],
+    stamp = True,
     symlinks = {
         "/clonerefs": "/app/prow/cmd/clonerefs/clonerefs-linux-amd64",
         "/etc/ssh/ssh_config": "/ssh_config",

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -30,20 +29,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
@@ -30,12 +31,19 @@ go_binary(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
 filegroup(
     name = "templates",
@@ -22,20 +22,9 @@ container_image(
     ],
 )
 
-go_image(
-    name = "app",
-    base = ":asset-base",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = ":asset-base",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -2,12 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 filegroup(
     name = "templates",
@@ -28,12 +23,19 @@ container_image(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     base = ":asset-base",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -22,20 +21,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     symlinks = {"/entrypoint": "/app/prow/cmd/entrypoint/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -22,9 +22,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-# same as binary above, but with goarch and goos for placing in the docker image
-go_binary(
-    name = "entrypoint-linux-amd64",
+go_image(
+    name = "app",
+    base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -32,19 +32,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "entrypoint-go_image",
-    base = "@git-base//image",
-    binary = ":entrypoint-linux-amd64",
-    visibility = ["//visibility:public"],
-)
-
 container_image(
     name = "image",
-    base = ":entrypoint-go_image",
-    symlinks = {
-        "/entrypoint": "/app/prow/cmd/entrypoint/entrypoint-linux-amd64",
-    },
+    base = ":app",
+    stamp = True,
+    symlinks = {"/entrypoint": "/app/prow/cmd/entrypoint/app.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -17,20 +16,9 @@ go_library(
     ],
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -15,15 +17,20 @@ go_library(
     ],
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -1,7 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -40,10 +41,17 @@ filegroup(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -40,18 +39,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -1,15 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -1,23 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -1,20 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -1,23 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -22,9 +22,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-# same as binary above, but with goarch and goos for placing in the docker image
-go_binary(
-    name = "initupload-linux-amd64",
+go_image(
+    name = "app",
+    base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -32,19 +32,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "initupload-go_image",
-    base = "@alpine-base//image",
-    binary = ":initupload-linux-amd64",
-    visibility = ["//visibility:public"],
-)
-
 container_image(
     name = "image",
-    base = ":initupload-go_image",
-    symlinks = {
-        "/initupload": "/app/prow/cmd/initupload/initupload-linux-amd64",
-    },
+    base = ":app",
+    stamp = True,
+    symlinks = {"/initupload": "/app/prow/cmd/initupload/app.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -22,20 +21,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     symlinks = {"/initupload": "/app/prow/cmd/initupload/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -2,21 +2,24 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -2,24 +2,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -1,4 +1,9 @@
+load("//def:configmap.bzl", "k8s_configmap")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 
 go_library(
     name = "go_default_library",
@@ -88,10 +93,6 @@ go_binary(
 
 # Usage:
 #   bazel run :dev-job.{create,delete,describe}
-load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
-load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
-load("//def:configmap.bzl", "k8s_configmap")
-
 CLUSTER = "gke_fejta-prod_us-central1-f_erick"  # TODO(fejta): fix
 
 k8s_object(
@@ -119,14 +120,19 @@ k8s_objects(
     ],
 )
 
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -1,9 +1,8 @@
 load("//def:configmap.bzl", "k8s_configmap")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -120,19 +119,8 @@ k8s_objects(
     ],
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -1,23 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -1,15 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -22,20 +21,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     symlinks = {"/sidecar": "/app/prow/cmd/sidecar/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -22,9 +22,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-# same as binary above, but with goarch and goos for placing in the docker image
-go_binary(
-    name = "sidecar-linux-amd64",
+go_image(
+    name = "app",
+    base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -32,19 +32,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_image(
-    name = "sidecar-go_image",
-    base = "@git-base//image",
-    binary = ":sidecar-linux-amd64",
-    visibility = ["//visibility:public"],
-)
-
 container_image(
     name = "image",
-    base = ":sidecar-go_image",
-    symlinks = {
-        "/sidecar": "/app/prow/cmd/sidecar/sidecar-linux-amd64",
-    },
+    base = ":app",
+    stamp = True,
+    symlinks = {"/sidecar": "/app/prow/cmd/sidecar/app.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -1,20 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -1,23 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -1,21 +1,9 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -1,17 +1,21 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -1,20 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -1,23 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -16,13 +16,11 @@ load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 load(
     "//:image.bzl",
-    docker_tags = "tags",
+    _docker_tags = "tags",
 )
 
 MULTI_KIND = None
-
 CORE_CLUSTER = "{STABLE_PROW_CLUSTER}"  # For components like hook
-
 BUILD_CLUSTER = "{STABLE_BUILD_CLUSTER}"  # For untrusted test code
 
 # image returns the image prefix for the command.
@@ -55,7 +53,7 @@ def target(cmd):
 #   }
 def tags(*cmds):
   # Create :YYYYmmdd-commitish :latest :latest-USER tags
-  return docker_tags(**{prefix(cmd): target(cmd) for cmd in cmds})
+  return _docker_tags(**{prefix(cmd): target(cmd) for cmd in cmds})
 
 def object(name, cluster=CORE_CLUSTER, **kwargs):
   k8s_object(

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -12,12 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 load(
     "//:image.bzl",
     _docker_tags = "tags",
 )
+
+## prow_image is a macro for creating :app and :image targets
+def prow_image(
+    name, # use "image"
+    base = None,
+    stamp = True,  # stamp by default, but allow overrides
+    **kwargs):
+  go_image(
+      name = "app",
+      base = base,
+      embed = [":go_default_library"],
+      goarch = "amd64",
+      goos = "linux",
+      pure = "on",
+  )
+
+  container_image(
+      name = name,
+      base = ":app",
+      stamp = stamp,
+      **kwargs)
+
+
 
 MULTI_KIND = None
 CORE_CLUSTER = "{STABLE_PROW_CLUSTER}"  # For components like hook

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -23,12 +24,19 @@ go_library(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -23,20 +22,9 @@ go_library(
     ],
 )
 
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@git-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -1,6 +1,8 @@
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 docker_bundle(
     name = "bundle",
@@ -18,7 +20,7 @@ docker_push(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@git-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
@@ -27,7 +29,12 @@ go_image(
     visibility = ["//visibility:public"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -1,38 +1,9 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
-docker_bundle(
-    name = "bundle",
-    images = {
-        "{STABLE_PROW_REPO}/needs-rebase:{DOCKER_TAG}": ":image",
-        "{STABLE_PROW_REPO}/needs-rebase:latest": ":image",
-        "{STABLE_PROW_REPO}/needs-rebase:latest-{BUILD_USER}": ":image",
-    },
-    stamp = True,
-)
-
-docker_push(
-    name = "push",
-    bundle = ":bundle",
-)
-
-go_image(
-    name = "app",
-    base = "@git-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/external-plugins/refresh/BUILD.bazel
+++ b/prow/external-plugins/refresh/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -25,20 +24,9 @@ go_library(
     ],
 )
 
-go_image(
-    name = "app",
-    base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-container_image(
+prow_image(
     name = "image",
-    base = ":app",
-    stamp = True,
+    base = "@alpine-base//image",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/external-plugins/refresh/BUILD.bazel
+++ b/prow/external-plugins/refresh/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -25,12 +26,19 @@ go_library(
 )
 
 go_image(
-    name = "image",
+    name = "app",
     base = "@alpine-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":app",
+    stamp = True,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Previously `gcloud container images list-tags gcr.io/k8s-prow/plank` thinks all images were created at `1969-12-31T16:00:00`. Add a `stamp=True` layer to our images with correct timestamps, so `:latest-fejta` now shows a timestamp of `2018-10-25T18:07:49`


Details:

* Replace all `go_image(binary=[":foo"])` instances with `go_image(embed=[":go_default_library"])`
* Add a `container_image(stamp=True)` layer on top of any `go_image()` targets
* Encapsulate all `go_image()` `container_image()` boilerplate into a `prow_image()` macro
* Update base images to latest versions
* Update `rules_docker` and `rules_k8s` bazel rules


/assign @BenTheElder @cjwagner 
/cc @munnerz 