### PR TITLE
Fix typos

### DIFF
--- a/maintenance/aws-janitor/main.go
+++ b/maintenance/aws-janitor/main.go
@@ -560,7 +560,7 @@ func (routeTables) MarkAndSweep(sess *session.Session, acct string, region strin
 
 	for _, rt := range resp.RouteTables {
 		// Filter out the RouteTables that have a main
-		// association. Given the documention for the main.association
+		// association. Given the documentation for the main.association
 		// filter, you'd think we could filter on the Describe, but it
 		// doesn't actually work, see e.g.
 		// https://github.com/aws/aws-cli/issues/1810

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -390,7 +390,7 @@ func handleCached(next http.Handler) http.Handler {
 
 func setHeadersNoCaching(w http.ResponseWriter) {
 	// Note that we need to set both no-cache and no-store because only some
-	// broswers decided to (incorrectly) treat no-cache as "never store"
+	// browsers decided to (incorrectly) treat no-cache as "never store"
 	// IE "no-store". for good measure to cover older browsers we also set
 	// expires and pragma: https://stackoverflow.com/a/2068407
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")


### PR DESCRIPTION
Fix typos in files:

1. maintenance/aws-janitor/main.go
2. prow/cmd/deck/main.go