### PR TITLE
deck: don't show tabs for disabled sections.

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -30,9 +30,13 @@
     <span class="mdl-layout-title">Prow Dashboard</span>
     <nav class="mdl-navigation">
       <a class="mdl-navigation__link{{if eq .PageName "index"}} mdl-navigation__link--current{{end}}" href="/">Prow Status</a>
-      <a class="mdl-navigation__link{{if eq .PageName "pr"}} mdl-navigation__link--current{{end}}" href="/pr">PR Status</a>
+      {{ if sections.PR }}
+        <a class="mdl-navigation__link{{if eq .PageName "pr"}} mdl-navigation__link--current{{end}}" href="/pr">PR Status</a>
+      {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "command-help"}} mdl-navigation__link--current{{end}}" href="/command-help">Command Help</a>
-      <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
+      {{ if sections.Tide }}
+        <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
+      {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
     </nav>
   </div>


### PR DESCRIPTION
Don't show the PR dashboard or the Tide dashboard if they aren't actually going to work. An exception is made when running locally with predefined data, on the assumption you know what you're doing in that case.

This has to propagate the information through to everything that ever renders a page, and at this point enough information needs to be shoved through that I just passed the `options` around everywhere, which I don't really love, but ¯\\\_(ツ)\_/¯

Fixes #9996.

/kind bug