### PR TITLE
Add config for a 'needs-priority' label in k/k.

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -12,6 +12,7 @@
 - [Labels that apply to kubernetes/enhancements, for both issues and PRs](#labels-that-apply-to-kubernetesenhancements-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/kubernetes, for both issues and PRs](#labels-that-apply-to-kuberneteskubernetes-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/kubernetes, only for issues](#labels-that-apply-to-kuberneteskubernetes-only-for-issues)
+- [Labels that apply to kubernetes/kubernetes, only for PRs](#labels-that-apply-to-kuberneteskubernetes-only-for-prs)
 - [Labels that apply to kubernetes/org, only for issues](#labels-that-apply-to-kubernetesorg-only-for-issues)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/website, for both issues and PRs](#labels-that-apply-to-kuberneteswebsite-for-both-issues-and-prs)
@@ -176,6 +177,12 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/admin" href="#area/admin">`area/admin`</a> | Indicates an issue on admin area.| label | |
 | <a id="area/api" href="#area/api">`area/api`</a> | Indicates an issue on api area.| label | |
+
+## Labels that apply to kubernetes/kubernetes, only for PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="needs-priority" href="#needs-priority">`needs-priority`</a> | Indicates a PR lacks a `priority/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 
 ## Labels that apply to kubernetes/org, only for issues
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -663,6 +663,12 @@ repos:
         name: area/conformance
         target: both
         addedBy: label
+      - color: ededed
+        description: Indicates a PR lacks a `priority/foo` label and requires one.
+        name: needs-priority
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
   kubernetes/org:
     labels:
       - color: 0052cc

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -388,6 +388,11 @@
     color: #ffffff;
 }
 
+.needsx00002dpriority {
+    background-color: #ededed;
+    color: #000000;
+}
+
 .needsx00002drebase {
     background-color: #BDBDBD;
     color: #000000;

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -237,6 +237,11 @@ require_matching_label:
 
     Note: Method 1 will trigger an email to the group. See the [group list](https://git.k8s.io/community/sig-list.md).
     The `<group-suffix>` in method 1 has to be replaced with one of these: _**bugs, feature-requests, pr-reviews, test-failures, proposals**_.
+- missing_label: needs-priority
+  org: kubernetes
+  repo: kubernetes
+  prs: true
+  regexp: ^priority/
 
 
 plugins:


### PR DESCRIPTION
Per the docs [here](https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#tldr), a `priority/*` label will be a merge requirement during code freeze.

To enforce this a new `needs-priority` label will configured as a merge blocking label for the `k/k` master and release-1.13 branches during code slush. Since the `needs-priority` label will not be applied to existing PRs until they are updated in a relevant way, we should start getting it applied to the appropriate PRs now (just applied to PRs for now, not blocking merge).

/assign @AishSundar 
/sig release
/cc @imkin @amwat @RahulMahale