### PR TITLE
Add presubmit jobs for Cluster API DO provider

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- andrewsykim
+- alvaroaleman
+- nikhita
+- xmudrii

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -1,0 +1,49 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+  - name: pull-cluster-api-provider-digitalocean-build
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
+    spec:
+      containers:
+      - image: golang:1.11
+        command:
+        - make
+        args:
+        - compile
+  - name: pull-cluster-api-provider-digitalocean-test
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
+    spec:
+      containers:
+      - image: golang:1.11
+        command:
+        - make
+        args:
+        - test-unit
+  - name: pull-cluster-api-provider-digitalocean-verify
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+        command:
+        - make
+        args:
+        - verify
+  - name: pull-cluster-api-provider-digitalocean-lint
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-experimental
+        command:
+        - runner.sh
+        - kubernetes_bazel.py
+        args:
+        - "--install=gubernator/test_requirements.txt"
+        - "--test=//..."
+        - "--test-args=--config=lint"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -291,16 +291,6 @@ branch-protection:
         contexts:
         - cla/linuxfoundation
       repos:
-        cluster-api-provider-digitalocean:
-          required_status_checks:
-            contexts:
-            - "ci/circleci: build"
-            - "ci/circleci: check-dependencies"
-            - "ci/circleci: checkout_code"
-            - "ci/circleci: e2e"
-            - "ci/circleci: lint"
-            - "ci/circleci: test"
-            - "ci/circleci: verify"
         kube-batch:
           required_status_checks:
             contexts:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -509,6 +509,9 @@ plugins:
   kubernetes-sigs/cluster-api-provider-aws:
   - trigger
 
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+  - trigger
+
   kubernetes-sigs/cluster-api-provider-gcp:
   - trigger
 

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -348,6 +348,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/aws-ebs-csi-driver",
 		"kubernetes-sigs/cluster-api",
 		"kubernetes-sigs/cluster-api-provider-aws",
+		"kubernetes-sigs/cluster-api-provider-digitalocean",
 		"kubernetes-sigs/cluster-api-provider-gcp",
 		"kubernetes-sigs/cluster-api-provider-vsphere",
 		"kubernetes-sigs/cluster-api-provider-openstack",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2469,6 +2469,18 @@ test_groups:
 - name: pull-cluster-api-provider-aws-bazel-e2e
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-e2e
   num_columns_recent: 20
+- name: pull-cluster-api-provider-digitalocean-build
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-digitalocean-build
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-digitalocean-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-digitalocean-test
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-digitalocean-verify
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-digitalocean-verify
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-digitalocean-lint
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-digitalocean-lint
+  num_columns_recent: 20
 - name: pull-cluster-api-provider-gcp-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-gcp-build
   num_columns_recent: 20
@@ -5914,6 +5926,17 @@ dashboards:
   - name: test-creds
     test_group_name: periodic-cluster-api-provider-aws-test-creds
 
+- name: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+  dashboard_tab:
+  - name: build
+    test_group_name: pull-cluster-api-provider-digitalocean-build
+  - name: test
+    test_group_name: pull-cluster-api-provider-digitalocean-test
+  - name: verify
+    test_group_name: pull-cluster-api-provider-digitalocean-verify
+  - name: lint
+    test_group_name: pull-cluster-api-provider-digitalocean-lint
+
 - name: sig-cluster-lifecycle-cluster-api-provider-gcp
   dashboard_tab:
   - name: build
@@ -7513,6 +7536,7 @@ dashboard_groups:
   - sig-cluster-lifecycle-multi-platform
   - sig-cluster-lifecycle-cluster-api
   - sig-cluster-lifecycle-cluster-api-provider-aws
+  - sig-cluster-lifecycle-cluster-api-provider-digitalocean
   - sig-cluster-lifecycle-cluster-api-provider-vsphere
   - sig-cluster-lifecycle-cluster-api-provider-gcp
   - sig-cluster-lifecycle-cluster-api-provider-openstack


### PR DESCRIPTION
This PR

* Converts Circle CI tests to Prowjobs and adds presubmit jobs for build, test, verify and lint.
* Adds the relevant entries for testgrid.
* Enables the trigger plugin for the repo.