### PR TITLE
Updating planter version to new bazel version

### DIFF
--- a/planter/Makefile
+++ b/planter/Makefile
@@ -14,8 +14,8 @@
 
 # note: sync this with planter.sh!
 # this should be bazel version - planter sub version
-BAZEL_VERSION ?= 0.18.1
-IMAGE_NAME = gcr.io/k8s-testimages/planter
+BAZEL_VERSION ?= 0.19.2
+IMAGE_NAME ?= gcr.io/k8s-testimages/planter
 TAG = $(BAZEL_VERSION)
 
 image:

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -42,7 +42,7 @@ set -o nounset
 # these can be overridden but otherwise default to the current stable image
 # used to build kubernetes from the master branch
 IMAGE_NAME="${IMAGE_NAME:-gcr.io/k8s-testimages/planter}"
-TAG="${TAG:-0.18.1}"
+TAG="${TAG:-0.19.2}"
 IMAGE=${IMAGE:-${IMAGE_NAME}:${TAG}}
 
 # We want to mount our bazel workspace and the bazel cache


### PR DESCRIPTION
- updated planter to bazel 0.19.2
- added capbility of overriding the image name in the Makefile