### PR TITLE
Gerrit: only run jobs when files match run_if_changed

### DIFF
--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/kube"
@@ -183,19 +184,15 @@ func makeCloneURI(instance, project string) (*url.URL, error) {
 	return u, nil
 }
 
-// lists the files changed as part of a Gerrit patchset
+// listChangedFiles lists (in lexicographic order) the files changed as part of a Gerrit patchset
 func listChangedFiles(changeInfo client.ChangeInfo) []string {
-	changed := make(map[string]bool)
+	changed := sets.NewString()
 	for _, revision := range changeInfo.Revisions {
 		for file := range revision.Files {
-			changed[file] = true
+			changed.Insert(file)
 		}
 	}
-	changedFiles := []string{}
-	for file := range changed {
-		changedFiles = append(changedFiles, file)
-	}
-	return changedFiles
+	return changed.List()
 }
 
 // ProcessChange creates new presubmit prowjobs base off the gerrit changes

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/kube"
@@ -186,13 +185,12 @@ func makeCloneURI(instance, project string) (*url.URL, error) {
 
 // listChangedFiles lists (in lexicographic order) the files changed as part of a Gerrit patchset
 func listChangedFiles(changeInfo client.ChangeInfo) []string {
-	changed := sets.NewString()
-	for _, revision := range changeInfo.Revisions {
-		for file := range revision.Files {
-			changed.Insert(file)
-		}
+	changed := []string{}
+	revision := changeInfo.Revisions[changeInfo.CurrentRevision]
+	for file := range revision.Files {
+		changed = append(changed, file)
 	}
-	return changed.List()
+	return changed
 }
 
 // ProcessChange creates new presubmit prowjobs base off the gerrit changes

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -183,6 +183,21 @@ func makeCloneURI(instance, project string) (*url.URL, error) {
 	return u, nil
 }
 
+// lists the files changed as part of a Gerrit patchset
+func listChangedFiles(changeInfo client.ChangeInfo) []string {
+	changed := make(map[string]bool)
+	for _, revision := range changeInfo.Revisions {
+		for file := range revision.Files {
+			changed[file] = true
+		}
+	}
+	changedFiles := []string{}
+	for file := range changed {
+		changedFiles = append(changedFiles, file)
+	}
+	return changedFiles
+}
+
 // ProcessChange creates new presubmit prowjobs base off the gerrit changes
 func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) error {
 	rev, ok := change.Revisions[change.CurrentRevision]
@@ -204,94 +219,73 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 
 	triggeredJobs := []string{}
 
+	kr := kube.Refs{
+		Org:      cloneURI.Host,  // Something like android.googlesource.com
+		Repo:     change.Project, // Something like platform/build
+		BaseRef:  change.Branch,
+		BaseSHA:  baseSHA,
+		CloneURI: cloneURI.String(), // Something like https://android.googlesource.com/platform/build
+		Pulls: []kube.Pull{
+			{
+				Number: change.Number,
+				Author: rev.Commit.Author.Name,
+				SHA:    change.CurrentRevision,
+				Ref:    rev.Ref,
+			},
+		},
+	}
+
+	type jobSpec struct {
+		spec   kube.ProwJobSpec
+		labels map[string]string
+	}
+
+	var jobSpecs []jobSpec
+
+	changedFiles := listChangedFiles(change)
+
 	switch change.Status {
 	case client.Merged:
 		postsubmits := c.ca.Config().Postsubmits[cloneURI.String()]
 		postsubmits = append(postsubmits, c.ca.Config().Postsubmits[cloneURI.Host+"/"+cloneURI.Path]...)
-		for _, spec := range postsubmits {
-			kr := kube.Refs{
-				Org:      cloneURI.Host,  // Something like android.googlesource.com
-				Repo:     change.Project, // Something like platform/build
-				BaseRef:  change.Branch,
-				BaseSHA:  baseSHA,
-				CloneURI: cloneURI.String(), // Something like https://android.googlesource.com/platform/build
-				Pulls: []kube.Pull{
-					{
-						Number: change.Number,
-						Author: rev.Commit.Author.Name,
-						SHA:    change.CurrentRevision,
-						Ref:    rev.Ref,
-					},
-				},
-			}
-
-			labels := make(map[string]string)
-			for k, v := range spec.Labels {
-				labels[k] = v
-			}
-			labels[client.GerritRevision] = change.CurrentRevision
-
-			pj := pjutil.NewProwJobWithAnnotation(
-				pjutil.PostsubmitSpec(spec, kr),
-				labels,
-				map[string]string{
-					client.GerritID:       change.ID,
-					client.GerritInstance: instance,
-				},
-			)
-
-			logger.WithFields(pjutil.ProwJobFields(&pj)).Infof("Creating a new postsubmit job for change %d.", change.Number)
-
-			if _, err := c.kc.CreateProwJob(pj); err != nil {
-				logger.WithError(err).Errorf("fail to create prowjob %v", pj)
-			} else {
-				triggeredJobs = append(triggeredJobs, spec.Name)
+		for _, postsubmit := range postsubmits {
+			if postsubmit.RunsAgainstChanges(changedFiles) {
+				jobSpecs = append(jobSpecs, jobSpec{
+					spec:   pjutil.PostsubmitSpec(postsubmit, kr),
+					labels: postsubmit.Labels,
+				})
 			}
 		}
 	case client.New:
 		presubmits := c.ca.Config().Presubmits[cloneURI.String()]
 		presubmits = append(presubmits, c.ca.Config().Presubmits[cloneURI.Host+"/"+cloneURI.Path]...)
-		for _, spec := range presubmits {
-			kr := kube.Refs{
-				Org:      cloneURI.Host,  // Something like android.googlesource.com
-				Repo:     change.Project, // Something like platform/build
-				BaseRef:  change.Branch,
-				BaseSHA:  baseSHA,
-				CloneURI: cloneURI.String(), // Something like https://android.googlesource.com/platform/build
-				Pulls: []kube.Pull{
-					{
-						Number: change.Number,
-						Author: rev.Commit.Author.Name,
-						SHA:    change.CurrentRevision,
-						Ref:    rev.Ref,
-					},
-				},
+		for _, presubmit := range presubmits {
+			if presubmit.RunsAgainstChanges(changedFiles) {
+				jobSpecs = append(jobSpecs, jobSpec{
+					spec:   pjutil.PresubmitSpec(presubmit, kr),
+					labels: presubmit.Labels,
+				})
 			}
+		}
+	}
 
-			// TODO(krzyzacy): Support AlwaysRun and RunIfChanged
+	annotations := map[string]string{
+		client.GerritID:       change.ID,
+		client.GerritInstance: instance,
+	}
 
-			labels := make(map[string]string)
-			for k, v := range spec.Labels {
-				labels[k] = v
-			}
-			labels[client.GerritRevision] = change.CurrentRevision
+	for _, jSpec := range jobSpecs {
+		labels := make(map[string]string)
+		for k, v := range jSpec.labels {
+			labels[k] = v
+		}
+		labels[client.GerritRevision] = change.CurrentRevision
 
-			pj := pjutil.NewProwJobWithAnnotation(
-				pjutil.PresubmitSpec(spec, kr),
-				labels,
-				map[string]string{
-					client.GerritID:       change.ID,
-					client.GerritInstance: instance,
-				},
-			)
-
-			logger.WithFields(pjutil.ProwJobFields(&pj)).Infof("Creating a new presubmit job for change %d.", change.Number)
-
-			if _, err := c.kc.CreateProwJob(pj); err != nil {
-				logger.WithError(err).Errorf("fail to create prowjob %v", pj)
-			} else {
-				triggeredJobs = append(triggeredJobs, spec.Name)
-			}
+		pj := pjutil.NewProwJobWithAnnotation(jSpec.spec, labels, annotations)
+		if _, err := c.kc.CreateProwJob(pj); err != nil {
+			logger.WithError(err).Errorf("fail to create prowjob %v", pj)
+		} else {
+			triggeredJobs = append(triggeredJobs, jSpec.spec.Job)
 		}
 	}
 

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -219,20 +219,69 @@ func TestProcessChange(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "presubmit runs when a file matches run_if_changed",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Status:          "NEW",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Files: map[string]client.FileInfo{
+							"bee-movie-script.txt": client.FileInfo{},
+							"africa-lyrics.txt":    client.FileInfo{},
+							"important-code.go":    client.FileInfo{},
+						},
+					},
+				},
+			},
+			numPJ: 2,
+		},
+		{
+			name: "presubmit doesn't run when no files match run_if_changed",
+			change: client.ChangeInfo{
+				CurrentRevision: "1",
+				Project:         "test-infra",
+				Status:          "NEW",
+				Revisions: map[string]client.RevisionInfo{
+					"1": {
+						Files: map[string]client.FileInfo{
+							"hacky-hack.sh": client.FileInfo{},
+							"README.md":     client.FileInfo{},
+							"let-it-go.txt": client.FileInfo{},
+						},
+					},
+				},
+			},
+			numPJ: 1,
+		},
 	}
 
 	for _, tc := range testcases {
+		testInfraPresubmits := []config.Presubmit{
+			{
+				JobBase: config.JobBase{
+					Name: "test-foo",
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "test-go",
+				},
+				RegexpChangeMatcher: config.RegexpChangeMatcher{
+					RunIfChanged: "\\.go",
+				},
+			},
+		}
+		if err := config.SetPresubmitRegexes(testInfraPresubmits); err != nil {
+			t.Fatalf("could not set regexes: %v", err)
+		}
+
 		fca := &fca{
 			c: &config.Config{
 				JobConfig: config.JobConfig{
 					Presubmits: map[string][]config.Presubmit{
-						"gerrit/test-infra": {
-							{
-								JobBase: config.JobBase{
-									Name: "test-foo",
-								},
-							},
-						},
+						"gerrit/test-infra": testInfraPresubmits,
 						"https://gerrit/other-repo": {
 							{
 								JobBase: config.JobBase{

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -228,9 +228,9 @@ func TestProcessChange(t *testing.T) {
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Files: map[string]client.FileInfo{
-							"bee-movie-script.txt": client.FileInfo{},
-							"africa-lyrics.txt":    client.FileInfo{},
-							"important-code.go":    client.FileInfo{},
+							"bee-movie-script.txt": {},
+							"africa-lyrics.txt":    {},
+							"important-code.go":    {},
 						},
 					},
 				},
@@ -246,9 +246,9 @@ func TestProcessChange(t *testing.T) {
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Files: map[string]client.FileInfo{
-							"hacky-hack.sh": client.FileInfo{},
-							"README.md":     client.FileInfo{},
-							"let-it-go.txt": client.FileInfo{},
+							"hacky-hack.sh": {},
+							"README.md":     {},
+							"let-it-go.txt": {},
 						},
 					},
 				},

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -117,6 +117,9 @@ type ChangeInfo = gerrit.ChangeInfo
 // RevisionInfo is a gerrit.RevisionInfo
 type RevisionInfo = gerrit.RevisionInfo
 
+// FileInfo is a gerrit.FileInfo
+type FileInfo = gerrit.FileInfo
+
 // NewClient returns a new gerrit client
 func NewClient(instances map[string][]string) (*Client, error) {
 	c := &Client{
@@ -255,7 +258,7 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 
 	opt := &gerrit.QueryChangeOptions{}
 	opt.Query = append(opt.Query, "project:"+project)
-	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT"}
+	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES"}
 
 	start := 0
 


### PR DESCRIPTION
Use `run_if_changed`/`RunsAgainstChanges` in the Gerrit adapter to run jobs only when a change affects ≥1 file with name matching the regexp.

I also tried squishing the pre- and post-submit cases together to reduce code duplication, but I was only partially successful.

/assign @krzyzacy 
/cc @AishSundar @BenTheElder 