### PR TITLE
kubeadm: Trigger kubeadm PR test when kubelet setup or bootstrapping changes

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1575,7 +1575,7 @@ presubmits:
       max_concurrency: 8
       name: pull-security-kubernetes-e2e-kubeadm-gce
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-      run_if_changed: ^(cmd/kubeadm|build/debs).*$
+      run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
       skip_branches:
       - release-1.13
       - release-1.10
@@ -1676,7 +1676,7 @@ presubmits:
       max_concurrency: 8
       name: pull-security-kubernetes-e2e-kubeadm-gce
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-      run_if_changed: ^(cmd/kubeadm|build/debs).*$
+      run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
       skip_report: true
       spec:
         containers:
@@ -1771,7 +1771,7 @@ presubmits:
       max_concurrency: 8
       name: pull-security-kubernetes-e2e-kubeadm-gce
       rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-      run_if_changed: ^(cmd/kubeadm|build/debs).*$
+      run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
       skip_report: true
       spec:
         containers:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -33,7 +33,7 @@ presubmits:
     - name: pull-kubernetes-e2e-kubeadm-gce
       max_concurrency: 8
       skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
       skip_branches:
       - release-1.13 # per-release job
       - release-1.10 # different bazel version
@@ -94,7 +94,7 @@ presubmits:
     - name: pull-kubernetes-e2e-kubeadm-gce
       max_concurrency: 8
       skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
       branches:
       - release-1.13
       labels:
@@ -154,7 +154,7 @@ presubmits:
     - name: pull-kubernetes-e2e-kubeadm-gce
       max_concurrency: 8
       skip_report: true
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
       branches:
       - release-1.10
       labels:


### PR DESCRIPTION
kubeadm depends on kubelet bootstrapping and is one of the few test suites
inside k8s that exercises the bootstrap flow. Add the primary locations
for bootstrap code to the trigger for pull-kubernetes-e2e-kubeadm-gce.

would have caught kubernetes/kubernetes#71173