### PR TITLE
New config to restrict trusted users for sticky LGTM

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -307,6 +307,20 @@ func (f *FakeClient) GetFile(org, repo, file, commit string) ([]byte, error) {
 	return nil, fmt.Errorf("could not find file %s with ref %s", file, commit)
 }
 
+// ListTeams return a list of fake teams that correspond to the fake team members returned by ListTeamMembers
+func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
+	return []github.Team{
+		{
+			ID:   0,
+			Name: "Admins",
+		},
+		{
+			ID:   42,
+			Name: "Leads",
+		},
+	}, nil
+}
+
 // ListTeamMembers return a fake team with a single "sig-lead" Github teammember
 func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]github.TeamMember, error) {
 	if role != github.RoleAll {

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
-        "//prow/plugins/trigger:go_default_library",
         "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -373,12 +373,9 @@ type Lgtm struct {
 	// WARNING: This disables the security mechanism that prevents a malicious member (or
 	// compromised GitHub account) from merging arbitrary code. Use with caution.
 	//
-	// StickyForTrustedAuthors indicates if LGTM is sticky for PRs authored by trusted users, and
-	// eliminates the need to re-lgtm minor fixes/updates. This does not apply if the author is
-	// not trusted. Trusted users are by default collaborators and org members, but can also be
-	// restricted to only org members using Trigger.OnlyOrgMembers. i.e. the same set of users
-	// who can issue "/ok-to-test".
-	StickyForTrustedAuthors bool `json:"sticky_for_trusted_authors,omitempty"`
+	// StickyLgtmTeam specifies the Github team whose members are trusted with sticky LGTM,
+	// which eliminates the need to re-lgtm minor fixes/updates.
+	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
 }
 
 type Cat struct {


### PR DESCRIPTION
Discussed with Erick and Cole offline, and we all agreed to further constaint trusted users by using github team membership.

This PR updates the LGTM plugin to use a github team to check if the PR author can be trusted with sticky LGTM.