### PR TITLE
make bazel rule for mkpj to work for splitted config files

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,5 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+sh_binary(
+    name = "mkpj",
+    srcs = ["mkpj_binary"],
+    args = [
+        "--config-path=$(location //prow:config.yaml)",
+        "--job-config-path=config/jobs",
+    ],
+    data = [
+        ":prowjobs",
+        "//prow:config.yaml",
+    ],
+)
+
+alias(
+    name = "mkpj_binary",
+    actual = "//prow/cmd/mkpj:mkpj",
+)
+
 filegroup(
     name = "prowjobs",
     srcs = glob([

--- a/prow/build_test_update.md
+++ b/prow/build_test_update.md
@@ -44,8 +44,15 @@ merges, cron schedule) are not sufficient for your testing you can use `mkpj` to
 manually trigger new ProwJob runs.
 To manually trigger any ProwJob, run the following, specifying `JOB_NAME`:
 
+For K8S Prow, you can trigger a job by running
 ```shell
-bazel run //prow/cmd/mkpj -- --job=JOB_NAME
+bazel run //config:mkpj -- --job=JOB_NAME
+```
+
+For your own prow instance, you can either define your own bazel rule, or
+just go run mkpj like:
+```shell
+go run k8s.io/test-infra/prow/cmd/mkpj --job=JOB_NAME --config-path=path/to/config.yaml
 ```
 
 This will print the ProwJob YAML to stdout. You may pipe it into `kubectl`.

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -7,13 +7,6 @@ load(
     "go_test",
 )
 
-go_binary(
-    name = "mkpj",
-    args = ["--config-path=$(location //prow:config.yaml)"],
-    data = ["//prow:config.yaml"],
-    embed = [":go_default_library"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
@@ -43,5 +36,10 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+)
+
+go_binary(
+    name = "mkpj",
     embed = [":go_default_library"],
 )


### PR DESCRIPTION
or our documented way in https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#how-to-manually-run-a-given-job-on-prow doesn't really work..

also cc @ixdy - this works locally, I've also tried with `($locations //foo:bar)` which gives me a list of filenames instead of the directory path, wonder if this is appropriate?

/area prow
/assign @cjwagner @ixdy 