### PR TITLE
Add gce scale performance test for kube-dns

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -229,7 +229,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: '1 8 * * 1,2,3,4,5' # Run at 00:01PST (8:01 UTC) from Mon to Fri
+- cron: '1 8 * * 1,2,4,5' # Run at 00:01PST (8:01 UTC) on Mon, Tues, Thurs, Fri
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -250,6 +250,42 @@ periodics:
       - --env=ENABLE_APISERVER_ADVANCED_AUDIT=false
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
       - --env=MASTER_MIN_CPU_ARCHITECTURE=Intel Broadwell
+      - --extract=ci/latest
+      - --gcp-nodes=5000
+      - --gcp-project=kubernetes-scale
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8 --node-schedulable-timeout=90m --gather-resource-usage=masteranddns --gather-metrics-at-teardown=master --vmodule=request=4
+      - --timeout=1290m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20181122-a5bf59311-master
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
+
+- cron: '1 8 * * 3' # Run at 00:01PST (8:01 UTC) on Wednesday
+  name: ci-kubernetes-e2e-gce-scale-performance-kube-dns
+  tags:
+  - "perfDashPrefix: gce-5000Nodes"
+  - "perfDashJobType: performance"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-highspeed-common: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=1320
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=gce-scale-cluster
+      - --env=ENABLE_APISERVER_ADVANCED_AUDIT=false
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
+      - --env=MASTER_MIN_CPU_ARCHITECTURE=Intel Broadwell
+      - --env=CLUSTER_DNS_CORE_DNS=false
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -357,6 +357,11 @@ test_groups:
   days_of_results: 60
   num_columns_recent: 3
   num_failures_to_alert: 1
+- name: ci-kubernetes-e2e-gce-scale-performance-kube-dns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance-kube-dns
+  days_of_results: 60
+  num_columns_recent: 3
+  num_failures_to_alert: 1
 - name: ci-kubernetes-e2e-gci-gce-es-logging
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-es-logging
 - name: ci-kubernetes-e2e-gci-gce-sd-logging
@@ -4717,6 +4722,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
   - name: gce-master-scale-performance
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
+  - name: gce-master-scale-performance-kube-dns
+    test_group_name: ci-kubernetes-e2e-gce-scale-performance-kube-dns
   - name: gce-cos-master-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
   - name: gce-cos-master-reboot
@@ -6442,6 +6449,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
   - name: gce-scale-performance
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
+  - name: gce-scale-performance-kube-dns
+    test_group_name: ci-kubernetes-e2e-gce-scale-performance-kube-dns
 
 - name: sig-scalability-gke
   dashboard_tab:


### PR DESCRIPTION
The existing `ci-kubernetes-e2e-gce-scale-performance` now runs from Monday to Thursday (previously from Mon - Fri)  and the new `ci-kubernetes-e2e-gce-scale-performance-kube-dns` runs on Friday, ensuring a check on kube-dns which is now an optional DNS server.