### PR TITLE
prevent seg fault if Gerrit auth fails

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -162,6 +162,7 @@ func auth(c *Client, cookiefilePath string) {
 			self, _, err := handler.accountService.GetAccount("self")
 			if err != nil {
 				logrus.WithError(err).Error("Failed to auth with token")
+				continue
 			}
 
 			logrus.Infof("Authentication to %s successful, Username: %s", handler.instance, self.Name)


### PR DESCRIPTION
Dereferencing `self.Name` causes a seg fault when getting the account fails.
/assign @krzyzacy 