### PR TITLE
Allow concurrent cron job execution

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -169,6 +169,8 @@ type Periodic struct {
 	Tags []string `json:"tags,omitempty"`
 	// Run these jobs after successfully running this one.
 	RunAfterSuccess []Periodic `json:"run_after_success,omitempty"`
+	// Maximum number concurrent executions of this jobs, unset is 1, 0 is infinite.
+	MaxConcurrency *int `json:"max_concurrency,omitempty"`
 
 	interval time.Duration
 }

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -119,6 +119,12 @@ func PeriodicSpec(p config.Periodic) kube.ProwJobSpec {
 	pjs := specFromJobBase(p.JobBase)
 	pjs.Type = kube.PeriodicJob
 
+	if p.MaxConcurrency == nil {
+		pjs.MaxConcurrency = 1
+	} else {
+		pjs.MaxConcurrency = *p.MaxConcurrency
+	}
+
 	for _, nextP := range p.RunAfterSuccess {
 		pjs.RunAfterSuccess = append(pjs.RunAfterSuccess, PeriodicSpec(nextP))
 	}

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -219,6 +219,23 @@ func GetLatestProwJobs(pjs []kube.ProwJob, jobType kube.ProwJobType) map[string]
 	return latestJobs
 }
 
+func GetTriggeredAndPendingProwJobs(pjs []kube.ProwJob, jobType kube.ProwJobType) map[string][]kube.ProwJob {
+	runningJobs := make(map[string][]kube.ProwJob)
+	for _, j := range pjs {
+		if j.Spec.Type != jobType {
+			continue
+		}
+		switch j.Status.State {
+		case kube.TriggeredState, kube.PendingState:
+		default:
+			continue
+		}
+		name := j.Spec.Job
+		runningJobs[name] = append(runningJobs[name], j)
+	}
+	return runningJobs
+}
+
 // ProwJobFields extracts logrus fields from a prowjob useful for logging.
 func ProwJobFields(pj *kube.ProwJob) logrus.Fields {
 	fields := make(logrus.Fields)


### PR DESCRIPTION
Allows for cron style periodic jobs to run concurrently.  They will obey MaxConcurrency (0 default is unlimited) and plank will also enforce the MaxConcurrency before starting the triggered job.