### PR TITLE
Prevent /reopen from posting multiple comments on failure.

### DIFF
--- a/prow/plugins/lifecycle/reopen.go
+++ b/prow/plugins/lifecycle/reopen.go
@@ -58,42 +58,59 @@ func handleReopen(gc githubClient, log *logrus.Entry, e *github.GenericCommentEv
 
 	// Only authors and collaborators are allowed to reopen issues or PRs.
 	if !isAuthor && !isCollaborator {
-		response := fmt.Sprintf("You can't reopen an issue/PR unless you authored it or you are a collaborator.")
+		response := "You can't reopen an issue/PR unless you authored it or you are a collaborator."
 		log.Infof("Commenting \"%s\".", response)
-		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response))
+		return gc.CreateComment(
+			org,
+			repo,
+			number,
+			plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response),
+		)
 	}
 
-	// Add a comment before reopening the PR or issue
-	// to leave an audit trail of who asked to reopen it.
 	if e.IsPR {
-		response := fmt.Sprintf("Reopening this PR.")
-		if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response)); err != nil {
-			log.WithError(err).Errorf("Failed adding comment while reopening the PR")
-		}
-
-		log.Infof("/reopen PR")
-		err := gc.ReopenPR(org, repo, number)
-		if err != nil {
+		log.Info("/reopen PR")
+		if err := gc.ReopenPR(org, repo, number); err != nil {
 			if scbc, ok := err.(github.StateCannotBeChanged); ok {
-				resp := fmt.Sprintf("failed to re-open PR: %v", scbc)
-				return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+				resp := fmt.Sprintf("Failed to re-open PR: %v", scbc)
+				return gc.CreateComment(
+					org,
+					repo,
+					number,
+					plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp),
+				)
 			}
+			return err
+		}
+		// Add a comment after reopening the PR to leave an audit trail of who
+		// asked to reopen it.
+		return gc.CreateComment(
+			org,
+			repo,
+			number,
+			plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, "Reopened this PR."),
+		)
+	}
+
+	log.Info("/reopen issue")
+	if err := gc.ReopenIssue(org, repo, number); err != nil {
+		if scbc, ok := err.(github.StateCannotBeChanged); ok {
+			resp := fmt.Sprintf("Failed to re-open Issue: %v", scbc)
+			return gc.CreateComment(
+				org,
+				repo,
+				number,
+				plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp),
+			)
 		}
 		return err
 	}
-
-	response := fmt.Sprintf("Reopening this issue.")
-	if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, response)); err != nil {
-		log.WithError(err).Errorf("Failed adding comment while reopening the issue")
-	}
-
-	log.Infof("/reopen issue")
-	err = gc.ReopenIssue(org, repo, number)
-	if err != nil {
-		if scbc, ok := err.(github.StateCannotBeChanged); ok {
-			resp := fmt.Sprintf("failed to re-open Issue: %v", scbc)
-			return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
-		}
-	}
-	return err
+	// Add a comment after reopening the issue to leave an audit trail of who
+	// asked to reopen it.
+	return gc.CreateComment(
+		org,
+		repo,
+		number,
+		plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, "Reopened this issue."),
+	)
 }


### PR DESCRIPTION
If `/reopen` fails because the PR state cannot be changed (e.g. the branch has been deleted), we currently post two comments. One that says we are reopening the PR and another that mentions the failure.
It is clearer and less spammy to just post the failure comment and only post a comment about reopening when `/reopen` succeeds.

fixes #9932 
/kind bug
/assign @BenTheElder 