### PR TITLE
Fix path in cluster-api-provider-digitalocean lint presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -48,6 +48,6 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_bazel.py
         args:
-        - "--install=gubernator/test_requirements.txt"
+        - "--install=hack/test_requirements.txt"
         - "--test=//..."
         - "--test-args=--config=lint"


### PR DESCRIPTION
The gubernator path only exists in test-infra. :woman_facepalming: 

The current [failure](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-digitalocean/120/pull-cluster-api-provider-digitalocean-lint/12/build-log.txt) is:

```
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_bazel.py", line 275, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_bazel.py", line 141, in main
    raise ValueError('Invalid install path: %s' % install)
ValueError: Invalid install path: gubernator/test_requirements.txt
```

https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/122 adds the `test-requirements.txt` file to `hack/`.

/cc @krzyzacy @xmudrii 
/assign @krzyzacy 