### PR TITLE
Add cloud-provider-aws prow and testgrid config

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-aws/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- mcrute

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -1,0 +1,38 @@
+presubmits:
+  kubernetes/cloud-provider-aws:
+  - name: pull-cloud-provider-aws-check
+    always_run: true
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - --scenario=execute
+        - --
+        - make
+        - check
+
+  - name: pull-cloud-provider-aws-test
+    always_run: true
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - --scenario=execute
+        - --
+        - make
+        - test
+

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -38,6 +38,7 @@ owners:
 
 approve:
 - repos:
+  - kubernetes/cloud-provider-aws
   - kubernetes/cloud-provider-azure
   - kubernetes/cluster-registry
   - kubernetes/contrib
@@ -246,6 +247,11 @@ require_matching_label:
   repo: kubernetes
   prs: true
   regexp: ^priority/
+- missing_label: needs-kind
+  org: kubernetes
+  repo: cloud-provider-aws
+  prs: true
+  regexp: ^kind/
 
 
 plugins:
@@ -320,6 +326,12 @@ plugins:
   - yuks
 
   kubernetes/cloud-provider-aws:
+  - milestone
+  - milestonestatus
+  - owners-label
+  - release-note
+  - require-matching-label
+  - welcome
   - trigger
 
   kubernetes/cloud-provider-azure:

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -335,6 +335,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubeflow/testing",
 		"kubeflow/tf-operator",
 		"kubeflow/website",
+		"kubernetes/cloud-provider-aws",
 		"kubernetes/cloud-provider-vsphere",
 		"kubernetes/cluster-registry",
 		"kubernetes/federation",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3302,6 +3302,12 @@ test_groups:
 - name: pull-aws-alb-ingress-controller-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-alb-ingress-controller-test
   num_columns_recent: 30
+- name: pull-cloud-provider-aws-check
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-aws-check
+  num_columns_recent: 30
+- name: pull-cloud-provider-aws-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-aws-test
+  num_columns_recent: 30
 - name: pull-aws-ebs-disk-csi-driver-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-ebs-disk-csi-driver-verify
   num_columns_recent: 30
@@ -5680,6 +5686,15 @@ dashboards:
     test_group_name: pull-aws-alb-ingress-controller-test
     description: "aws alb ingress controller tests"
 
+- name: sig-aws-cloud-provider-aws
+  dashboard_tab:
+  - name: check
+    test_group_name: pull-cloud-provider-aws-check
+    description: "aws cloud provider checks"
+  - name: test
+    test_group_name: pull-cloud-provider-aws-test
+    description: "aws cloud provider tests"
+
 - name: sig-aws-ebs-csi-driver
   dashboard_tab:
   - name: verify
@@ -7469,6 +7484,7 @@ dashboard_groups:
 - name: sig-aws
   dashboard_names:
   - sig-aws-alb-ingress-controller
+  - sig-aws-cloud-provider-aws
   - sig-aws-ebs-csi-driver
   - sig-aws-eks-ci-kubernetes-e2e-1-10
   - sig-aws-eks-ci-kubernetes-e2e-stable


### PR DESCRIPTION
This change adds test and check presubmit hooks for cloud-provider-aws and adds the results of those tests to testgrid.

/cc @gyuho @d-nishi 
/assign @krzyzacy 
/milestone v1.13
/kind feature
/sig aws
/sig cloud-provider