### PR TITLE
add run_if_changed/RunsAgainstChanges for prow postsubmit jobs

### DIFF
--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -308,7 +308,7 @@ func TestJobRequirements(t *testing.T) {
 				},
 				{
 					Context: "run-if-changed",
-					ChangeMatcher: ChangeMatcher{
+					RegexpChangeMatcher: RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 					AlwaysRun:  false,
@@ -354,7 +354,7 @@ func TestJobRequirements(t *testing.T) {
 				},
 				{
 					Context: "run-if-changed",
-					ChangeMatcher: ChangeMatcher{
+					RegexpChangeMatcher: RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 					SkipReport: true,

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -307,10 +307,12 @@ func TestJobRequirements(t *testing.T) {
 					SkipReport: false,
 				},
 				{
-					Context:      "run-if-changed",
-					RunIfChanged: "foo",
-					AlwaysRun:    false,
-					SkipReport:   false,
+					Context: "run-if-changed",
+					ChangeMatcher: ChangeMatcher{
+						RunIfChanged: "foo",
+					},
+					AlwaysRun:  false,
+					SkipReport: false,
 				},
 				{
 					Context:    "not-always",
@@ -351,10 +353,12 @@ func TestJobRequirements(t *testing.T) {
 					},
 				},
 				{
-					Context:      "run-if-changed",
-					RunIfChanged: "foo",
-					SkipReport:   true,
-					AlwaysRun:    false,
+					Context: "run-if-changed",
+					ChangeMatcher: ChangeMatcher{
+						RunIfChanged: "foo",
+					},
+					SkipReport: true,
+					AlwaysRun:  false,
 					RunAfterSuccess: []Presubmit{
 						{
 							Context: "me2",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1175,11 +1175,11 @@ func SetPresubmitRegexes(js []Presubmit) error {
 		}
 		js[i].Brancher = b
 
-		c, err := setChangeRegexes(j.ChangeMatcher)
+		c, err := setChangeRegexes(j.RegexpChangeMatcher)
 		if err != nil {
 			return fmt.Errorf("could not set change regexes for %s: %v", j.Name, err)
 		}
-		js[i].ChangeMatcher = c
+		js[i].RegexpChangeMatcher = c
 
 		if err := SetPresubmitRegexes(j.RunAfterSuccess); err != nil {
 			return err
@@ -1208,7 +1208,7 @@ func setBrancherRegexes(br Brancher) (Brancher, error) {
 	return br, nil
 }
 
-func setChangeRegexes(cm ChangeMatcher) (ChangeMatcher, error) {
+func setChangeRegexes(cm RegexpChangeMatcher) (RegexpChangeMatcher, error) {
 	if cm.RunIfChanged != "" {
 		re, err := regexp.Compile(cm.RunIfChanged)
 		if err != nil {
@@ -1228,11 +1228,11 @@ func SetPostsubmitRegexes(ps []Postsubmit) error {
 			return fmt.Errorf("could not set branch regexes for %s: %v", j.Name, err)
 		}
 		ps[i].Brancher = b
-		c, err := setChangeRegexes(j.ChangeMatcher)
+		c, err := setChangeRegexes(j.RegexpChangeMatcher)
 		if err != nil {
 			return fmt.Errorf("could not set change regexes for %s: %v", j.Name, err)
 		}
-		ps[i].ChangeMatcher = c
+		ps[i].RegexpChangeMatcher = c
 		if err := SetPostsubmitRegexes(j.RunAfterSuccess); err != nil {
 			return err
 		}

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -134,7 +134,7 @@ type Presubmit struct {
 
 	Brancher
 
-	ChangeMatcher
+	RegexpChangeMatcher
 
 	// We'll set these when we load it.
 	re *regexp.Regexp // from Trigger.
@@ -144,7 +144,7 @@ type Presubmit struct {
 type Postsubmit struct {
 	JobBase
 
-	ChangeMatcher
+	RegexpChangeMatcher
 
 	Brancher
 
@@ -191,9 +191,10 @@ type Brancher struct {
 	reSkip *regexp.Regexp
 }
 
-// ChangeMatcher is for code shared between jobs that run only when certain files are changed.
-type ChangeMatcher struct {
-	// RunIfChanged automatically run if the PR modifies a file that matches this regex.
+// RegexpChangeMatcher is for code shared between jobs that run only when certain files are changed.
+type RegexpChangeMatcher struct {
+	// RunIfChanged defines a regex used to select which subset of file changes should trigger this job.
+	// If any file in the changeset matches this regex, the job will be triggered
 	RunIfChanged string         `json:"run_if_changed,omitempty"`
 	reChanges    *regexp.Regexp // from RunIfChanged
 }
@@ -246,7 +247,7 @@ func (br Brancher) Intersects(other Brancher) bool {
 }
 
 // RunsAgainstChanges returns true if any of the changed input paths match the run_if_changed regex.
-func (cm ChangeMatcher) RunsAgainstChanges(changes []string) bool {
+func (cm RegexpChangeMatcher) RunsAgainstChanges(changes []string) bool {
 	if cm.RunIfChanged == "" {
 		return true
 	}

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -247,6 +247,9 @@ func (br Brancher) Intersects(other Brancher) bool {
 
 // RunsAgainstChanges returns true if any of the changed input paths match the run_if_changed regex.
 func (cm ChangeMatcher) RunsAgainstChanges(changes []string) bool {
+	if cm.RunIfChanged == "" {
+		return true
+	}
 	for _, change := range changes {
 		if cm.reChanges.MatchString(change) {
 			return true

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -370,7 +370,9 @@ func TestConditionalPresubmits(t *testing.T) {
 			JobBase: JobBase{
 				Name: "cross build",
 			},
-			RunIfChanged: `(Makefile|\.sh|_(windows|linux|osx|unknown)(_test)?\.go)$`,
+			ChangeMatcher: ChangeMatcher{
+				RunIfChanged: `(Makefile|\.sh|_(windows|linux|osx|unknown)(_test)?\.go)$`,
+			},
 		},
 	}
 	SetPresubmitRegexes(presubmits)

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -370,7 +370,7 @@ func TestConditionalPresubmits(t *testing.T) {
 			JobBase: JobBase{
 				Name: "cross build",
 			},
-			ChangeMatcher: ChangeMatcher{
+			RegexpChangeMatcher: RegexpChangeMatcher{
 				RunIfChanged: `(Makefile|\.sh|_(windows|linux|osx|unknown)(_test)?\.go)$`,
 			},
 		},

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -51,7 +51,9 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, operators []config.Jen
 					JobBase: config.JobBase{
 						Name: "test-kubeadm-cloud",
 					},
-					RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
+					},
 				},
 			},
 		},

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -51,7 +51,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, operators []config.Jen
 					JobBase: config.JobBase{
 						Name: "test-kubeadm-cloud",
 					},
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
 					},
 				},

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -56,7 +56,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 					JobBase: config.JobBase{
 						Name: "test-kubeadm-cloud",
 					},
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
 					},
 				},

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -56,7 +56,9 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 					JobBase: config.JobBase{
 						Name: "test-kubeadm-cloud",
 					},
-					RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^(cmd/kubeadm|build/debs).*$",
+					},
 				},
 			},
 		},

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -110,7 +110,7 @@ func TestSkipStatus(t *testing.T) {
 					Context:   "extended-tests",
 				},
 				{
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^(test/integration)",
 					},
 					Context: "integration-tests",
@@ -171,7 +171,7 @@ func TestSkipStatus(t *testing.T) {
 
 			presubmits: []config.Presubmit{
 				{
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^(test/integration)",
 					},
 					Context: "integration-tests",
@@ -217,7 +217,7 @@ func TestSkipStatus(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					SkipReport: true,
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^(test/integration)",
 					},
 					Context: "integration-tests",

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -110,8 +110,10 @@ func TestSkipStatus(t *testing.T) {
 					Context:   "extended-tests",
 				},
 				{
-					RunIfChanged: "^(test/integration)",
-					Context:      "integration-tests",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^(test/integration)",
+					},
+					Context: "integration-tests",
 				},
 			},
 			sha: "shalala",
@@ -169,8 +171,10 @@ func TestSkipStatus(t *testing.T) {
 
 			presubmits: []config.Presubmit{
 				{
-					RunIfChanged: "^(test/integration)",
-					Context:      "integration-tests",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^(test/integration)",
+					},
+					Context: "integration-tests",
 				},
 			},
 			sha: "shalala",
@@ -212,9 +216,11 @@ func TestSkipStatus(t *testing.T) {
 
 			presubmits: []config.Presubmit{
 				{
-					SkipReport:   true,
-					RunIfChanged: "^(test/integration)",
-					Context:      "integration-tests",
+					SkipReport: true,
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^(test/integration)",
+					},
+					Context: "integration-tests",
 				},
 			},
 			sha: "shalala",

--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "generic-comment_test.go",
         "pull-request_test.go",
+        "push_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -295,7 +295,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 						SkipReport:   true,
@@ -320,7 +320,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 						Context:      "pull-jib",
@@ -344,7 +344,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 						Context:      "pull-jub",
@@ -368,7 +368,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
 						Context:      "pull-jib",
@@ -391,7 +391,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 						Context:      "pull-jab",
@@ -481,7 +481,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jeb",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
 						Context:      "pull-jeb",
@@ -505,7 +505,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jeb",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
 						Context:      "pull-jib",
@@ -528,7 +528,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 						Context:      "pull-jub",
@@ -552,7 +552,7 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
 						Context:      "pull-jub",

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -295,7 +295,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 						SkipReport:   true,
 						Context:      "pull-jab",
 						Trigger:      `/test all`,
@@ -318,7 +320,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 						Context:      "pull-jib",
 						Trigger:      `/test all`,
 						RerunCommand: `/test all`,
@@ -340,7 +344,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
 						RerunCommand: `/test jub`,
@@ -362,7 +368,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						RunIfChanged: "CHANGED2",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED2",
+						},
 						Context:      "pull-jib",
 						Trigger:      `/test all`,
 						RerunCommand: `/test all`,
@@ -383,7 +391,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 						Context:      "pull-jab",
 						Trigger:      `/test all`,
 						RerunCommand: `/test all`,
@@ -471,7 +481,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jeb",
 						},
-						RunIfChanged: "CHANGED2",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED2",
+						},
 						Context:      "pull-jeb",
 						Trigger:      `/test all`,
 						RerunCommand: `/test all`,
@@ -493,7 +505,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jeb",
 						},
-						RunIfChanged: "CHANGED2",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED2",
+						},
 						Context:      "pull-jib",
 						Trigger:      `/test (all|pull-jeb)`,
 						RerunCommand: `/test pull-jeb`,
@@ -514,7 +528,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
 						RerunCommand: `/test jub`,
@@ -536,7 +552,9 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jub",
 						},
-						RunIfChanged: "CHANGED2",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED2",
+						},
 						Context:      "pull-jub",
 						Trigger:      `/test jub`,
 						RerunCommand: `/test jub`,

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -40,7 +40,7 @@ func TestHandlePE(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "pass-butter",
 				},
-				ChangeMatcher: config.ChangeMatcher{
+				RegexpChangeMatcher: config.RegexpChangeMatcher{
 					RunIfChanged: "\\.sh$",
 				},
 			},

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trigger
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestHandlePE(t *testing.T) {
+	g := &fakegithub.FakeClient{}
+	kc := &fkc{}
+	c := client{
+		GitHubClient: g,
+		KubeClient:   kc,
+		Config:       &config.Config{},
+		Logger:       logrus.WithField("plugin", pluginName),
+	}
+	postsubmits := map[string][]config.Postsubmit{
+		"org/repo": {
+			{
+				JobBase: config.JobBase{
+					Name: "pass-butter",
+				},
+				ChangeMatcher: config.ChangeMatcher{
+					RunIfChanged: "\\.sh$",
+				},
+			},
+		},
+		"org2/repo2": {
+			{
+				JobBase: config.JobBase{
+					Name: "pass-salt",
+				},
+			},
+		},
+	}
+	if err := c.Config.SetPostsubmits(postsubmits); err != nil {
+		t.Fatalf("failed to set postsubmits: %v", err)
+	}
+	testCases := []struct {
+		name      string
+		pe        github.PushEvent
+		jobsToRun int
+	}{
+		{
+			name: "no matching files",
+			pe: github.PushEvent{
+				Ref: "master",
+				Commits: []github.Commit{
+					{
+						Added: []string{"example.txt"},
+					},
+				},
+				Repo: github.Repo{
+					FullName: "org/repo",
+				},
+			},
+		},
+		{
+			name: "one matching file",
+			pe: github.PushEvent{
+				Ref: "master",
+				Commits: []github.Commit{
+					{
+						Added:    []string{"example.txt"},
+						Modified: []string{"hack.sh"},
+					},
+				},
+				Repo: github.Repo{
+					FullName: "org/repo",
+				},
+			},
+			jobsToRun: 1,
+		},
+		{
+			name: "no change matcher",
+			pe: github.PushEvent{
+				Ref: "master",
+				Commits: []github.Commit{
+					{
+						Added: []string{"example.txt"},
+					},
+				},
+				Repo: github.Repo{
+					FullName: "org2/repo2",
+				},
+			},
+			jobsToRun: 1,
+		},
+	}
+	for _, tc := range testCases {
+		err := handlePE(c, tc.pe)
+		if err != nil {
+			t.Errorf("test %q: handlePE returned unexpected error %v", tc.name, err)
+		}
+		if len(kc.started) != tc.jobsToRun {
+			t.Errorf("test %q: expected %d jobs to run, got %d", tc.name, tc.jobsToRun, len(kc.started))
+		}
+	}
+}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -959,7 +959,7 @@ func TestTakeAction(t *testing.T) {
 						Context:      "if-changed",
 						Trigger:      "/test if-changed",
 						RerunCommand: "/test if-changed",
-						ChangeMatcher: config.ChangeMatcher{
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
 					},
@@ -1799,7 +1799,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Context: "always",
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 				},
@@ -1830,7 +1830,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Context: "always",
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 				},
@@ -1896,7 +1896,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Context: "presubmit",
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^CHANGE.$",
 					},
 				},
@@ -1916,7 +1916,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Context: "presubmit",
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^FIL.$",
 					},
 				},
@@ -1937,7 +1937,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Context: "presubmit",
-					ChangeMatcher: config.ChangeMatcher{
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^CHANGE.$",
 					},
 				},

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -959,7 +959,9 @@ func TestTakeAction(t *testing.T) {
 						Context:      "if-changed",
 						Trigger:      "/test if-changed",
 						RerunCommand: "/test if-changed",
-						RunIfChanged: "CHANGED",
+						ChangeMatcher: config.ChangeMatcher{
+							RunIfChanged: "CHANGED",
+						},
 					},
 				},
 			},
@@ -1796,8 +1798,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "no matching presubmits",
 			presubmits: []config.Presubmit{
 				{
-					Context:      "always",
-					RunIfChanged: "foo",
+					Context: "always",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "foo",
+					},
 				},
 				{
 					Context: "never",
@@ -1825,8 +1829,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "no matching presubmits (check cache retention)",
 			presubmits: []config.Presubmit{
 				{
-					Context:      "always",
-					RunIfChanged: "foo",
+					Context: "always",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "foo",
+					},
 				},
 				{
 					Context: "never",
@@ -1889,8 +1895,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (uncached)",
 			presubmits: []config.Presubmit{
 				{
-					Context:      "presubmit",
-					RunIfChanged: "^CHANGE.$",
+					Context: "presubmit",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^CHANGE.$",
+					},
 				},
 				{
 					Context:   "always",
@@ -1907,8 +1915,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (cached)",
 			presubmits: []config.Presubmit{
 				{
-					Context:      "presubmit",
-					RunIfChanged: "^FIL.$",
+					Context: "presubmit",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^FIL.$",
+					},
 				},
 				{
 					Context:   "always",
@@ -1926,8 +1936,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (cached) (skippable)",
 			presubmits: []config.Presubmit{
 				{
-					Context:      "presubmit",
-					RunIfChanged: "^CHANGE.$",
+					Context: "presubmit",
+					ChangeMatcher: config.ChangeMatcher{
+						RunIfChanged: "^CHANGE.$",
+					},
 				},
 				{
 					Context:   "always",


### PR DESCRIPTION
Create a `ChangeMatcher` struct to enable `RunsAgainstChanges` on prow postsubmit jobs (this was already present in presubmits, but not shared). This will allow Prow components (such as the Gerrit adapter) to selectively run postsubmit jobs depending on which files were changed.

/shrug
/assign @krzyzacy 
/cc @BenTheElder 