### PR TITLE
AWS: re-enable zones previously affected by c4 capacity

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -40,28 +40,28 @@ DEFAULT_AWS_ZONES = [
     'ap-northeast-1a',
     'ap-northeast-1c',
     'ap-northeast-1d',
-    #'ap-northeast-2a', InsufficientInstanceCapacity for c4.large 2018-05-30
+    'ap-northeast-2a',
     #'ap-northeast-2b' - AZ does not exist, so we're breaking the 3 AZs per region target here
-    #'ap-northeast-2c', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-south-1a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-south-1b', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-1a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-1b', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-1c', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-2a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-2b', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ap-southeast-2c', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ca-central-1a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'ca-central-1b', InsufficientInstanceCapacity for c4.large 2018-05-30
+    'ap-northeast-2c',
+    'ap-south-1a',
+    'ap-south-1b',
+    'ap-southeast-1a',
+    'ap-southeast-1b',
+    'ap-southeast-1c',
+    'ap-southeast-2a',
+    'ap-southeast-2b',
+    'ap-southeast-2c',
+    'ca-central-1a',
+    'ca-central-1b',
     'eu-central-1a',
     'eu-central-1b',
     'eu-central-1c',
     'eu-west-1a',
     'eu-west-1b',
     'eu-west-1c',
-    #'eu-west-2a', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'eu-west-2b', InsufficientInstanceCapacity for c4.large 2018-05-30
-    #'eu-west-2c', InsufficientInstanceCapacity for c4.large 2018-05-30
+    'eu-west-2a',
+    'eu-west-2b',
+    'eu-west-2c',
     #'eu-west-3a', documented to not support c4 family
     #'eu-west-3b', documented to not support c4 family
     #'eu-west-3c', documented to not support c4 family

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -68,9 +68,9 @@ DEFAULT_AWS_ZONES = [
     'sa-east-1a',
     #'sa-east-1b', AZ does not exist, so we're breaking the 3 AZs per region target here
     'sa-east-1c',
-    'us-east-1a',
-    'us-east-1b',
-    'us-east-1c',
+    #'us-east-1a', # temporarily removing due to lack of quota #10043
+    #'us-east-1b', # temporarily removing due to lack of quota #10043
+    #'us-east-1c', # temporarily removing due to lack of quota #10043
     #'us-east-1d', # limiting to 3 zones to not overallocate
     #'us-east-1e', # limiting to 3 zones to not overallocate
     #'us-east-1f', # limiting to 3 zones to not overallocate
@@ -80,9 +80,9 @@ DEFAULT_AWS_ZONES = [
     'us-west-1a',
     'us-west-1b',
     #'us-west-1c', AZ does not exist, so we're breaking the 3 AZs per region target here
-    'us-west-2a',
-    'us-west-2b',
-    'us-west-2c'
+    #'us-west-2a', # temporarily removing due to lack of quota #10043
+    #'us-west-2b', # temporarily removing due to lack of quota #10043
+    #'us-west-2c', # temporarily removing due to lack of quota #10043
 ]
 
 def test_infra(*paths):


### PR DESCRIPTION
I was able to launch instances into each of these zones, so there is now at
least _some_ capacity.