### PR TITLE
testgrid/config: update kubeadm jobs for 1.13 release

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-upgrade.yaml
@@ -1,39 +1,8 @@
 # kubeadm upgrade tests
 periodics:
 # manual-release-bump-required (create a new job and delete the oldest)
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20181122-3648a2bf2
-      args:
-      - --repo=k8s.io/kubernetes=release-1.10
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-version-skew=false
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=release/latest-1.10
-      - --extract=ci/latest-bazel-1.9
-      - --gcp-zone=us-central1-f
-      - --kubeadm=periodic
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.9
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.9
-      - --kubernetes-anywhere-upgrade-method=upgrade
-      - --provider=kubernetes-anywhere
-      - --skew
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
-      - --timeout=300m
-      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.10
-
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
-  interval: 2h
+  interval: 12h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -64,7 +33,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.11
 
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
-  interval: 6h
+  interval: 12h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -95,7 +64,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --ginkgo.skip=statefulset-upgrade|hpa-upgrade|service-upgrade --upgrade-target=release/latest-1.12
 
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-12-1-13
-  interval: 6h
+  interval: 12h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-x-on-y.yaml
@@ -1,31 +1,5 @@
 # kubeadm x-on-y tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20181122-3648a2bf2
-      args:
-      - --repo=k8s.io/kubernetes=release-1.11
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.10
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8
-      - --timeout=300m
-
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   interval: 12h
   labels:
@@ -79,7 +53,7 @@ periodics:
       - --timeout=300m
 
 - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
-  interval: 6h
+  interval: 4h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -1,33 +1,7 @@
 # kubeadm release and master tests
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20181122-3648a2bf2
-      args:
-      - --repo=k8s.io/kubernetes=release-1.10
-      - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-      - --timeout=320
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --extract=ci/latest-bazel-1.10
-      - --gcp-zone=us-central1-f
-      - --kubeadm=ci
-      - --kubernetes-anywhere-kubelet-ci-version=latest-bazel-1.10
-      - --kubernetes-anywhere-kubernetes-version=ci/latest-1.10
-      - --provider=kubernetes-anywhere
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\]
-      - --timeout=300m
-
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11
-  interval: 6h
+  interval: 12h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2132,8 +2132,6 @@ test_groups:
 - name: periodic-multi-platform-kubeadm-packet-arm64
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-packet-arm64
 # kubeadm tests
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11
 - name: ci-kubernetes-e2e-kubeadm-gce-1-12
@@ -2143,8 +2141,6 @@ test_groups:
 - name: ci-kubernetes-e2e-kubeadm-gce-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master
 # kubeadm x-on-y tests
-- name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
 - name: ci-kubernetes-e2e-kubeadm-gce-1-12-on-1-13
@@ -2152,8 +2148,6 @@ test_groups:
 - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-stable-on-master
 # kubeadm upgrade tests
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-11-1-12
@@ -5826,8 +5820,6 @@ dashboards:
 - name: sig-cluster-lifecycle-all
   dashboard_tab:
 # kubeadm tests
-  - name: kubeadm-gce-1.10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10
   - name: kubeadm-gce-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11
   - name: kubeadm-gce-1.12
@@ -5849,8 +5841,6 @@ dashboards:
     alert_stale_results_hours: 24
     num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for 24 hours
 # kubeadm x-on-y tests
-  - name: kubeadm-gce-1.10-on-1.11
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-10-on-1-11
   - name: kubeadm-gce-1.11-on-1.12
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   - name: kubeadm-gce-1.12-on-1.13
@@ -5862,8 +5852,6 @@ dashboards:
     alert_stale_results_hours: 24
     num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for 24 hours
 # kubeadm upgrade tests
-  - name: kubeadm-gce-upgrade-1.9-1.10
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-9-1-10
   - name: kubeadm-gce-upgrade-1.10-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-10-1-11
   - name: kubeadm-gce-upgrade-1.11-1.12


### PR DESCRIPTION
- remove 1.9 jobs
- remove 1.10 jobs
- remove 1.10 on 1.11 jobs
- update frequency of some tests:
  - old version upgrade tests to 12h
  - stable-master to 4h from 6h
  - gce-1.11 to 12h from 6h

/area config
/area testgrid
/kind cleanup
/priority important-soon

/assign @timothysc @krzyzacy 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
