### PR TITLE
Fix pull-kubernetes-e2e-gce-alpha-features

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -717,6 +717,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --root=/go/src
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --timeout=200
         - --scenario=kubernetes_e2e

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -132,6 +132,7 @@ presubmits:
       - args:
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=200
         - --scenario=kubernetes_e2e


### PR DESCRIPTION
This PR fixes presubmit pull-kubernetes-e2e-gce-alpha-features configuration.

This is part of [KEP-0009](https://github.com/kubernetes/community/blob/master/keps/sig-node/0009-node-heartbeat.md), feature [#589](https://github.com/kubernetes/features/issues/589) and issue [#14733](https://github.com/kubernetes/kubernetes/issues/14733).