### PR TITLE
limit retries when GCS iterator encounters error

### DIFF
--- a/prow/spyglass/gcsartifact_fetcher.go
+++ b/prow/spyglass/gcsartifact_fetcher.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/url"
 	"path"
 	"strings"
@@ -118,7 +119,7 @@ func (af *GCSArtifactFetcher) artifacts(key string) ([]string, error) {
 		Versions: false,
 	}
 	objIter := bkt.Objects(context.Background(), &q)
-	wait := []time.Duration{1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
+	wait := []time.Duration{16, 32, 64, 128, 256, 256, 512, 512}
 	for i := 0; ; {
 		oAttrs, err := objIter.Next()
 		if err == iterator.Done {
@@ -129,7 +130,7 @@ func (af *GCSArtifactFetcher) artifacts(key string) ([]string, error) {
 			if i >= len(wait) {
 				return artifacts, fmt.Errorf("timed out: error accessing GCS artifact: %v", err)
 			}
-			time.Sleep(wait[i] * time.Millisecond)
+			time.Sleep((wait[i] + time.Duration(rand.Intn(10))) * time.Millisecond)
 			i++
 			continue
 		}

--- a/prow/spyglass/gcsartifact_fetcher.go
+++ b/prow/spyglass/gcsartifact_fetcher.go
@@ -118,17 +118,23 @@ func (af *GCSArtifactFetcher) artifacts(key string) ([]string, error) {
 		Versions: false,
 	}
 	objIter := bkt.Objects(context.Background(), &q)
-	for {
+	wait := []time.Duration{1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
+	for i := 0; ; {
 		oAttrs, err := objIter.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
 			logrus.WithFields(fieldsForJob(src)).WithError(err).Error("Error accessing GCS artifact.")
+			if i >= len(wait) {
+				return artifacts, fmt.Errorf("timed out: error accessing GCS artifact: %v", err)
+			}
+			time.Sleep(wait[i] * time.Millisecond)
+			i++
 			continue
 		}
 		artifacts = append(artifacts, strings.TrimPrefix(oAttrs.Name, prefix))
-
+		i = 0
 	}
 	listElapsed := time.Since(listStart)
 	logrus.WithField("duration", listElapsed).Infof("Listed %d artifacts.", len(artifacts))


### PR DESCRIPTION
When the GCS iterator encounters errors, do a limited number of retries with exponential backoff. 

fixes #9646 
/assign @cjwagner 