### PR TITLE
config/jobs/kubernetes/sig-aws/eks: do not use GCE SSH

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -83,6 +83,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
+      - --gce-ssh=""
       - --extract=ci/latest-1.10
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -106,6 +107,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
+      - --gce-ssh=""
       - --extract=ci/k8s-stable1
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -129,6 +131,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
+      - --gce-ssh=""
       - --extract=ci/latest
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8


### PR DESCRIPTION
Fix https://github.com/kubernetes/test-infra/issues/10051.

Seems like `JENKINS_GCE_SSH_PRIVATE_KEY_FILE` is set somewhere upstream, so `args.gce_ssh` is not empty, even if we pass `--deployment=eks` which does not require GCE SSH key.

/cc @BenTheElder @krzyzacy 

Thanks!