### PR TITLE
Incremental log loading for spyglass

### DIFF
--- a/prow/spyglass/gcsartifact.go
+++ b/prow/spyglass/gcsartifact.go
@@ -17,7 +17,6 @@ limitations under the License.
 package spyglass
 
 import (
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -141,10 +140,6 @@ func (a *GCSArtifact) ReadAtMost(n int64) ([]byte, error) {
 		reader, err = a.handle.NewReader(a.ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error getting artifact reader: %v", err)
-		}
-		reader, err = gzip.NewReader(reader)
-		if err != nil {
-			return nil, fmt.Errorf("error getting gzip reader: %v", err)
 		}
 		defer reader.Close()
 		p, err = ioutil.ReadAll(reader) // Must readall for gzipped files

--- a/prow/spyglass/gcsartifact_test.go
+++ b/prow/spyglass/gcsartifact_test.go
@@ -180,17 +180,6 @@ func TestReadAtMost(t *testing.T) {
 	if err := zw.Close(); err != nil {
 		t.Fatalf("Failed to close gzip writer, err: %v", err)
 	}
-	gzippedLog := buf.Bytes()
-	var noReadBuf bytes.Buffer
-	zw = gzip.NewWriter(&noReadBuf)
-	_, err = zw.Write([]byte("unreadable contents"))
-	if err != nil {
-		t.Fatalf("Failed to gzip unreadable text, err: %v", err)
-	}
-	if err := zw.Close(); err != nil {
-		t.Fatalf("Failed to close gzip writer, err: %v", err)
-	}
-	noReadGzipped := noReadBuf.Bytes()
 	testCases := []struct {
 		name      string
 		n         int64
@@ -208,26 +197,12 @@ func TestReadAtMost(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "ReadAtMost build log, gzipped",
-			n:         23,
-			contents:  gzippedLog,
-			encoding:  "gzip",
-			expected:  []byte("Oh wow\nlogs\nthis is\ncra"),
-			expectErr: false,
-		},
-		{
-			name:      "ReadAtMost build log, claimed gzipped but not actually gzipped",
-			n:         2333,
+			name:      "ReadAtMost build log, transparently gzipped",
+			n:         8,
 			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			expected:  []byte("Oh wow\nl"),
 			encoding:  "gzip",
-			expectErr: true,
-		},
-		{
-			name:      "ReadAtMost unreadable gzipped contents",
-			n:         2,
-			contents:  noReadGzipped,
-			encoding:  "gzip",
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name:      "ReadAtMost unreadable contents",
@@ -246,15 +221,6 @@ func TestReadAtMost(t *testing.T) {
 			n:         2222,
 			contents:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
 			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
-			expectErr: true,
-			expectEOF: true,
-		},
-		{
-			name:      "ReadAtMost N>size of build log, gzipped",
-			n:         2222,
-			contents:  gzippedLog,
-			expected:  []byte("Oh wow\nlogs\nthis is\ncrazy"),
-			encoding:  "gzip",
 			expectErr: true,
 			expectEOF: true,
 		},

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -150,9 +150,9 @@ func TestGroupLines(t *testing.T) {
 			},
 		},
 	}
-	for i, test := range tests {
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := groupLines(test.lines, i)
+			got := groupLines(highlightLines(test.lines, 0))
 			if len(got) != len(test.groups) {
 				t.Fatalf("Expected %d groups, got %d", len(test.groups), len(got))
 			}

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -5,34 +5,41 @@
 {{define "body"}}
 <div style="font-family:monospace;">
 {{range $log := .LogViews}}
-  <div id="{{$log | logID}}">
+  <div>
     <h4 style="margin: 0;">
       <a href="{{$log.ArtifactLink}}">{{$log.ArtifactName}}<i class="material-icons" style="font-size: 1em; vertical-align: middle;">link</i></a>
-      <button id="{{$log | logID}}-show-all" onclick="showAllLines({{$log | logID}})">Show all hidden lines</button>
+      <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
     </h4>
-    <table class="loglines">
+    <table class="loglines" id="{{$log.ArtifactName}}-content">
     {{range $g := $log.LineGroups}}
     {{if $g.Skip}}
-      <tbody class="show-skipped" id="{{$g | skipID}}">
+      <tbody class="show-skipped" data-artifact="{{$log.ArtifactName}}" data-offset="{{$g.ByteOffset}}" data-length="{{$g.ByteLength}}" data-start-line="{{$g.Start}}">
       <tr>
         <td></td>
-        <td><button onclick="showLines({{$log | logID}}, {{$g | linesID}}, {{$g | skipID}})">Show {{$g | linesSkipped}} hidden lines</button></td>
+        <td><button>Show {{$g.LinesSkipped}} hidden lines</button></td>
       </tr>
+      </tbody>
+    {{else}}
+      <tbody class="shown">
+      {{template "line group" $g.LogLines}}
       </tbody>
     {{end}}
-      <tbody class="{{if $g.Skip}}skipped{{else}}shown{{end}}" id="{{$g | linesID}}">
-      {{range $line := $g.LogLines}}
-      <tr>
-        <td class="linenum">{{$line.Number}}</td>
-        <td>
-          <span {{if $line.Highlighted}}class="line-highlighted"{{end}}>{{range $s := $line.SubLines}}<span {{if $s.Highlighted}}class="match-highlighted"{{end}}>{{$s.Text}}</span>{{end}}</span>
-        </td>
-      </tr>
-      {{end}}
-      </tbody>
     {{end}}
     </table>
   </div>
 {{end}}
 </div>
+{{end}}
+
+{{define "line group"}}
+  {{range .}}
+    <tr>
+      <td class="linenum">{{.Number}}</td>
+      <td>
+        <span {{if .Highlighted}}class="line-highlighted"{{end}}>
+          {{- range .SubLines -}}<span {{if .Highlighted}}class="match-highlighted"{{end}}>{{.Text}}</span>{{- end -}}
+        </span>
+      </td>
+    </tr>
+  {{end}}
 {{end}}


### PR DESCRIPTION
Implement incremental log loading in spyglass. This actually has fewer lines of code than the original implementation!

Also fixes some gzip-related confusion in `gcsartifact.ReadAtMost`.

This PR depends on #10208, which is currently blocked by code freeze. Only [the last two commits](https://github.com/kubernetes/test-infra/pull/10242/files/60d779ea05cf72c9cb84671c88950760a5db634e..5ad6dc69253b1c909a9c9f4c09c3365cc1baf14e) are interesting.

cc @ibzib 
/cc @BenTheElder 