### PR TITLE
Fix some typos

### DIFF
--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -173,7 +173,7 @@ func (ud *UserData) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implents JSON Marshaler interface
+// MarshalJSON implements JSON Marshaler interface
 func (ud *UserData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ud.ToMap())
 }

--- a/kubetest/eks/eks.go
+++ b/kubetest/eks/eks.go
@@ -131,7 +131,7 @@ func NewDeployer(timeout time.Duration, verbose bool) (ekstester.Deployer, error
 // Up creates a new EKS cluster.
 func (dp *deployer) Up() (err error) {
 	// "create cluster" command outputs cluster information
-	// in the configuraion file (e.g. VPC ID, ALB DNS names, etc.)
+	// in the configuration file (e.g. VPC ID, ALB DNS names, etc.)
 	// this needs be reloaded for other deployer method calls
 	createCmd := exec.Command(
 		dp.awsK8sTesterPath,
@@ -256,7 +256,7 @@ func (dp *deployer) DumpClusterLogs(artifactDir, _ string) (err error) {
 
 // Stop stops ongoing operations.
 // This is useful for local development.
-// For example, one may run "Up" but have to cancel onging "Up"
+// For example, one may run "Up" but have to cancel ongoing "Up"
 // operation. Then, it can just send syscall.SIGINT to trigger "Stop".
 func (dp *deployer) Stop() {
 	close(dp.stopc)


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

Fix some typos in below files:

1. boskos/common/common.go
2. kubetest/eks/eks.go