### PR TITLE
Update merge requirements for 1.13 code freeze.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -399,6 +399,8 @@ tide:
     - lgtm
     - approved
     - "cncf-cla: yes"
+    - priority/critical-urgent
+    - kind/bug
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -407,10 +409,30 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
-    - needs-kind
     - needs-rebase
     - needs-sig
-    - needs-priority
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.13
+    includedBranches:
+    - master
+    - release-1.13
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    - priority/critical-urgent
+    - kind/failing-test
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - needs-sig
   - repos:
     - kubernetes/kubernetes
     excludedBranches:


### PR DESCRIPTION
This differs a bit from what is described in the [role handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/test-infra#code-freeze) and what we did last release because we were not enforcing the requirement that the kind label be either `kind/bug` or `kind/failing-test` (described [here](https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#tldr)).

If it isn't important to specifically require the `kind/bug` or `kind/failing-test` label  we could save some API tokens by just requiring a `kind/*` label, but I don't think this will be a problem.

/cc @AishSundar @amwat @imkin @RahulMahale 
/sig release

Hold until 5pm on Friday (tomorrow).
/hold