### PR TITLE
spyglass: use the configured plank job URL prefix

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -349,7 +349,7 @@ func initSpyglass(configAgent *config.Agent, o options, mux *http.ServeMux, ja *
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GCS client")
 	}
-	sg := spyglass.New(ja, c)
+	sg := spyglass.New(ja, configAgent, c)
 
 	mux.Handle("/view/render", gziphandler.GzipHandler(handleArtifactView(sg, configAgent)))
 	mux.Handle("/view/", gziphandler.GzipHandler(handleRequestJobViews(sg, configAgent, o)))

--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/spyglass",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/deck/jobs:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/spyglass/viewers:go_default_library",


### PR DESCRIPTION
Spyglass currently assumes that the job status URLs are always Gubernator URLs. Given that the ultimate intent is for Spyglass to replace Gubernator, this is surprising behaviour.

Instead, assume that the the prefix used by plank for podutils is correct. This should be true for decorated jobs, and should be a slightly better heuristic than blindly assuming gubernator for others.

I'm not really convinced this is the best approach though.

/shrug
/cc @BenTheElder 
also cc @ibzib 