### PR TITLE
Always pull latest bazel image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -6,6 +6,7 @@ postsubmits:
     spec:
       containers:
       - image: launcher.gcr.io/google/bazel
+        imagePullPolicy: Always
         command:
         - bazel
         args:
@@ -53,6 +54,7 @@ periodics:
   spec:
     containers:
     - image: launcher.gcr.io/google/bazel
+      imagePullPolicy: Always
       command:
       - bazel
       args:


### PR DESCRIPTION
/assign @krzyzacy @cjwagner 

```console
Current Bazel version is 0.17.2, expected at least 0.18.0
ERROR: Error evaluating WORKSPACE file
```

https://gubernator.k8s.io/build/kubernetes-jenkins/logs/post-test-infra-push-prow/253

https://testgrid.k8s.io/sig-testing-misc#push-prow&width=80