### PR TITLE
retire "version" key in metadata

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -544,7 +544,6 @@ func writeMetadata(path, metadataSources string) error {
 	}
 
 	ver := findVersion()
-	m["version"] = ver // TODO(fejta): retire
 	m["job-version"] = ver
 	re := regexp.MustCompile(`^BUILD_METADATA_(.+)$`)
 	for _, e := range os.Environ() {

--- a/kubetest/main_test.go
+++ b/kubetest/main_test.go
@@ -38,7 +38,7 @@ func TestWriteMetadata(t *testing.T) {
 	}{
 		{
 			sources: nil,
-			key:     "version",
+			key:     "job-version",
 			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
 		},
 		{


### PR DESCRIPTION
bootstrap logic: https://github.com/kubernetes/test-infra/blob/be93b6afb606bef48f52c4b8936e673d8a0b4bda/jenkins/bootstrap.py#L539-L559

At least clean up kubetest, and leave bootstrap as is.

/assign @fejta 