### PR TITLE
Omit node_modules from verify-spelling.sh.

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -45,5 +45,6 @@ find -L . -type f -not \( \
     -path '*/vendor/*' \
     -o -path '*/static/*' \
     -o -path '*/third_party/*' \
+    -o -path '*/node_modules/*' \
     \) -prune \
   \) | xargs "${misspell}" -error


### PR DESCRIPTION
This isn't our code, we aren't responsible for its spelling.

No `node_modules` are created in CI because bazel doesn't use it, but for development it is helpful if your tooling can see the modules that would be installed, so skipping `node_modules` is helpful when running locally.

(The old implementation that only used files that were in git wouldn't have had this problem. Can we not use that under bazel?)