### PR TITLE
make base url configurable

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -42,6 +42,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "github_test.go",
         "kubernetes_cluster_clients_test.go",
         "kubernetes_test.go",
     ],

--- a/prow/flagutil/github_test.go
+++ b/prow/flagutil/github_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+)
+
+func TestGithubOptions_getBaseURL(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		endpoints   Strings
+		gitURL      string
+		tokenPath   string
+		expectedErr bool
+	}{
+		{
+			name:        "no token provided",
+			endpoints:   NewStrings("https://github.mycorp.com/apis/v3"),
+			gitURL:      "https://github.mycorp.com",
+			tokenPath:   "",
+			expectedErr: false,
+		},
+		{
+			name:        "good github options",
+			endpoints:   NewStrings("http://ghproxy", "https://api.github.com"),
+			gitURL:      "https://github.com",
+			tokenPath:   "token",
+			expectedErr: false,
+		},
+		{
+			name:        "invalid git url provided",
+			endpoints:   NewStrings("http://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitURL:      "://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid github endpoint provided",
+			endpoints:   NewStrings("://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitURL:      "http://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			o := GitHubOptions{
+				endpoint:  testCase.endpoints,
+				gitURL:    testCase.gitURL,
+				TokenPath: testCase.tokenPath,
+			}
+			err := o.Validate(false)
+			if testCase.expectedErr && err == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+		})
+	}
+}

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -48,7 +48,7 @@ func New() (*LocalGit, *git.Client, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	c, err := git.NewClient()
+	c, err := git.NewClient("github.com")
 	if err != nil {
 		os.RemoveAll(t)
 		return nil, nil, err


### PR DESCRIPTION
This changes add the possibility to pass the 'base-url' to the following
components: hook, tide and the cherrypicker external plugin.

Fixes #10068 

/assign @fejta @stevekuznetsov