### PR TITLE
Bump Prow to 'v20181109-1a84354'.

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20181109-591c3bc
+            image: gcr.io/k8s-prow/branchprotector:v20181109-1a84354
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20181109-591c3bc
+        image: gcr.io/k8s-prow/deck:v20181109-1a84354
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20181109-591c3bc
+        image: gcr.io/k8s-prow/grandmatriarch:v20181109-1a84354
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20181109-591c3bc
+        image: gcr.io/k8s-prow/hook:v20181109-1a84354
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20181109-591c3bc
+        image: gcr.io/k8s-prow/horologium:v20181109-1a84354
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20181109-591c3bc
+        image: gcr.io/k8s-prow/needs-rebase:v20181109-1a84354
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       # serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20181109-591c3bc
+        image: gcr.io/k8s-prow/plank:v20181109-1a84354
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20181109-591c3bc
+        image: gcr.io/k8s-prow/sinker:v20181109-1a84354
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -100,7 +100,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20181109-591c3bc
+        image: gcr.io/k8s-prow/hook:v20181109-1a84354
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20181109-591c3bc
+        image: gcr.io/k8s-prow/plank:v20181109-1a84354
         args:
         - --dry-run=false
         volumeMounts:
@@ -199,7 +199,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20181109-591c3bc
+        image: gcr.io/k8s-prow/sinker:v20181109-1a84354
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -232,7 +232,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20181109-591c3bc
+        image: gcr.io/k8s-prow/deck:v20181109-1a84354
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
@@ -279,7 +279,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20181109-591c3bc
+        image: gcr.io/k8s-prow/horologium:v20181109-1a84354
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -306,7 +306,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20181109-591c3bc
+        image: gcr.io/k8s-prow/tide:v20181109-1a84354
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       # serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20181109-591c3bc
+        image: gcr.io/k8s-prow/tide:v20181109-1a84354
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -60,7 +60,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20181109-591c3bc
+        image: gcr.io/k8s-prow/tot:v20181109-1a84354
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,10 +7,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20181109-591c3bc"
-      initupload: "gcr.io/k8s-prow/initupload:v20181109-591c3bc"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20181109-591c3bc"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20181109-591c3bc"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20181109-1a84354"
+      initupload: "gcr.io/k8s-prow/initupload:v20181109-1a84354"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20181109-1a84354"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20181109-1a84354"
     gcs_configuration:
       bucket: "kubernetes-jenkins"
       path_strategy: "legacy"


### PR DESCRIPTION
Picks up the `cat` plugin fix: https://github.com/kubernetes/test-infra/pull/10111
The new deployment process is nice. Now I want a command that makes this PR too 😛 
/assign @fejta 