### PR TITLE
Improve Slack merge warning messages (again)

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -494,7 +494,6 @@ type PushEvent struct {
 	Before  string   `json:"before"`
 	After   string   `json:"after"`
 	Compare string   `json:"compare"`
-	Size    int      `json:"size"`
 	Commits []Commit `json:"commits"`
 	// Pusher is the user that pushed the commit, valid in a webhook event.
 	Pusher User `json:"pusher"`

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -493,6 +493,9 @@ type PushEvent struct {
 	Ref     string   `json:"ref"`
 	Before  string   `json:"before"`
 	After   string   `json:"after"`
+	Created bool     `json:"created"`
+	Deleted bool     `json:"deleted"`
+	Forced  bool     `json:"forced"`
 	Compare string   `json:"compare"`
 	Commits []Commit `json:"commits"`
 	// Pusher is the user that pushed the commit, valid in a webhook event.

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -103,7 +103,7 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	if mw := getMergeWarning(pc.SlackConfig.MergeWarnings, pe.Repo.Owner.Login, pe.Repo.Name); mw != nil {
 		//If the MergeWarning whitelist has the merge user then no need to send a message.
 		if wl := !isWhiteListed(mw, pe); wl {
-			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, pe.Size, pe.Branch(), pe.Compare)
+			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, len(pe.Commits), pe.Branch(), pe.Compare)
 			for _, channel := range mw.Channels {
 				if err := pc.SlackClient.WriteMessage(message, channel); err != nil {
 					return err

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -103,7 +103,17 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	if mw := getMergeWarning(pc.SlackConfig.MergeWarnings, pe.Repo.Owner.Login, pe.Repo.Name); mw != nil {
 		//If the MergeWarning whitelist has the merge user then no need to send a message.
 		if wl := !isWhiteListed(mw, pe); wl {
-			message := fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, len(pe.Commits), pe.Branch(), pe.Compare)
+			var message string
+			switch {
+			case pe.Created:
+				message = fmt.Sprintf("*Warning:* %s (<@%s>) pushed a new branch (%s): %s", pe.Sender.Login, pe.Sender.Login, pe.Branch(), pe.Compare)
+			case pe.Deleted:
+				message = fmt.Sprintf("*Warning:* %s (<@%s>) deleted a branch (%s): %s", pe.Sender.Login, pe.Sender.Login, pe.Branch(), pe.Compare)
+			case pe.Forced:
+				message = fmt.Sprintf("*Warning:* %s (<@%s>) *force* merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, len(pe.Commits), pe.Branch(), pe.Compare)
+			default:
+				message = fmt.Sprintf("*Warning:* %s (<@%s>) manually merged %d commit(s) into %s: %s", pe.Sender.Login, pe.Sender.Login, len(pe.Commits), pe.Branch(), pe.Compare)
+			}
 			for _, channel := range mw.Channels {
 				if err := pc.SlackClient.WriteMessage(message, channel); err != nil {
 					return err

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -41,6 +41,9 @@ func TestPush(t *testing.T) {
   "ref": "refs/heads/master",
   "before": "d73a75b4b1ddb63870954b9a60a63acaa4cb1ca5",
   "after": "045a6dca07840efaf3311450b615e19b5c75f787",
+  "created": false,
+  "deleted": false,
+  "forced": false,
   "compare": "https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784",
   "commits": [
     {
@@ -90,10 +93,35 @@ func TestPush(t *testing.T) {
 	pushEvManualNotBranchWhiteListed := pushEvManualBranchWhiteListed
 	pushEvManualNotBranchWhiteListed.Ref = "refs/head/master"
 
+	pushEvManualCreated := pushEvManual
+	pushEvManualCreated.Created = true
+	pushEvManualCreated.Ref = "refs/head/release-1.99"
+	pushEvManualCreated.Compare = "https://github.com/kubernetes/kubernetes/compare/045a6dca0784"
+
+	pushEvManualDeleted := pushEvManual
+	pushEvManualDeleted.Deleted = true
+	pushEvManualDeleted.Ref = "refs/head/release-1.99"
+	pushEvManualDeleted.Compare = "https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"
+
+	pushEvManualForced := pushEvManual
+	pushEvManualForced.Forced = true
+
 	noMessages := map[string][]string{}
 	stdWarningMessages := map[string][]string{
 		"sig-contribex":  {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
 		"kubernetes-dev": {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
+
+	createdWarningMessages := map[string][]string{
+		"sig-contribex":  {"*Warning:* tester (<@tester>) pushed a new branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/045a6dca0784"},
+		"kubernetes-dev": {"*Warning:* tester (<@tester>) pushed a new branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/045a6dca0784"}}
+
+	deletedWarningMessages := map[string][]string{
+		"sig-contribex":  {"*Warning:* tester (<@tester>) deleted a branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"},
+		"kubernetes-dev": {"*Warning:* tester (<@tester>) deleted a branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"}}
+
+	forcedWarningMessages := map[string][]string{
+		"sig-contribex":  {"*Warning:* tester (<@tester>) *force* merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
+		"kubernetes-dev": {"*Warning:* tester (<@tester>) *force* merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
 
 	type testCase struct {
 		name             string
@@ -103,9 +131,14 @@ func TestPush(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:             "If PR merged manually by a user we send message to sig-contribex and kubernetes-dev.",
+			name:             "If PR merged manually by a user, we send message to sig-contribex and kubernetes-dev.",
 			pushReq:          pushEvManual,
 			expectedMessages: stdWarningMessages,
+		},
+		{
+			name:             "If PR force merged by a user, we send message to sig-contribex and kubernetes-dev with force merge message.",
+			pushReq:          pushEvManualForced,
+			expectedMessages: forcedWarningMessages,
 		},
 		{
 			name:             "If PR merged by k8s merge bot we should NOT send message to sig-contribex and kubernetes-dev.",
@@ -121,6 +154,16 @@ func TestPush(t *testing.T) {
 			name:             "If PR merged by a user not in the whitelist, in a branch whitelist, but not THIS branch whitelist, we should send a message to sig-contrib-ax and kubernetes-dev.",
 			pushReq:          pushEvManualBranchWhiteListed,
 			expectedMessages: noMessages,
+		},
+		{
+			name:             "If a branch is created by a non-whitelisted user, we send message to sig-contribex and kubernetes-dev with branch created message.",
+			pushReq:          pushEvManualCreated,
+			expectedMessages: createdWarningMessages,
+		},
+		{
+			name:             "If a branch is deleted by a non-whitelisted user, we send message to sig-contribex and kubernetes-dev with branch deleted message.",
+			pushReq:          pushEvManualDeleted,
+			expectedMessages: deletedWarningMessages,
 		},
 	}
 

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -41,7 +41,6 @@ func TestPush(t *testing.T) {
   "ref": "refs/heads/master",
   "before": "d73a75b4b1ddb63870954b9a60a63acaa4cb1ca5",
   "after": "045a6dca07840efaf3311450b615e19b5c75f787",
-  "size": 2,
   "compare": "https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784",
   "commits": [
     {


### PR DESCRIPTION
A couple fixes:
- GitHub's [documentation](https://developer.github.com/v3/activity/events/types/#pushevent) on their Events API vs webhook payloads is unclear. Apparently they only support `size` as a field if you poll the API, but not in the webhook event. Use the length of `Commits` to get around this.
- Add support for the `created`, `deleted`, and `forced` fields in the webhook payload. Tested this, and they seem to come through.