### PR TITLE
revert PR10196 and call ci-test.sh in args

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -8,11 +8,8 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181120-dea0825e3-master
+        command:
+        - runner.sh
         args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./scripts/ci-test.sh"
+        - ./scripts/ci-test.sh


### PR DESCRIPTION
this is to revert https://github.com/kubernetes/test-infra/pull/10196
and call ci-test.sh in args.

cc @krzyzacy @sflxn 
assign @krzyzacy