### PR TITLE
Re-add "Check APIReachability" to kubetest

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -144,6 +144,16 @@ func run(deploy deployer, o options) error {
 				return fmt.Errorf("error starting federation: %s", err)
 			}
 		}
+		// If node testing is enabled, check that the api is reachable before
+		// proceeding with further steps. This is accomplished by listing the nodes.
+		if !o.nodeTests {
+			errs = util.AppendError(errs, control.XMLWrap(&suite, "Check APIReachability", getKubectlVersion))
+			if dump != "" {
+				errs = util.AppendError(errs, control.XMLWrap(&suite, "list nodes", func() error {
+					return listNodes(dump)
+				}))
+			}
+		}
 	}
 
 	if o.checkLeaks {


### PR DESCRIPTION
This was removed in error in #10076 (https://github.com/kubernetes/test-infra/commit/5d1934bf56797b882312169ec18a9594e5cd0b85#diff-58b4b7bf4170631c1dbda0e0bc5c3b05).

/assign @BenTheElder 
/cc @AishSundar @liggitt 