### PR TITLE
make gerrit report label customizable

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -42,6 +42,8 @@ const (
 	GerritInstance = "gerrit-instance"
 	// GerritRevision is the SHA of current patchset from a gerrit change
 	GerritRevision = "gerrit-revision"
+	// GerritReportLabel is the gerrit label prow will cast vote on, fallback to CodeReview label if unset
+	GerritReportLabel = "gerrit-report-label"
 )
 
 // ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client

--- a/prow/gerrit/reporter/BUILD.bazel
+++ b/prow/gerrit/reporter/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/listers/prowjobs/v1:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],

--- a/prow/gerrit/reporter/reporter_test.go
+++ b/prow/gerrit/reporter/reporter_test.go
@@ -18,6 +18,7 @@ package reporter
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -25,10 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
 	pjlister "k8s.io/test-infra/prow/client/listers/prowjobs/v1"
+	"k8s.io/test-infra/prow/gerrit/client"
 )
 
 type fgc struct {
 	reportMessage string
+	reportLabel   map[string]string
 	instance      string
 }
 
@@ -37,6 +40,7 @@ func (f *fgc) SetReview(instance, id, revision, message string, labels map[strin
 		return fmt.Errorf("wrong instance: %s", instance)
 	}
 	f.reportMessage = message
+	f.reportLabel = labels
 	return nil
 }
 
@@ -68,6 +72,7 @@ func TestReport(t *testing.T) {
 		expectReport  bool
 		reportInclude []string
 		reportExclude []string
+		expectLabel   map[string]string
 	}{
 		{
 			name: "1 job, unfinished, should not report",
@@ -90,10 +95,10 @@ func TestReport(t *testing.T) {
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-instance": "gerrit",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -106,8 +111,8 @@ func TestReport(t *testing.T) {
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -120,10 +125,10 @@ func TestReport(t *testing.T) {
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id": "123-abc",
+						client.GerritID: "123-abc",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -136,11 +141,11 @@ func TestReport(t *testing.T) {
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -156,17 +161,46 @@ func TestReport(t *testing.T) {
 			},
 			expectReport:  true,
 			reportInclude: []string{"1 out of 1", "ci-foo", "success", "guber/foo"},
+			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
+		},
+		{
+			name: "1 job, passed, with customized label, should report to customized label",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						client.GerritRevision:    "abc",
+						client.GerritReportLabel: "foobar-label",
+					},
+					Annotations: map[string]string{
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			expectReport:  true,
+			reportInclude: []string{"1 out of 1", "ci-foo", "success", "guber/foo"},
+			expectLabel:   map[string]string{"foobar-label": client.LGTM},
 		},
 		{
 			name: "1 job, failed, should report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -182,17 +216,18 @@ func TestReport(t *testing.T) {
 			},
 			expectReport:  true,
 			reportInclude: []string{"0 out of 1", "ci-foo", "failure", "guber/foo"},
+			expectLabel:   map[string]string{client.CodeReview: client.LBTM},
 		},
 		{
 			name: "1 job, passed, has slash in repo name, should report and handle slash properly",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -209,17 +244,18 @@ func TestReport(t *testing.T) {
 			expectReport:  true,
 			reportInclude: []string{"1 out of 1", "ci-foo-bar", "success", "guber/foo/bar"},
 			reportExclude: []string{"foo_bar"},
+			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
 		},
 		{
 			name: "2 jobs, one passed, other job finished but on different revision, should report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -237,11 +273,11 @@ func TestReport(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"gerrit-revision": "def",
+							client.GerritRevision: "def",
 						},
 						Annotations: map[string]string{
-							"gerrit-id":       "123-def",
-							"gerrit-instance": "gerrit",
+							client.GerritID:       "123-def",
+							client.GerritInstance: "gerrit",
 						},
 					},
 					Status: v1.ProwJobStatus{
@@ -259,17 +295,18 @@ func TestReport(t *testing.T) {
 			expectReport:  true,
 			reportInclude: []string{"1 out of 1", "ci-foo", "success", "guber/foo"},
 			reportExclude: []string{"2", "bar"},
+			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
 		},
 		{
 			name: "2 jobs, one passed, other job unfinished, should not report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -287,11 +324,11 @@ func TestReport(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"gerrit-revision": "abc",
+							client.GerritRevision: "abc",
 						},
 						Annotations: map[string]string{
-							"gerrit-id":       "123-abc",
-							"gerrit-instance": "gerrit",
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
 						},
 					},
 					Status: v1.ProwJobStatus{
@@ -312,11 +349,11 @@ func TestReport(t *testing.T) {
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -334,11 +371,11 @@ func TestReport(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"gerrit-revision": "abc",
+							client.GerritRevision: "abc",
 						},
 						Annotations: map[string]string{
-							"gerrit-id":       "123-abc",
-							"gerrit-instance": "gerrit",
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
 						},
 					},
 					Status: v1.ProwJobStatus{
@@ -356,17 +393,18 @@ func TestReport(t *testing.T) {
 			expectReport:  true,
 			reportInclude: []string{"1 out of 2", "ci-foo", "success", "ci-bar", "failure", "guber/foo", "guber/bar"},
 			reportExclude: []string{"0", "2 out of 2"},
+			expectLabel:   map[string]string{client.CodeReview: client.LBTM},
 		},
 		{
 			name: "2 jobs, both passed, should report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"gerrit-revision": "abc",
+						client.GerritRevision: "abc",
 					},
 					Annotations: map[string]string{
-						"gerrit-id":       "123-abc",
-						"gerrit-instance": "gerrit",
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
 					},
 				},
 				Status: v1.ProwJobStatus{
@@ -384,11 +422,11 @@ func TestReport(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"gerrit-revision": "abc",
+							client.GerritRevision: "abc",
 						},
 						Annotations: map[string]string{
-							"gerrit-id":       "123-abc",
-							"gerrit-instance": "gerrit",
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
 						},
 					},
 					Status: v1.ProwJobStatus{
@@ -406,6 +444,7 @@ func TestReport(t *testing.T) {
 			expectReport:  true,
 			reportInclude: []string{"2 out of 2", "ci-foo", "success", "ci-bar", "guber/foo", "guber/bar"},
 			reportExclude: []string{"1", "0", "failure"},
+			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
 		},
 	}
 
@@ -443,6 +482,10 @@ func TestReport(t *testing.T) {
 				if strings.Contains(fgc.reportMessage, exclude) {
 					t.Errorf("test: %s: reported with: %s, should not contain: %s", tc.name, fgc.reportMessage, exclude)
 				}
+			}
+
+			if !reflect.DeepEqual(tc.expectLabel, fgc.reportLabel) {
+				t.Errorf("test: %s: reported with %s label, should have %s label", tc.name, fgc.reportLabel, tc.expectLabel)
 			}
 		}
 	}


### PR DESCRIPTION
So that prow can cast vote on other labels other than "Code-Review"

/assign @AishSundar @amwat @BenTheElder 

cc @javier-b-perez