### PR TITLE
More fixes to pull-kubernetes-e2e-gce-alpha-features

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -722,7 +722,10 @@ presubmits:
         - --timeout=200
         - --scenario=kubernetes_e2e
         - --
-        - --check-leaked-resources
+        - --build=bazel
+        - --cluster=
+        - --env-file=jobs/env/pull-kubernetes-e2e.env
+        - --env-file=jobs/env/pull-kubernetes-e2e-gce.env
         - --env=KUBE_FEATURE_GATES=AllAlpha=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
@@ -741,6 +744,8 @@ presubmits:
         resources:
           requests:
             memory: 6Gi
+        securityContext:
+          privileged: true
         volumeMounts:
         - mountPath: /etc/ssh-security
           name: ssh-security

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -137,7 +137,10 @@ presubmits:
         - --timeout=200
         - --scenario=kubernetes_e2e
         - --
-        - --check-leaked-resources
+        - --build=bazel
+        - --cluster=
+        - --env-file=jobs/env/pull-kubernetes-e2e.env
+        - --env-file=jobs/env/pull-kubernetes-e2e-gce.env
         - --env=KUBE_FEATURE_GATES=AllAlpha=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
@@ -149,6 +152,9 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
         - --timeout=180m
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
         image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
         resources:
           requests:


### PR DESCRIPTION
More fixes to presubmit pull-kubernetes-e2e-gce-alpha-features configuration.

This is part of [KEP-0009](https://github.com/kubernetes/community/blob/master/keps/sig-node/0009-node-heartbeat.md), feature [#589](https://github.com/kubernetes/features/issues/589) and issue [#14733](https://github.com/kubernetes/kubernetes/issues/14733).