### PR TITLE
spyglass: prevent slice from going out of bounds

### DIFF
--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -261,7 +261,7 @@ func (s *Spyglass) prowToGCS(prowKey string) (string, error) {
 
 	url := job.Status.URL
 	prefix := s.ConfigAgent.Config().Plank.JobURLPrefix
-	if url[:len(prefix)] != prefix {
+	if !strings.HasPrefix(url, prefix) {
 		return "", fmt.Errorf("unexpected job URL %q when finding GCS path: expected something starting with %q", url, prefix)
 	}
 	return url[len(prefix):], nil

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -19,6 +19,7 @@ package spyglass
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -496,6 +497,12 @@ func TestProwToGCS(t *testing.T) {
 			key:          "spyglass-job/1111",
 			configPrefix: "https://gubernator.example.com/build/",
 			expectedPath: "",
+			expectError:  true,
+		},
+		{
+			name:         "prefix longer than URL",
+			key:          "spyglass-job/2222",
+			configPrefix: strings.Repeat("!", 100),
 			expectError:  true,
 		},
 	}


### PR DESCRIPTION
I was late to reviewing #10228. Slicing out of bounds causes a panic, whereas `strings.HasPrefix` is safe. Probably not very likely to matter in this case, but who knows

/assign @Katharine 
/meow