### PR TITLE
add Katharine to spyglass and coverage approvers

### DIFF
--- a/prow/spyglass/OWNERS
+++ b/prow/spyglass/OWNERS
@@ -1,4 +1,5 @@
 approvers:
 - paulangton
+- Katharine
 labels:
  - area/prow/spyglass

--- a/robots/coverage/OWNERS
+++ b/robots/coverage/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- Katharine


### PR DESCRIPTION
Katharine has been reviewing both of these and has been in the org for a while now.

cc @Katharine

/assign @krzyzacy @amwat 

Really just join the oncall and start tackling that and we should get another root reviewer / approver, then you can review all the job configs, bash fun etc :-)