### PR TITLE
config/jobs/kubernetes/sig-aws/eks: use latest "kubekins-e2e" image

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -73,7 +73,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       args:
       - --timeout=200
       - --bare
@@ -97,7 +97,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       args:
       - --timeout=200
       - --bare
@@ -121,7 +121,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       args:
       - --timeout=200
       - --bare


### PR DESCRIPTION
Seems like we were too late to include https://github.com/kubernetes/test-infra/pull/10040 in https://github.com/kubernetes/test-infra/pull/10033.

Otherwise, until the next image bump, EKS jobs will
keep seeing 'unknown deployment strategy "eks"', or
use the old kubetest, which does not download "aws-k8s-tester" binary.

We will use the stable "kubekins-e2e" image once it includes the
latest EKS plugin changes.

/cc @krzyzacy @BenTheElder 

How often do we build `gcr.io/k8s-testimages/kubekins-e2e:latest-master`? Hope this can pick up the latest change to EKS kubetest plugin.