### PR TITLE
Migrate the migratestatus tool to use Prow's GitHub Client

### DIFF
--- a/maintenance/migratestatus/BUILD.bazel
+++ b/maintenance/migratestatus/BUILD.bazel
@@ -17,8 +17,11 @@ go_library(
     importpath = "k8s.io/test-infra/maintenance/migratestatus",
     deps = [
         "//maintenance/migratestatus/migrator:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/google/go-github/github:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/logrusutil:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -18,84 +18,112 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
-	"strings"
 
-	"github.com/golang/glog"
-	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/maintenance/migratestatus/migrator"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/logrusutil"
 )
 
+type options struct {
+	org, repo                                            string
+	copyContext, moveContext, retireContext, destContext string
+	continueOnError, dryRun                              bool
+	github                                               prowflagutil.GitHubOptions
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.org, "org", "", "The organization that owns the repo.")
+	fs.StringVar(&o.repo, "repo", "", "The repo needing status migration.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Run in dry-run mode, performing no modifying actions.")
+	fs.BoolVar(&o.continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
+
+	fs.StringVar(&o.copyContext, "copy", "", "Indicates copy mode and specifies the context to copy.")
+	fs.StringVar(&o.moveContext, "move", "", "Indicates move mode and specifies the context to move.")
+	fs.StringVar(&o.retireContext, "retire", "", "Indicates retire mode and specifies the context to retire.")
+	fs.StringVar(&o.destContext, "dest", "", "The destination context to copy or move to. For retire mode this is the context that replaced the retired context.")
+
+	o.github.AddFlags(fs)
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) Validate() error {
+	if o.org == "" {
+		return errors.New("'--org' must be set.\n")
+	}
+	if o.repo == "" {
+		return errors.New("'--repo' must be set.\n")
+	}
+
+	if o.destContext == "" && o.retireContext == "" {
+		return errors.New("'--dest' is required unless using '--retire' mode.\n")
+	}
+
+	var optionCount int
+	if o.copyContext != "" {
+		optionCount++
+	}
+	if o.moveContext != "" {
+		optionCount++
+	}
+	if o.retireContext != "" {
+		optionCount++
+	}
+	if optionCount != 1 {
+		return errors.New("Exactly one mode must be specified [--copy|--retire|--move].")
+	}
+
+	if err := o.github.Validate(o.dryRun); err != nil {
+		return err
+	}
+	return nil
+}
+
 func main() {
-	var tokenFile, org, repo, copyContext, moveContext, retireContext, destContext string
-	var continueOnError, dryRun bool
-
-	flag.StringVar(&tokenFile, "tokenfile", "", "The file containing the token to use for authentication.")
-	flag.StringVar(&org, "org", "", "The organization that owns the repo.")
-	flag.StringVar(&repo, "repo", "", "The repo needing status migration.")
-	flag.BoolVar(&dryRun, "dry-run", true, "Run in dry-run mode, performing no modifying actions.")
-	flag.BoolVar(&continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
-
-	flag.StringVar(&copyContext, "copy", "", "Indicates copy mode and specifies the context to copy.")
-	flag.StringVar(&moveContext, "move", "", "Indicates move mode and specifies the context to move.")
-	flag.StringVar(&retireContext, "retire", "", "Indicates retire mode and specifies the context to retire.")
-	flag.StringVar(&destContext, "dest", "", "The destination context to copy or move to. For retire mode this is the context that replaced the retired context.")
-	flag.Parse()
-
-	if org == "" {
-		errorfExit("'--org' must be set.\n")
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
 	}
-	if repo == "" {
-		errorfExit("'--repo' must be set.\n")
+
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "migratestatus"}),
+	)
+
+	secretAgent := &config.SecretAgent{}
+	if o.github.TokenPath != "" {
+		if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
 	}
-	if tokenFile == "" {
-		errorfExit("'--tokenfile' must be set.\n")
-	}
-	tokenData, err := ioutil.ReadFile(tokenFile)
+
+	githubClient, err := o.github.GitHubClient(secretAgent, o.dryRun)
 	if err != nil {
-		errorfExit("Error loading token file: %v\n", err)
-	}
-
-	if destContext == "" && retireContext == "" {
-		errorfExit("'--dest' is required unless using '--retire' mode.\n")
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
 	var mode *migrator.Mode
-	modeMsg := "Exactly one mode must be specified [--copy|--retire|--move].\n"
-	if copyContext != "" {
-		mode = migrator.CopyMode(copyContext, destContext)
+	if o.copyContext != "" {
+		mode = migrator.CopyMode(o.copyContext, o.destContext)
 	}
-	if moveContext != "" {
-		if mode != nil {
-			errorfExit(modeMsg)
-		}
-		mode = migrator.MoveMode(moveContext, destContext)
+	if o.moveContext != "" {
+		mode = migrator.MoveMode(o.moveContext, o.destContext)
 	}
-	if retireContext != "" {
-		if mode != nil {
-			errorfExit(modeMsg)
-		}
-		mode = migrator.RetireMode(retireContext, destContext)
-	}
-	if mode == nil {
-		errorfExit(modeMsg)
+	if o.retireContext != "" {
+		mode = migrator.RetireMode(o.retireContext, o.destContext)
 	}
 
 	// Note that continueOnError is false by default so that errors can be addressed when they occur
 	// instead of blindly continuing to the next PR, possibly continuing to error.
-	m := migrator.New(*mode, strings.TrimSpace(string(tokenData)), org, repo, dryRun, continueOnError)
-
-	prOptions := &github.PullRequestListOptions{}
-	if err := m.Migrate(prOptions); err != nil {
-		errorfExit("Error during status migration: %v\n", err)
+	m := migrator.New(*mode, githubClient, o.org, o.repo, o.continueOnError)
+	if err := m.Migrate(); err != nil {
+		logrus.WithError(err).Fatal("Error during status migration")
 	}
-	glog.Flush()
 	os.Exit(0)
-}
-
-func errorfExit(format string, args ...interface{}) {
-	glog.Errorf(format, args...)
-	glog.Flush()
-	os.Exit(1)
 }

--- a/maintenance/migratestatus/migrator/BUILD.bazel
+++ b/maintenance/migratestatus/migrator/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = ["migrator_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
+    deps = ["//prow/github:go_default_library"],
 )
 
 go_library(
@@ -18,9 +18,9 @@ go_library(
     srcs = ["migrator.go"],
     importpath = "k8s.io/test-infra/maintenance/migratestatus/migrator",
     deps = [
-        "//pkg/ghclient:go_default_library",
+        "//prow/errorutil:go_default_library",
+        "//prow/github:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/google/go-github/github:go_default_library",
     ],
 )
 

--- a/maintenance/migratestatus/migrator/migrator.go
+++ b/maintenance/migratestatus/migrator/migrator.go
@@ -19,10 +19,10 @@ package migrator
 import (
 	"fmt"
 
-	"k8s.io/test-infra/pkg/ghclient"
-
 	"github.com/golang/glog"
-	"github.com/google/go-github/github"
+	"k8s.io/test-infra/prow/errorutil"
+
+	"k8s.io/test-infra/prow/github"
 )
 
 var (
@@ -46,7 +46,7 @@ type Mode struct {
 	conditions []*contextCondition
 	// actions returns the status updates to make based on the current statuses and the sha.
 	// When actions is called, the Mode may assume that it's conditions are met.
-	actions func(statuses []github.RepoStatus, sha string) []*github.RepoStatus
+	actions func(statuses []github.Status, sha string) []github.Status
 }
 
 // MoveMode creates a mode that both copies and retires.
@@ -61,7 +61,7 @@ func MoveMode(origContext, newContext string) *Mode {
 			{context: origContext, state: stateAny},
 			{context: newContext, state: stateDNE},
 		},
-		actions: func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+		actions: func(statuses []github.Status, sha string) []github.Status {
 			return append(dup(statuses, sha), dep(statuses, sha)...)
 		},
 	}
@@ -99,23 +99,25 @@ func RetireMode(origContext, newContext string) *Mode {
 // copyAction creates a function that returns a copy action.
 // Specifically the returned function returns a RepoStatus that will create a status for newContext
 // with state set to the state of origContext.
-func copyAction(origContext, newContext string) func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
-	return func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
-		var oldStatus *github.RepoStatus
+func copyAction(origContext, newContext string) func(statuses []github.Status, sha string) []github.Status {
+	return func(statuses []github.Status, sha string) []github.Status {
+		var oldStatus github.Status
+		var found bool
 		for _, status := range statuses {
-			if status.Context != nil && *status.Context == origContext {
-				oldStatus = &status
+			if status.Context == origContext {
+				oldStatus = status
+				found = true
 				break
 			}
 		}
-		if oldStatus == nil {
+		if !found {
 			// This means the conditions were not met! Should never have called this function, but it is a recoverable error.
 			glog.Error("failed to find original context in status list thus conditions for this duplicate action were not met. This should never happen!")
 			return nil
 		}
-		return []*github.RepoStatus{
+		return []github.Status{
 			{
-				Context:     &newContext,
+				Context:     newContext,
 				State:       oldStatus.State,
 				TargetURL:   oldStatus.TargetURL,
 				Description: oldStatus.Description,
@@ -127,7 +129,7 @@ func copyAction(origContext, newContext string) func(statuses []github.RepoStatu
 // retireAction creates a function that returns a retire action.
 // Specifically the returned function returns a RepoStatus that will update the origContext status
 // to 'success' and set it's description to mark it as retired and replaced by newContext.
-func retireAction(origContext, newContext string) func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+func retireAction(origContext, newContext string) func(statuses []github.Status, sha string) []github.Status {
 	stateSuccess := "success"
 	var desc string
 	if newContext == "" {
@@ -135,65 +137,60 @@ func retireAction(origContext, newContext string) func(statuses []github.RepoSta
 	} else {
 		desc = fmt.Sprintf("Context retired. Status moved to \"%s\".", newContext)
 	}
-	return func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
-		return []*github.RepoStatus{
+	return func(statuses []github.Status, sha string) []github.Status {
+		return []github.Status{
 			{
-				Context:     &origContext,
-				State:       &stateSuccess,
-				TargetURL:   nil,
-				Description: &desc,
+				Context:     origContext,
+				State:       stateSuccess,
+				Description: desc,
 			},
 		}
 	}
 }
 
 // processStatuses checks the mode against the combined status of a PR and emits the actions to take.
-func (m Mode) processStatuses(combStatus *github.CombinedStatus) []*github.RepoStatus {
-	var sha string
-	if combStatus.SHA != nil {
-		sha = *combStatus.SHA
-	}
-
+func (m Mode) processStatuses(combStatus *github.CombinedStatus) []github.Status {
 	for _, cond := range m.conditions {
-		var match *github.RepoStatus
-		match = nil
+		var match github.Status
+		var found bool
 		for _, status := range combStatus.Statuses {
-			if status.Context == nil {
-				glog.Errorf("a status context for SHA ref '%s' had a nil Context field.", sha)
+			if status.Context == "" {
+				glog.Errorf("a status context for SHA ref '%s' had an empty Context field.", combStatus.SHA)
 				continue
 			}
-			if *status.Context == cond.context {
-				match = &status
+			if status.Context == cond.context {
+				match = status
+				found = true
 				break
 			}
 		}
 
 		switch cond.state {
 		case stateDNE:
-			if match != nil {
+			if found {
 				return nil
 			}
 		case stateAny:
-			if match == nil {
+			if !found {
 				return nil
 			}
 		default:
 			// Looking for a specific state in this case.
-			if match == nil {
+			if !found {
 				// Did not find the context.
 				return nil
 			}
-			if match.State == nil {
-				glog.Errorf("context '%s' of SHA ref '%s' has a nil state.", cond.context, sha)
+			if match.State == "" {
+				glog.Errorf("context '%s' of SHA ref '%s' has an empty state.", cond.context, combStatus.SHA)
 				return nil
 			}
-			if *match.State != cond.state {
+			if match.State != cond.state {
 				// Context had a different state than what the condition requires.
 				return nil
 			}
 		}
 	}
-	return m.actions(combStatus.Statuses, sha)
+	return m.actions(combStatus.Statuses, combStatus.SHA)
 }
 
 // Migrator will search github for PRs with a given context and migrate/retire/move them.
@@ -202,42 +199,30 @@ type Migrator struct {
 	repo            string
 	continueOnError bool
 
-	client *ghclient.Client
+	client *github.Client
 	Mode
 }
 
-// New creates a new migrator with specified options.
-//
-// If dryRun is true it will only perform GET requests that do not change github.
-func New(mode Mode, token, org, repo string, dryRun, continueOnError bool) *Migrator {
+// New creates a new migrator with specified options and client.
+func New(mode Mode, client *github.Client, org, repo string, continueOnError bool) *Migrator {
 	return &Migrator{
 		org:             org,
 		repo:            repo,
 		continueOnError: continueOnError,
-		client:          ghclient.NewClient(token, dryRun),
+		client:          client,
 		Mode:            mode,
 	}
 }
 
-func (m *Migrator) processPR(pr *github.PullRequest) error {
-	if pr == nil {
-		return fmt.Errorf("migrator cannot process a nil PullRequest")
-	}
-	if pr.Head == nil {
-		return fmt.Errorf("migrator cannot process a PullRequest with a nil 'Head' field")
-	}
-	if pr.Head.SHA == nil {
-		return fmt.Errorf("migrator cannot process a PullRequest with a nil 'Head.SHA' field")
-	}
-
-	combined, err := m.client.GetCombinedStatus(m.org, m.repo, *pr.Head.SHA)
+func (m *Migrator) processPR(pr github.PullRequest) error {
+	combined, err := m.client.GetCombinedStatus(m.org, m.repo, pr.Head.SHA)
 	if err != nil {
 		return err
 	}
 	actions := m.processStatuses(combined)
 
 	for _, action := range actions {
-		if _, err = m.client.CreateStatus(m.org, m.repo, *pr.Head.SHA, action); err != nil {
+		if err := m.client.CreateStatus(m.org, m.repo, pr.Head.SHA, action); err != nil {
 			return err
 		}
 	}
@@ -245,6 +230,21 @@ func (m *Migrator) processPR(pr *github.PullRequest) error {
 }
 
 // Migrate will retire/migrate/copy statuses for all matching PRs.
-func (m *Migrator) Migrate(prOptions *github.PullRequestListOptions) error {
-	return m.client.ForEachPR(m.org, m.repo, prOptions, m.continueOnError, m.processPR)
+func (m *Migrator) Migrate() error {
+	prs, err := m.client.GetPullRequests(m.org, m.repo)
+	if err != nil {
+		return err
+	}
+
+	var errors []error
+	for _, pr := range prs {
+		if err := m.processPR(pr); err != nil {
+			if m.continueOnError {
+				errors = append(errors, err)
+				continue
+			}
+			return err
+		}
+	}
+	return errorutil.NewAggregate(errors...)
 }

--- a/maintenance/migratestatus/migrator/migrator_test.go
+++ b/maintenance/migratestatus/migrator/migrator_test.go
@@ -139,7 +139,7 @@ func TestMoveMode(t *testing.T) {
 		},
 	}
 
-	m := *MoveMode(contextA, contextB)
+	m := *MoveMode(contextA, contextB, "")
 	for _, test := range tests {
 		diff := m.processStatuses(&github.CombinedStatus{Statuses: test.start})
 		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
@@ -298,7 +298,7 @@ func TestRetireModeReplacement(t *testing.T) {
 		},
 	}
 
-	m := *RetireMode(contextA, contextB)
+	m := *RetireMode(contextA, contextB, "")
 	for _, test := range tests {
 		diff := m.processStatuses(&github.CombinedStatus{Statuses: test.start})
 		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
@@ -347,7 +347,7 @@ func TestRetireModeNoReplacement(t *testing.T) {
 		},
 	}
 
-	m := *RetireMode(contextA, "")
+	m := *RetireMode(contextA, "", "")
 	for _, test := range tests {
 		diff := m.processStatuses(&github.CombinedStatus{Statuses: test.start})
 		if err := compareDiffs(diff, test.expectedDiffs); err != nil {

--- a/maintenance/migratestatus/migrator/migrator_test.go
+++ b/maintenance/migratestatus/migrator/migrator_test.go
@@ -20,59 +20,58 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/github"
+	"k8s.io/test-infra/prow/github"
 )
 
 type modeTest struct {
 	name          string
-	start         []github.RepoStatus
-	expectedDiffs []*github.RepoStatus
+	start         []github.Status
+	expectedDiffs []github.Status
 }
 
 // compareDiffs checks if a list of status updates matches an expected list of status updates.
-func compareDiffs(diffs []*github.RepoStatus, expectedDiffs []*github.RepoStatus) error {
+func compareDiffs(diffs []github.Status, expectedDiffs []github.Status) error {
 	if len(diffs) != len(expectedDiffs) {
 		return fmt.Errorf("failed because the returned diff had %d changes instead of %d", len(diffs), len(expectedDiffs))
 	}
 	for _, diff := range diffs {
-		if diff == nil {
-			return fmt.Errorf("failed because the returned diff contained a nil RepoStatus")
+		if diff.Context == "" {
+			return fmt.Errorf("failed because the returned diff contained a Status with an empty Context field")
 		}
-		if diff.Context == nil {
-			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil Context field")
+		if diff.Description == "" {
+			return fmt.Errorf("failed because the returned diff contained a Status with an empty Description field")
 		}
-		if diff.Description == nil {
-			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil Description field")
+		if diff.State == "" {
+			return fmt.Errorf("failed because the returned diff contained a Status with an empty State field")
 		}
-		if diff.State == nil {
-			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil State field")
-		}
-		var match *github.RepoStatus
+		var match github.Status
+		var found bool
 		for _, expected := range expectedDiffs {
-			if *expected.Context == *diff.Context {
+			if expected.Context == diff.Context {
 				match = expected
+				found = true
 				break
 			}
 		}
-		if match == nil {
-			return fmt.Errorf("failed because the returned diff contained an unexpected change to context '%s'", *diff.Context)
+		if !found {
+			return fmt.Errorf("failed because the returned diff contained an unexpected change to context '%s'", diff.Context)
 		}
 		// Found a matching context. Make sure that fields are equal.
-		if *match.Description != *diff.Description {
-			return fmt.Errorf("failed because the returned diff for context '%s' had Description '%s' instead of '%s'", *diff.Context, *diff.Description, *match.Description)
+		if match.Description != diff.Description {
+			return fmt.Errorf("failed because the returned diff for context '%s' had Description '%s' instead of '%s'", diff.Context, diff.Description, match.Description)
 		}
-		if *match.State != *diff.State {
-			return fmt.Errorf("failed because the returned diff for context '%s' had State '%s' instead of '%s'", *diff.Context, *diff.State, *match.State)
+		if match.State != diff.State {
+			return fmt.Errorf("failed because the returned diff for context '%s' had State '%s' instead of '%s'", diff.Context, diff.State, match.State)
 		}
 
-		if match.TargetURL == nil {
-			if diff.TargetURL != nil {
-				return fmt.Errorf("failed because the returned diff for context '%s' had a non-nil TargetURL", *diff.Context)
+		if match.TargetURL == "" {
+			if diff.TargetURL != "" {
+				return fmt.Errorf("failed because the returned diff for context '%s' had a non-empty TargetURL", diff.Context)
 			}
-		} else if diff.TargetURL == nil {
-			return fmt.Errorf("failed because the returned diff for context '%s' had a nil TargetURL", *diff.Context)
-		} else if *match.TargetURL != *diff.TargetURL {
-			return fmt.Errorf("failed because the returned diff for context '%s' had TargetURL '%s' instead of '%s'", *diff.Context, *diff.TargetURL, *match.TargetURL)
+		} else if diff.TargetURL == "" {
+			return fmt.Errorf("failed because the returned diff for context '%s' had an empty TargetURL", diff.Context)
+		} else if match.TargetURL != diff.TargetURL {
+			return fmt.Errorf("failed because the returned diff for context '%s' had TargetURL '%s' instead of '%s'", diff.Context, diff.TargetURL, match.TargetURL)
 		}
 	}
 	return nil
@@ -86,57 +85,57 @@ func TestMoveMode(t *testing.T) {
 	tests := []*modeTest{
 		{
 			name: "simple",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
 		{
 			name: "unrelated contexts",
-			start: []github.RepoStatus{
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+			start: []github.Status{
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
 		{
 			name: "unrelated contexts; missing context A",
-			start: []github.RepoStatus{
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+			start: []github.Status{
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts; already have context A and B",
-			start: []github.RepoStatus{
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts; already have context B; no context A",
-			start: []github.RepoStatus{
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name:          "no contexts",
-			start:         []github.RepoStatus{},
-			expectedDiffs: []*github.RepoStatus{},
+			start:         []github.Status{},
+			expectedDiffs: []github.Status{},
 		},
 	}
 
@@ -156,70 +155,70 @@ func TestCopyMode(t *testing.T) {
 	tests := []*modeTest{
 		{
 			name: "simple",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
 		{
 			name: "unrelated contexts",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
 		{
 			name: "already have context B",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "already have updated context B",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus(contextB, "success", "description 2", "url 2"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus(contextB, "success", "description 2", "url 2"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts already have updated context B",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus(contextB, "error", "description 3", "url 3"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus(contextB, "error", "description 3", "url 3"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "only have context B",
-			start: []github.RepoStatus{
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts; context B but not A",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name:          "no contexts",
-			start:         []github.RepoStatus{},
-			expectedDiffs: []*github.RepoStatus{},
+			start:         []github.Status{},
+			expectedDiffs: []github.Status{},
 		},
 	}
 
@@ -240,62 +239,62 @@ func TestRetireModeReplacement(t *testing.T) {
 	tests := []*modeTest{
 		{
 			name: "simple",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
 		{
 			name: "unrelated contexts;updated context B",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus(contextB, "success", "description 3", "url 3"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus(contextB, "success", "description 3", "url 3"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
 		{
 			name: "missing context B",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts;missing context B",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "missing context A",
-			start: []github.RepoStatus{
-				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts;missing context A",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
-				*makeStatus(contextB, "success", "description 3", "url 3"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
+				makeStatus(contextB, "success", "description 3", "url 3"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name:          "no contexts",
-			start:         []github.RepoStatus{},
-			expectedDiffs: []*github.RepoStatus{},
+			start:         []github.Status{},
+			expectedDiffs: []github.Status{},
 		},
 	}
 
@@ -315,36 +314,36 @@ func TestRetireModeNoReplacement(t *testing.T) {
 	tests := []*modeTest{
 		{
 			name: "simple",
-			start: []github.RepoStatus{
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			start: []github.Status{
+				makeStatus(contextA, "failure", "description 1", "url 1"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
 		{
 			name: "unrelated contexts",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus(contextA, "failure", "description 1", "url 1"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus(contextA, "failure", "description 1", "url 1"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
 			},
-			expectedDiffs: []*github.RepoStatus{
+			expectedDiffs: []github.Status{
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
 		{
 			name:          "missing context A",
-			start:         []github.RepoStatus{},
-			expectedDiffs: []*github.RepoStatus{},
+			start:         []github.Status{},
+			expectedDiffs: []github.Status{},
 		},
 		{
 			name: "unrelated contexts;missing context A",
-			start: []github.RepoStatus{
-				*makeStatus("unrelated context", "success", "description 2", "url 2"),
-				*makeStatus("also not related", "error", "description 4", "url 4"),
+			start: []github.Status{
+				makeStatus("unrelated context", "success", "description 2", "url 2"),
+				makeStatus("also not related", "error", "description 4", "url 4"),
 			},
-			expectedDiffs: []*github.RepoStatus{},
+			expectedDiffs: []github.Status{},
 		},
 	}
 
@@ -357,17 +356,17 @@ func TestRetireModeNoReplacement(t *testing.T) {
 	}
 }
 
-// makeStatus returns a new RepoStatus struct with the specified fields.
+// makeStatus returns a new Status struct with the specified fields.
 // targetURL=="" means TargetURL==nil
-func makeStatus(context, state, description, targetURL string) *github.RepoStatus {
-	var url *string
+func makeStatus(context, state, description, targetURL string) github.Status {
+	var url string
 	if targetURL != "" {
-		url = &targetURL
+		url = targetURL
 	}
-	return &github.RepoStatus{
-		Context:     &context,
-		State:       &state,
-		Description: &description,
+	return github.Status{
+		Context:     context,
+		State:       state,
+		Description: description,
 		TargetURL:   url,
 	}
 }

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -864,9 +864,9 @@ func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment
 	return comments, nil
 }
 
-// GetPullRequests get all pull requests.
+// GetPullRequests get all open pull requests for a repo.
 //
-// See https://developer.github.com/v3/pulls/#get-a-single-pull-request
+// See https://developer.github.com/v3/pulls/#list-pull-requests
 func (c *Client) GetPullRequests(org, repo string) ([]PullRequest, error) {
 	c.log("GetPullRequests", org, repo)
 	var prs []PullRequest

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -140,6 +140,7 @@ type Status struct {
 
 // CombinedStatus is the latest statuses for a ref.
 type CombinedStatus struct {
+	SHA      string   `json:"sha"`
 	Statuses []Status `json:"statuses"`
 }
 


### PR DESCRIPTION
Use of the go-github client in the migratestatus tool is a historical
artifact and makes it harder to integrat the tool with the rest of Prow.
There is no change to the usefulness of the tool with the change of the
underlying client library in use.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 
/cc @fejta @BenTheElder 