### PR TITLE
kubetest: add "KubectlCommand" to "deployer" interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -135,7 +135,7 @@
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
-  digest = "1:1baf5324beded9ad7e1c5b808b89cd3a3c58cb7ae393b168f4f14e516c65f28b"
+  digest = "1:d47a7946633fc621db8587690253bba78ee390586bc84b94e56831def0a116a5"
   name = "github.com/aws/aws-k8s-tester"
   packages = [
     "ec2config",
@@ -147,7 +147,7 @@
     "pkg/awsapi/ec2",
   ]
   pruneopts = "NUT"
-  revision = "7a149356ae339b531b6189f4a801378b62c7b98b"
+  revision = "4349ca61b2788db7b3197856c7ccf5cd615d70aa"
   version = "0.1.3"
 
 [[projects]]

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -4,13 +4,19 @@ presets:
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
     value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.3/aws-k8s-tester-0.1.3-linux-amd64
+  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/aws-k8s-tester
   # URL to download 'kubectl', required for 'kubectl' calls to EKS
   # TODO: use upstream 'kubectl'
   - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
     value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/kubectl
   # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
   - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
     value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/aws-iam-authenticator
   # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
   - name: AWS_K8S_TESTER_EKS_TEST_MODE
     value: "embedded"

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -291,6 +291,8 @@ func (k *kubernetesAnywhere) GetClusterCreated(gcpProject string) (time.Time, er
 	return time.Time{}, errors.New("not implemented")
 }
 
+func (_ *kubernetesAnywhere) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+
 const defaultConfigFile = ".config"
 
 type kubernetesAnywhereMultiCluster struct {
@@ -429,3 +431,5 @@ func (k *kubernetesAnywhereMultiCluster) Down() error {
 	}
 	return control.FinishRunningParallel(cmds...)
 }
+
+func (_ *kubernetesAnywhereMultiCluster) KubectlCommand() (*exec.Cmd, error) { return nil, nil }

--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -604,3 +604,5 @@ func (c Cluster) TestSetup() error {
 func (c Cluster) IsUp() error {
 	return isUp(c)
 }
+
+func (_ Cluster) KubectlCommand() (*exec.Cmd, error) { return nil, nil }

--- a/kubetest/bash.go
+++ b/kubetest/bash.go
@@ -102,6 +102,8 @@ func (b *bashDeployer) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return created, nil
 }
 
+func (_ *bashDeployer) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+
 // Calculates the cluster IP range based on the no. of nodes in the cluster.
 // Note: This mimics the function get-cluster-ip-range used by kube-up script.
 func getClusterIPRange(numNodes int) string {

--- a/kubetest/conformance/conformance.go
+++ b/kubetest/conformance/conformance.go
@@ -19,7 +19,9 @@ package conformance
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"os/exec"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -131,4 +133,9 @@ func (d *Deployer) Down() error {
 // GetClusterCreated returns the start time of the cluster container. If the container doesn't exist, has no start time, or has a malformed start time, then an error is returned.
 func (d *Deployer) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("cannot get cluster create time for conformance cluster")
+}
+
+func (_ *Deployer) KubectlCommand() (*exec.Cmd, error) {
+	log.Print("Noop - Conformance KubectlCommand()")
+	return nil, nil
 }

--- a/kubetest/eks/eks.go
+++ b/kubetest/eks/eks.go
@@ -26,13 +26,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
+	osexec "os/exec"
 	"syscall"
 	"time"
 
 	"github.com/aws/aws-k8s-tester/eksconfig"
 	"github.com/aws/aws-k8s-tester/ekstester"
-
 	"k8s.io/test-infra/kubetest/process"
 	"k8s.io/test-infra/kubetest/util"
 )
@@ -102,7 +101,7 @@ func (dp *deployer) Up() (err error) {
 	// "create cluster" command outputs cluster information
 	// in the configuration file (e.g. VPC ID, ALB DNS names, etc.)
 	// this needs be reloaded for other deployer method calls
-	createCmd := exec.Command(
+	createCmd := osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -130,7 +129,7 @@ func (dp *deployer) Down() (err error) {
 	if _, err = dp.LoadConfig(); err != nil {
 		return err
 	}
-	_, err = dp.ctrl.Output(exec.Command(
+	_, err = dp.ctrl.Output(osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -146,7 +145,7 @@ func (dp *deployer) IsUp() (err error) {
 	if _, err = dp.LoadConfig(); err != nil {
 		return err
 	}
-	_, err = dp.ctrl.Output(exec.Command(
+	_, err = dp.ctrl.Output(osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -187,7 +186,7 @@ func (dp *deployer) GetWorkerNodeLogs() (err error) {
 	if _, err = dp.LoadConfig(); err != nil {
 		return err
 	}
-	_, err = dp.ctrl.Output(exec.Command(
+	_, err = dp.ctrl.Output(osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -204,7 +203,7 @@ func (dp *deployer) DumpClusterLogs(artifactDir, _ string) (err error) {
 	if _, err = dp.LoadConfig(); err != nil {
 		return err
 	}
-	_, err = dp.ctrl.Output(exec.Command(
+	_, err = dp.ctrl.Output(osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -213,7 +212,7 @@ func (dp *deployer) DumpClusterLogs(artifactDir, _ string) (err error) {
 	if err != nil {
 		return err
 	}
-	_, err = dp.ctrl.Output(exec.Command(
+	_, err = dp.ctrl.Output(osexec.Command(
 		dp.cfg.AWSK8sTesterPath,
 		"eks",
 		"--path="+dp.cfg.ConfigPath,
@@ -221,6 +220,15 @@ func (dp *deployer) DumpClusterLogs(artifactDir, _ string) (err error) {
 		artifactDir,
 	))
 	return err
+}
+
+// KubectlCommand returns "kubectl" command object for API reachability tests.
+func (dp *deployer) KubectlCommand() (*osexec.Cmd, error) {
+	// reload configuration from disk to read the latest configuration
+	if _, err := dp.LoadConfig(); err != nil {
+		return nil, err
+	}
+	return osexec.Command(dp.cfg.KubectlPath, "--kubeconfig="+dp.cfg.KubeConfigPath), nil
 }
 
 // Stop stops ongoing operations.

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -652,3 +652,5 @@ func (g *gkeDeployer) GetClusterCreated(gcpProject string) (time.Time, error) {
 	}
 	return created, nil
 }
+
+func (_ *gkeDeployer) KubectlCommand() (*exec.Cmd, error) { return nil, nil }

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -653,6 +653,8 @@ func (k kops) Publish() error {
 	})
 }
 
+func (_ kops) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+
 // getRandomAWSZones looks up all regions, and the availability zones for those regions.  A random
 // region is then chosen and the AZ's for that region is returned. At least masterCount zones will be
 // returned, all in the same region.

--- a/kubetest/kubeadmdind/kubeadm_dind.go
+++ b/kubetest/kubeadmdind/kubeadm_dind.go
@@ -312,6 +312,8 @@ func (d *Deployer) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, errors.New("not implemented")
 }
 
+func (_ *Deployer) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+
 // findPath looks for the existence of a file or directory based on a
 // a github organization, github repo, and a relative path.  It looks
 // for the file/directory in this order:

--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -234,3 +234,5 @@ func (n localCluster) Down() error {
 func (n localCluster) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, errors.New("GetClusterCreated not implemented in localCluster")
 }
+
+func (_ localCluster) KubectlCommand() (*exec.Cmd, error) { return nil, nil }

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -226,6 +226,7 @@ type deployer interface {
 	TestSetup() error
 	Down() error
 	GetClusterCreated(gcpProject string) (time.Time, error)
+	KubectlCommand() (*exec.Cmd, error)
 }
 
 // publisher is implemented by deployers that want to publish status on success

--- a/kubetest/node.go
+++ b/kubetest/node.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"log"
+	"os/exec"
 	"time"
 )
 
@@ -54,4 +55,9 @@ func (n nodeDeploy) Down() error {
 
 func (n nodeDeploy) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, errors.New("not implemented")
+}
+
+func (_ nodeDeploy) KubectlCommand() (*exec.Cmd, error) {
+	log.Print("Noop - Node KubectlCommand()")
+	return nil, nil
 }

--- a/kubetest/none.go
+++ b/kubetest/none.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"log"
+	"os/exec"
 	"time"
 )
 
@@ -52,4 +53,9 @@ func (n noneDeploy) Down() error {
 
 func (n noneDeploy) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, errors.New("not implemented")
+}
+
+func (_ noneDeploy) KubectlCommand() (*exec.Cmd, error) {
+	log.Print("Noop KubectlCommand()")
+	return nil, nil
 }

--- a/vendor/github.com/aws/aws-k8s-tester/ec2config/BUILD.bazel
+++ b/vendor/github.com/aws/aws-k8s-tester/ec2config/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     deps = [
         "//vendor/github.com/aws/aws-k8s-tester/ec2config/plugins:go_default_library",
         "//vendor/github.com/aws/aws-k8s-tester/pkg/awsapi/ec2:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/vendor/github.com/aws/aws-k8s-tester/ec2config/config.go
+++ b/vendor/github.com/aws/aws-k8s-tester/ec2config/config.go
@@ -15,8 +15,7 @@ import (
 
 	"github.com/aws/aws-k8s-tester/ec2config/plugins"
 	ec2types "github.com/aws/aws-k8s-tester/pkg/awsapi/ec2"
-
-	gyaml "github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // Config defines EC2 configuration.
@@ -119,7 +118,7 @@ type Config struct {
 	// If empty, it will fetch subnets from a given or created VPC.
 	// And randomly assign them to instances.
 	SubnetIDs                  []string          `json:"subnet-ids,omitempty"`
-	SubnetIDToAvailibilityZone map[string]string `json:"subnet-id-to-availability-zone,omitempty"` // read-only to user
+	SubnetIDToAvailabilityZone map[string]string `json:"subnet-id-to-availability-zone,omitempty"` // read-only to user
 
 	// IngressRulesTCP is a map from TCP port range to CIDR to allow via security groups.
 	IngressRulesTCP map[string]string `json:"ingress-rules-tcp,omitempty"`
@@ -136,6 +135,9 @@ type Config struct {
 
 	// Wait is true to wait until all EC2 instances are ready.
 	Wait bool `json:"wait"`
+
+	// InstanceProfileName is the name of an instance profile with permissions to manage EC2 instances.
+	InstanceProfileName string `json:"instance-profile-name,omitempty"`
 }
 
 // Instance represents an EC2 instance.
@@ -448,7 +450,7 @@ func Load(p string) (cfg *Config, err error) {
 		return nil, err
 	}
 	cfg = new(Config)
-	if err = gyaml.Unmarshal(d, cfg); err != nil {
+	if err = yaml.Unmarshal(d, cfg); err != nil {
 		return nil, err
 	}
 
@@ -485,7 +487,7 @@ func (cfg *Config) Sync() (err error) {
 	}
 	cfg.UpdatedAt = time.Now().UTC()
 	var d []byte
-	d, err = gyaml.Marshal(cfg)
+	d, err = yaml.Marshal(cfg)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/aws/aws-k8s-tester/ec2config/plugins/plugins.go
+++ b/vendor/github.com/aws/aws-k8s-tester/ec2config/plugins/plugins.go
@@ -5,8 +5,6 @@ package plugins
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,16 +34,14 @@ func (ss scripts) Less(i, j int) bool { return keyPriorities[ss[i].key] < keyPri
 var keyPriorities = map[string]int{ // in the order of:
 	"update-amazon-linux-2":                1,
 	"update-ubuntu":                        2,
-	"set-env-aws-cred":                     3, // TODO: use instance role instead
-	"mount-aws-cred":                       4, // TODO: use instance role instead
-	"install-go":                           5,
-	"install-csi":                          6,
-	"install-etcd":                         7,
-	"install-aws-k8s-tester":               8,
-	"install-wrk":                          9,
-	"install-alb":                          10,
-	"install-start-docker-amazon-linux-2":  11,
-	"install-start-kubeadm-amazon-linux-2": 12,
+	"install-go":                           3,
+	"install-csi":                          4,
+	"install-etcd":                         5,
+	"install-aws-k8s-tester":               6,
+	"install-wrk":                          7,
+	"install-alb":                          8,
+	"install-start-docker-amazon-linux-2":  9,
+	"install-start-kubeadm-amazon-linux-2": 10,
 }
 
 func convertToScript(userName, plugin string) (script, error) {
@@ -55,65 +51,6 @@ func convertToScript(userName, plugin string) (script, error) {
 
 	case plugin == "update-ubuntu":
 		return script{key: "update-ubuntu", data: updateUbuntu}, nil
-
-	case strings.HasPrefix(plugin, "set-env-aws-cred-"):
-		// TODO: use instance role instead
-		env := strings.Replace(plugin, "set-env-aws-cred-", "", -1)
-		if os.Getenv(env) == "" {
-			return script{}, fmt.Errorf("%q is not defined", env)
-		}
-		d, derr := ioutil.ReadFile(os.Getenv(env))
-		if derr != nil {
-			return script{}, derr
-		}
-		lines := strings.Split(string(d), "\n")
-		prevDefault := false
-		accessKey, accessSecret := "", ""
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			if line == "[default]" {
-				prevDefault = true
-				continue
-			}
-			if prevDefault {
-				if strings.HasPrefix(line, "aws_access_key_id = ") {
-					accessKey = strings.Replace(line, "aws_access_key_id = ", "", -1)
-				}
-				if strings.HasPrefix(line, "aws_secret_access_key = ") {
-					accessSecret = strings.Replace(line, "aws_secret_access_key = ", "", -1)
-					break
-				}
-			}
-		}
-		return script{
-			key: "set-env-aws-cred",
-			data: fmt.Sprintf(`echo "export AWS_ACCESS_KEY_ID=%s" >> /home/%s/.bashrc
-echo "export AWS_SECRET_ACCESS_KEY=%s" >> /home/%s/.bashrc
-`, accessKey, userName, accessSecret, userName),
-		}, nil
-
-	case strings.HasPrefix(plugin, "mount-aws-cred-"):
-		// TODO: use instance role instead
-		env := strings.Replace(plugin, "mount-aws-cred-", "", -1)
-		if os.Getenv(env) == "" {
-			return script{}, fmt.Errorf("%q is not defined", env)
-		}
-		d, derr := ioutil.ReadFile(os.Getenv(env))
-		if derr != nil {
-			return script{}, derr
-		}
-		return script{
-			key: "mount-aws-cred",
-			data: fmt.Sprintf(`
-mkdir -p /home/%s/.aws/
-
-cat << EOT > /home/%s/.aws/credentials
-%s
-EOT`, userName, userName, string(d)),
-		}, nil
 
 	case strings.HasPrefix(plugin, "install-go-"):
 		goVer := strings.Replace(plugin, "install-go-", "", -1)

--- a/vendor/github.com/aws/aws-k8s-tester/eksconfig/BUILD.bazel
+++ b/vendor/github.com/aws/aws-k8s-tester/eksconfig/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
     deps = [
         "//vendor/github.com/aws/aws-k8s-tester/ec2config:go_default_library",
         "//vendor/github.com/aws/aws-k8s-tester/pkg/awsapi/ec2:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/client-go/util/homedir:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/vendor/github.com/aws/aws-k8s-tester/ekstester/tester.go
+++ b/vendor/github.com/aws/aws-k8s-tester/ekstester/tester.go
@@ -2,6 +2,7 @@
 package ekstester
 
 import (
+	osexec "os/exec"
 	"time"
 
 	"github.com/aws/aws-k8s-tester/eksconfig"
@@ -39,6 +40,9 @@ type Deployer interface {
 	// cluster configuration and its states.
 	// It's either reloaded from disk or returned from embedded EKS deployer.
 	LoadConfig() (eksconfig.Config, error)
+
+	// KubectlCommand returns "kubectl" command object for API reachability tests.
+	KubectlCommand() (*osexec.Cmd, error)
 }
 
 // ALB defines AWS application load balancer tester.


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/pull/71322 and https://github.com/aws/aws-k8s-tester.

- Update EKS test plugin vendor to configure kubectl download path
- Use that download path to configure "kubectl version" commands in e2e tests

Our issue was that all e2e tests were failing as below:

> W1121 23:44:50.939] 2018/11/21 23:44:50 main.go:312: Something went wrong: encountered 2 errors: [error during ./cluster/kubectl.sh --match-server-version=false version: exit status 1 error during ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8 --report-dir=/workspace/_artifacts --disable-log-dump=true: exit status 1]

And this `Something went wrong` error happens when

https://github.com/kubernetes/test-infra/blob/db6a12c4d12bcd77f4bcd2f84ba691dc496d71f1/kubetest/main.go#L406-L408

ref. https://github.com/kubernetes/test-infra/issues/9814