### PR TITLE
Update version of gcloud-in-go image for cluster-api jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -5,7 +5,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+    - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
       args:
       - "--repo=sigs.k8s.io/cluster-api"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
+      - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"


### PR DESCRIPTION
Update version of the gcloud-in-go image for cluster-api jobs, since the current version in use does not provide go v1.10+