### PR TITLE
Add Kubectl tests back into coverage-conformance job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -40,7 +40,7 @@ periodics:
           --gcp-zone=us-central1-f \
           --provider=gce \
           --timeout=150m \
-          --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
+          --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
         cd ../test-infra
         bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
         bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"


### PR DESCRIPTION
Your weekly reminder that we haven't yet verified the whole
skipl regex has been pulled and enforced upstream so that we
can just focus on Conformance w/o the added skip regex

/cc @katharine @BenTheElder
/kind cleanup