### PR TITLE
Enable CSIDriverRegistry feature tests.

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -233,7 +233,7 @@ periodics:
       - --gcp-zone=us-central1-f
       - --provider=gce
       - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|gcePD-external --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished|NodeLease|CSIDriverRegistry)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|gcePD-external --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
 


### PR DESCRIPTION
CSIDriverRegistry is alpha feature in 1.12 and 1.13 and sig-storage wants it tested regularly.

