### PR TITLE
Add optional presubmit pull-kubernetes-e2e-gce-alpha-features tests

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -701,6 +701,56 @@ presubmits:
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-gce,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce-alpha-features
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-gce-alpha-features
+    rerun_command: /test pull-security-kubernetes-e2e-gce-alpha-features
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=200
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true
+        - --env=KUBE_PROXY_DAEMONSET=true
+        - --env=ENABLE_POD_PRIORITY=true
+        - --extract=local
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-f
+        - --provider=gce
+        - --runtime-config=api/all=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
+        - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished)\]|Networking
+          --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+        - --timeout=180m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-alpha-features
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-gce-alpha-features,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
     cluster: security
     context: pull-security-kubernetes-e2e-gke
     labels:

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -119,6 +119,39 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+  - name: pull-kubernetes-e2e-gce-alpha-features
+    always_run: false
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=200
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true
+        - --env=KUBE_PROXY_DAEMONSET=true
+        - --env=ENABLE_POD_PRIORITY=true
+        - --extract=local
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-f
+        - --provider=gce
+        - --runtime-config=api/all=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
+        - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+        - --timeout=180m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+        resources:
+          requests:
+            memory: "6Gi"
 
 periodics:
 - interval: 30m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2486,6 +2486,9 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-100-performance
   days_of_results: 60
   num_columns_recent: 20
+- name: pull-kubernetes-e2e-gce-alpha-features
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-alpha-features
+  num_columns_recent: 20
 - name: pull-kubernetes-e2e-gce-big-performance
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-big-performance
   days_of_results: 60
@@ -6920,6 +6923,9 @@ dashboards:
   dashboard_tab:
   - name: pull-kubernetes-cross
     test_group_name: pull-kubernetes-cross
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-alpha-features
+    test_group_name: pull-kubernetes-e2e-gce-alpha-features
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-device-plugin-gpu
     test_group_name: pull-kubernetes-e2e-gce-device-plugin-gpu


### PR DESCRIPTION
This PR adds optional presubmit pull-kubernetes-e2e-gce-alpha-features tests.

This is part of [KEP-0009](https://github.com/kubernetes/community/blob/master/keps/sig-node/0009-node-heartbeat.md), feature [#589](https://github.com/kubernetes/features/issues/589) and issue [#14733](https://github.com/kubernetes/kubernetes/issues/14733).