### PR TITLE
prow: Fix nil dereference in flagutil/github.go

### DIFF
--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -90,11 +90,15 @@ func (o *GitHubOptions) GitClient(secretAgent *config.SecretAgent, dryRun bool) 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
+
+	// We must capture the value of client here to prevent issues related
+	// to the use of named return values when an error is encountered.
+	// Without this, we risk a nil pointer dereference.
+	defer func(client *git.Client) {
 		if err != nil {
 			client.Clean()
 		}
-	}()
+	}(client)
 
 	// Get the bot's name in order to set credentials for the Git client.
 	githubClient, err := o.GitHubClient(secretAgent, dryRun)


### PR DESCRIPTION
Related to #9956 

This is related to the use of named return values. If an error is
returned, the value of client becomes set to `nil`. When the `defer`
runs after that, it takes that `nil` value and attempts to call the
`Clean()` method on it, resulting in a nil pointer dereference.