### PR TITLE
Gubernator: fix log duplication

### DIFF
--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -142,7 +142,7 @@ function ansi_to_html(orig) {
 			return '<span class="ansi-' + (code - 30) + '">' + body + '</span>'
 		else if (90 <= code && code <= 97) // foreground color, bright
 			return '<span class="ansi-' + (code - 90 + 8) + '">' + body + '</span>'
-		return orig;  // fallback: don't change anything
+		return body;  // fallback: don't change anything
 	}
 	// Find commands, optionally followed by a bold command, with some content, then a reset command.
 	// Unpaired commands are *not* handled here, but they're very uncommon.


### PR DESCRIPTION
Fixes a bug causing ANSI escape sequences to potentially result in multiple interleaved copies of a log being displayed (e.g. https://gubernator.k8s.io/build/kubernetes-jenkins/logs/post-test-infra-deploy-prow/1/?log#log)

/assign @BenTheElder 