### PR TITLE
Add support for error_on_eviction job config field.

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -128,6 +128,11 @@ type ProwJobSpec struct {
 	// MaxConcurrency restricts the total number of instances
 	// of this job that can run in parallel at once
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
+	// ErrorOnEviction indicates that the ProwJob should be completed and given
+	// the ErrorState status if the pod that is executing the job is evicted.
+	// If this field is unspecified or false, a new pod will be created to replace
+	// the evicted one.
+	ErrorOnEviction bool `json:"error_on_eviction,omitempty"`
 
 	// PodSpec provides the basis for running the test under
 	// a Kubernetes agent

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -985,6 +985,8 @@ func validateAgent(v JobBase, podNamespace string) error {
 	case v.DecorationConfig != nil && agent != k:
 		// TODO(fejta): support decoration
 		return fmt.Errorf("decoration requires agent: %s (found %q)", k, agent)
+	case v.ErrorOnEviction && agent != k:
+		return fmt.Errorf("error_on_eviction only applies to agent: %s (found %q)", k, agent)
 	case v.Namespace == nil || *v.Namespace == "":
 		return fmt.Errorf("failed to default namespace")
 	case *v.Namespace != podNamespace && agent != b:
@@ -1123,6 +1125,9 @@ func (c *ProwConfig) defaultJobBase(base *JobBase) {
 	if base.Namespace == nil || *base.Namespace == "" {
 		s := c.PodNamespace
 		base.Namespace = &s
+	}
+	if base.Cluster == "" {
+		base.Cluster = kube.DefaultClusterAlias
 	}
 }
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -42,6 +42,7 @@ func TestDefaultJobBase(t *testing.T) {
 	filled := JobBase{
 		Agent:     "foo",
 		Namespace: &bar,
+		Cluster:   "build",
 	}
 	cases := []struct {
 		name     string
@@ -88,6 +89,15 @@ func TestDefaultJobBase(t *testing.T) {
 			expected: func(j *JobBase) {
 				p := "new-pod-namespace"
 				j.Namespace = &p
+			},
+		},
+		{
+			name: "empty cluster becomes DefaultClusterAlias",
+			base: func(j *JobBase) {
+				j.Cluster = ""
+			},
+			expected: func(j *JobBase) {
+				j.Cluster = kube.DefaultClusterAlias
 			},
 		},
 	}
@@ -516,6 +526,20 @@ func TestValidateAgent(t *testing.T) {
 				j.Agent = jenk
 				j.Spec = nil
 				j.DecorationConfig = nil
+			},
+			pass: true,
+		},
+		{
+			name: "error_on_eviction requires kubernetes agent",
+			base: func(j *JobBase) {
+				j.Agent = b
+				j.ErrorOnEviction = true
+			},
+		},
+		{
+			name: "error_on_eviction allowed for kubernetes agent",
+			base: func(j *JobBase) {
+				j.ErrorOnEviction = true
 			},
 			pass: true,
 		},

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -95,6 +95,11 @@ type JobBase struct {
 	//   nil: results in config.PodNamespace (aka pod default)
 	//   empty: results in config.ProwJobNamespace (aka same as prowjob)
 	Namespace *string `json:"namespace,omitempty"`
+	// ErrorOnEviction indicates that the ProwJob should be completed and given
+	// the ErrorState status if the pod that is executing the job is evicted.
+	// If this field is unspecified or false, a new pod will be created to replace
+	// the evicted one.
+	ErrorOnEviction bool `json:"error_on_eviction,omitempty"`
 	// SourcePath contains the path where this job is defined
 	SourcePath string `json:"-"`
 	// Spec is the Kubernetes pod spec used if Agent is kubernetes.

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -31,6 +31,7 @@ spec:
       initupload: initupload:default
       sidecar: sidecar:default
   job: kubernetes-defaulted-decoration
+  namespace: default
   pod_spec:
     containers:
     - args:

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -31,6 +31,7 @@ spec:
       initupload: initupload:explicit
       sidecar: sidecar:explicit
   job: kubernetes-explicit-decoration
+  namespace: default
   pod_spec:
     containers:
     - args:

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -17,6 +17,7 @@ spec:
   cluster: default
   context: kubernetes-no-decoration
   job: kubernetes-no-decoration
+  namespace: default
   pod_spec:
     containers:
     - args:


### PR DESCRIPTION
This PR adds a per job config field, `error_on_eviction` that changes how `plank` handles evicted pods for the job. If this field is set to `true`, instead of silently creating a new pod for the ProwJob to continue with, `plank` will mark the ProwJob as completed and errored.

I also included some other fixes for problems that I noticed along the way:
- Move `Cluster` field defaulting to be with the rest of the config defaulting.
- Actually transfer `Namespace` and `BuildSpec` fields from job config to ProwJobSpec (previously they were ignored when creating new ProwJobSpecs).
- Generalize the steps of ProwJobSpec creation that are common to the different job types.
- Transfer `Cluster` field from job config to ProwJobSpec for all agents, not just the kubernetes agent (build-CRD controller will need this).

fixes #10188 
/cc @fejta @BenTheElder @mborsz @stevekuznetsov 
/kind feature
/kind bug