### PR TITLE
Update to rules_go 0.16.2 and go 1.11.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,15 +15,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f5127a8f911468cd0b2d7a141f17253db81177523e4429796e14d429f5444f5f",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.1/rules_go-0.16.1.tar.gz"],
+    sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.11.1")
+go_register_toolchains(go_version = "1.11.2")
 
 http_archive(
     name = "io_bazel_rules_docker",


### PR DESCRIPTION
`bazel coverage //prow/...` now "works" again, i.e. it links and then fails with data races.

/assign @BenTheElder 