### PR TITLE
prow: make PR status dashboard setup docs more discoverable

### DIFF
--- a/prow/docs/pr_status_setup.md
+++ b/prow/docs/pr_status_setup.md
@@ -62,4 +62,4 @@ When testing locally, pass the path to your secrets to `deck` using the `--githu
 
 Run the commands:
 
-`go build . && ./deck --config-path=../../config.yaml --github-oauth-config-file=<PATH_TO_YOUR_GITHUB_OAUTH_SECRET> --cookie-secret=<PATH_TO_YOUR_COOKIE_SECRET> --oauth_url=/pr`
+`go build . && ./deck --config-path=../../config.yaml --github-oauth-config-file=<PATH_TO_YOUR_GITHUB_OAUTH_SECRET> --cookie-secret=<PATH_TO_YOUR_COOKIE_SECRET> --oauth-url=/pr`

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -366,6 +366,11 @@ automatically merged by [Tide][6].
 Tide can be enabled by modifying `config.yaml`.
 See [how to configure tide][7] for more details.
 
+### Setup PR status dashboard
+
+To setup a PR status dashboard like https://prow.k8s.io/pr, follow the
+instructions in [`pr_status_setup.md`](https://github.com/kubernetes/test-infra/blob/master/prow/docs/pr_status_setup.md).
+
 ## Configure SSL
 
 Use [cert-manager][3] for automatic LetsEncrypt integration. If you


### PR DESCRIPTION
This doc isn't mentioned anywhere in [`getting_started_deploy.md`](https://github.com/kubernetes/test-infra/blob/6410647d1b4a2ad39d717448d35157c47fc91571/prow/getting_started_deploy.md) doc. Also, unlike other docs, this doc is not at the root of the `prow/` dir, which makes it harder to find it.