### PR TITLE
Add a canary coverage job for e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -32,16 +32,84 @@ periodics:
       - -c
       - |
         shopt -s globstar
-        ../test-infra/scenarios/kubernetes_e2e.py --build=quick --dump-before-and-after --extract=local \
-                                                  --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-conformance-coverage \
-                                                  --gcp-zone=us-central1-f --provider=gce --timeout=150m \
-                                                  --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
+        ../test-infra/scenarios/kubernetes_e2e.py \
+          --build=quick \
+          --dump-before-and-after \
+          --extract=local \
+          --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-conformance-coverage \
+          --gcp-zone=us-central1-f \
+          --provider=gce \
+          --timeout=150m \
+          --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
         cd ../test-infra
         bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
         bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"
         bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/conformance.cov"
         bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/,alpha,beta  "${ARTIFACTS}/conformance.cov" > "${ARTIFACTS}/filtered.cov"
         bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/conformance.html"
+      env:
+      - name: KUBE_BUILD_WITH_COVERAGE
+        value: "true"
+      - name: KUBE_BUILD_HYPERKUBE
+        value: "n"
+      - name: KUBE_BUILD_CONFORMANCE
+        value: "n"
+      securityContext:
+        privileged: true
+# coverage for same tests that run in ci-kubernetes-e2e-gci-gce
+- interval: 1h
+  name: ci-kubernetes-coverage-e2e-gci-gce
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  - org: kubernetes
+    repo: release
+    base_ref: master
+    path_alias: k8s.io/release
+  decoration_config:
+    timeout: 10800000000000 # 3 hours
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+      command:
+      - runner.sh
+      - bash
+      args:
+      - -e
+      - -c
+      - |
+        shopt -s globstar
+        ../test-infra/scenarios/kubernetes_e2e.py \
+          --env=ENABLE_POD_SECURITY_POLICY=true \
+          --build=quick \
+          --dump-before-and-after \
+          --extract=local \
+          --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-coverage-e2e-gci-gce \
+          --gcp-master-image=gci \
+          --gcp-node-image=gci \
+          --gcp-nodes=4 \
+          --gcp-zone=us-central1-f \
+          --ginkgo-parallel=30 \
+          --provider=gce \
+          --timeout=150m \
+          --test_args="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8"
+        cd ../test-infra
+        bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
+        bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"
+        bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/e2e.cov"
+        bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/ "${ARTIFACTS}/e2e.cov" > "${ARTIFACTS}/filtered.cov"
+        bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/e2e.html"
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -287,6 +287,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary
 - name: ci-kubernetes-coverage-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-conformance
+- name: ci-kubernetes-coverage-e2e-gci-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-e2e-gci-gce
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-device-plugin-gpu
   alert_stale_results_hours: 24
@@ -6723,6 +6725,10 @@ dashboards:
     test_group_name: pull-kubernetes-integration-prow
   - name: ci-kubernetes-coverage-conformance
     test_group_name: ci-kubernetes-coverage-conformance
+    description: build instrumented kubernetes, run conformance tests, generate line coverage using gopherage
+  - name: ci-kubernetes-coverage-e2e-gci-gce
+    test_group_name: ci-kubernetes-coverage-e2e-gci-gce
+    description: build instrumented kubernetes, run (non-slow/serial/disruptive/flaky/feature) e2e tests, generate line coverage using gopherage
 
 - name: sig-testing-org
   dashboard_tab:


### PR DESCRIPTION
I'm curious what coverage data for a larger suite of e2e runs looks like,
and this is bound to change more often than the conformance coverage

Based off of ci-kubernetes-e2e-gci-gce in config/jobs/...
...kubernetes/sig-gcp/sig-gcp-gce-config.yaml

Flags I added from that job: env, gcp-*-image, gcp-nodes,
ginko-parallel, and test_args. The rest are from above.