### PR TITLE
Remove --ginkgo-parallel for NodeLease e2e tests

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -82,7 +82,6 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=cos_containerd
       - --gcp-zone=us-central1-f
-      - --ginkgo-parallel
       - --gke-create-command=container clusters create --quiet --enable-kubernetes-alpha
       - --gke-environment=test
       - --provider=gke
@@ -248,7 +247,6 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-f
-      - --ginkgo-parallel
       - --gke-create-command=container clusters create --quiet --enable-kubernetes-alpha
       - --gke-environment=test
       - --provider=gke


### PR DESCRIPTION
One of the NodeLease e2e test is disruptive (resizing number of nodes). So the tests cannot run in parallel.

This is part of [KEP-0009](https://github.com/kubernetes/community/blob/master/keps/sig-node/0009-node-heartbeat.md), feature [#589](https://github.com/kubernetes/features/issues/589) and issue [#14733](https://github.com/kubernetes/kubernetes/issues/14733).