### PR TITLE
Fix the rerun copy button

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -603,17 +603,17 @@ function createLinkCell(text: string, url: string, title: string): HTMLTableData
 }
 
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
-    const url = "https://" + window.location.hostname + "/rerun?prowjob="
-        + prowjob;
+    const url = `https://${window.location.hostname}/rerun?prowjob=${prowjob}`;
     const c = document.createElement("td");
     const icon = createIcon("refresh", "Show instructions for rerunning this job");
-    icon.onclick = function () {
+    icon.onclick = () => {
         modal.style.display = "block";
-        rerunElement.innerHTML = "kubectl create -f \"<a href='" + url + "'>"
-        + url + "</a>\" " 
-        + "<a class='mdl-button mdl-js-button mdl-button--icon' onclick=\""+
-        "copyToClipboardWithToast('kubectl create -f " + url + "')\">"
-        + "<i class='material-icons state triggered' style='color: gray'>file_copy</i></a>";
+        rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
+        const copyButton = document.createElement('a');
+        copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
+        copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}`);
+        copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
+        rerunElement.appendChild(copyButton);
     };
     c.appendChild(icon);
     c.classList.add("icon-cell");


### PR DESCRIPTION
I broke this during the typescript migration: it referenced a function by name, which would later be looked up in the global namespace, but we no longer put anything in the global namespace where we can avoid it.

Fixed it, and cleaned up `createRerunCell` a bit in the process.

Fixes #10157.

/kind bug
/cc @BenTheElder @amwat 