### PR TITLE
run unit tests with kubebuilder

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -8,9 +8,11 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181120-dea0825e3-master
-        command:
-        - runner.sh
+      - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
         args:
-        - make
-        - test
+        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
+        - "./scripts/ci-test.sh"


### PR DESCRIPTION
there are cluster-api-provider-vsphere tests that generated
by kubebuilder that requires kubebuilder to run.

so update the job definition to call the shell script
"ci-test.sh" which will download kubebuilder to container.

cc @sflxn @akutz @krzyzacy @BenTheElder 