### PR TITLE
fixs typo: dont -> don't and Dont -> Don't

### DIFF
--- a/prow/plugins/milestonestatus/milestonestatus_test.go
+++ b/prow/plugins/milestonestatus/milestonestatus_test.go
@@ -51,21 +51,21 @@ func TestMilestoneStatus(t *testing.T) {
 	}
 	testcases := []testCase{
 		{
-			name:              "Dont label when non sig-lead user approves",
+			name:              "Don't label when non sig-lead user approves",
 			body:              "/status approved-for-milestone",
 			expectedNewLabels: []string{},
 			commenter:         "sig-follow",
 			shouldComment:     true,
 		},
 		{
-			name:              "Dont label when non sig-lead user marks in progress",
+			name:              "Don't label when non sig-lead user marks in progress",
 			body:              "/status in-progress",
 			expectedNewLabels: []string{},
 			commenter:         "sig-follow",
 			shouldComment:     true,
 		},
 		{
-			name:              "Dont label when non sig-lead user marks in review",
+			name:              "Don't label when non sig-lead user marks in review",
 			body:              "/status in-review",
 			expectedNewLabels: []string{},
 			commenter:         "sig-follow",
@@ -93,14 +93,14 @@ func TestMilestoneStatus(t *testing.T) {
 			shouldComment:     false,
 		},
 		{
-			name:              "Dont label when sig-lead user marks invalid status",
+			name:              "Don't label when sig-lead user marks invalid status",
 			body:              "/status in-valid",
 			expectedNewLabels: []string{},
 			commenter:         "sig-lead",
 			shouldComment:     false,
 		},
 		{
-			name:              "Dont label when sig-lead user marks empty status",
+			name:              "Don't label when sig-lead user marks empty status",
 			body:              "/status ",
 			expectedNewLabels: []string{},
 			commenter:         "sig-lead",

--- a/prow/plugins/sigmention/sigmention_test.go
+++ b/prow/plugins/sigmention/sigmention_test.go
@@ -58,7 +58,7 @@ func TestSigMention(t *testing.T) {
 	}
 	testcases := []testCase{
 		{
-			name:              "Dont repeat when org member mentions sig",
+			name:              "Don't repeat when org member mentions sig",
 			body:              "@kubernetes/sig-node-misc",
 			expectedRepeats:   []string{},
 			expectedNewLabels: []string{"sig/node"},
@@ -67,7 +67,7 @@ func TestSigMention(t *testing.T) {
 			commenter:         orgMember,
 		},
 		{
-			name:              "Dont repeat or label when bot adds mentions sig",
+			name:              "Don't repeat or label when bot adds mentions sig",
 			body:              "@kubernetes/sig-node-misc",
 			expectedRepeats:   []string{},
 			expectedNewLabels: []string{},
@@ -94,7 +94,7 @@ func TestSigMention(t *testing.T) {
 			commenter:         nonOrgMember,
 		},
 		{
-			name:              "Dont repeat multiple if org member (all labels present).",
+			name:              "Don't repeat multiple if org member (all labels present).",
 			body:              "@kubernetes/sig-node-misc @kubernetes/sig-api-machinery-bugs",
 			expectedRepeats:   []string{},
 			expectedNewLabels: []string{},

--- a/vendor/github.com/docker/docker/api/types/stats.go
+++ b/vendor/github.com/docker/docker/api/types/stats.go
@@ -120,7 +120,7 @@ type NetworkStats struct {
 	RxBytes uint64 `json:"rx_bytes"`
 	// Packets received. Windows and Linux.
 	RxPackets uint64 `json:"rx_packets"`
-	// Received errors. Not used on Windows. Note that we dont `omitempty` this
+	// Received errors. Not used on Windows. Note that we don't `omitempty` this
 	// field as it is expected in the >=v1.21 API stats structure.
 	RxErrors uint64 `json:"rx_errors"`
 	// Incoming packets dropped. Windows and Linux.
@@ -129,7 +129,7 @@ type NetworkStats struct {
 	TxBytes uint64 `json:"tx_bytes"`
 	// Packets sent. Windows and Linux.
 	TxPackets uint64 `json:"tx_packets"`
-	// Sent errors. Not used on Windows. Note that we dont `omitempty` this
+	// Sent errors. Not used on Windows. Note that we don't `omitempty` this
 	// field as it is expected in the >=v1.21 API stats structure.
 	TxErrors uint64 `json:"tx_errors"`
 	// Outgoing packets dropped. Windows and Linux.


### PR DESCRIPTION
fixs typo error: dont -> don't and Dont -> Don't
/assign @gnufied 