### PR TITLE
Drop the todo to deprecate interval field in periodic jobs

### DIFF
--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -89,7 +89,6 @@ func sync(kc kubeClient, cfg *config.Config, cr cronClient, now time.Time) error
 	}
 	latestJobs := pjutil.GetLatestProwJobs(jobs, kube.PeriodicJob)
 
-	// TODO(krzyzacy): retire the interval check, migrate everything to use cron
 	if err := cr.SyncConfig(cfg); err != nil {
 		logrus.WithError(err).Error("Error syncing cron jobs.")
 	}


### PR DESCRIPTION
Not gonna happen, and interval is easier to configure than a cron string, so, drop the TODO to avoid confusion.

/assign @BenTheElder @cjwagner @stevekuznetsov 
cc @mattlandis