### PR TITLE
 config/jobs/*/eks: disable S3 log uploads, add conformance tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -115,10 +115,11 @@
     "eksconfig",
     "ekstester",
     "etcdconfig/plugins",
+    "kubeadmconfig/plugins",
     "pkg/awsapi/ec2",
   ]
-  revision = "1cd3e8ae2b5c41662eb4008bbb3fb9736dc651c7"
-  version = "0.1.2"
+  revision = "7a149356ae339b531b6189f4a801378b62c7b98b"
+  version = "0.1.3"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -1270,6 +1271,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a6d1c21e9d72d50a0968342de074652f4e589e061d7d52e66c1d71cf7d6dc534"
+  inputs-digest = "4e42140600055c4abd3f81c94fe0a73c70bfd520954970ff07bbfb3545331f2a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -4,6 +4,10 @@ presets:
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
     value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.3/aws-k8s-tester-0.1.3-linux-amd64
+  # URL to download 'kubectl', required for 'kubectl' calls to EKS
+  # TODO: use upstream 'kubectl'
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
   # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
   - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
     value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
@@ -25,13 +29,21 @@ presets:
   # 'true' to open port 22 in security group, and enable SSH for log dumper
   - name: AWS_K8S_TESTER_EKS_ENABLE_NODE_SSH
     value: "true"
-    value: "true"
-  # 'true' to upload 'aws-k8s-tester' logs to S3 buckets
+  # 'true' to enable S3 Access Logs and AWS ALB Access Logs
+  # use it for debug, dump cluster log already handles log artifacts
+  - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
+    value: "false"
+  # 'true' to upload 'aws-k8s-tester' logs to S3 buckets, in addition to log dumper
+  # use it for debug, dump cluster log already handles log artifacts
   - name: AWS_K8S_TESTER_EKS_UPLOAD_TESTER_LOGS
-    value: "true"
-  # 'true' to upload worker node logs to S3
+    value: "false"
+  # 'true' to upload worker node logs to S3, in addition to log dumper
+  # use it for debug, dump cluster log already handles worker node logs
   - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
-    value: "true"
+    value: "false"
+  # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
+    value: ami-0f54a2f7d2e9c88b3
   # worker node EC2 instance type
   - name: AWS_K8S_TESTER_EKS_WORKER_NODE_INSTANCE_TYPE
     value: m3.xlarge
@@ -44,9 +56,6 @@ presets:
   # 'true' to enable debug level logs
   - name: AWS_K8S_TESTER_EKS_LOG_DEBUG
     value: "false"
-  # 'true' to open port 22 in security group, and enable SSH for log dumper
-  - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
-    value: "true"
   # 'true' to create AWS ALB
   - name: AWS_K8S_TESTER_EKS_ALB_ENABLE
     value: "false"
@@ -66,7 +75,7 @@ presets:
 
 periodics:
 # Run Kubernetes 1.10 branch e2e tests with EKS prod build 1.10
-- interval: 1h
+- interval: 2h
   name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"
@@ -89,8 +98,33 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
 
+# Run Kubernetes 1.10 branch e2e tests with EKS prod build 1.10
+# run conformance tests
+- interval: 2h
+  name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+  labels:
+    preset-service-account: "true"
+    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      args:
+      - --timeout=200
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-version-skew=false
+      - --deployment=eks
+      - --provider=eks
+      - --gce-ssh=
+      - --extract=ci/latest-1.10
+      - --ginkgo-parallel=30
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=180m
+
 # Run Kubernetes stable e2e tests with EKS prod build 1.10
-- interval: 1h
+- interval: 2h
   name: ci-kubernetes-e2e-stable-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"
@@ -114,7 +148,7 @@ periodics:
       - --timeout=180m
 
 # Run Kubernetes latest e2e tests with EKS prod build 1.10
-- interval: 1h
+- interval: 2h
   name: ci-kubernetes-e2e-latest-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"

--- a/kubetest/eks/eks.go
+++ b/kubetest/eks/eks.go
@@ -45,7 +45,6 @@ type deployer struct {
 	stopc            chan struct{}
 	cfg              *eksconfig.Config
 	awsK8sTesterPath string
-	kubectlPath      string
 	ctrl             *process.Control
 }
 
@@ -84,47 +83,21 @@ func NewDeployer(timeout time.Duration, verbose bool) (ekstester.Deployer, error
 
 	dp.awsK8sTesterPath, err = exec.LookPath("aws-k8s-tester")
 	if err != nil {
-		dp.awsK8sTesterPath = filepath.Join(os.TempDir(), "aws-k8s-tester")
 		var f *os.File
-		f, err = os.Create(dp.awsK8sTesterPath)
+		f, err = ioutil.TempFile(os.TempDir(), "aws-k8s-tester")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create %q (%v)", dp.awsK8sTesterPath, err)
 		}
-		defer f.Close()
+		dp.awsK8sTesterPath = f.Name()
+		dp.awsK8sTesterPath, _ = filepath.Abs(dp.awsK8sTesterPath)
 		if err = httpRead(cfg.AWSK8sTesterDownloadURL, f); err != nil {
 			return nil, err
 		}
+		f.Close()
 		if err = util.EnsureExecutable(dp.awsK8sTesterPath); err != nil {
 			return nil, err
 		}
 	}
-
-	dp.kubectlPath, err = exec.LookPath("kubectl")
-	if err != nil {
-		return nil, fmt.Errorf("cannot find 'kubectl' executable (%v)", err)
-	}
-
-	// TODO(gyuho): replace this kubernetes native Go client
-	_, err = exec.LookPath("aws-iam-authenticator")
-	if err != nil {
-		bin := filepath.Join(os.TempDir(), "aws-iam-authenticator")
-		var f *os.File
-		f, err = os.Create(bin)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create %q (%v)", bin, err)
-		}
-		defer f.Close()
-		if err = httpRead(cfg.AWSIAMAuthenticatorDownloadURL, f); err != nil {
-			return nil, err
-		}
-		if err = util.EnsureExecutable(bin); err != nil {
-			return nil, err
-		}
-		if err = os.Rename(bin, "/usr/local/bin/aws-iam-authenticator"); err != nil {
-			return nil, err
-		}
-	}
-
 	return dp, nil
 }
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2172,6 +2172,8 @@ test_groups:
 # EKS e2e results
 - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
+- name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
 - name: ci-kubernetes-e2e-stable-aws-eks-1-10-prod
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-stable-aws-eks-1-10-prod
 - name: ci-kubernetes-e2e-latest-aws-eks-1-10-prod
@@ -5709,6 +5711,9 @@ dashboards:
   - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
     test_group_name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
     description: Kubernetes 1.10 branch e2e tests with EKS prod build 1.10
+  - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    test_group_name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    description: Kubernetes 1.10 branch e2e tests with EKS prod build 1.10, Conformance tests
 - name: sig-aws-eks-ci-kubernetes-e2e-stable
   dashboard_tab:
   - name: ci-kubernetes-e2e-stable-aws-eks-1-10-prod

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -34,6 +34,7 @@ filegroup(
         "//vendor/github.com/aws/aws-k8s-tester/eksconfig:all-srcs",
         "//vendor/github.com/aws/aws-k8s-tester/ekstester:all-srcs",
         "//vendor/github.com/aws/aws-k8s-tester/etcdconfig/plugins:all-srcs",
+        "//vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins:all-srcs",
         "//vendor/github.com/aws/aws-k8s-tester/pkg/awsapi/ec2:all-srcs",
         "//vendor/github.com/aws/aws-sdk-go/aws:all-srcs",
         "//vendor/github.com/aws/aws-sdk-go/internal/shareddefaults:all-srcs",

--- a/vendor/github.com/aws/aws-k8s-tester/ec2config/plugins/doc.go
+++ b/vendor/github.com/aws/aws-k8s-tester/ec2config/plugins/doc.go
@@ -1,3 +1,0 @@
-// Package plugins defines various plugins to install on EC2 creation,
-// using init scripts or EC2 user data.
-package plugins

--- a/vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins/BUILD.bazel
+++ b/vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins/BUILD.bazel
@@ -3,13 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["plugins.go"],
-    importmap = "k8s.io/test-infra/vendor/github.com/aws/aws-k8s-tester/ec2config/plugins",
-    importpath = "github.com/aws/aws-k8s-tester/ec2config/plugins",
+    importmap = "k8s.io/test-infra/vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins",
+    importpath = "github.com/aws/aws-k8s-tester/kubeadmconfig/plugins",
     visibility = ["//visibility:public"],
-    deps = [
-        "//vendor/github.com/aws/aws-k8s-tester/etcdconfig/plugins:go_default_library",
-        "//vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins:go_default_library",
-    ],
 )
 
 filegroup(

--- a/vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins/plugins.go
+++ b/vendor/github.com/aws/aws-k8s-tester/kubeadmconfig/plugins/plugins.go
@@ -1,0 +1,107 @@
+// Package plugins implements kubeadm plugins.
+package plugins
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// CreateInstallStart creates kubeadm install init script.
+func CreateInstallStart(ver string) (string, error) {
+	tpl := template.Must(template.New("installStartKubeadmAmazonLinux2Template").Parse(installStartKubeadmAmazonLinux2Template))
+	buf := bytes.NewBuffer(nil)
+	kv := kubeadmInfo{Version: ver}
+	if err := tpl.Execute(buf, kv); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+type kubeadmInfo struct {
+	Version string
+}
+
+// https://kubernetes.io/docs/setup/independent/install-kubeadm/
+const installStartKubeadmAmazonLinux2Template = `
+
+################################## install kubeadm on Amazon Linux 2
+
+cat <<EOF > /tmp/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kube*
+EOF
+sudo cp /tmp/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+
+cat <<EOF > /tmp/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+EOF
+sudo cp /tmp/k8s.conf /etc/sysctl.d/k8s.conf
+sudo sysctl --system
+sudo sysctl net.bridge.bridge-nf-call-iptables=1
+
+# Set SELinux in permissive mode (effectively disabling it)
+setenforce 0
+sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+
+sudo yum install -y cri-tools ebtables kubernetes-cni socat iproute-tc
+
+RELEASE=v{{ .Version }}
+
+cd /usr/bin
+sudo rm -f /usr/bin/{kubeadm,kubelet,kubectl}
+
+sudo curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+sudo chmod +x {kubeadm,kubelet,kubectl}
+
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" > /tmp/kubelet.service
+cat /tmp/kubelet.service
+
+# curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" > /tmp/10-kubeadm.conf
+# sudo sed -i 's/cgroup-driver=cgroupfs/cgroup-driver=systemd/' /tmp/10-kubeadm.conf
+
+# delete cni binary
+# https://github.com/coreos/coreos-kubernetes/issues/874
+cat << EOT > /tmp/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
+Environment="KUBELET_NETWORK_ARGS="
+Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
+Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
+# Value should match Docker daemon settings.
+# Defaults are "cgroupfs" for Debian/Ubuntu/OpenSUSE and "systemd" for Fedora/CentOS/RHEL
+Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=systemd"
+Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
+Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true"
+ExecStart=
+ExecStart=/usr/bin/kubelet __KUBELET_KUBECONFIG_ARGS __KUBELET_SYSTEM_PODS_ARGS __KUBELET_NETWORK_ARGS __KUBELET_DNS_ARGS __KUBELET_AUTHZ_ARGS __KUBELET_CGROUP_ARGS __KUBELET_CADVISOR_ARGS __KUBELET_CERTIFICATE_ARGS __KUBELET_EXTRA_ARGS
+EOT
+cat /tmp/10-kubeadm.conf
+sed -i.bak 's|__KUBELET|\$KUBELET|g' /tmp/10-kubeadm.conf
+cat /tmp/10-kubeadm.conf
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+sudo cp /tmp/kubelet.service /etc/systemd/system/kubelet.service
+sudo cp /tmp/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+sudo systemctl daemon-reload
+sudo systemctl cat kubelet.service
+sudo systemctl enable kubelet && sudo systemctl restart kubelet
+sudo systemctl status kubelet --full --no-pager || true
+sudo journalctl --no-pager --output=cat -u kubelet
+
+kubeadm version
+kubelet --version
+kubectl version --client
+crictl --version
+
+##################################
+
+`


### PR DESCRIPTION
Now basic e2e tests are working (thanks SIG testing team!) We'd like to add another test to run conformance. And disable log S3 uploads, which was enabled for initial debugging purposes. Changing the test run period from 1h to 2h. And also using EKS vendored kubectl for now; it was getting token errors, which I am still debugging around.


ref. https://github.com/kubernetes/test-infra/issues/9814

/cc @BenTheElder @krzyzacy 