### PR TITLE
OAuth: Invalidate GH session on failures instead of server errors

### DIFF
--- a/prow/prstatus/BUILD.bazel
+++ b/prow/prstatus/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",
+        "//vendor/github.com/gorilla/sessions:go_default_library",
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	gogithub "github.com/google/go-github/github"
+	"github.com/gorilla/sessions"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -152,6 +153,21 @@ func NewDashboardAgent(repos []string, config *config.GithubOAuthConfig, log *lo
 	}
 }
 
+func invalidateGitHubSession(w http.ResponseWriter, r *http.Request, session *sessions.Session) error {
+	// Invalidate github login session
+	http.SetCookie(w, &http.Cookie{
+		Name:    loginSession,
+		Path:    "/",
+		Expires: time.Now().Add(-time.Hour * 24),
+		MaxAge:  -1,
+		Secure:  true,
+	})
+
+	// Invalidate access token session
+	session.Options.MaxAge = -1
+	return session.Save(r, w)
+}
+
 // HandlePrStatus returns a http handler function that handles request to /pr-status
 // endpoint. The handler takes user access token stored in the cookie to query to Github on behalf
 // of the user and serve the data in return. The Query handler is passed to the method so as it
@@ -164,40 +180,37 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			http.Error(w, msg, http.StatusInternalServerError)
 		}
 
-		session, err := da.goac.CookieStore.Get(r, tokenSession)
-		if err != nil {
-			serverError("Error with getting git token session.", err)
-			return
-		}
-		token, ok := session.Values[tokenKey].(*oauth2.Token)
 		data := UserData{
 			Login: false,
 		}
 
+		// Get existing session. Invalidate everything if we fail and continue as
+		// if not logged in.
+		session, err := da.goac.CookieStore.Get(r, tokenSession)
+		if err != nil {
+			da.log.WithError(err).Info("Failed to get existing session, invalidating GitHub login session")
+			if err := invalidateGitHubSession(w, r, session); err != nil {
+				serverError("Failed to invalidate GitHub session", err)
+				return
+			}
+		}
+
+		// If access token exists, get user login using the access token. This is a
+		// chance to validate whether the access token is consumable or not. If
+		// not, we invalidate the sessions and continue as if not logged in.
+		token, ok := session.Values[tokenKey].(*oauth2.Token)
 		var user *gogithub.User
 		if ok && token.Valid() {
-			// If access token exist, get user login using the access token. This is a chance
-			// to validate whether the access token is consumable or not. If not, invalidate the
-			// session.
 			goGithubClient := ghclient.NewClient(token.AccessToken, false)
 			var err error
 			user, err = queryHandler.GetUser(goGithubClient)
 			if err != nil {
 				if strings.Contains(err.Error(), "401") {
-					// Invalidate access token session
-					session.Options.MaxAge = -1
-					if err := session.Save(r, w); err != nil {
-						serverError("Error with saving invalidated session", err)
+					da.log.Info("Failed to access GitHub with existing access token, invalidating GitHub login session")
+					if err := invalidateGitHubSession(w, r, session); err != nil {
+						serverError("Failed to invalidate GitHub session", err)
 						return
 					}
-					// Invalidate github login session
-					http.SetCookie(w, &http.Cookie{
-						Name:    loginSession,
-						Path:    "/",
-						Expires: time.Now().Add(-time.Hour * 24),
-						MaxAge:  -1,
-						Secure:  true,
-					})
 				} else {
 					serverError("Error with getting user login", err)
 					return
@@ -258,6 +271,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 
 			data.PullRequestsWithContexts = pullRequestWithContexts
 		}
+
 		marshaledData, err := json.Marshal(data)
 		if err != nil {
 			da.log.WithError(err).Error("Error with marshalling user data.")

--- a/prow/prstatus/prstatus_test.go
+++ b/prow/prstatus/prstatus_test.go
@@ -119,6 +119,43 @@ func TestHandlePrStatusWithoutLogin(t *testing.T) {
 	}
 }
 
+func TestHandlePrStatusWithInvalidToken(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
+	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
+	mockConfig := &config.GithubOAuthConfig{
+		CookieStore: mockCookieStore,
+	}
+	mockAgent := createMockAgent(repos, mockConfig)
+	mockQueryHandler := newMockQueryHandler([]PullRequest{}, map[int][]Context{})
+
+	rr := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/pr-data.js", nil)
+	request.AddCookie(&http.Cookie{Name: tokenSession, Value: "garbage"})
+	prHandler := mockAgent.HandlePrStatus(mockQueryHandler)
+	prHandler.ServeHTTP(rr, request)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Bad status code: %d", rr.Code)
+	}
+	response := rr.Result()
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("Error with reading response body: %v", err)
+	}
+
+	var dataReturned UserData
+	if err := yaml.Unmarshal(body, &dataReturned); err != nil {
+		t.Errorf("Error with unmarshaling response: %v", err)
+	}
+
+	expectedData := UserData{Login: false}
+	if !reflect.DeepEqual(dataReturned, expectedData) {
+		t.Fatalf("Invalid user data. Got %v, expected %v.", dataReturned, expectedData)
+	}
+}
+
 func TestHandlePrStatusWithLogin(t *testing.T) {
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))


### PR DESCRIPTION
Previously, `HandlePrStatus` failed with 500 when the user has an
invalid/stale cookie. After the fix, the behavior is the same like when
the token is successfuly extracted from the cookie but fails to
authenticate with GH. The sessions are invalidated by deleting the
cookie and `HandlePrStatus` returns indicating the user is not properly
logged in with GitHub via OAuth.

Fixes: #10063