### PR TITLE
bump kubekins-test to 1.13-latest for pull-heapster-e2e

### DIFF
--- a/images/heapster/Dockerfile
+++ b/images/heapster/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kubekins 1.10 + gcloud + heapster
-FROM gcr.io/k8s-testimages/kubekins-test:1.10-latest
+# Kubekins 1.13 + gcloud + heapster
+FROM gcr.io/k8s-testimages/kubekins-test:1.13-latest
 LABEL maintainer "senlu@google.com"
 
 ENV GCLOUD_VERSION 144.0.0

--- a/images/heapster/Makefile
+++ b/images/heapster/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.9
+VERSION = 0.10
 
 image:
 	docker build -t "gcr.io/k8s-testimages/heapster-test:$(VERSION)" .

--- a/scenarios/kubernetes_heapster.py
+++ b/scenarios/kubernetes_heapster.py
@@ -32,7 +32,7 @@ def check(*cmd):
     print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
-HEAPSTER_IMAGE_VERSION = '0.9'
+HEAPSTER_IMAGE_VERSION = '0.10'
 
 def main(ssh, ssh_pub, robot, project):
     """Run unit/integration heapster test against master in docker"""


### PR DESCRIPTION
This is a follow up for #10218.

This PR will bump kubekins-test to `1.13-latest` which is the latest stable image for kubekins-test.