### PR TITLE
prow: add required contexts and merge method for Cluster-API DO provider

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -291,6 +291,16 @@ branch-protection:
         contexts:
         - cla/linuxfoundation
       repos:
+        cluster-api-provider-digitalocean:
+          required_status_checks:
+            contexts:
+            - "ci/circleci: build"
+            - "ci/circleci: check-dependencies"
+            - "ci/circleci: checkout_code"
+            - "ci/circleci: e2e"
+            - "ci/circleci: lint"
+            - "ci/circleci: test"
+            - "ci/circleci: verify"
         kube-batch:
           required_status_checks:
             contexts:
@@ -416,6 +426,7 @@ tide:
     kubernetes-incubator/service-catalog: squash
     kubernetes-incubator/kubespray: squash
     kubernetes-sigs/cluster-api-provider-aws: squash
+    kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-gcp: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-sigs/cluster-api-provider-vsphere: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -619,3 +619,7 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+  - name: needs-rebase
+    events:
+      - pull_request


### PR DESCRIPTION
This PR adds required status checks for recently migrated Cluster-API provider for DigitalOcean (https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean), as per https://github.com/kubernetes/org/issues/196#issuecomment-433531532.

/assign @cblecker 