### PR TITLE
Refactor how we provide data to plugins

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -145,7 +145,7 @@ func main() {
 	}
 	cfg := configAgent.Config()
 
-	pluginAgent := plugins.PluginAgent{}
+	pluginAgent := plugins.ConfigAgent{}
 	if err := pluginAgent.Load(o.pluginConfig); err != nil {
 		logrus.WithError(err).Fatal("Error loading Prow plugin config.")
 	}

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pluginhelp/hook:go_default_library",
         "//prow/plugins:go_default_library",
-        "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/test-infra/prow/metrics"
 	pluginhelp "k8s.io/test-infra/prow/pluginhelp/hook"
 	"k8s.io/test-infra/prow/plugins"
-	"k8s.io/test-infra/prow/repoowners"
 	"k8s.io/test-infra/prow/slack"
 )
 
@@ -141,22 +140,14 @@ func main() {
 		slackClient = slack.NewFakeClient()
 	}
 
-	pluginAgent := &plugins.ConfigAgent{}
-
-	ownersClient := repoowners.NewClient(
-		gitClient, githubClient,
-		configAgent, pluginAgent.MDYAMLEnabled,
-		pluginAgent.SkipCollaborators,
-	)
-
-	pluginAgent.Agent = plugins.Agent{
+	clientAgent := &plugins.ClientAgent{
 		GitHubClient: githubClient,
 		KubeClient:   kubeClient,
 		GitClient:    gitClient,
 		SlackClient:  slackClient,
-		OwnersClient: ownersClient,
-		Logger:       logrus.WithField("agent", "plugin"),
 	}
+
+	pluginAgent := &plugins.ConfigAgent{}
 	if err := pluginAgent.Start(o.pluginConfig); err != nil {
 		logrus.WithError(err).Fatal("Error starting plugins.")
 	}
@@ -170,6 +161,7 @@ func main() {
 	}
 
 	server := &hook.Server{
+		ClientAgent:    clientAgent,
 		ConfigAgent:    configAgent,
 		Plugins:        pluginAgent,
 		Metrics:        promMetrics,

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -141,7 +141,7 @@ func main() {
 		slackClient = slack.NewFakeClient()
 	}
 
-	pluginAgent := &plugins.PluginAgent{}
+	pluginAgent := &plugins.ConfigAgent{}
 
 	ownersClient := repoowners.NewClient(
 		gitClient, githubClient,

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -149,7 +149,7 @@ func main() {
 		pluginAgent.SkipCollaborators,
 	)
 
-	pluginAgent.PluginClient = plugins.PluginClient{
+	pluginAgent.Agent = plugins.Agent{
 		GitHubClient: githubClient,
 		KubeClient:   kubeClient,
 		GitClient:    gitClient,

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -24,7 +24,7 @@ import (
 
 // Make sure that our plugins are valid.
 func TestPlugins(t *testing.T) {
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 	if err := pa.Load("../../plugins.yaml"); err != nil {
 		t.Fatalf("Could not load plugins: %v.", err)
 	}

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -102,7 +102,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting secrets agent.")
 	}
 
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 	if err := pa.Start(o.pluginConfig); err != nil {
 		log.WithError(err).Fatalf("Error loading plugin config from %q.", o.pluginConfig)
 	}
@@ -173,7 +173,7 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 	return nil
 }
 
-func periodicUpdate(log *logrus.Entry, pa *plugins.PluginAgent, ghc *github.Client, period time.Duration) {
+func periodicUpdate(log *logrus.Entry, pa *plugins.ConfigAgent, ghc *github.Client, period time.Duration) {
 	update := func() {
 		start := time.Now()
 		if err := plugin.HandleAll(log, ghc, pa.Config()); err != nil {

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -55,14 +55,6 @@ type commentPruner interface {
 	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
-// func init() {
-// 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, helpProvider)
-// }
-
-// func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
-// 	return handleEvent(pc.Logger, pc.GitHubClient, pc.CommentPruner, &pre)
-// }
-
 func HelpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 			Description: `The needs-rebase plugin manages the '` + labels.NeedsRebase + `' label by removing it from Pull Requests that are mergeable and adding it to those which are not.

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -59,7 +59,7 @@ type commentPruner interface {
 // 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, helpProvider)
 // }
 
-// func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+// func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
 // 	return handleEvent(pc.Logger, pc.GitHubClient, pc.CommentPruner, &pre)
 // }
 

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/hook",
     deps = [
-        "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -65,7 +65,7 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.ReviewEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -121,7 +121,7 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 		s.wg.Add(1)
 		go func(p string, h plugins.ReviewCommentEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -176,7 +176,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 		s.wg.Add(1)
 		go func(p string, h plugins.PullRequestHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -232,7 +232,7 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.PushEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -257,7 +257,7 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.IssueHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -314,7 +314,7 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 		s.wg.Add(1)
 		go func(p string, h plugins.IssueCommentHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -370,7 +370,7 @@ func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.StatusEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
@@ -401,7 +401,7 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericComment
 		s.wg.Add(1)
 		go func(p string, h plugins.GenericCommentHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.PluginClient
+			pc := s.Plugins.Agent
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -19,7 +19,6 @@ package hook
 import (
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/commentpruner"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -65,19 +64,14 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.ReviewEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				re.Repo.Owner.Login,
 				re.Repo.Name,
 				re.PullRequest.Number,
 			)
-			if err := h(pc, re); err != nil {
-				pc.Logger.WithError(err).Error("Error handling ReviewEvent.")
+			if err := h(agent, re); err != nil {
+				agent.Logger.WithError(err).Error("Error handling ReviewEvent.")
 			}
 		}(p, h)
 	}
@@ -121,19 +115,14 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 		s.wg.Add(1)
 		go func(p string, h plugins.ReviewCommentEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				rce.Repo.Owner.Login,
 				rce.Repo.Name,
 				rce.PullRequest.Number,
 			)
-			if err := h(pc, rce); err != nil {
-				pc.Logger.WithError(err).Error("Error handling ReviewCommentEvent.")
+			if err := h(agent, rce); err != nil {
+				agent.Logger.WithError(err).Error("Error handling ReviewCommentEvent.")
 			}
 		}(p, h)
 	}
@@ -176,19 +165,14 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 		s.wg.Add(1)
 		go func(p string, h plugins.PullRequestHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				pr.Repo.Owner.Login,
 				pr.Repo.Name,
 				pr.PullRequest.Number,
 			)
-			if err := h(pc, pr); err != nil {
-				pc.Logger.WithError(err).Error("Error handling PullRequestEvent.")
+			if err := h(agent, pr); err != nil {
+				agent.Logger.WithError(err).Error("Error handling PullRequestEvent.")
 			}
 		}(p, h)
 	}
@@ -232,12 +216,9 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.PushEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			if err := h(pc, pe); err != nil {
-				pc.Logger.WithError(err).Error("Error handling PushEvent.")
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			if err := h(agent, pe); err != nil {
+				agent.Logger.WithError(err).Error("Error handling PushEvent.")
 			}
 		}(p, h)
 	}
@@ -257,19 +238,14 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.IssueHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				i.Repo.Owner.Login,
 				i.Repo.Name,
 				i.Issue.Number,
 			)
-			if err := h(pc, i); err != nil {
-				pc.Logger.WithError(err).Error("Error handling IssueEvent.")
+			if err := h(agent, i); err != nil {
+				agent.Logger.WithError(err).Error("Error handling IssueEvent.")
 			}
 		}(p, h)
 	}
@@ -314,19 +290,14 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 		s.wg.Add(1)
 		go func(p string, h plugins.IssueCommentHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				ic.Repo.Owner.Login,
 				ic.Repo.Name,
 				ic.Issue.Number,
 			)
-			if err := h(pc, ic); err != nil {
-				pc.Logger.WithError(err).Error("Error handling IssueCommentEvent.")
+			if err := h(agent, ic); err != nil {
+				agent.Logger.WithError(err).Error("Error handling IssueCommentEvent.")
 			}
 		}(p, h)
 	}
@@ -370,12 +341,9 @@ func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
 		s.wg.Add(1)
 		go func(p string, h plugins.StatusEventHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			if err := h(pc, se); err != nil {
-				pc.Logger.WithError(err).Error("Error handling StatusEvent.")
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			if err := h(agent, se); err != nil {
+				agent.Logger.WithError(err).Error("Error handling StatusEvent.")
 			}
 		}(p, h)
 	}
@@ -401,19 +369,14 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericComment
 		s.wg.Add(1)
 		go func(p string, h plugins.GenericCommentHandler) {
 			defer s.wg.Done()
-			pc := s.Plugins.Agent
-			pc.Logger = l.WithField("plugin", p)
-			pc.Config = s.ConfigAgent.Config()
-			pc.PluginConfig = s.Plugins.Config()
-			pc.CommentPruner = commentpruner.NewEventClient(
-				pc.GitHubClient,
-				l.WithField("client", "commentpruner"),
+			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, l.WithField("plugin", p))
+			agent.InitializeCommentPruner(
 				ce.Repo.Owner.Login,
 				ce.Repo.Name,
 				ce.Number,
 			)
-			if err := h(pc, *ce); err != nil {
-				pc.Logger.WithError(err).Error("Error handling GenericCommentEvent.")
+			if err := h(agent, *ce); err != nil {
+				agent.Logger.WithError(err).Error("Error handling GenericCommentEvent.")
 			}
 		}(p, h)
 	}

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -50,7 +50,7 @@ func TestHook(t *testing.T) {
 	}
 	plugins.RegisterIssueHandler(
 		"baz",
-		func(pc plugins.PluginClient, ie github.IssueEvent) error {
+		func(pc plugins.Agent, ie github.IssueEvent) error {
 			called <- true
 			return nil
 		},

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -56,7 +56,7 @@ func TestHook(t *testing.T) {
 		},
 		nil,
 	)
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
 	metrics := NewMetrics()

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -59,6 +59,7 @@ func TestHook(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
+	clientAgent := &plugins.ClientAgent{}
 	metrics := NewMetrics()
 
 	getSecret := func() []byte {
@@ -66,6 +67,7 @@ func TestHook(t *testing.T) {
 	}
 
 	s := httptest.NewServer(&Server{
+		ClientAgent:    clientAgent,
 		Plugins:        pa,
 		ConfigAgent:    ca,
 		Metrics:        metrics,

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -37,6 +37,7 @@ import (
 // Server implements http.Handler. It validates incoming GitHub webhooks and
 // then dispatches them to the appropriate plugins.
 type Server struct {
+	ClientAgent    *plugins.ClientAgent
 	Plugins        *plugins.ConfigAgent
 	ConfigAgent    *config.Agent
 	TokenGenerator func() []byte

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -37,7 +37,7 @@ import (
 // Server implements http.Handler. It validates incoming GitHub webhooks and
 // then dispatches them to the appropriate plugins.
 type Server struct {
-	Plugins        *plugins.PluginAgent
+	Plugins        *plugins.ConfigAgent
 	ConfigAgent    *config.Agent
 	TokenGenerator func() []byte
 	Metrics        *Metrics

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestServeHTTPErrors(t *testing.T) {
 	metrics := NewMetrics()
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 	pa.Set(&plugins.Configuration{})
 
 	getSecret := func() []byte {
@@ -242,7 +242,7 @@ func TestNeedDemux(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("Running scenario %q", test.name)
 
-		pa := &plugins.PluginAgent{}
+		pa := &plugins.ConfigAgent{}
 		pa.Set(&plugins.Configuration{
 			ExternalPlugins: test.plugins,
 		})

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -133,7 +133,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {
+func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) error {
 	return handleGenericComment(
 		pc.Logger,
 		pc.GitHubClient,
@@ -188,7 +188,7 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, 
 
 // handleReviewEvent should only handle reviews that have no approval command.
 // Reviews with approval commands will be handled by handleGenericCommentEvent.
-func handleReviewEvent(pc plugins.PluginClient, re github.ReviewEvent) error {
+func handleReviewEvent(pc plugins.Agent, re github.ReviewEvent) error {
 	return handleReview(
 		pc.Logger,
 		pc.GitHubClient,
@@ -247,7 +247,7 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, config *
 
 }
 
-func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return handlePullRequest(
 		pc.Logger,
 		pc.GitHubClient,

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -41,7 +41,7 @@ const prNumber = 1
 
 // TestPluginConfig validates that there are no duplicate repos in the approve plugin config.
 func TestPluginConfig(t *testing.T) {
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 
 	b, err := ioutil.ReadFile("../../plugins.yaml")
 	if err != nil {

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -72,7 +72,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}

--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -86,22 +86,18 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 type blockCalc func([]github.PullRequestChange, []blockade) summary
 
 type client struct {
-	ghc    githubClient
-	log    *logrus.Entry
-	pruner pruneClient
+	ghc githubClient
+	log *logrus.Entry
 
 	blockCalc blockCalc
 }
 
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
-	c := &client{
-		ghc:    pc.GitHubClient,
-		log:    pc.Logger,
-		pruner: pc.CommentPruner,
-
-		blockCalc: calculateBlocks,
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
 	}
-	return handle(c, pc.PluginConfig.Blockades, &pre)
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.Blockades, cp, calculateBlocks, &pre)
 }
 
 // blockade is a compiled version of a plugins.Blockade config struct.
@@ -131,7 +127,7 @@ func (s summary) String() string {
 	return buf.String()
 }
 
-func handle(c *client, config []plugins.Blockade, pre *github.PullRequestEvent) error {
+func handle(ghc githubClient, log *logrus.Entry, config []plugins.Blockade, cp pruneClient, blockCalc blockCalc, pre *github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionSynchronize &&
 		pre.Action != github.PullRequestActionOpened &&
 		pre.Action != github.PullRequestActionReopened {
@@ -140,13 +136,13 @@ func handle(c *client, config []plugins.Blockade, pre *github.PullRequestEvent) 
 
 	org := pre.Repo.Owner.Login
 	repo := pre.Repo.Name
-	issueLabels, err := c.ghc.GetIssueLabels(org, repo, pre.Number)
+	issueLabels, err := ghc.GetIssueLabels(org, repo, pre.Number)
 	if err != nil {
 		return err
 	}
 
 	labelPresent := hasBlockedLabel(issueLabels)
-	blockades := compileApplicableBlockades(org, repo, c.log, config)
+	blockades := compileApplicableBlockades(org, repo, log, config)
 	if len(blockades) == 0 && !labelPresent {
 		// Since the label is missing, we assume that we removed any associated comments.
 		return nil
@@ -154,27 +150,27 @@ func handle(c *client, config []plugins.Blockade, pre *github.PullRequestEvent) 
 
 	var sum summary
 	if len(blockades) > 0 {
-		changes, err := c.ghc.GetPullRequestChanges(org, repo, pre.Number)
+		changes, err := ghc.GetPullRequestChanges(org, repo, pre.Number)
 		if err != nil {
 			return err
 		}
-		sum = c.blockCalc(changes, blockades)
+		sum = blockCalc(changes, blockades)
 	}
 
 	shouldBlock := len(sum) > 0
 	if shouldBlock && !labelPresent {
 		// Add the label and leave a comment explaining why the label was added.
-		if err := c.ghc.AddLabel(org, repo, pre.Number, labels.BlockedPaths); err != nil {
+		if err := ghc.AddLabel(org, repo, pre.Number, labels.BlockedPaths); err != nil {
 			return err
 		}
 		msg := plugins.FormatResponse(pre.PullRequest.User.Login, blockedPathsBody, sum.String())
-		return c.ghc.CreateComment(org, repo, pre.Number, msg)
+		return ghc.CreateComment(org, repo, pre.Number, msg)
 	} else if !shouldBlock && labelPresent {
 		// Remove the label and delete any comments created by this plugin.
-		if err := c.ghc.RemoveLabel(org, repo, pre.Number, labels.BlockedPaths); err != nil {
+		if err := ghc.RemoveLabel(org, repo, pre.Number, labels.BlockedPaths); err != nil {
 			return err
 		}
-		c.pruner.PruneComments(func(ic github.IssueComment) bool {
+		cp.PruneComments(func(ic github.IssueComment) bool {
 			return strings.Contains(ic.Body, blockedPathsBody)
 		})
 	}

--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -93,7 +93,7 @@ type client struct {
 	blockCalc blockCalc
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	c := &client{
 		ghc:    pc.GitHubClient,
 		log:    pc.Logger,

--- a/prow/plugins/blockade/blockade_test.go
+++ b/prow/plugins/blockade/blockade_test.go
@@ -323,13 +323,7 @@ func TestHandle(t *testing.T) {
 			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 			Number: 1,
 		}
-		c := &client{
-			ghc:       fakeClient,
-			log:       logrus.WithField("plugin", PluginName),
-			pruner:    &fakePruner{},
-			blockCalc: calcF,
-		}
-		if err := handle(c, tc.config, pre); err != nil {
+		if err := handle(fakeClient, logrus.WithField("plugin", PluginName), tc.config, &fakePruner{}, calcF, pre); err != nil {
 			t.Errorf("[%s] Unexpected error from handle: %v.", tc.name, err)
 			continue
 		}

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -96,7 +96,7 @@ type githubClient interface {
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened || assign.CCRegexp.MatchString(pre.PullRequest.Body) {
 		return nil
 	}

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -72,7 +72,7 @@ type githubClient interface {
 	ListPullRequestComments(org, repo string, number int) ([]github.ReviewComment, error)
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, &e)
 }
 

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -173,7 +173,7 @@ func (r *realClowder) readCat(category string, movieCat bool) (string, error) {
 	return a.Format()
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(
 		pc.GitHubClient,
 		pc.Logger,

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -66,7 +66,14 @@ type commentPruner interface {
 }
 
 func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
-	return handlePR(pc.GitHubClient, pc.Logger, &pr, pc.CommentPruner, pc.PluginConfig.CherryPickUnapproved.BranchRe, pc.PluginConfig.CherryPickUnapproved.Comment)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handlePR(
+		pc.GitHubClient, pc.Logger, &pr, cp,
+		pc.PluginConfig.CherryPickUnapproved.BranchRe, pc.PluginConfig.CherryPickUnapproved.Comment,
+	)
 }
 
 func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, cp commentPruner, branchRe *regexp.Regexp, commentBody string) error {

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -65,7 +65,7 @@ type commentPruner interface {
 	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, pc.Logger, &pr, pc.CommentPruner, pc.PluginConfig.CherryPickUnapproved.BranchRe, pc.PluginConfig.CherryPickUnapproved.Comment)
 }
 

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"regexp"
+
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
-	"regexp"
 )
 
 const (
@@ -89,7 +90,7 @@ type gitHubClient interface {
 	ListStatuses(org, repo, ref string) ([]github.Status, error)
 }
 
-func handleStatusEvent(pc plugins.PluginClient, se github.StatusEvent) error {
+func handleStatusEvent(pc plugins.Agent, se github.StatusEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, se)
 }
 
@@ -189,7 +190,7 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 	return nil
 }
 
-func handleCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {
+func handleCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) error {
 	return handleComment(pc.GitHubClient, pc.Logger, &ce)
 }
 

--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -57,7 +57,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, pe)
 }
 

--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -128,7 +128,7 @@ func (u realPack) readDog(dogURL string) (string, error) {
 	return FormatURL(dogURL)
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, dogURL)
 }
 

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -80,7 +80,7 @@ func minConfidence(g *plugins.Golint) float64 {
 	return *g.MinimumConfidence
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(minConfidence(pc.PluginConfig.Golint), pc.GitHubClient, pc.GitClient, pc.Logger, &e)
 }
 

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -74,18 +74,18 @@ type client struct {
 	Logger       *logrus.Entry
 }
 
-func getClient(pc plugins.PluginClient) client {
+func getClient(pc plugins.Agent) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
 		Logger:       pc.Logger,
 	}
 }
 
-func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+func handleIssueComment(pc plugins.Agent, ic github.IssueCommentEvent) error {
 	return handleIC(getClient(pc), pc.PluginConfig.Heart.Adorees, ic)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return handlePR(getClient(pc), pre)
 }
 

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -87,7 +87,7 @@ type commentPruner interface {
 	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, pc.CommentPruner, &e)
 }
 

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -88,7 +87,11 @@ type commentPruner interface {
 }
 
 func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, pc.CommentPruner, &e)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.GitHubClient, pc.Logger, cp, &e)
 }
 
 func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.GenericCommentEvent) error {

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -66,7 +66,7 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	hasLabel := func(label string, labels []github.Label) bool {
 		return github.HasLabel(label, labels)
 	}

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -57,7 +57,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	var labels []string
 	if pc.PluginConfig.Label != nil {
 		labels = pc.PluginConfig.Label.AdditionalLabels

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -51,7 +51,7 @@ type commentPruner interface {
 
 func init() {
 	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(PluginName, func(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+	plugins.RegisterPullRequestHandler(PluginName, func(pc plugins.Agent, pe github.PullRequestEvent) error {
 		return handlePullRequestEvent(pc, pe)
 	}, helpProvider)
 	plugins.RegisterReviewEventHandler(PluginName, handlePullRequestReviewEvent, helpProvider)
@@ -120,11 +120,11 @@ type reviewCtx struct {
 	number                             int
 }
 
-func handleGenericCommentEvent(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, pc.CommentPruner, e)
 }
 
-func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return handlePullRequest(
 		pc.Logger,
 		pc.GitHubClient,
@@ -133,7 +133,7 @@ func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent
 	)
 }
 
-func handlePullRequestReviewEvent(pc plugins.PluginClient, e github.ReviewEvent) error {
+func handlePullRequestReviewEvent(pc plugins.Agent, e github.ReviewEvent) error {
 	// If ReviewActsAsLgtm is disabled, ignore review event.
 	opts := optionsForRepo(pc.PluginConfig, e.Repo.Owner.Login, e.Repo.Name)
 	if !opts.ReviewActsAsLgtm {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -121,7 +121,11 @@ type reviewCtx struct {
 }
 
 func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
-	return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, pc.CommentPruner, e)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
 }
 
 func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
@@ -139,7 +143,11 @@ func handlePullRequestReviewEvent(pc plugins.Agent, e github.ReviewEvent) error 
 	if !opts.ReviewActsAsLgtm {
 		return nil
 	}
-	return handlePullRequestReview(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, pc.CommentPruner, e)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handlePullRequestReview(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
 }
 
 func handleGenericComment(gc githubClient, config *plugins.Configuration, ownersClient repoowners.Interface, log *logrus.Entry, cp commentPruner, e github.GenericCommentEvent) error {

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -70,7 +70,7 @@ type lifecycleClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
-func lifecycleHandleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func lifecycleHandleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	gc := pc.GitHubClient
 	log := pc.Logger
 	if err := handleReopen(gc, log, &e); err != nil {

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -78,7 +78,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.RepoMilestone)
 }
 

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -78,7 +78,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.RepoMilestone)
 }
 

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -117,7 +117,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	c := client{
 		gc: pc.GitHubClient,
 		jc: pc.Config.JobConfig,

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -54,7 +54,7 @@ type githubClient interface {
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
 		return nil
 	}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -63,64 +63,64 @@ func HelpProviders() map[string]HelpProvider {
 	return pluginHelp
 }
 
-type IssueHandler func(PluginClient, github.IssueEvent) error
+type IssueHandler func(Agent, github.IssueEvent) error
 
 func RegisterIssueHandler(name string, fn IssueHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	issueHandlers[name] = fn
 }
 
-type IssueCommentHandler func(PluginClient, github.IssueCommentEvent) error
+type IssueCommentHandler func(Agent, github.IssueCommentEvent) error
 
 func RegisterIssueCommentHandler(name string, fn IssueCommentHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	issueCommentHandlers[name] = fn
 }
 
-type PullRequestHandler func(PluginClient, github.PullRequestEvent) error
+type PullRequestHandler func(Agent, github.PullRequestEvent) error
 
 func RegisterPullRequestHandler(name string, fn PullRequestHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	pullRequestHandlers[name] = fn
 }
 
-type StatusEventHandler func(PluginClient, github.StatusEvent) error
+type StatusEventHandler func(Agent, github.StatusEvent) error
 
 func RegisterStatusEventHandler(name string, fn StatusEventHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	statusEventHandlers[name] = fn
 }
 
-type PushEventHandler func(PluginClient, github.PushEvent) error
+type PushEventHandler func(Agent, github.PushEvent) error
 
 func RegisterPushEventHandler(name string, fn PushEventHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	pushEventHandlers[name] = fn
 }
 
-type ReviewEventHandler func(PluginClient, github.ReviewEvent) error
+type ReviewEventHandler func(Agent, github.ReviewEvent) error
 
 func RegisterReviewEventHandler(name string, fn ReviewEventHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	reviewEventHandlers[name] = fn
 }
 
-type ReviewCommentEventHandler func(PluginClient, github.ReviewCommentEvent) error
+type ReviewCommentEventHandler func(Agent, github.ReviewCommentEvent) error
 
 func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	reviewCommentEventHandlers[name] = fn
 }
 
-type GenericCommentHandler func(PluginClient, github.GenericCommentEvent) error
+type GenericCommentHandler func(Agent, github.GenericCommentEvent) error
 
 func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help HelpProvider) {
 	pluginHelp[name] = help
 	genericCommentHandlers[name] = fn
 }
 
-// PluginClient may be used concurrently, so each entry must be thread-safe.
-type PluginClient struct {
+// Agent may be used concurrently, so each entry must be thread-safe.
+type Agent struct {
 	GitHubClient *github.Client
 	KubeClient   *kube.Client
 	GitClient    *git.Client
@@ -139,7 +139,7 @@ type PluginClient struct {
 }
 
 type ConfigAgent struct {
-	PluginClient
+	Agent
 
 	mut           sync.Mutex
 	configuration *Configuration

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -138,7 +138,7 @@ type PluginClient struct {
 	Logger *logrus.Entry
 }
 
-type PluginAgent struct {
+type ConfigAgent struct {
 	PluginClient
 
 	mut           sync.Mutex
@@ -251,7 +251,7 @@ type Owners struct {
 	LabelsBlackList []string `json:"labels_blacklist,omitempty"`
 }
 
-func (pa *PluginAgent) MDYAMLEnabled(org, repo string) bool {
+func (pa *ConfigAgent) MDYAMLEnabled(org, repo string) bool {
 	full := fmt.Sprintf("%s/%s", org, repo)
 	for _, elem := range pa.Config().Owners.MDYAMLRepos {
 		if elem == org || elem == full {
@@ -261,7 +261,7 @@ func (pa *PluginAgent) MDYAMLEnabled(org, repo string) bool {
 	return false
 }
 
-func (pa *PluginAgent) SkipCollaborators(org, repo string) bool {
+func (pa *ConfigAgent) SkipCollaborators(org, repo string) bool {
 	full := fmt.Sprintf("%s/%s", org, repo)
 	for _, elem := range pa.Config().Owners.SkipCollaborators {
 		if elem == org || elem == full {
@@ -683,7 +683,7 @@ The list of patch release managers for each release can be found [here](https://
 
 // Load attempts to load config from the path. It returns an error if either
 // the file can't be read or it contains an unknown plugin.
-func (pa *PluginAgent) Load(path string) error {
+func (pa *ConfigAgent) Load(path string) error {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
@@ -726,7 +726,7 @@ func (pa *PluginAgent) Load(path string) error {
 	return nil
 }
 
-func (pa *PluginAgent) Config() *Configuration {
+func (pa *ConfigAgent) Config() *Configuration {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 	return pa.configuration
@@ -896,7 +896,7 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 // as a map from repositories to the list of plugins that are enabled on them.
 // Specifying simply an org name will also work, and will enable the plugin on
 // all repos in the org.
-func (pa *PluginAgent) Set(pc *Configuration) {
+func (pa *ConfigAgent) Set(pc *Configuration) {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 	pa.configuration = pc
@@ -904,7 +904,7 @@ func (pa *PluginAgent) Set(pc *Configuration) {
 
 // Start starts polling path for plugin config. If the first attempt fails,
 // then start returns the error. Future errors will halt updates but not stop.
-func (pa *PluginAgent) Start(path string) error {
+func (pa *ConfigAgent) Start(path string) error {
 	if err := pa.Load(path); err != nil {
 		return err
 	}
@@ -920,7 +920,7 @@ func (pa *PluginAgent) Start(path string) error {
 }
 
 // GenericCommentHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) GenericCommentHandlers(owner, repo string) map[string]GenericCommentHandler {
+func (pa *ConfigAgent) GenericCommentHandlers(owner, repo string) map[string]GenericCommentHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -934,7 +934,7 @@ func (pa *PluginAgent) GenericCommentHandlers(owner, repo string) map[string]Gen
 }
 
 // IssueHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) IssueHandlers(owner, repo string) map[string]IssueHandler {
+func (pa *ConfigAgent) IssueHandlers(owner, repo string) map[string]IssueHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -948,7 +948,7 @@ func (pa *PluginAgent) IssueHandlers(owner, repo string) map[string]IssueHandler
 }
 
 // IssueCommentHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) IssueCommentHandlers(owner, repo string) map[string]IssueCommentHandler {
+func (pa *ConfigAgent) IssueCommentHandlers(owner, repo string) map[string]IssueCommentHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -963,7 +963,7 @@ func (pa *PluginAgent) IssueCommentHandlers(owner, repo string) map[string]Issue
 }
 
 // PullRequestHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) PullRequestHandlers(owner, repo string) map[string]PullRequestHandler {
+func (pa *ConfigAgent) PullRequestHandlers(owner, repo string) map[string]PullRequestHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -978,7 +978,7 @@ func (pa *PluginAgent) PullRequestHandlers(owner, repo string) map[string]PullRe
 }
 
 // ReviewEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) ReviewEventHandlers(owner, repo string) map[string]ReviewEventHandler {
+func (pa *ConfigAgent) ReviewEventHandlers(owner, repo string) map[string]ReviewEventHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -993,7 +993,7 @@ func (pa *PluginAgent) ReviewEventHandlers(owner, repo string) map[string]Review
 }
 
 // ReviewCommentEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) ReviewCommentEventHandlers(owner, repo string) map[string]ReviewCommentEventHandler {
+func (pa *ConfigAgent) ReviewCommentEventHandlers(owner, repo string) map[string]ReviewCommentEventHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -1008,7 +1008,7 @@ func (pa *PluginAgent) ReviewCommentEventHandlers(owner, repo string) map[string
 }
 
 // StatusEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) StatusEventHandlers(owner, repo string) map[string]StatusEventHandler {
+func (pa *ConfigAgent) StatusEventHandlers(owner, repo string) map[string]StatusEventHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -1023,7 +1023,7 @@ func (pa *PluginAgent) StatusEventHandlers(owner, repo string) map[string]Status
 }
 
 // PushEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *PluginAgent) PushEventHandlers(owner, repo string) map[string]PushEventHandler {
+func (pa *ConfigAgent) PushEventHandlers(owner, repo string) map[string]PushEventHandler {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 
@@ -1038,7 +1038,7 @@ func (pa *PluginAgent) PushEventHandlers(owner, repo string) map[string]PushEven
 }
 
 // getPlugins returns a list of plugins that are enabled on a given (org, repository).
-func (pa *PluginAgent) getPlugins(owner, repo string) []string {
+func (pa *ConfigAgent) getPlugins(owner, repo string) []string {
 	var plugins []string
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -71,7 +71,7 @@ func TestGetPlugins(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		pa := PluginAgent{configuration: &Configuration{Plugins: tc.pluginMap}}
+		pa := ConfigAgent{configuration: &Configuration{Plugins: tc.pluginMap}}
 
 		plugins := pa.getPlugins(tc.owner, tc.repo)
 		if len(plugins) != len(tc.expectedPlugins) {

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -99,7 +99,7 @@ type githubClient interface {
 	BotName() (string, error)
 }
 
-func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+func handleIssueComment(pc plugins.Agent, ic github.IssueCommentEvent) error {
 	return handleComment(pc.GitHubClient, pc.Logger, ic)
 }
 
@@ -191,7 +191,7 @@ func removeOtherLabels(remover func(string) error, label string, labelSet []stri
 	return nil
 }
 
-func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, pc.Logger, &pr)
 }
 

--- a/prow/plugins/require-matching-label/require-matching-label.go
+++ b/prow/plugins/require-matching-label/require-matching-label.go
@@ -110,7 +110,11 @@ func handleIssue(pc plugins.Agent, ie github.IssueEvent) error {
 		label:         ie.Label.Name, // This will be empty for non-label events.
 		currentLabels: ie.Issue.Labels,
 	}
-	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, pc.PluginConfig.RequireMatchingLabel, e)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.Logger, pc.GitHubClient, cp, pc.PluginConfig.RequireMatchingLabel, e)
 }
 
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
@@ -125,7 +129,11 @@ func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 		author: pre.PullRequest.User.Login,
 		label:  pre.Label.Name, // This will be empty for non-label events.
 	}
-	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, pc.PluginConfig.RequireMatchingLabel, e)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.Logger, pc.GitHubClient, cp, pc.PluginConfig.RequireMatchingLabel, e)
 }
 
 // matchingConfigs filters irrelevant RequireMtchingLabel configs from

--- a/prow/plugins/require-matching-label/require-matching-label.go
+++ b/prow/plugins/require-matching-label/require-matching-label.go
@@ -98,7 +98,7 @@ type event struct {
 	currentLabels []github.Label
 }
 
-func handleIssue(pc plugins.PluginClient, ie github.IssueEvent) error {
+func handleIssue(pc plugins.Agent, ie github.IssueEvent) error {
 	if !handleIssueActions[ie.Action] {
 		return nil
 	}
@@ -113,7 +113,7 @@ func handleIssue(pc plugins.PluginClient, ie github.IssueEvent) error {
 	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, pc.PluginConfig.RequireMatchingLabel, e)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if !handlePRActions[pre.Action] {
 		return nil
 	}

--- a/prow/plugins/requiresig/requiresig.go
+++ b/prow/plugins/requiresig/requiresig.go
@@ -56,6 +56,8 @@ type githubClient interface {
 	AddLabel(org, repo string, number int, label string) error
 	RemoveLabel(org, repo string, number int, label string) error
 	CreateComment(org, repo string, number int, content string) error
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	DeleteComment(org, repo string, id int) error
 }
 
 type commentPruner interface {
@@ -89,7 +91,11 @@ func helpProvider(config *plugins.Configuration, _ []string) (*pluginhelp.Plugin
 }
 
 func handleIssue(pc plugins.Agent, ie github.IssueEvent) error {
-	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, &ie, pc.PluginConfig.SigMention.Re)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.Logger, pc.GitHubClient, cp, &ie, pc.PluginConfig.SigMention.Re)
 }
 
 func isSigLabel(label string) bool {

--- a/prow/plugins/requiresig/requiresig.go
+++ b/prow/plugins/requiresig/requiresig.go
@@ -88,7 +88,7 @@ func helpProvider(config *plugins.Configuration, _ []string) (*pluginhelp.Plugin
 		nil
 }
 
-func handleIssue(pc plugins.PluginClient, ie github.IssueEvent) error {
+func handleIssue(pc plugins.Agent, ie github.IssueEvent) error {
 	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, &ie, pc.PluginConfig.SigMention.Re)
 }
 

--- a/prow/plugins/shrug/shrug.go
+++ b/prow/plugins/shrug/shrug.go
@@ -73,7 +73,7 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e)
 }
 

--- a/prow/plugins/sigmention/sigmention.go
+++ b/prow/plugins/sigmention/sigmention.go
@@ -71,7 +71,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.SigMention.Re)
 }
 

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -63,7 +63,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, sizesOrDefault(pc.PluginConfig.Size), pc.Logger, pe)
 }
 

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -62,7 +62,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.Config.Presubmits[e.Repo.FullName])
 }
 

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -80,7 +80,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-func handleComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	c := client{
 		GithubClient: pc.GitHubClient,
 		SlackConfig:  pc.PluginConfig.Slack,
@@ -89,7 +89,7 @@ func handleComment(pc plugins.PluginClient, e github.GenericCommentEvent) error 
 	return echoToSlack(c, e)
 }
 
-func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {
+func handlePush(pc plugins.Agent, pe github.PushEvent) error {
 	c := client{
 		GithubClient: pc.GitHubClient,
 		SlackConfig:  pc.PluginConfig.Slack,

--- a/prow/plugins/stage/stage.go
+++ b/prow/plugins/stage/stage.go
@@ -61,7 +61,7 @@ type stageClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
-func stageHandleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func stageHandleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e)
 }
 

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -118,7 +118,7 @@ type trustedUserClient interface {
 	IsMember(org, user string) (bool, error)
 }
 
-func getClient(pc plugins.PluginClient) client {
+func getClient(pc plugins.Agent) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
 		Config:       pc.Config,
@@ -127,16 +127,16 @@ func getClient(pc plugins.PluginClient) client {
 	}
 }
 
-func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 	org, repo, _ := orgRepoAuthor(pr.PullRequest)
 	return handlePR(getClient(pc), pc.PluginConfig.TriggerFor(org, repo), pr)
 }
 
-func handleGenericCommentEvent(pc plugins.PluginClient, gc github.GenericCommentEvent) error {
+func handleGenericCommentEvent(pc plugins.Agent, gc github.GenericCommentEvent) error {
 	return handleGenericComment(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Owner.Login, gc.Repo.Name), gc)
 }
 
-func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {
+func handlePush(pc plugins.Agent, pe github.PushEvent) error {
 	return handlePE(getClient(pc), pe)
 }
 

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -68,11 +68,11 @@ type kubeClient interface {
 	CreateConfigMap(content kube.ConfigMap) (kube.ConfigMap, error)
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return handle(pc.GitHubClient, pc.KubeClient, pc.Logger, pre, maps(pc))
 }
 
-func maps(pc plugins.PluginClient) map[string]plugins.ConfigMapSpec {
+func maps(pc plugins.Agent) map[string]plugins.ConfigMapSpec {
 	return pc.PluginConfig.ConfigUpdater.Maps
 }
 

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -63,7 +63,7 @@ type githubClient interface {
 	RemoveLabel(owner, repo string, number int, label string) error
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
 		return nil
 	}

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -76,14 +76,14 @@ type client struct {
 	Logger       *logrus.Entry
 }
 
-func getClient(pc plugins.PluginClient) client {
+func getClient(pc plugins.Agent) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
 		Logger:       pc.Logger,
 	}
 }
 
-func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return handlePR(getClient(pc), pre, welcomeMessageForRepo(pc.PluginConfig, pre.Repo.Owner.Login, pre.Repo.Name))
 }
 

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -292,7 +292,7 @@ func TestWelcomeConfig(t *testing.T) {
 
 // TestPluginConfig validates that there are no duplicate repos in the welcome plugin config.
 func TestPluginConfig(t *testing.T) {
-	pa := &plugins.PluginAgent{}
+	pa := &plugins.ConfigAgent{}
 
 	b, err := ioutil.ReadFile("../../plugins.yaml")
 	if err != nil {

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -68,7 +68,7 @@ type githubClient interface {
 	RemoveLabel(owner, repo string, number int, label string) error
 }
 
-func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 	// These are the only actions indicating the PR title may have changed.
 	if pe.Action != github.PullRequestActionOpened &&
 		pe.Action != github.PullRequestActionReopened &&

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -97,7 +97,7 @@ func (url realJoke) readJoke() (string, error) {
 	return a.Joke, nil
 }
 
-func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, jokeURL)
 }
 

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -100,22 +100,6 @@ func patternAll(values ...string) map[string]sets.String {
 	return map[string]sets.String{"": sets.NewString(values...)}
 }
 
-type testConfigGetter struct {
-	defaultBlacklist []string
-	repoBlacklist    map[string][]string
-}
-
-func (c testConfigGetter) Config() *prowConf.Config {
-	return &prowConf.Config{
-		ProwConfig: prowConf.ProwConfig{
-			OwnersDirBlacklist: prowConf.OwnersDirBlacklist{
-				Repos:   c.repoBlacklist,
-				Default: c.defaultBlacklist,
-			},
-		},
-	}
-}
-
 func getTestClient(
 	files map[string][]byte,
 	enableMdYaml,
@@ -172,9 +156,13 @@ func getTestClient(
 			skipCollaborators: func(org, repo string) bool {
 				return skipCollab
 			},
-			configGetter: testConfigGetter{
-				repoBlacklist:    ownersDirBlacklistByRepo,
-				defaultBlacklist: ownersDirBlacklistDefault,
+			config: &prowConf.Config{
+				ProwConfig: prowConf.ProwConfig{
+					OwnersDirBlacklist: prowConf.OwnersDirBlacklist{
+						Repos:   ownersDirBlacklistByRepo,
+						Default: ownersDirBlacklistDefault,
+					},
+				},
 			},
 		},
 		// Clean up function


### PR DESCRIPTION
I needed to be able to access the plugin configuration as a standalone thing, and figured the refactor was better than a hack-ey closure around the larger PluginAgent.

---

Rename the plugin configuration agent appropriately

The types for these objects were unclear and mixed terms. The plugin
configuration agent is now imported as `plugins.ConfigAgent{}`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Rename the plugin agent struct appropriately

This struct was also unclear and also stuttered. The plugin's agent is
now imported as `plugins.Agent{}`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Remove commented code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Stop resolving config separately in repo-owners client

The repo-owners plugin client was resolving configuration at run-time,
unlike the rest of the plugins.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Refactor the plugin agent to separate concerns

Hook provides each registered plugin a large container of global state
when the plugin is executed to handle an incoming event. Previously,
this container was conflating a number of uses and was storing truth in
more than once place. The following changes have been made:

 - the plugin config agent has been split out to a standalone entity
   like the secret agent or the prow config agent, to allow for it to be
   used independently and to encapsulate that logic
 - the assorted clients have been collected into a shallow wrapper for
   passing through the chain
 - derivative clients reuse singular sources of truth and are created
   on-demand by plugins, providing only the necessary data
 - as minimal an impact as possible was left on the plugin code,
   especially on interfaces that drive test fakes

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @cjwagner @BenTheElder 
/cc @fejta @krzyzacy 
