### PR TITLE
Remove KUBERNETES_CONFORMANCE_PROVIDER env variable in acs-engine

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -173,9 +173,6 @@ func newAcsEngine() (*Cluster, error) {
 	if err := os.Setenv("KUBERNETES_CONFORMANCE_TEST", "yes"); err != nil {
 		return nil, err
 	}
-	if err := os.Setenv("KUBERNETES_CONFORMANCE_PROVIDER", "azure"); err != nil {
-		return nil, err
-	}
 
 	return &c, nil
 }


### PR DESCRIPTION
There is no need to set KUBERNETES_CONFORMANCE_PROVIDER when running windows conformance tests.