### PR TITLE
Fix lint prowjob for cluster-api-provider-digitalocean

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -37,12 +37,16 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
+    labels:
+        preset-service-account: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181024-be2f242dd-experimental
         command:
         - runner.sh
-        - kubernetes_bazel.py
+        - /workspace/scenarios/kubernetes_bazel.py
         args:
         - "--install=gubernator/test_requirements.txt"
         - "--test=//..."


### PR DESCRIPTION
This job was added in https://github.com/kubernetes/test-infra/pull/9954 but it gives the following error (can be seen on https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/119):

```
/usr/local/bin/runner.sh: line 103: kubernetes_bazel.py: command not found
```