### PR TITLE
Create prow/autobump.sh and run every day

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,6 +99,7 @@ filegroup(
         "//prow:all-srcs",
         "//robots/commenter:all-srcs",
         "//robots/issue-creator:all-srcs",
+        "//robots/pr-creator:all-srcs",
         "//robots/pr-labeler:all-srcs",
         "//scenarios:all-srcs",
         "//testgrid:all-srcs",

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -53,9 +53,7 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-bazel:v20181107-d88dbbf
         command:
-        - prow/bump.sh
-        args:
-        - --push
+        - prow/push.sh
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /creds/service-account.json

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -93,3 +93,26 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
+- interval: 24h
+  name: ci-test-infra-autobump-prow
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/gcloud-bazel:v20181107-d88dbbf
+      command:
+      - prow/autobump.sh
+      args:
+      - k8s-ci-robot
+      - /etc/github-token/oauth
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token

--- a/prow/autobump.sh
+++ b/prow/autobump.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# bump.sh will
+# * ensure there are no pending changes
+# * optionally activate GOOGLE_APPLICATION_CREDENTIALS and configure-docker if set
+# * run //prow:release-push to build and push prow images
+# * update all the cluster/*.yaml files to use the new image tags
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(fejta): rewrite this in a better language REAL SOON
+
+# See https://misc.flogisoft.com/bash/tip_colors_and_formatting
+
+color-version() { # Bold blue
+  echo -e "\x1B[1;34m${@}\x1B[0m"
+}
+
+cd "$(dirname "${BASH_SOURCE}")"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $(basename "$0") <github-login> </path/to/github/token> [default-name] [default-email]" >&2
+    exit 1
+fi
+user=$1
+token=$2
+shift
+shift
+ensure-config() {
+  git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+  if [[ $# -lt 2 ]]; then
+      echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+      return 1
+  fi
+  echo "git config user.name=$1 user.email=$2..." >&2
+  git config user.name "$1"
+  git config user.email "$2"
+}
+ensure-config "$@"
+
+echo "Bumping prow to latest..." >&2
+./bump.sh --latest
+
+# Convert image: gcr.io/k8s-prow/plank:v20181122-abcd to v20181122-abcd
+extract-version() {
+  local v=$(grep plank:v "$@")
+  echo ${v##*plank:}
+}
+
+# Convert v20181111-abcd to abcd
+extract-commit() {
+  local c=$1
+  echo ${c##*-}
+}
+
+old_version=$(git show HEAD:prow/cluster/plank_deployment.yaml | extract-version)
+version=$(cat cluster/plank_deployment.yaml | extract-version)
+comparison=$(extract-commit "$old_version")...$(extract-commit "$version")
+echo -e "Pushing $(color-version $version) to ${user}:autobump..." >&2
+
+title="Bump prow from $old_version to $version"
+git add -A
+git commit -m "$title"
+git push -f "git@github.com:${user}/test-infra.git" HEAD:autobump
+
+echo "Creating PR to merge ${user}:autobump into master..." >&2
+bazel run //robots/pr-creator -- \
+    --github-token-path="$token" \
+    --org=kubernetes --repo=test-infra --branch=master \
+    --title="$title" --match-title="Bump prow to" \
+    --body="Included changes: https://github.com/kubernetes/test-infra/compare/$comparison" \
+    --source="${user}":autobump \
+    --confirm

--- a/prow/push.sh
+++ b/prow/push.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# bump.sh will
+# * ensure there are no pending changes
+# * optionally activate GOOGLE_APPLICATION_CREDENTIALS and configure-docker if set
+# * run //prow:release-push to build and push prow images
+# * update all the cluster/*.yaml files to use the new image tags
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(fejta): rewrite this in a better language REAL SOON
+
+# See https://misc.flogisoft.com/bash/tip_colors_and_formatting
+
+color-version() { # Bold blue
+  echo -e "\x1B[1;34m${@}\x1B[0m"
+}
+
+color-error() { # Light red
+  echo -e "\x1B[91m${@}\x1B[0m"
+}
+
+color-target() { # Bold cyan
+  echo -e "\x1B[1;33m${@}\x1B[0m"
+}
+
+# darwin is great
+SED=sed
+if which gsed &>/dev/null; then
+  SED=gsed
+fi
+if ! ($SED --version 2>&1 | grep -q GNU); then
+  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
+  exit 1
+fi
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
+  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+  gcloud auth configure-docker
+fi
+
+# Build and push the current commit, failing on any uncommitted changes.
+new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
+echo -e "version: $(color-version ${new_version})" >&2
+if [[ "${new_version}" == *-dirty ]]; then
+  echo -e "$(color-error ERROR): uncommitted changes to repo" >&2
+  echo "  Fix with git commit" >&2
+  exit 1
+fi
+echo -e "Pushing $(color-version ${new_version}) via $(color-target //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64) ..." >&2
+bazel run //prow:release-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64

--- a/robots/pr-creator/BUILD.bazel
+++ b/robots/pr-creator/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/robots/pr-creator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "pr-creator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
+
+	"github.com/sirupsen/logrus"
+)
+
+type options struct {
+	github flagutil.GitHubOptions
+
+	branch  string
+	confirm bool
+	local   bool
+	org     string
+	repo    string
+	source  string
+
+	title      string
+	matchTitle string
+	body       string
+}
+
+func (o options) validate() error {
+	switch {
+	case o.org == "":
+		return errors.New("--org must be set")
+	case o.repo == "":
+		return errors.New("--repo must be set")
+	case o.branch == "":
+		return errors.New("--branch must be set")
+	case o.source == "":
+		return errors.New("--source must be set")
+	case !o.local && !strings.Contains(o.source, ":"):
+		return fmt.Errorf("--source=%s requires --local", o.source)
+	}
+	if err := o.github.Validate(!o.confirm); err != nil {
+		return err
+	}
+	return nil
+}
+
+func optionsFromFlags() options {
+	var o options
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	o.github.AddFlags(fs)
+	fs.StringVar(&o.repo, "repo", "", "Github repo")
+	fs.StringVar(&o.org, "org", "", "Github org")
+	fs.StringVar(&o.branch, "branch", "", "Repo branch to merge into")
+	fs.StringVar(&o.source, "source", "", "The user:branch to merge from")
+
+	fs.BoolVar(&o.confirm, "confirm", false, "Set to mutate github instead of a dry run")
+	fs.BoolVar(&o.local, "local", false, "Allow source to be local-branch instead of remote-user:branch")
+	fs.StringVar(&o.title, "title", "", "Title of PR")
+	fs.StringVar(&o.matchTitle, "match-title", "", "Reuse any self-authored, open PR matching title")
+	fs.StringVar(&o.body, "body", "", "Body of PR")
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	o := optionsFromFlags()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("bad flags")
+	}
+
+	var jamesBond config.SecretAgent
+	if err := jamesBond.Start([]string{o.github.TokenPath}); err != nil {
+		logrus.WithError(err).Fatal("Failed to start secrets agent")
+	}
+
+	gc, err := o.github.GitHubClient(&jamesBond, !o.confirm)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create github client")
+	}
+
+	n, err := updatePR(o, gc)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to update %d", n)
+	}
+	if n == nil {
+		allowMods := true
+		pr, err := gc.CreatePullRequest(o.org, o.repo, o.title, o.body, o.source, o.branch, allowMods)
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to create PR")
+		}
+		n = &pr
+	}
+
+	logrus.Infof("PR %s/%s#%d will merge %s into %s: %s", o.org, o.repo, *n, o.source, o.branch, o.title)
+
+	fmt.Println(*n)
+}
+
+type updateClient interface {
+	UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error
+	BotName() (string, error)
+	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+}
+
+func updatePR(o options, gc updateClient) (*int, error) {
+	if o.matchTitle == "" {
+		return nil, nil
+	}
+
+	logrus.Info("Looking for a PR to reuse...")
+	me, err := gc.BotName()
+	if err != nil {
+		return nil, fmt.Errorf("bot name: %v", err)
+	}
+
+	issues, err := gc.FindIssues("is:open is:pr archived:false in:title author:"+me+" "+o.matchTitle, "updated", true)
+	if err != nil {
+		return nil, fmt.Errorf("find issues: %v", err)
+	} else if len(issues) == 0 {
+		logrus.Info("No reusable issues found")
+		return nil, nil
+	}
+	n := issues[0].Number
+	logrus.Infof("Found %d", n)
+	var ignoreOpen *bool
+	var ignoreBranch *string
+	var ignoreModify *bool
+	if err := gc.UpdatePullRequest(o.org, o.repo, n, &o.title, &o.body, ignoreOpen, ignoreBranch, ignoreModify); err != nil {
+		return nil, fmt.Errorf("update %d: %v", n, err)
+	}
+
+	return &n, nil
+}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2625,6 +2625,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-deploy-prow
 - name: post-test-infra-push-prow
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-prow
+- name: ci-test-infra-autobump-prow
+  gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-autobump-prow
 - name: pull-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel
   num_columns_recent: 20
@@ -6686,12 +6688,17 @@ dashboards:
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: push-prow
-    description: builds and pushes all prow on each commit by running bump.sh
+    description: builds and pushes all prow on each commit by running prow/push.sh
     test_group_name: post-test-infra-push-prow
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: autobump-prow
+    description: runs prow/autobump.sh to create/update a PR that bumps prow to the latest RC
+    test_group_name: ci-test-infra-autobump-prow
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: deploy-prow
-    description: deploys the configured version of prow by running deploy.sh
+    description: deploys the configured version of prow by running prow/deploy.sh
     test_group_name: post-test-infra-deploy-prow
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>


### PR DESCRIPTION
/assign @BenTheElder @stevekuznetsov @ixdy @cjwagner 

* Move `push.sh` logic from `bump.sh` into its own file
  - Update `post-test-infra-push-prow` to use it
  - Make these work on mac
* Create `robots/pr-creator` to create/update a PR
  - `--match-title` will cause it to try and update an existing, open PR
* Create `prow/autobump.sh` to use `bump.sh --latest` and `pr-creator`
  - Always pushes to the user's `autobump` branch
  - Includes a link to the changes in the PR description