### PR TITLE
disable automagical service account token for decorated jobs

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,8 @@
 # Announcements
 
 New features added to each component:
+ - *November 8, 2018* `plank` now defaults jobs with `decorate: true` to have 
+   `automountServiceAccountToken: false` in their PodSpec if unset.
  - *October 10, 2018* `tide` now supports the `-repo:foo/bar` tag in queries via
    the `excludedRepos` YAML field.
  - *October 3, 2018* `welcome` now supports a configurable message on a per-org,

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -149,6 +149,13 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	spec.RestartPolicy = "Never"
 	spec.Containers[0].Name = kube.TestContainerName
 
+	// we treat this as false if unset, while kubernetes treats it as true if
+	// unset because it was added in v1.6
+	if spec.AutomountServiceAccountToken == nil {
+		myFalse := false
+		spec.AutomountServiceAccountToken = &myFalse
+	}
+
 	if pj.Spec.DecorationConfig == nil {
 		spec.Containers[0].Env = append(spec.Containers[0].Env, kubeEnv(rawEnv)...)
 	} else {

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -357,6 +357,7 @@ func TestCloneRefs(t *testing.T) {
 
 func TestProwJobToPod(t *testing.T) {
 	truth := true
+	falseth := false
 	var sshKeyMode int32 = 0400
 	tests := []struct {
 		podName string
@@ -415,7 +416,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					Containers: []v1.Container{
 						{
 							Name:  "test",
@@ -511,7 +513,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "clonerefs",
@@ -731,7 +734,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "clonerefs",
@@ -952,7 +956,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "clonerefs",
@@ -1197,7 +1202,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "clonerefs",
@@ -1426,7 +1432,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "initupload",
@@ -1608,7 +1615,8 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: "Never",
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
 					InitContainers: []v1.Container{
 						{
 							Name:    "initupload",
@@ -1736,7 +1744,7 @@ func TestProwJobToPod(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			if !equality.Semantic.DeepEqual(got, test.expected) {
-				t.Errorf("expected pod diff:\n%s", diff.ObjectReflectDiff(test.expected, got))
+				t.Errorf("unexpected pod diff:\n%s", diff.ObjectReflectDiff(test.expected, got))
 			}
 		})
 	}


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/issues/7901

if a job has `decorate: true` and `automountServiceAccountToken` is not set in the spec, we will set it to `false`. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

This means unless a prowjob really wants access to the current cluster, it will not have any automagical kube credentials / namespace etc, which will make running prowjobs a little bit closer to just running the same container locally.

I've only done this to `decorate: true` jobs for now, but this might make sense to do at config load time instead for any job with a podspec...

/assign @cjwagner @fejta 
cc @stevekuznetsov 