### PR TITLE
clean up deprecated gerrit labels

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -45,14 +45,6 @@ const (
 	// GerritReportLabel is the gerrit label prow will cast vote on, fallback to CodeReview label if unset
 	GerritReportLabel = "prow.k8s.io/gerrit-report-label"
 
-	// TODO(krzyzacy): remove them after we don't have deployment uses deprecated labels
-	// DeprecatedGerritID is the deprecated version of GerritID
-	DeprecatedGerritID = "gerrit-id"
-	// DeprecatedGerritInstance is the deprecated version of GerritInstance
-	DeprecatedGerritInstance = "gerrit-instance"
-	// DeprecatedGerritRevision is the deprecated version of GerritRevision
-	DeprecatedGerritRevision = "gerrit-revision"
-
 	// Merged status indicates a Gerrit change has been merged
 	Merged = "MERGED"
 	// New status indicates a Gerrit change is new (ie pending)

--- a/prow/gerrit/reporter/reporter_test.go
+++ b/prow/gerrit/reporter/reporter_test.go
@@ -164,34 +164,6 @@ func TestReport(t *testing.T) {
 			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
 		},
 		{
-			// TODO(krzyzacy): remove after we clean up deprecated labels
-			name: "1 job, passed, has deprecated labels, should report",
-			pj: &v1.ProwJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						client.DeprecatedGerritRevision: "abc",
-					},
-					Annotations: map[string]string{
-						client.DeprecatedGerritID:       "123-abc",
-						client.DeprecatedGerritInstance: "gerrit",
-					},
-				},
-				Status: v1.ProwJobStatus{
-					State: v1.SuccessState,
-					URL:   "guber/foo",
-				},
-				Spec: v1.ProwJobSpec{
-					Refs: &v1.Refs{
-						Repo: "foo",
-					},
-					Job: "ci-foo",
-				},
-			},
-			expectReport:  true,
-			reportInclude: []string{"1 out of 1", "ci-foo", "success", "guber/foo"},
-			expectLabel:   map[string]string{client.CodeReview: client.LGTM},
-		},
-		{
 			name: "1 job, passed, with customized label, should report to customized label",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
our gerrit deployment has been upgraded and working fine on new labels, and I'm not aware of other gerrit deployment (if there are, they should've noticed the previous announcement :-) )

/area gerrit
/assign @amwat @cjwagner 