### PR TITLE
Create prow/deploy.sh, run at every commit

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -23,6 +23,27 @@ postsubmits:
         secret:
           secretName: oauth-token
   kubernetes/test-infra:
+  - name: post-test-infra-deploy-prow
+    cluster: test-infra-trusted
+    decorate: true
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20181107-d88dbbf
+        command:
+        - prow/deploy.sh
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
+        - name: creds
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
+
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     decorate: true

--- a/prow/deploy.sh
+++ b/prow/deploy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# bump.sh will
+# * ensure there are no pending changes
+# * optionally activate GOOGLE_APPLICATION_CREDENTIALS and configure-docker if set
+# * run //prow:release-push to build and push prow images
+# * update all the cluster/*.yaml files to use the new image tags
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(fejta): rewrite this in a better language REAL SOON
+# TODO(fejta): update this and hack/print-workspace-status to customize STABLE_*_CLUSTER
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
+  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+fi
+
+# See https://misc.flogisoft.com/bash/tip_colors_and_formatting
+
+color-green() { # Green
+  echo -e "\x1B[1;32m${@}\x1B[0m"
+}
+
+color-context() { # Bold blue
+  echo -e "\x1B[1;34m${@}\x1B[0m"
+}
+
+color-missing() { # Yellow
+  echo -e "\x1B[1;33m${@}\x1B[0m"
+}
+
+ensure-context() {
+  local proj=$1
+  local zone=$2
+  local cluster=$3
+  local context="gke_${proj}_${zone}_${cluster}"
+  echo -n " $(color-context "$context")"
+  kubectl config get-contexts "$context" &> /dev/null && return 0
+  echo ": $(color-missing MISSING), getting credentials..."
+  gcloud container clusters get-credentials --project="$proj" --zone="$zone" "$cluster"
+  kubectl config get-contexts "$context" > /dev/null
+  echo -n "Ensuring contexts exist:"
+}
+
+echo -n "Ensuring contexts exist:"
+current_context=$(kubectl config current-context 2>/dev/null || true)
+restore-context() {
+  if [[ -n "$current_context" ]]; then
+    kubectl config set-context "$current_context"
+  fi
+}
+trap restore-context EXIT
+ensure-context k8s-prow-builds us-central1-f prow
+ensure-context k8s-prow us-central1-f prow
+echo " $(color-green done), Deploying prow..."
+bazel run //prow/cluster:production.apply --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+echo "$(color-green SUCCESS)"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2619,6 +2619,8 @@ test_groups:
 - name: pull-publishing-bot-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-publishing-bot-build
   num_columns_recent: 20
+- name: post-test-infra-deploy-prow
+  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-deploy-prow
 - name: post-test-infra-push-prow
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-prow
 - name: pull-test-infra-bazel
@@ -6652,6 +6654,11 @@ dashboards:
   - name: push-prow
     description: builds and pushes all prow on each commit by running bump.sh
     test_group_name: post-test-infra-push-prow
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: deploy-prow
+    description: deploys the configured version of prow by running deploy.sh
+    test_group_name: post-test-infra-deploy-prow
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 


### PR DESCRIPTION
This will allow us to automatically deploy prow by merging a PR


Tested locally with:
```console
$ docker run --rm=true --entrypoint prow/deploy.sh -v $PWD:/whatever -w /whatever -v /var/all-your-secrets-belong-to-us:/creds -e GOOGLE_APPLICATION_CREDENTIALS=/creds/secret.json
```

/assign @cjwagner 