### PR TITLE
enable Gerrit adapter to trigger postsubmit jobs

### DIFF
--- a/prow/cmd/gerrit/README.md
+++ b/prow/cmd/gerrit/README.md
@@ -1,8 +1,8 @@
 # Gerrit
 
 Gerrit is a Prow-gerrit adapter for handling CI on gerrit workflows. It can poll gerrit
-changes from multiple gerrit instances, and trigger presubmits on Prow upon new patchsets on
-gerrit changes.
+changes from multiple gerrit instances, and trigger presubmits on Prow upon new patchsets
+on Gerrit changes, and postsubmits when Gerrit changes are merged.
 
 ## Deployment Usage
 

--- a/prow/cmd/gerrit/README.md
+++ b/prow/cmd/gerrit/README.md
@@ -29,4 +29,4 @@ it empty for anonymous access to gerrit API.
 
 Also take a look at [gerrit related packages](/prow/gerrit/README.md) for implementation details.
 
-you might also want to deploy [Crier](/prow/cmd/crier) which handles report presubmit jobs back to gerrit.
+You might also want to deploy [Crier](/prow/cmd/crier) which reports job results back to gerrit.

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -204,7 +204,8 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 
 	triggeredJobs := []string{}
 
-	if change.Status == client.Merged {
+	switch change.Status {
+	case client.Merged:
 		postsubmits := c.ca.Config().Postsubmits[cloneURI.String()]
 		postsubmits = append(postsubmits, c.ca.Config().Postsubmits[cloneURI.Host+"/"+cloneURI.Path]...)
 		for _, spec := range postsubmits {
@@ -243,7 +244,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 				triggeredJobs = append(triggeredJobs, spec.Name)
 			}
 		}
-	} else {
+	case client.New:
 		presubmits := c.ca.Config().Presubmits[cloneURI.String()]
 		presubmits = append(presubmits, c.ca.Config().Presubmits[cloneURI.Host+"/"+cloneURI.Path]...)
 		for _, spec := range presubmits {

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -128,6 +128,7 @@ func TestProcessChange(t *testing.T) {
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
+				Status:          "NEW",
 			},
 			shouldError: true,
 		},
@@ -136,6 +137,7 @@ func TestProcessChange(t *testing.T) {
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "woof",
+				Status:          "NEW",
 				Revisions: map[string]client.RevisionInfo{
 					"1": {},
 				},
@@ -146,6 +148,7 @@ func TestProcessChange(t *testing.T) {
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
+				Status:          "NEW",
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Ref: "refs/changes/00/1/1",
@@ -160,6 +163,7 @@ func TestProcessChange(t *testing.T) {
 			change: client.ChangeInfo{
 				CurrentRevision: "2",
 				Project:         "test-infra",
+				Status:          "NEW",
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Ref: "refs/changes/00/2/1",
@@ -177,6 +181,7 @@ func TestProcessChange(t *testing.T) {
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "other-repo",
+				Status:          "NEW",
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Ref: "refs/changes/00/1/1",
@@ -185,6 +190,34 @@ func TestProcessChange(t *testing.T) {
 			},
 			numPJ: 1,
 			pjRef: "refs/changes/00/1/1",
+		},
+		{
+			name: "merged change should trigger postsubmit",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "postsubmits-project",
+				Status:          "MERGED",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Ref: "refs/changes/00/1/1",
+					},
+				},
+			},
+			numPJ: 1,
+			pjRef: "refs/changes/00/1/1",
+		},
+		{
+			name: "merged change on project without postsubmits",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Status:          "MERGED",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Ref: "refs/changes/00/1/1",
+					},
+				},
+			},
 		},
 	}
 
@@ -204,6 +237,15 @@ func TestProcessChange(t *testing.T) {
 							{
 								JobBase: config.JobBase{
 									Name: "other-test",
+								},
+							},
+						},
+					},
+					Postsubmits: map[string][]config.Postsubmit{
+						"gerrit/postsubmits-project": {
+							{
+								JobBase: config.JobBase{
+									Name: "test-bar",
 								},
 							},
 						},

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -52,6 +52,9 @@ const (
 	DeprecatedGerritInstance = "gerrit-instance"
 	// DeprecatedGerritRevision is the deprecated version of GerritRevision
 	DeprecatedGerritRevision = "gerrit-revision"
+
+	// Merged status indicates a Gerrit change has been merged
+	Merged = "MERGED"
 )
 
 // ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client
@@ -255,7 +258,7 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 	pending := []gerrit.ChangeInfo{}
 
 	opt := &gerrit.QueryChangeOptions{}
-	opt.Query = append(opt.Query, "project:"+project+"+status:open")
+	opt.Query = append(opt.Query, "project:"+project)
 	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT"}
 
 	start := 0
@@ -290,11 +293,25 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 				continue
 			}
 
-			logrus.Infof("Change %d, last updated %s", change.Number, change.Updated)
+			logrus.Infof("Change %d, last updated %s, status %s", change.Number, change.Updated, change.Status)
 
 			// process if updated later than last updated
 			// stop if update was stale
 			if !updated.Before(lastUpdate) {
+				if change.Status == Merged {
+					submitted, err := time.Parse(layout, change.Submitted)
+					if err != nil {
+						logrus.WithError(err).Errorf("Parse time %v failed", change.Submitted)
+						continue
+					}
+					if submitted.Before(lastUpdate) {
+						logrus.Infof("Change %d, submitted %s before lastUpdate %s, skipping this patchset", change.Number, submitted, lastUpdate)
+						continue
+					}
+					pending = append(pending, change)
+					continue
+				}
+
 				// we need to make sure the change update is from a new commit change
 				rev, ok := change.Revisions[change.CurrentRevision]
 				if !ok {

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -93,6 +93,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Add(-time.Hour).Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -113,6 +114,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -135,6 +137,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -157,6 +160,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Add(-time.Hour).Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -177,6 +181,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -197,6 +202,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -217,6 +223,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 					{
 						Project:         "bar",
@@ -228,6 +235,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -250,6 +258,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 					{
 						Project:         "bar",
@@ -261,6 +270,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Add(-time.Hour).Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
@@ -283,6 +293,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 					{
 						Project:         "bar",
@@ -294,6 +305,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 				"baz": {
@@ -310,6 +322,7 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 					{
 						Project:         "evil",
@@ -321,12 +334,92 @@ func TestQueryChange(t *testing.T) {
 								Created: now.Add(-time.Hour).Format(layout),
 							},
 						},
+						Status: "NEW",
 					},
 				},
 			},
 			revisions: map[string][]string{
 				"foo": {"1-1", "2-1"},
 				"baz": {"3-2"},
+			},
+		},
+		{
+			name:       "one up-to-date merged change",
+			lastUpdate: now.Add(-time.Minute),
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						CurrentRevision: "1-1",
+						Updated:         now.Format(layout),
+						Submitted:       now.Format(layout),
+						Status:          "MERGED",
+					},
+				},
+			},
+			revisions: map[string][]string{
+				"foo": {"1-1"},
+			},
+		},
+		{
+			name:       "one up-to-date abandoned change",
+			lastUpdate: now.Add(-time.Minute),
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						CurrentRevision: "1-1",
+						Updated:         now.Format(layout),
+						Submitted:       now.Format(layout),
+						Status:          "ABANDONED",
+					},
+				},
+			},
+			revisions: map[string][]string{},
+		},
+		{
+			name:       "merged change recently updated but submitted before last update",
+			lastUpdate: now.Add(-time.Minute),
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						CurrentRevision: "1-1",
+						Updated:         now.Format(layout),
+						Submitted:       now.Add(-2 * time.Minute).Format(layout),
+						Status:          "MERGED",
+					},
+				},
+			},
+			revisions: map[string][]string{},
+		},
+		{
+			name:       "one abandoned, one merged",
+			lastUpdate: now.Add(-time.Minute),
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "1",
+						CurrentRevision: "1-1",
+						Updated:         now.Format(layout),
+						Status:          "ABANDONED",
+					},
+					{
+						Project:         "bar",
+						ID:              "2",
+						CurrentRevision: "2-1",
+						Updated:         now.Format(layout),
+						Submitted:       now.Format(layout),
+						Status:          "MERGED",
+					},
+				},
+			},
+			revisions: map[string][]string{
+				"foo": {"2-1"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR enables the Prow/Gerrit adapter to
1. poll for _all_ Gerrit changes, open and closed (including both merged and abandoned changes)
2. ignore abandoned changes and merged changes that have already been processed
3. run postsubmits on freshly merged changes

I'll update the [reporter](https://github.com/kubernetes/test-infra/blob/master/prow/gerrit/reporter/reporter.go) soon in another PR.

/assign @krzyzacy 
/cc @AishSundar @BenTheElder 