### PR TITLE
Define a formal job name regex

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -32,6 +32,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 26, 2018* job names must now match `^[A-Za-z0-9-._]+$`. Jobs that did not
+   match this before were allowed but did not provide a good user experience.
  - *November 15, 2018* the `hook` service account now requires RBAC privileges
    to create `ConfigMaps` to support new functionality in the `updateconfig` plugin.
  - *November 9, 2018* Prow gerrit client label/annotations now have a `prow.k8s.io/` namespace

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -629,7 +629,12 @@ func (c *Config) validateComponentConfig() error {
 	return nil
 }
 
+var jobNameRegex = regexp.MustCompile(`^[A-Za-z0-9-._]+$`)
+
 func validateJobBase(v JobBase, jobType kube.ProwJobType, podNamespace string) error {
+	if !jobNameRegex.MatchString(v.Name) {
+		return fmt.Errorf("name: must match regex %q", jobNameRegex.String())
+	}
 	// Ensure max_concurrency is non-negative.
 	if v.MaxConcurrency < 0 {
 		return fmt.Errorf("max_concurrency: %d must be a non-negative number", v.MaxConcurrency)

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -816,6 +816,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "valid kubernetes job",
 			base: JobBase{
+				Name:      "name",
 				Agent:     ka,
 				Spec:      &goodSpec,
 				Namespace: &ns,
@@ -825,6 +826,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "valid build job",
 			base: JobBase{
+				Name:      "name",
 				Agent:     ba,
 				BuildSpec: &buildv1alpha1.BuildSpec{},
 				Namespace: &ns,
@@ -834,6 +836,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "valid jenkins job",
 			base: JobBase{
+				Name:      "name",
 				Agent:     ja,
 				Namespace: &ns,
 			},
@@ -842,6 +845,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "invalid concurrency",
 			base: JobBase{
+				Name:           "name",
 				MaxConcurrency: -1,
 				Agent:          ka,
 				Spec:           &goodSpec,
@@ -851,6 +855,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "invalid agent",
 			base: JobBase{
+				Name:      "name",
 				Agent:     ba,
 				Spec:      &goodSpec, // want BuildSpec
 				Namespace: &ns,
@@ -859,6 +864,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "invalid pod spec",
 			base: JobBase{
+				Name:      "name",
 				Agent:     ka,
 				Namespace: &ns,
 				Spec:      &v1.PodSpec{}, // no containers
@@ -867,6 +873,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "invalid decoration",
 			base: JobBase{
+				Name:  "name",
 				Agent: ka,
 				Spec:  &goodSpec,
 				UtilityConfig: UtilityConfig{
@@ -878,6 +885,7 @@ func TestValidateJobBase(t *testing.T) {
 		{
 			name: "invalid labels",
 			base: JobBase{
+				Name:  "name",
 				Agent: ka,
 				Spec:  &goodSpec,
 				Labels: map[string]string{
@@ -885,6 +893,26 @@ func TestValidateJobBase(t *testing.T) {
 				},
 				Namespace: &ns,
 			},
+		},
+		{
+			name: "invalid name",
+			base: JobBase{
+				Name:      "a/b",
+				Agent:     ka,
+				Spec:      &goodSpec,
+				Namespace: &ns,
+			},
+			pass: false,
+		},
+		{
+			name: "valid complex name",
+			base: JobBase{
+				Name:      "a-b.c",
+				Agent:     ka,
+				Spec:      &goodSpec,
+				Namespace: &ns,
+			},
+			pass: true,
 		},
 	}
 

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -79,7 +79,7 @@ func mergePreset(preset Preset, labels map[string]string, pod *v1.PodSpec) error
 
 // JobBase contains attributes common to all job types
 type JobBase struct {
-	// The name of the job.
+	// The name of the job. Must match regex [A-Za-z0-9-._]+
 	// e.g. pull-test-infra-bazel-build
 	Name string `json:"name"`
 	// Labels are added to prowjobs and pods created for this job.

--- a/prow/jobs.md
+++ b/prow/jobs.md
@@ -14,7 +14,7 @@ Periodic config looks like so:
 
 ```yaml
 periodics:
-- name: foo-job         # Names need not be unique.
+- name: foo-job         # Names need not be unique, but must match the regex ^[A-Za-z0-9-._]+$
   decorate: true        # Enable Pod Utility decoration. (see below)
   interval: 1h          # Anything that can be parsed by time.ParseDuration.
   spec: {}              # Valid Kubernetes PodSpec.


### PR DESCRIPTION
Previously, no formal specification for the content of a job name was
given, but implicit requirements did exist. This change defines a strict
regex that job names must match to expose those requirements publically.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @BenTheElder @cjwagner 
/cc @fejta 
fixes https://github.com/kubernetes/test-infra/issues/10209