### PR TITLE
config/jobs/kubernetes/sig-aws/eks: pass empty "gce-ssh" for non-GCE jobs

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -83,7 +83,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
-      - --gce-ssh=""
+      - --gce-ssh=
       - --extract=ci/latest-1.10
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -107,7 +107,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
-      - --gce-ssh=""
+      - --gce-ssh=
       - --extract=ci/k8s-stable1
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -131,7 +131,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
-      - --gce-ssh=""
+      - --gce-ssh=
       - --extract=ci/latest
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8


### PR DESCRIPTION
Fix again https://github.com/kubernetes/test-infra/issues/10051.

/cc @krzyzacy @BenTheElder 