### PR TITLE
Send e2e coverage results to testgrid

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -47,6 +47,7 @@ periodics:
         bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/conformance.cov"
         bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/,alpha,beta  "${ARTIFACTS}/conformance.cov" > "${ARTIFACTS}/filtered.cov"
         bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/conformance.html"
+        bazel run //gopherage -- junit "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
@@ -110,6 +111,7 @@ periodics:
         bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/e2e.cov"
         bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/ "${ARTIFACTS}/e2e.cov" > "${ARTIFACTS}/filtered.cov"
         bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/e2e.html"
+        bazel run //gopherage -- junit "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -47,7 +47,7 @@ periodics:
         bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/conformance.cov"
         bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/,alpha,beta  "${ARTIFACTS}/conformance.cov" > "${ARTIFACTS}/filtered.cov"
         bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/conformance.html"
-        bazel run //gopherage -- junit "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
+        bazel run //gopherage -- junit --threshold 0.6 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
@@ -111,7 +111,7 @@ periodics:
         bazel run //gopherage -- diff "${ARTIFACTS}/before/merged.cov" "${ARTIFACTS}/after/merged.cov" > "${ARTIFACTS}/e2e.cov"
         bazel run //gopherage -- filter --exclude-path=zz_generated,third_party/,cmd/,cloudprovider/providers/ "${ARTIFACTS}/e2e.cov" > "${ARTIFACTS}/filtered.cov"
         bazel run //gopherage -- html "${ARTIFACTS}/filtered.cov"  > "${ARTIFACTS}/e2e.html"
-        bazel run //gopherage -- junit "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
+        bazel run //gopherage -- junit --threshold 0.6 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml"
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"


### PR DESCRIPTION
I think this is all that's necessary for them to be picked up?

The resulting junit looks like this:

```xml
<testsuite>
    <testcase class_name="go_coverage" name="OVERALL" time="0">
        <failure>true</failure>
        <properties>
            <property name="coverage" value="29.0"></property>
        </properties>
    </testcase>
    <testcase class_name="go_coverage" name="k8s.io/kubernetes/pkg/api/endpoints/util.go" time="0">
        <properties>
            <property name="coverage" value="90.7"></property>
        </properties>
    </testcase>
    <testcase class_name="go_coverage" name="k8s.io/kubernetes/pkg/api/persistentvolume/util.go" time="0">
        <failure>true</failure>
        <properties>
            <property name="coverage" value="0.0"></property>
        </properties>
    </testcase>
    <!-- and so on -->
</testsuite>
```

/cc @spiffxp