### PR TITLE
testgrid: add missing 1.12-1.13 upgrade test

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5815,6 +5815,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
   - name: kubeadm-gce-upgrade-1.11-1.12
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
+  - name: kubeadm-gce-upgrade-1.12-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-12-1-13
   - name: kubeadm-gce-upgrade-stable-master
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
 # packages tests


### PR DESCRIPTION
i did not notice this single test missing from the sig-cluster-lifecycle-all dashboard from this PR:
https://github.com/kubernetes/test-infra/pull/10033

/priority important-soon
/kind cleanup
/area testgrid
/assign @cjwagner @krzyzacy
cc @timothysc 
