### PR TITLE
kubetest/eks: do not delete binaries on "Down" call, switch EKS jobs to latest "kubekins-e2e"

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -73,7 +73,8 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       args:
       - --timeout=200
       - --bare
@@ -97,7 +98,8 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       args:
       - --timeout=200
       - --bare
@@ -121,7 +123,8 @@ periodics:
     preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181106-9fd606c0b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       args:
       - --timeout=200
       - --bare

--- a/kubetest/eks/eks.go
+++ b/kubetest/eks/eks.go
@@ -157,10 +157,6 @@ func (dp *deployer) Up() (err error) {
 
 // Down tears down the existing EKS cluster.
 func (dp *deployer) Down() (err error) {
-	defer func() {
-		os.RemoveAll(dp.awsK8sTesterPath)
-		os.RemoveAll("/usr/local/bin/aws-iam-authenticator")
-	}()
 	// reload configuration from disk to read the latest configuration
 	if _, err = dp.LoadConfig(); err != nil {
 		return err


### PR DESCRIPTION
My assumption was "Down" is only called once at the very end of the
tests, but it turns out kubetest may call "Down" multiple times
while we download the binaries only once when we create EKS deployer
objects.

The downloaded artifacts will be gone anyway on pod termination.
This PR removes the "os.RemoveAll" calls, so that the downloaded
binaries can be reused.

/cc @BenTheElder @krzyzacy 

We were so close to running the very first one :)

Fix https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-stable-aws-eks-1-10-prod/204/build-log.txt.

```
I1107 18:54:09.296] md5sum(kubernetes-test.tar.gz)=6d9f9d788f21f3dc1e04b1beb04f92a7
I1107 18:54:13.053] sha1sum(kubernetes-test.tar.gz)=720c7274f71acfbbd3a45c8c0ab33025bdba5ea4
I1107 18:54:13.053] 
I1107 18:54:13.054] Extracting kubernetes-test.tar.gz into /workspace/kubernetes
W1107 18:55:04.308] 2018/11/07 18:55:04 process.go:155: Step './get-kube.sh' finished in 1m11.929446007s
W1107 18:55:04.310] 2018/11/07 18:55:04 process.go:153: Running: /tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 delete cluster
W1107 18:55:05.671] {"level":"info","ts":"2018-11-07T18:55:05.671Z","caller":"eks/tester_embedded.go:243","msg":"created EKS deployer","cluster-name":"awsk8stester-eks-20181107-l8h8esl","aws-k8s-tester-eksconfig-path":"/tmp/aws-k8s-tester712040431","request-started":"1 second ago"}
W1107 18:55:05.673] {"level":"info","ts":"2018-11-07T18:55:05.673Z","caller":"eks/tester_embedded.go:440","msg":"uploading worker node logs before shutdown","cluster-name":"awsk8stester-eks-20181107-l8h8esl"}
W1107 18:55:05.962] {"level":"info","ts":"2018-11-07T18:55:05.962Z","caller":"eks/worker_node_log_embedded.go:28","msg":"updated worker node logs","synced-config-path":"/tmp/aws-k8s-tester712040431"}
W1107 18:55:05.963] {"level":"info","ts":"2018-11-07T18:55:05.962Z","caller":"eks/tester_embedded.go:449","msg":"Down","cluster-name":"awsk8stester-eks-20181107-l8h8esl"}
W1107 18:55:05.963] {"level":"info","ts":"2018-11-07T18:55:05.962Z","caller":"eks/tester_embedded.go:496","msg":"Down finished","cluster-name":"awsk8stester-eks-20181107-l8h8esl","request-started":"now"}
W1107 18:55:06.830] {"level":"warn","ts":"2018-11-07T18:55:06.829Z","caller":"s3/plugin_embedded.go:163","msg":"bucket already owned by me","bucket":"awsk8stester-eks-20181107-aidaicxaslknce","error":"BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.\n\tstatus code: 409, request id: C02939D7209ED5A1, host id: PL66sLYyU//XTQcNtZjEjk6SZJNOcxXBXIpC+XtSPBvmQqs6RFxsDcbGDS2k9b6Q6AnU5BCwJjk="}
W1107 18:55:08.000] {"level":"info","ts":"2018-11-07T18:55:07.999Z","caller":"s3/plugin_embedded.go:198","msg":"created bucket","bucket":"awsk8stester-eks-20181107-aidaicxaslknce"}
W1107 18:55:08.232] 2018/11/07 18:55:08 process.go:155: Step '/tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 delete cluster' finished in 3.922679537s
W1107 18:55:08.246] 2018/11/07 18:55:08 e2e.go:452: Listing resources...
W1107 18:55:08.246] 2018/11/07 18:55:08 process.go:153: Running: ./cluster/gce/list-resources.sh
W1107 18:55:08.249] ./cluster/gce/list-resources.sh: line 69: PROJECT: unbound variable
W1107 18:55:08.249] 2018/11/07 18:55:08 process.go:155: Step './cluster/gce/list-resources.sh' finished in 3.239273ms
W1107 18:55:08.249] 2018/11/07 18:55:08 process.go:153: Running: /tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 create cluster
W1107 18:55:08.250] 2018/11/07 18:55:08 process.go:155: Step '/tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 create cluster' finished in 404.597Âµs
W1107 18:55:08.251] 2018/11/07 18:55:08 process.go:153: Running: /tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 test get-worker-node-logs
W1107 18:55:08.251] 2018/11/07 18:55:08 process.go:155: Step '/tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 test get-worker-node-logs' finished in 479.601Âµs
W1107 18:55:08.252] 2018/11/07 18:55:08 process.go:153: Running: /tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 delete cluster
W1107 18:55:08.252] 2018/11/07 18:55:08 process.go:155: Step '/tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 delete cluster' finished in 332.923Âµs
W1107 18:55:08.253] 2018/11/07 18:55:08 process.go:96: Saved XML output to /workspace/_artifacts/junit_runner.xml.
W1107 18:55:08.253] 2018/11/07 18:55:08 main.go:317: Something went wrong: starting e2e cluster: error starting /tmp/aws-k8s-tester eks --path=/tmp/aws-k8s-tester712040431 create cluster: fork/exec /tmp/aws-k8s-tester: no such file or directory
```
