### PR TITLE
Adding aws credentials to build Job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -4,6 +4,10 @@ periodics:
   always_run: true
   optional: false
   decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -20,5 +20,3 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-1.12
         command:
         - "./scripts/ci-bazel-build.sh"
-
-


### PR DESCRIPTION
Build finally ran as intended and failed due to actual reasons (namely the lack of aws credentials). As per code here: https://github.com/kubernetes/test-infra/blob/ac923b864d0606d34d14a365aafae613dde8baf7/config/jobs/kubernetes/kops/kops-config.yaml#L59-L67 this should do the job. 🤞 

/assign @detiber 
/assign @spiffxp 
