### PR TITLE
Test configuration change

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -2,17 +2,11 @@ periodics:
 - interval: 4h
   name: periodic-cluster-api-provider-aws-test-creds
   always_run: true
-  labels:
-    preset-service-account: "true"
-    preset-aws-credential: "true"
+  optional: false
+  decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.10      
-      args:
-      - "--repo=sigs.k8s.io/cluster-api-provider-aws"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--scenario=execute"
-      - "--"
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.12
+      command:
       - "./scripts/ci-aws-cred-test.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,0 +1,19 @@
+periodics:  
+- interval: 4h
+  name: cluster-api-provider-aws-test-creds
+  always_run: true
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-aws-credential: "true"
+  path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975      
+      args:
+      - "--repo=sigs.k8s.io/cluster-api-provider-aws"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./scripts/ci-aws-cred-test.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,6 +1,6 @@
 periodics:  
 - interval: 4h
-  name: cluster-api-provider-aws-test-creds
+  name: periodic-cluster-api-provider-aws-test-creds
   always_run: true
   decorate: true
   labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -2,14 +2,13 @@ periodics:
 - interval: 4h
   name: periodic-cluster-api-provider-aws-test-creds
   always_run: true
-  decorate: true
   labels:
     preset-service-account: "true"
     preset-aws-credential: "true"
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975      
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.10      
       args:
       - "--repo=sigs.k8s.io/cluster-api-provider-aws"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -20,18 +20,5 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.12
         command:
         - "./scripts/ci-bazel-build.sh"
-periodics:  
-  - interval: 4h
-    name: pull-cluster-api-provider-aws-test-creds
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-aws-credential: "true"
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master      
-        command:
-          - "./scripts/ci-aws-cred-test.sh"
+
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2447,8 +2447,8 @@ test_groups:
 - name: pull-cluster-api-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-test
   num_columns_recent: 20
-- name: cluster-api-provider-aws-test-creds
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/cluster-api-provider-aws-test-creds
+- name: periodic-cluster-api-provider-aws-test-creds
+  gcs_prefix: kubernetes-jenkins/logs/directory/periodic-cluster-api-provider-aws-test-creds
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-build
@@ -5868,7 +5868,7 @@ dashboards:
   - name: bazel-pr-test
     test_group_name: pull-cluster-api-provider-aws-bazel-test
   - name: test-creds
-    test_group_name: cluster-api-provider-aws-test-creds
+    test_group_name: periodic-cluster-api-provider-aws-test-creds
 
 - name: sig-cluster-lifecycle-cluster-api-provider-gcp
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2447,8 +2447,8 @@ test_groups:
 - name: pull-cluster-api-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-test
   num_columns_recent: 20
-- name: pull-cluster-api-provider-aws-test-creds
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-test-creds
+- name: cluster-api-provider-aws-test-creds
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/cluster-api-provider-aws-test-creds
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-build
@@ -5868,7 +5868,7 @@ dashboards:
   - name: bazel-pr-test
     test_group_name: pull-cluster-api-provider-aws-bazel-test
   - name: test-creds
-    test_group_name: pull-cluster-api-provider-aws-test-creds
+    test_group_name: cluster-api-provider-aws-test-creds
 
 - name: sig-cluster-lifecycle-cluster-api-provider-gcp
   dashboard_tab:


### PR DESCRIPTION
Moved the periodic job to its own file to be aligned with unspoken convention.

Changed the job to have the arguments needed for periodic runs (which is different that those of PR-related CI jobs)

Signed-off-by: Ruben Orduz <rubenoz@gmail.com>