### PR TITLE
config/jobs/kubernetes/sig-aws-eks: bump up image to v20181106-9fd606c0b-master

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -73,7 +73,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
       args:
       - --timeout=200
       - --bare
@@ -97,7 +97,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
       args:
       - --timeout=200
       - --bare
@@ -121,7 +121,7 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
       args:
       - --timeout=200
       - --bare


### PR DESCRIPTION
To include latest change to EKS plugin.

/cc @krzyzacy @BenTheElder 

Thanks! (ref. https://github.com/kubernetes/test-infra/pull/10060#issuecomment-436502553)