### PR TITLE
config/jobs/kubernetes/sig-aws/eks: bump up EKS plugin version

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -3,7 +3,7 @@ presets:
 - env:
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.2/aws-k8s-tester-0.1.2-linux-amd64
+    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.3/aws-k8s-tester-0.1.3-linux-amd64
   # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
   - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
     value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
@@ -80,7 +80,6 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
@@ -105,7 +104,6 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks
@@ -130,7 +128,6 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=eks
       - --provider=eks


### PR DESCRIPTION
Trying to debug test failures by adding retries:

```
W1108 01:33:52.498] {"level":"warn","ts":"2018-11-08T01:33:52.497Z","caller":"eks/tester_embedded.go:301","msg":"reverted Up","error":"'kubectl get all' output unexpected: No resources found.\n"}
W1108 01:33:52.498] failed to create cluster 'kubectl get all' output unexpected: No resources found.
```

/cc @BenTheElder @krzyzacy 