### PR TITLE
Use gcr.io/k8s-testimages/gcloud-bazel:v20181107-d88dbbf

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -28,7 +28,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20181002-996397d
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20181107-d88dbbf
         command:
         - prow/bump.sh
         env:


### PR DESCRIPTION
Updates to bazel 0.19.0

Image from `make push PROJECT=k8s-testimages` on https://github.com/bazelbuild/rules_k8s/pull/217