### PR TITLE
Specify required status checks for Dashboard repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -106,6 +106,9 @@ branch-protection:
             teams:
             - stage-bots
         dashboard:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
         dns:
@@ -455,6 +458,12 @@ tide:
   context_options:
     optional-contexts:
     - "Submit Queue"
+    orgs:
+     kubernetes:
+      repos:
+        dashboard:
+          skip-unknown-contexts: true
+          from-branch-protection: true
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
In the current setup Tide requires all status checks green to merge pull requests in Dashboard repo. It should not happen as we are using Codecov to indicate code coverage and its diff, but the tool is not always 100% precise and sometimes we would like to merge anyway. I suppose this change should fix this and allow Tide to merge when Travis job will be successful no matter what Codecov will report. Am I right?

Done according to:
https://github.com/kubernetes/test-infra/blob/b5f298b6851f4db24587301840e7b7630747d315/prow/cmd/branchprotector/README.md

/cc @floreks @nikhita 