### PR TITLE
Add check-pr.sh command for local validation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -60,6 +60,12 @@ workspace_binary(
     cmd = "@go_sdk//:bin/gofmt",
 )
 
+workspace_binary(
+    name = "govet",
+    args = ["vet"],
+    cmd = "@go_sdk//:bin/go",
+)
+
 filegroup(
     name = "all-srcs",
     srcs = [

--- a/hack/check-pr.sh
+++ b/hack/check-pr.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: check-pr [ref]
+#
+# Ideally if check-pr passes then your golang PR will pass presubmit tests.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+dirs=()
+tests=()
+ref="${1:-HEAD}"
+echo -n "Packages changed since $ref: "
+for d in $(git diff --name-only "$ref" | xargs -n 1 dirname | sort -u); do
+    if ! ls "./$d/"*.go &> /dev/null; then
+        continue
+    fi
+    echo -n "$d "
+    dirs+=("./$d")
+    tests+=("//$d:all")
+done
+
+if [[ ${#dirs[@]} == 0 ]]; then
+    echo NONE
+    exit 0
+fi
+echo
+
+# step <name> <command ...> runs command and prints the output if it fails.
+step() {
+    echo -n "Running $1... "
+    shift
+    tmp="$(mktemp)"
+    if ! "$@" &> "$tmp"; then
+        echo FAIL:
+        cat "$tmp"
+        rm -f "$tmp"
+        return 1
+    fi
+    rm -f "$tmp"
+    echo PASS
+    return 0
+}
+
+failing=()
+step hack/verify-bazel.sh hack/verify-bazel.sh || failing+=("bazel")
+step hack/verify-gofmt.sh hack/verify-gofmt.sh || failing+=("gofmt")
+step //:golint bazel run //:golint -- "${dirs[@]}" || failing+=("golint")
+step //:govet bazel run //:govet -- "${dirs[@]}" || failing+=("govet")
+step "bazel test" bazel test --build_tests_only "${tests[@]}" || failing+=("bazel test")
+
+if [[ "${#failing[@]}" != 0 ]]; then
+    echo "FAILURE: ${#failing[@]} steps failed: ${failing[@]}"
+    exit 1
+fi
+echo "SUCCESS"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -34,7 +34,7 @@ deprecated-update() {
 mkdir -p ./vendor
 touch "./vendor/BUILD.bazel"
 
-if ! which bazel > /dev/null; then
+if ! which bazel &> /dev/null; then
   echo "Bazel is the preferred way to build and test the test-infra repo." >&2
   echo "Please install bazel at https://bazel.build/ (future commits may require it)" >&2
   deprecated-update

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -18,4 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -w
+cmd="bazel run //:gofmt --"
+if ! which bazel &> /dev/null; then
+  echo "Bazel is the preferred way to build and test the test-infra repo." >&2
+  echo "Please install bazel at https://bazel.build/ (future commits may require it)" >&2
+  cmd="gofmt"
+fi
+find . -name "*.go" | grep -v "\/vendor\/" | xargs $cmd -s -w

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -17,7 +17,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
+cmd="bazel run //:gofmt --"
+if ! which bazel &> /dev/null; then
+  echo "Bazel is the preferred way to build and test the test-infra repo." >&2
+  echo "Please install bazel at https://bazel.build/ (future commits may require it)" >&2
+  cmd="gofmt"
+fi
+diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs $cmd -s -d)
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo


### PR DESCRIPTION
Create a `hack/check-pr.sh` script that will hopefully ensure that your changes will pass presubmits by running `verify-bazel` and `verify-gofmt` as well as `golint`, `go vet` and unit tests on any changed packages with go files.

Also:
* Create `//:govet` rule
* Update `hack/*-gofmt.sh` and `hack/verify-bazel.sh` to prefer bazel if present.

/assign @ixdy @krzyzacy @BenTheElder