### PR TITLE
add a periodic job for verifying manifest lists

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -1,0 +1,17 @@
+# manifest list tests
+periodics:
+- name: periodic-kubernetes-e2e-manifest-lists
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=60
+      - --repo=k8s.io/kubeadm=master
+      - --scenario=execute
+      - --
+      - ./tests/e2e/manifests/verify_manifest_lists.sh
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2163,6 +2163,9 @@ test_groups:
 # packages tests
 - name: periodic-kubernetes-e2e-packages-pushed
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-packages-pushed
+# manifest list tests
+- name: periodic-kubernetes-e2e-manifest-lists
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-manifest-lists
 
 # EKS e2e results
 - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
@@ -5846,6 +5849,9 @@ dashboards:
 # packages tests
   - name: periodic-packages-pushed
     test_group_name: periodic-kubernetes-e2e-packages-pushed
+# manifest list tests
+  - name: periodic-manifest-lists
+    test_group_name: periodic-kubernetes-e2e-manifest-lists
 
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:


### PR DESCRIPTION
Runs the following test:
https://github.com/kubernetes/kubeadm/tree/master/tests/e2e/manifests

The job is only added to the cluster-lifecycle-all dashboard for now.

follow up from:
https://github.com/kubernetes/kubeadm/pull/1157

/assign @BenTheElder @timothysc 
/cc @dims @mkumatag 

/area jobs
/area testgrid
/kind feature
