### PR TITLE
diff two coverage lists and produce bot post

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,6 +98,7 @@ filegroup(
         "//pkg/ghclient:all-srcs",
         "//prow:all-srcs",
         "//robots/commenter:all-srcs",
+        "//robots/coverage:all-srcs",
         "//robots/issue-creator:all-srcs",
         "//robots/pr-labeler:all-srcs",
         "//scenarios:all-srcs",

--- a/gopherage/pkg/cov/junit/calculation/calculation.go
+++ b/gopherage/pkg/cov/junit/calculation/calculation.go
@@ -30,12 +30,12 @@ func ProduceCovList(profiles []*cover.Profile) *CoverageList {
 	return covList
 }
 
-func summarizeBlocks(profile *cover.Profile) coverage {
-	cov := coverage{Name: profile.FileName}
+func summarizeBlocks(profile *cover.Profile) Coverage {
+	cov := Coverage{Name: profile.FileName}
 	for _, blk := range profile.Blocks {
-		cov.nAllStmts += blk.NumStmt
+		cov.NumAllStmts += blk.NumStmt
 		if blk.Count > 0 {
-			cov.nCoveredStmts += blk.NumStmt
+			cov.NumCoveredStmts += blk.NumStmt
 		}
 	}
 	return cov

--- a/gopherage/pkg/cov/junit/calculation/calculation_test.go
+++ b/gopherage/pkg/cov/junit/calculation/calculation_test.go
@@ -45,14 +45,14 @@ func TestCovList(t *testing.T) {
 	}
 
 	testCases := []struct {
-		covExpected coverage
-		covActual   coverage
+		covExpected Coverage
+		covActual   Coverage
 	}{
-		{coverage{Name: "a", nCoveredStmts: 105, nAllStmts: 2123},
+		{Coverage{Name: "a", NumCoveredStmts: 105, NumAllStmts: 2123},
 			covList.Group[0]},
-		{coverage{Name: "b", nCoveredStmts: 1559, nAllStmts: 3559},
+		{Coverage{Name: "b", NumCoveredStmts: 1559, NumAllStmts: 3559},
 			covList.Group[1]},
-		{coverage{Name: "a/c"},
+		{Coverage{Name: "a/c"},
 			covList.Group[2]},
 	}
 

--- a/gopherage/pkg/cov/junit/calculation/coverage.go
+++ b/gopherage/pkg/cov/junit/calculation/coverage.go
@@ -16,17 +16,17 @@ limitations under the License.
 
 package calculation
 
-// coverage stores test coverage summary data for one file
-type coverage struct {
-	Name          string
-	nCoveredStmts int
-	nAllStmts     int
+// Coverage stores test coverage summary data for one file
+type Coverage struct {
+	Name            string
+	NumCoveredStmts int
+	NumAllStmts     int
 }
 
 // Ratio returns the percentage of statements that are covered
-func (c *coverage) Ratio() float32 {
-	if c.nAllStmts == 0 {
+func (c *Coverage) Ratio() float32 {
+	if c.NumAllStmts == 0 {
 		return 1
 	}
-	return float32(c.nCoveredStmts) / float32(c.nAllStmts)
+	return float32(c.NumCoveredStmts) / float32(c.NumAllStmts)
 }

--- a/gopherage/pkg/cov/junit/calculation/coveragelist.go
+++ b/gopherage/pkg/cov/junit/calculation/coveragelist.go
@@ -23,31 +23,31 @@ import (
 
 // CoverageList is a collection and summary over multiple file Coverage objects
 type CoverageList struct {
-	*coverage
-	Group []coverage
+	*Coverage
+	Group []Coverage
 }
 
 // CovList constructs new (file) Group Coverage
 func newCoverageList(name string) *CoverageList {
 	return &CoverageList{
-		coverage: &coverage{Name: name},
-		Group:    []coverage{},
+		Coverage: &Coverage{Name: name},
+		Group:    []Coverage{},
 	}
 }
 
 // Ratio summarizes the list of coverages and returns the summarized ratio
 func (covList *CoverageList) Ratio() float32 {
 	covList.summarize()
-	return covList.coverage.Ratio()
+	return covList.Coverage.Ratio()
 }
 
 // summarize summarizes all items in the Group and stores the result
 func (covList *CoverageList) summarize() {
-	covList.nCoveredStmts = 0
-	covList.nAllStmts = 0
+	covList.NumCoveredStmts = 0
+	covList.NumAllStmts = 0
 	for _, item := range covList.Group {
-		covList.nCoveredStmts += item.nCoveredStmts
-		covList.nAllStmts += item.nAllStmts
+		covList.NumCoveredStmts += item.NumCoveredStmts
+		covList.NumAllStmts += item.NumAllStmts
 	}
 }
 

--- a/robots/coverage/BUILD.bazel
+++ b/robots/coverage/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//robots/coverage/cmd/diff:all-srcs",
+        "//robots/coverage/diff:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/robots/coverage",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/coverage/cmd/diff:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "coverage",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/coverage/cmd/diff/BUILD.bazel
+++ b/robots/coverage/cmd/diff/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["diff.go"],
+    importpath = "k8s.io/test-infra/robots/coverage/cmd/diff",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gopherage/pkg/util:go_default_library",
+        "//robots/coverage/diff:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/coverage/cmd/diff/diff.go
+++ b/robots/coverage/cmd/diff/diff.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/test-infra/gopherage/pkg/util"
+	"k8s.io/test-infra/robots/coverage/diff"
+)
+
+type flags struct {
+	outputFile string
+	threshold  float32
+	jobName    string
+}
+
+// MakeCommand returns a `junit` command.
+func MakeCommand() *cobra.Command {
+	flags := &flags{}
+	cmd := &cobra.Command{
+		Use:   "diff [base-profile] [new-profile]",
+		Short: "Summarize coverage profile and produce the result in junit xml format.",
+		Long: `Summarize coverage profile and produce the result in junit xml format.
+Summary done at per-file and per-package level. Any coverage below coverage-threshold will be marked
+with a <failure> tag in the xml produced.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			run(flags, cmd, args)
+		},
+	}
+	cmd.Flags().StringVarP(&flags.outputFile, "output", "o", "-", "output file")
+	cmd.Flags().StringVarP(&flags.jobName, "jobname", "j", "", "prow job name")
+	cmd.Flags().Float32VarP(&flags.threshold, "threshold", "t", .8, "code coverage threshold")
+	return cmd
+}
+
+func run(flags *flags, cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "Expected exactly two arguments: base-profile & new-profile")
+		cmd.Usage()
+		os.Exit(2)
+	}
+
+	if flags.threshold < 0 || flags.threshold > 1 {
+		fmt.Fprintln(os.Stderr, "coverage threshold must be a float number between 0 to 1, inclusive")
+		os.Exit(1)
+	}
+
+	baseProfilePath := args[0]
+	newProfilePath := args[1]
+
+	baseProfiles, err := util.LoadProfile(baseProfilePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse base profile file: %v.\n", err)
+		os.Exit(1)
+	}
+
+	newProfiles, err := util.LoadProfile(newProfilePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse new profile file: %v.\n", err)
+		os.Exit(1)
+	}
+
+	postContent, isCoverageLow := diff.ContentForGithubPost(baseProfiles, newProfiles, flags.jobName, flags.threshold)
+
+	var file io.WriteCloser
+	if flags.outputFile == "-" {
+		file = os.Stdout
+	} else {
+		file, err = os.Create(flags.outputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create output file: %v.", err)
+			os.Exit(1)
+		}
+		defer file.Close()
+	}
+
+	_, err = io.WriteString(file, fmt.Sprintf("isCoverageLow = %v\n", isCoverageLow))
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write low coverage check: %v.\n", err)
+		os.Exit(1)
+	}
+
+	_, err = io.WriteString(file, fmt.Sprintf("Post content:\n%v", postContent))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write post content: %v.\n", err)
+		os.Exit(1)
+	}
+}

--- a/robots/coverage/diff/BUILD.bazel
+++ b/robots/coverage/diff/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "diff.go",
+        "view.go",
+    ],
+    importpath = "k8s.io/test-infra/robots/coverage/diff",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gopherage/pkg/cov/junit/calculation:go_default_library",
+        "//vendor/golang.org/x/tools/cover:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["view_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//gopherage/pkg/cov/junit/calculation:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/coverage/diff/diff.go
+++ b/robots/coverage/diff/diff.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package diff calculates the difference of two coverage lists and produces a collection of
+// individual coverage difference. The result is formatted optionally to a table in coverage bot post
+package diff
+
+import (
+	"k8s.io/test-infra/gopherage/pkg/cov/junit/calculation"
+)
+
+// deltaSensitivity is checked against to tell whether the coverage delta is worth reporting. Coverage delta is displayed as a percentage with one decimal place. Any difference smaller than this value will not appear different.
+const deltaSensitivity = 0.001
+
+type coverageChange struct {
+	name      string
+	baseRatio float32
+	newRatio  float32
+}
+
+func isChangeSignificant(baseRatio, newRatio float32) bool {
+	diff := newRatio - baseRatio
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff > deltaSensitivity
+}
+
+// toMap returns maps the file name to its coverage for faster retrieval
+// & membership check
+func toMap(g *calculation.CoverageList) map[string]calculation.Coverage {
+	m := make(map[string]calculation.Coverage)
+	for _, cov := range g.Group {
+		m[cov.Name] = cov
+	}
+	return m
+}
+
+// findChanges compares the newList of coverage against the base list and returns the result
+func findChanges(baseList *calculation.CoverageList, newList *calculation.CoverageList) []*coverageChange {
+	var changes []*coverageChange
+	baseFilesMap := toMap(baseList)
+	for _, newCov := range newList.Group {
+		baseCov, ok := baseFilesMap[newCov.Name]
+		var baseRatio float32
+		if !ok {
+			baseRatio = -1
+		} else {
+			baseRatio = baseCov.Ratio()
+		}
+		newRatio := newCov.Ratio()
+		if isChangeSignificant(baseRatio, newRatio) {
+			changes = append(changes, &coverageChange{
+				name:      newCov.Name,
+				baseRatio: baseRatio,
+				newRatio:  newRatio,
+			})
+		}
+	}
+	return changes
+}

--- a/robots/coverage/diff/view.go
+++ b/robots/coverage/diff/view.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/cover"
+	"k8s.io/test-infra/gopherage/pkg/cov/junit/calculation"
+)
+
+// formatPercentage converts a coverage ratio into a string value to be displayed by coverage robot
+func formatPercentage(ratio float32) string {
+	if ratio < 0 {
+		return "Does not exist"
+	}
+	return fmt.Sprintf("%.1f%%", ratio*100)
+}
+
+// deltaDisplayed converts a coverage ratio delta into a string value to be displayed by coverage robot
+func deltaDisplayed(change *coverageChange) string {
+	if change.baseRatio < 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f", (change.newRatio-change.baseRatio)*100)
+}
+
+// makeTable checks each coverage change and produce the table content for coverage bot post
+// It also report on whether any coverage fells below the given threshold
+func makeTable(baseCovList, newCovList *calculation.CoverageList, coverageThreshold float32) (string, bool) {
+	var rows []string
+	isCoverageLow := false
+	for _, change := range findChanges(baseCovList, newCovList) {
+		filePath := change.name
+		rows = append(rows, fmt.Sprintf("%s | %s | %s | %s",
+			filePath,
+			formatPercentage(change.baseRatio),
+			formatPercentage(change.newRatio),
+			deltaDisplayed(change)))
+
+		if change.newRatio < coverageThreshold {
+			isCoverageLow = true
+		}
+	}
+	return strings.Join(rows, "\n"), isCoverageLow
+}
+
+// ContentForGithubPost constructs the message covbot posts
+func ContentForGithubPost(baseProfiles, newProfiles []*cover.Profile, jobName string, coverageThreshold float32) (
+	string, bool) {
+
+	rows := []string{
+		"The following is the code coverage report",
+		fmt.Sprintf("Say `/test %s` to re-run this coverage report", jobName),
+		"",
+		"File | Old Coverage | New Coverage | Delta",
+		"---- |:------------:|:------------:|:-----:",
+	}
+
+	table, isCoverageLow := makeTable(calculation.ProduceCovList(baseProfiles), calculation.ProduceCovList(newProfiles), coverageThreshold)
+
+	if table == "" {
+		return "", false
+	}
+
+	rows = append(rows, table)
+	rows = append(rows, "")
+
+	return strings.Join(rows, "\n"), isCoverageLow
+}

--- a/robots/coverage/diff/view_test.go
+++ b/robots/coverage/diff/view_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"testing"
+
+	"k8s.io/test-infra/gopherage/pkg/cov/junit/calculation"
+)
+
+func TestMakeTable(t *testing.T) {
+	type args struct {
+		baseCovList       *calculation.CoverageList
+		newCovList        *calculation.CoverageList
+		jobName           string
+		coverageThreshold float32
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantRes           string
+		wantIsCoverageLow bool
+	}{
+		{
+			name: "A",
+			args: args{
+				baseCovList: &calculation.CoverageList{
+					Group: []calculation.Coverage{
+						{Name: "a", NumCoveredStmts: 10, NumAllStmts: 100},
+						{Name: "a2", NumCoveredStmts: 12, NumAllStmts: 100},
+						{Name: "c", NumCoveredStmts: 20, NumAllStmts: 100},
+						{Name: "d", NumCoveredStmts: 30, NumAllStmts: 100},
+					},
+				},
+				newCovList: &calculation.CoverageList{
+					Group: []calculation.Coverage{
+						{Name: "a", NumCoveredStmts: 5, NumAllStmts: 100},
+						{Name: "b", NumCoveredStmts: 10, NumAllStmts: 100},
+						{Name: "c", NumCoveredStmts: 20, NumAllStmts: 100},
+						{Name: "d", NumCoveredStmts: 40, NumAllStmts: 100},
+					},
+				},
+				jobName:           "example-coverage-test",
+				coverageThreshold: 30,
+			},
+			wantRes: "a | 10.0% | 5.0% | -5.0\n" +
+				"b | Does not exist | 10.0% | \n" +
+				"d | 30.0% | 40.0% | 10.0",
+			wantIsCoverageLow: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRes, gotIsCoverageLow := makeTable(tt.args.baseCovList, tt.args.newCovList, tt.args.coverageThreshold)
+			if gotRes != tt.wantRes {
+				t.Errorf("makeTable() gotRes = %v, want %v", gotRes, tt.wantRes)
+			}
+			if gotIsCoverageLow != tt.wantIsCoverageLow {
+				t.Errorf("makeTable() gotIsCoverageLow = %v, want %v", gotIsCoverageLow, tt.wantIsCoverageLow)
+			}
+		})
+	}
+}

--- a/robots/coverage/main.go
+++ b/robots/coverage/main.go
@@ -14,25 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package calculation
+package main
 
 import (
-	"testing"
+	"log"
+
+	"github.com/spf13/cobra"
+	"k8s.io/test-infra/robots/coverage/cmd/diff"
 )
 
-func TestRatio(t *testing.T) {
-	t.Run("regular", func(t *testing.T) {
-		c := &Coverage{Name: "fake-coverage", NumCoveredStmts: 105, NumAllStmts: 210}
-		actualRatio := c.Ratio()
-		if actualRatio != float32(.5) {
-			t.Fatalf("incorrect coverage ratio: expected 0.5, got %f", actualRatio)
-		}
-	})
+var rootCommand = &cobra.Command{
+	Use:   "coverage-robot",
+	Short: "coverage-robot is a tool for posting content related to pre-submit coverage change on github",
+}
 
-	t.Run("no actual statements", func(t *testing.T) {
-		c := &Coverage{Name: "fake-coverage", NumCoveredStmts: 0, NumAllStmts: 0}
-		if c.Ratio() != float32(1) {
-			t.Fatalf("incorrect coverage ratio: expected 1, got %f", c.Ratio())
-		}
-	})
+func run() error {
+	rootCommand.AddCommand(diff.MakeCommand())
+
+	return rootCommand.Execute()
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Package diff calculates the difference of two coverage lists and produces a collection of individual coverage difference. The result is formatted optionally to a table in coverage bot post