### PR TITLE
[WIP] convert branch protector to trusted job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -68,3 +68,38 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
+- cron: "54 * * * *"  # Every hour at 54 minutes past the hour 
+  name: ci-branchprotector
+  cluster: test-infra-trusted
+  decorate: true
+  spec: 
+    containers:
+    - name: branchprotector
+      image: gcr.io/k8s-prow/branchprotector:v20181019-08e9d55c9
+      args:
+      - --config-path=/etc/config/config.yaml
+      - --job-config-path=/etc/job-config
+      - --github-token-path=/etc/github/oauth
+      - --confirm
+      - --github-endpoint=http://ghproxy
+      - --github-endpoint=https://api.github.com
+      volumeMounts:
+      - name: oauth
+        mountPath: /etc/github
+        readOnly: true
+      - name: config
+        mountPath: /etc/config
+        readOnly: true
+      - name: job-config
+        mountPath: /etc/job-config
+        readOnly: true
+    volumes:
+    - name: oauth
+      secret:
+        secretName: oauth-token
+    - name: config
+      configMap:
+        name: config
+    - name: job-config
+      configMap:
+        name: job-config


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/10015

TODO:
-  [ ] the job-config configmap (?)
- [ ] remove the old k8s cron
- [ ] update the docs / add an announcement for other prow users