### PR TITLE
List repos when org protection is configured

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -325,6 +325,39 @@ branch-protection:
 			},
 		},
 		{
+			name:     "protect all repos when protection configured at org level",
+			branches: []string{"kubernetes/test-infra=master", "kubernetes/publishing-bot=master"},
+			config: `
+branch-protection:
+  orgs:
+    kubernetes:
+      protect: true
+      repos:
+        test-infra:
+          required_status_checks:
+            contexts:
+            - hello-world
+`,
+			expected: []requirements{
+				{
+					Org:    "kubernetes",
+					Repo:   "test-infra",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						RequiredStatusChecks: &github.RequiredStatusChecks{
+							Contexts: []string{"hello-world"},
+						},
+					},
+				},
+				{
+					Org:     "kubernetes",
+					Repo:    "publishing-bot",
+					Branch:  "master",
+					Request: &github.BranchProtectionRequest{},
+				},
+			},
+		},
+		{
 			name:     "require a defined branch to make a protection decision",
 			branches: []string{"org/repo=branch"},
 			config: `


### PR DESCRIPTION
* Add unit test to cover this scenario
* List repos whenever applied `org.Protect != nil`
* Separate out `GetPolicy()` from `GetBranchProtection()` so it can be reused by the branch protector


ref https://github.com/kubernetes/test-infra/issues/10114
/assign @sebastienvas @nikhita @cblecker @cjwagner 