### PR TITLE
Don't exclude the `needs-ok-to-test` label for merge

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -318,7 +318,6 @@ tide:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
-    - needs-ok-to-test
     - needs-rebase
   - repos:
     - helm/charts
@@ -334,7 +333,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
-    - needs-ok-to-test
     - needs-rebase
   - orgs:
     - kubernetes-client
@@ -399,7 +397,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
-    - needs-ok-to-test
     - needs-rebase
   - repos:
     - kubernetes/kubernetes

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -521,13 +521,23 @@ func TestHandleIssueComment(t *testing.T) {
 			ShouldReport: true,
 		},
 		{
-			name:        "accept /test all from submit-queue",
+			name:        "accept /test all from trusted user",
 			Author:      "t",
 			PRAuthor:    "t",
-			Body:        "/test all [submit-queue is verifying that this PR is safe to merge]",
+			Body:        "/test all",
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,
+		},
+		{
+			name:        `Non-trusted member after "/lgtm" and "/approve"`,
+			Author:      "u",
+			PRAuthor:    "u",
+			Body:        "/retest",
+			State:       "open",
+			IsPR:        true,
+			ShouldBuild: false,
+			IssueLabels: []github.Label{{Name: labels.LGTM}, {Name: labels.Approved}},
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
If the lgtm plugin is enabled and is required for merge, the query should not exclude the `needs-ok-to-test` label.

The lgtm plugin triggers one round of testing when applied to an untrusted PR and removes the lgtm label if the PR changes so it indicates to Tide that the current version of the PR is considered trusted and can be retested safely.