### PR TITLE
Extra refs for build job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -4,7 +4,11 @@ periodics:
   always_run: true
   optional: false
   decorate: true
-  path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.12


### PR DESCRIPTION
Adds extra refs to build job. `decorate: true` by itself isn't sufficient for periodic jobs.

/assign @neolit123 
 
Signed-off-by: Ruben Orduz <rubenoz@gmail.com>