### PR TITLE
Use go 1.11 for containerd code verify test in master branch.

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -113,15 +113,32 @@ presubmits:
 
   - name: pull-cri-containerd-verify
     always_run: true
-    skip_branches:
-    - v0.1
+    branches:
+    - release/1.0
+    - release/1.2
     labels:
       preset-service-account: "true"
     spec:
       containers:
-      # TODO(random-liu): Update to gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
-      # after containerd is updated to go 1.11.
+      # Use go 1.10 for old branches, because gofmt result changed in go 1.11.
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-1.12
+        args:
+        - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - --scenario=execute
+        - --
+        - ./test/verify.sh
+
+  - name: pull-cri-containerd-verify
+    always_run: true
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"


### PR DESCRIPTION
Use golang 1.11 for containerd master code verification.

Signed-off-by: Lantao Liu <lantaol@google.com>