### PR TITLE
Ensure correct blocking presubmit state on config reload

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -27,6 +27,7 @@ container_bundle(
         "plank",
         "sidecar",
         "sinker",
+        "status-reconciler",
         "tide",
         "tot",
     ) + image_tags(**{
@@ -90,6 +91,7 @@ filegroup(
         "//prow/cmd/plank:all-srcs",
         "//prow/cmd/sidecar:all-srcs",
         "//prow/cmd/sinker:all-srcs",
+        "//prow/cmd/status-reconciler:all-srcs",
         "//prow/cmd/tide:all-srcs",
         "//prow/cmd/tot:all-srcs",
         "//prow/cmd/util:all-srcs",
@@ -137,6 +139,7 @@ filegroup(
         "//prow/sidecar:all-srcs",
         "//prow/slack:all-srcs",
         "//prow/spyglass:all-srcs",
+        "//prow/statusreconciler:all-srcs",
         "//prow/test:all-srcs",
         "//prow/tide:all-srcs",
     ],

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -1,0 +1,70 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: default
+  name: statusreconciler
+  labels:
+    app: statusreconciler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: statusreconciler
+    spec:
+      # serviceAccountName: "statusreconciler" # Uncomment for use with RBAC
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: statusreconciler
+        image: gcr.io/k8s-prow/statusreconciler:v20181129-31c544b
+        imagePullPolicy: Always
+        args:
+        - --dry-run=false
+        - --continue-on-error=true
+        - --plugin-config=/etc/plugins/plugins.yaml
+        - --config-path=/etc/config/config.yaml
+        - --github-token-path=/etc/github/oauth
+        - --job-config-path=/etc/job-config
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config
+      - name: plugins
+        configMap:
+          name: plugins

--- a/prow/cluster/statusreconciler_rbac.yaml
+++ b/prow/cluster/statusreconciler_rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: default
+  name: "statusreconciler"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: "statusreconciler"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: "statusreconciler"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "statusreconciler"
+subjects:
+- kind: ServiceAccount
+  name: "statusreconciler"

--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -1,0 +1,45 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
+
+prow_image(
+    name = "image",
+    base = "@alpine-base//image",
+)
+
+go_binary(
+    name = "status-reconciler",
+    embed = [":go_default_library"],
+    pure = "on",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/status-reconciler",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/flagutil:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/logrusutil:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/statusreconciler:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/status-reconciler/OWNERS
+++ b/prow/cmd/status-reconciler/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- stevekuznetsov
+labels:
+ - area/prow/status-reconciler

--- a/prow/cmd/status-reconciler/README.md
+++ b/prow/cmd/status-reconciler/README.md
@@ -1,0 +1,13 @@
+# `status-reconciler`
+
+`status-reconciler` ensures that changes to blocking presubmits in Prow configuration while PRs are
+in flight do not cause those PRs to get stuck.
+
+When the set of blocking presubmits changes for a repository, one of three cases occurs:
+
+ - a new blocking presubmit exists and should be triggered for every trusted pull request in flight
+ - an existing blocking presubmit is removed and should have its' status retired
+ - an existing blocking presubmit is renamed and should have its' status migrated
+
+The `status-reconciler` watches the job configuration for Prow and ensures that the above actions
+are taken as necessary.

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/statusreconciler"
+)
+
+type options struct {
+	configPath    string
+	jobConfigPath string
+	pluginConfig  string
+
+	continueOnError bool
+	dryRun          bool
+	kubernetes      prowflagutil.KubernetesOptions
+	github          prowflagutil.GitHubOptions
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+	fs.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
+
+	fs.BoolVar(&o.continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+		group.AddFlags(fs)
+	}
+
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) Validate() error {
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "status-reconciler"}),
+	)
+
+	configAgent := &config.Agent{}
+	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+	changes := make(chan config.ConfigDelta)
+	configAgent.Subscribe(changes)
+
+	secretAgent := &config.SecretAgent{}
+	if o.github.TokenPath != "" {
+		if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
+	}
+
+	pluginAgent := &plugins.ConfigAgent{}
+	if err := pluginAgent.Start(o.pluginConfig); err != nil {
+		logrus.WithError(err).Fatal("Error starting plugin configuration agent.")
+	}
+
+	githubClient, err := o.github.GitHubClient(secretAgent, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+
+	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting kube client.")
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+
+	c := statusreconciler.NewController(o.continueOnError, kubeClient, githubClient, pluginAgent)
+	c.Run(sig, changes)
+}

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -94,7 +94,7 @@ func handleGenericComment(c client, trigger *plugins.Trigger, gc github.GenericC
 	var l []github.Label
 	if !trusted {
 		// Skip untrusted PRs.
-		l, trusted, err = trustedPullRequest(c.GitHubClient, trigger, gc.IssueAuthor.Login, org, repo, number, nil)
+		l, trusted, err = TrustedPullRequest(c.GitHubClient, trigger, gc.IssueAuthor.Login, org, repo, number, nil)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ func handleGenericComment(c client, trigger *plugins.Trigger, gc github.GenericC
 	}
 
 	// At this point we can trust the PR, so we eventually update labels.
-	// Ensure we have labels before test, because trustedPullRequest() won't be called
+	// Ensure we have labels before test, because TrustedPullRequest() won't be called
 	// when commentAuthor is trusted.
 	if l == nil {
 		l, err = c.GitHubClient.GetIssueLabels(org, repo, number)

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -51,7 +51,7 @@ func handlePR(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) er
 	case github.PullRequestActionReopened:
 		// When a PR is reopened, check that the user is in the org or that an org
 		// member had said "/ok-to-test" before building, resulting in label ok-to-test.
-		l, trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
+		l, trusted, err := TrustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
 		if err != nil {
 			return fmt.Errorf("could not validate PR: %s", err)
 		} else if trusted {
@@ -92,7 +92,7 @@ func handlePR(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) er
 	case github.PullRequestActionLabeled:
 		// When a PR is LGTMd, if it is untrusted then build it once.
 		if pr.Label.Name == labels.LGTM {
-			_, trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
+			_, trusted, err := TrustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
 			if err != nil {
 				return fmt.Errorf("could not validate PR: %s", err)
 			} else if !trusted {
@@ -120,7 +120,7 @@ func buildAllIfTrusted(c client, trigger *plugins.Trigger, pr github.PullRequest
 	org, repo, a := orgRepoAuthor(pr.PullRequest)
 	author := string(a)
 	num := pr.PullRequest.Number
-	l, trusted, err := trustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
+	l, trusted, err := TrustedPullRequest(c.GitHubClient, trigger, author, org, repo, num, nil)
 	if err != nil {
 		return fmt.Errorf("could not validate PR: %s", err)
 	} else if trusted {
@@ -195,9 +195,9 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands)
 	return nil
 }
 
-// trustedPullRequest returns whether or not the given PR should be tested.
+// TrustedPullRequest returns whether or not the given PR should be tested.
 // It first checks if the author is in the org, then looks for "ok-to-test" label.
-func trustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
+func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
 	// First check if the author is a member of the org.
 	if orgMember, err := TrustedUser(ghc, trigger, author, org, repo); err != nil {
 		return l, false, fmt.Errorf("error checking %s for trust: %v", author, err)

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -95,7 +95,7 @@ func TestTrusted(t *testing.T) {
 					Name: label,
 				})
 			}
-			_, actual, err := trustedPullRequest(g, &trigger, tc.author, "kubernetes-incubator", "random-repo", 1, labels)
+			_, actual, err := TrustedPullRequest(g, &trigger, tc.author, "kubernetes-incubator", "random-repo", 1, labels)
 			if err != nil {
 				t.Fatalf("Didn't expect error: %s", err)
 			}

--- a/prow/statusreconciler/BUILD.bazel
+++ b/prow/statusreconciler/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "controller.go",
+        "doc.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/statusreconciler",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//maintenance/migratestatus/migrator:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/errorutil:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/kube:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/trigger:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["controller_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/kube:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/statusreconciler/OWNERS
+++ b/prow/statusreconciler/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- stevekuznetsov
+labels:
+ - area/prow/status-reconciler

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreconciler
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/maintenance/migratestatus/migrator"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/trigger"
+)
+
+// NewController constructs a new controller to reconcile stauses on config change
+func NewController(continueOnError bool, kubeClient *kube.Client, githubClient *github.Client, pluginAgent *plugins.ConfigAgent) *Controller {
+	return &Controller{
+		continueOnError: continueOnError,
+		kubeClient:      kubeClient,
+		githubClient:    githubClient,
+		statusMigrator: &gitHubMigrator{
+			githubClient:    githubClient,
+			continueOnError: continueOnError,
+		},
+		trustedChecker: &githubTrustedChecker{
+			githubClient: githubClient,
+			pluginAgent:  pluginAgent,
+		},
+	}
+}
+
+type statusMigrator interface {
+	retire(org, repo, context string) error
+	migrate(org, repo, from, to string) error
+}
+
+type gitHubMigrator struct {
+	githubClient    *github.Client
+	continueOnError bool
+}
+
+func (m *gitHubMigrator) retire(org, repo, context string) error {
+	return migrator.New(
+		*migrator.RetireMode(context, "", ""),
+		m.githubClient, org, repo, m.continueOnError,
+	).Migrate()
+}
+
+func (m *gitHubMigrator) migrate(org, repo, from, to string) error {
+	return migrator.New(
+		*migrator.MoveMode(from, to, ""),
+		m.githubClient, org, repo, m.continueOnError,
+	).Migrate()
+}
+
+type kubeClient interface {
+	CreateProwJob(j kube.ProwJob) (kube.ProwJob, error)
+}
+
+type githubClient interface {
+	GetPullRequests(org, repo string) ([]github.PullRequest, error)
+	GetRef(org, repo, ref string) (string, error)
+}
+
+type trustedChecker interface {
+	trustedPullRequest(author, org, repo string, num int) (bool, error)
+}
+
+type githubTrustedChecker struct {
+	githubClient *github.Client
+	pluginAgent  *plugins.ConfigAgent
+}
+
+func (c *githubTrustedChecker) trustedPullRequest(author, org, repo string, num int) (bool, error) {
+	_, trusted, err := trigger.TrustedPullRequest(
+		c.githubClient,
+		c.pluginAgent.Config().TriggerFor(org, repo),
+		author, org, repo, num, nil,
+	)
+	return trusted, err
+}
+
+// Controller reconciles statuses on PRs when config changes impact blocking presubmits
+type Controller struct {
+	continueOnError bool
+	kubeClient      kubeClient
+	githubClient    githubClient
+	statusMigrator  statusMigrator
+	trustedChecker  trustedChecker
+}
+
+// Run monitors the incoming configuration changes to determine when statuses need to be
+// reconciled on PRs in flight when blocking presubmits change
+func (c *Controller) Run(stop <-chan os.Signal, changes <-chan config.ConfigDelta) {
+	for {
+		select {
+		case change := <-changes:
+			start := time.Now()
+			if err := c.reconcile(change); err != nil {
+				logrus.WithError(err).Error("Error reconciling statuses.")
+			}
+			logrus.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Statuses reconciled")
+		case <-stop:
+			logrus.Info("status-reconciler is shutting down...")
+			return
+		}
+	}
+}
+
+func (c *Controller) reconcile(delta config.ConfigDelta) error {
+	var errors []error
+	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+		errors = append(errors, err)
+		if !c.continueOnError {
+			return errorutil.NewAggregate(errors...)
+		}
+	}
+
+	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+		errors = append(errors, err)
+		if !c.continueOnError {
+			return errorutil.NewAggregate(errors...)
+		}
+	}
+
+	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+		errors = append(errors, err)
+		if !c.continueOnError {
+			return errorutil.NewAggregate(errors...)
+		}
+	}
+
+	return errorutil.NewAggregate(errors...)
+}
+
+func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Presubmit) error {
+	var triggerErrors []error
+	for orgrepo, presubmits := range addedPresubmits {
+		if len(presubmits) == 0 {
+			continue
+		}
+		parts := strings.SplitN(orgrepo, "/", 2)
+		org, repo := parts[0], parts[1]
+		prs, err := c.githubClient.GetPullRequests(org, repo)
+		if err != nil {
+			triggerErrors = append(triggerErrors, fmt.Errorf("failed to list pull requests for %s: %v", orgrepo, err))
+			if !c.continueOnError {
+				return errorutil.NewAggregate(triggerErrors...)
+			}
+			continue
+		}
+		for _, pr := range prs {
+			if err := c.triggerIfTrusted(org, repo, pr, presubmits); err != nil {
+				triggerErrors = append(triggerErrors, fmt.Errorf("failed to trigger jobs for %s#%d: %v", orgrepo, pr.Number, err))
+				if !c.continueOnError {
+					return errorutil.NewAggregate(triggerErrors...)
+				}
+				continue
+			}
+		}
+	}
+	return errorutil.NewAggregate(triggerErrors...)
+}
+
+func (c *Controller) triggerIfTrusted(org, repo string, pr github.PullRequest, presubmits []config.Presubmit) error {
+	trusted, err := c.trustedChecker.trustedPullRequest(pr.User.Login, org, repo, pr.Number)
+	if err != nil {
+		return fmt.Errorf("failed to determine if %s/%s#%d is trusted: %v", org, repo, pr.Number, err)
+	}
+	if !trusted {
+		return nil
+	}
+	baseSHA, err := c.githubClient.GetRef(org, repo, "heads/"+pr.Base.Ref)
+	if err != nil {
+		return fmt.Errorf("failed to determine base SHA for %s/%s#%d: %v", org, repo, pr.Number, err)
+	}
+	var triggerErrors []error
+	for _, presubmit := range presubmits {
+		pj := pjutil.NewPresubmit(pr, baseSHA, presubmit, "none")
+		logrus.WithFields(pjutil.ProwJobFields(&pj)).Info("Triggering new ProwJob to create newly-required context.")
+		if _, err := c.kubeClient.CreateProwJob(pj); err != nil {
+			triggerErrors = append(triggerErrors, err)
+			if !c.continueOnError {
+				break
+			}
+		}
+	}
+	return errorutil.NewAggregate(triggerErrors...)
+}
+
+func (c *Controller) retireRemovedContexts(retiredPresubmits map[string][]config.Presubmit) error {
+	var retireErrors []error
+	for orgrepo, presubmits := range retiredPresubmits {
+		parts := strings.SplitN(orgrepo, "/", 2)
+		org, repo := parts[0], parts[1]
+		for _, presubmit := range presubmits {
+			logrus.WithFields(logrus.Fields{
+				"org":     org,
+				"repo":    repo,
+				"context": presubmit.Context,
+			}).Info("Retiring context.")
+			if err := c.statusMigrator.retire(org, repo, presubmit.Context); err != nil {
+				if c.continueOnError {
+					retireErrors = append(retireErrors, err)
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return errorutil.NewAggregate(retireErrors...)
+}
+
+func (c *Controller) updateMigratedContexts(migrations map[string][]presubmitMigration) error {
+	var migrateErrors []error
+	for orgrepo, migrations := range migrations {
+		parts := strings.SplitN(orgrepo, "/", 2)
+		org, repo := parts[0], parts[1]
+		for _, migration := range migrations {
+			logrus.WithFields(logrus.Fields{
+				"org":  org,
+				"repo": repo,
+				"from": migration.from.Context,
+				"to":   migration.to.Context,
+			}).Info("Migrating context.")
+			if err := c.statusMigrator.migrate(org, repo, migration.from.Context, migration.to.Context); err != nil {
+				if c.continueOnError {
+					migrateErrors = append(migrateErrors, err)
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return errorutil.NewAggregate(migrateErrors...)
+}
+
+// addedBlockingPresubmits determines new blocking presubmits based on a
+// config update. New blocking presubmits are either brand-new presubmits
+// or extant presubmits that are now reporting. Previous presubmits that
+// reported but were optional that are no longer optional require no action
+// as their contexts will already exist on PRs.
+func addedBlockingPresubmits(old, new map[string][]config.Presubmit) map[string][]config.Presubmit {
+	added := map[string][]config.Presubmit{}
+
+	for repo, oldPresubmits := range old {
+		added[repo] = []config.Presubmit{}
+		for _, newPresubmit := range new[repo] {
+			if !newPresubmit.ContextRequired() {
+				continue
+			}
+			var found bool
+			for _, oldPresubmit := range oldPresubmits {
+				if oldPresubmit.Name == newPresubmit.Name {
+					if oldPresubmit.SkipReport && !newPresubmit.SkipReport {
+						added[repo] = append(added[repo], newPresubmit)
+						logrus.WithFields(logrus.Fields{
+							"repo": repo,
+							"name": oldPresubmit.Name,
+						}).Debug("Identified a newly-reporting blocking presubmit.")
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				added[repo] = append(added[repo], newPresubmit)
+				logrus.WithFields(logrus.Fields{
+					"repo": repo,
+					"name": newPresubmit.Name,
+				}).Debug("Identified an added blocking presubmit.")
+			}
+		}
+	}
+
+	logrus.Infof("Identified %d added blocking presubmits.", len(added))
+	return added
+}
+
+// removedBlockingPresubmits determines stale blocking presubmits based on a
+// config update. Presubmits that are no longer blocking due to no longer
+// reporting or being optional require no action as Tide will honor those
+// statuses correctly.
+func removedBlockingPresubmits(old, new map[string][]config.Presubmit) map[string][]config.Presubmit {
+	removed := map[string][]config.Presubmit{}
+
+	for repo, oldPresubmits := range old {
+		removed[repo] = []config.Presubmit{}
+		for _, oldPresubmit := range oldPresubmits {
+			if !oldPresubmit.ContextRequired() {
+				continue
+			}
+			var found bool
+			for _, newPresubmit := range new[repo] {
+				if oldPresubmit.Name == newPresubmit.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				removed[repo] = append(removed[repo], oldPresubmit)
+				logrus.WithFields(logrus.Fields{
+					"repo": repo,
+					"name": oldPresubmit.Name,
+				}).Debug("Identified a removed blocking presubmit.")
+			}
+		}
+	}
+
+	logrus.Infof("Identified %d removed blocking presubmits.", len(removed))
+	return removed
+}
+
+type presubmitMigration struct {
+	from, to config.Presubmit
+}
+
+// migratedBlockingPresubmits determines blocking presubmits that have had
+// their status contexts migrated. This is a best-effort evaluation as we
+// can only track a presubmit between configuration versions by its name.
+// A presubmit "migration" that had its underlying job and context changed
+// will be treated as a deletion and creation.
+func migratedBlockingPresubmits(old, new map[string][]config.Presubmit) map[string][]presubmitMigration {
+	migrated := map[string][]presubmitMigration{}
+
+	for repo, oldPresubmits := range old {
+		migrated[repo] = []presubmitMigration{}
+		for _, newPresubmit := range new[repo] {
+			if !newPresubmit.ContextRequired() {
+				continue
+			}
+			for _, oldPresubmit := range oldPresubmits {
+				if oldPresubmit.Context != newPresubmit.Context && oldPresubmit.Name == newPresubmit.Name {
+					migrated[repo] = append(migrated[repo], presubmitMigration{from: oldPresubmit, to: newPresubmit})
+					logrus.WithFields(logrus.Fields{
+						"repo": repo,
+						"name": oldPresubmit.Name,
+						"from": oldPresubmit.Context,
+						"to":   newPresubmit.Context,
+					}).Debug("Identified a migrated blocking presubmit.")
+				}
+			}
+		}
+	}
+
+	logrus.Infof("Identified %d migrated blocking presubmits.", len(migrated))
+	return migrated
+}

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -1,0 +1,784 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreconciler
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+func TestAddedBlockingPresubmits(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		old, new string
+		expected map[string][]config.Presubmit
+	}{
+		{
+			name: "no change in blocking presubmits means no added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "added optional presubmit means no added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+- name: new-job
+  context: new-context
+  optional: true`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "added non-reporting presubmit means no added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+- name: new-job
+  context: new-context
+  skip_report: true`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "added required presubmit means added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+- name: new-job
+  context: new-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {{
+					JobBase:    config.JobBase{Name: "new-job"},
+					Context:    "new-context",
+					Optional:   false,
+					SkipReport: false,
+				}},
+			},
+		},
+		{
+			name: "optional presubmit transitioning to required means no added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  optional: true`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "non-reporting presubmit transitioning to required means added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  skip_report: true`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {{
+					JobBase: config.JobBase{Name: "old-job"},
+					Context: "old-context",
+				}},
+			},
+		},
+		{
+			name: "required presubmit transitioning to new context means no added blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: new-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var oldConfig, newConfig map[string][]config.Presubmit
+			if err := yaml.Unmarshal([]byte(testCase.old), &oldConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal old config: %v", testCase.name, err)
+			}
+			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
+			}
+			if actual, expected := addedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct added presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestRemovedBlockingPresubmits(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		old, new string
+		expected map[string][]config.Presubmit
+	}{
+		{
+			name: "no change in blocking presubmits means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed optional presubmit means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  optional: true`,
+			new: `"org/repo": []`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed non-reporting presubmit means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  skip_report: true`,
+			new: `"org/repo": []`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed required presubmit means removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo": []`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {{
+					JobBase: config.JobBase{Name: "old-job"},
+					Context: "old-context",
+				}},
+			},
+		},
+		{
+			name: "required presubmit transitioning to optional means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+  optional: true`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "reporting presubmit transitioning to non-reporting means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+  skip_report: true`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "all presubmits removed means removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `{}`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {{
+					JobBase: config.JobBase{Name: "old-job"},
+					Context: "old-context",
+				}},
+			},
+		},
+		{
+			name: "required presubmit transitioning to new context means no removed blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: new-context`,
+			expected: map[string][]config.Presubmit{
+				"org/repo": {},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var oldConfig, newConfig map[string][]config.Presubmit
+			if err := yaml.Unmarshal([]byte(testCase.old), &oldConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal old config: %v", testCase.name, err)
+			}
+			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
+			}
+			if actual, expected := removedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestMigratedBlockingPresubmits(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		old, new string
+		expected map[string][]presubmitMigration
+	}{
+		{
+			name: "no change in blocking presubmits means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed optional presubmit means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  optional: true`,
+			new: `"org/repo": []`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed non-reporting presubmit means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context
+  skip_report: true`,
+			new: `"org/repo": []`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "removed required presubmit means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo": []`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "required presubmit transitioning to optional means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+  optional: true`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "reporting presubmit transitioning to non-reporting means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: old-context
+  skip_report: true`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "all presubmits removed means no migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `{}`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {},
+			},
+		},
+		{
+			name: "required presubmit transitioning to new context means migrated blocking jobs",
+			old: `"org/repo":
+- name: old-job
+  context: old-context`,
+			new: `"org/repo":
+- name: old-job
+  context: new-context`,
+			expected: map[string][]presubmitMigration{
+				"org/repo": {{
+					from: config.Presubmit{
+						JobBase: config.JobBase{Name: "old-job"},
+						Context: "old-context",
+					},
+					to: config.Presubmit{
+						JobBase: config.JobBase{Name: "old-job"},
+						Context: "new-context",
+					},
+				}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var oldConfig, newConfig map[string][]config.Presubmit
+			if err := yaml.Unmarshal([]byte(testCase.old), &oldConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal old config: %v", testCase.name, err)
+			}
+			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
+				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
+			}
+			if actual, expected := migratedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+type orgRepo struct {
+	org, repo string
+}
+
+type orgRepoSet map[orgRepo]interface{}
+
+func (s orgRepoSet) has(item orgRepo) bool {
+	_, contained := s[item]
+	return contained
+}
+
+type migration struct {
+	from, to string
+}
+
+type migrationSet map[migration]interface{}
+
+func (s migrationSet) insert(items ...migration) {
+	for _, item := range items {
+		s[item] = nil
+	}
+}
+
+func (s migrationSet) has(item migration) bool {
+	_, contained := s[item]
+	return contained
+}
+
+func newFakeMigrator(key orgRepo) fakeMigrator {
+	return fakeMigrator{
+		retireErrors:  map[orgRepo]sets.String{key: sets.NewString()},
+		migrateErrors: map[orgRepo]migrationSet{key: {}},
+		retired:       map[orgRepo]sets.String{key: sets.NewString()},
+		migrated:      map[orgRepo]migrationSet{key: {}},
+	}
+}
+
+type fakeMigrator struct {
+	retireErrors  map[orgRepo]sets.String
+	migrateErrors map[orgRepo]migrationSet
+
+	retired  map[orgRepo]sets.String
+	migrated map[orgRepo]migrationSet
+}
+
+func (m *fakeMigrator) retire(org, repo, context string) error {
+	key := orgRepo{org: org, repo: repo}
+	if contexts, exist := m.retireErrors[key]; exist && contexts.Has(context) {
+		return errors.New("failed to retire context")
+	}
+	if _, exist := m.retired[key]; exist {
+		m.retired[key].Insert(context)
+	} else {
+		m.retired[key] = sets.NewString(context)
+	}
+	return nil
+}
+
+func (m *fakeMigrator) migrate(org, repo, from, to string) error {
+	key := orgRepo{org: org, repo: repo}
+	item := migration{from: from, to: to}
+	if contexts, exist := m.migrateErrors[key]; exist && contexts.has(item) {
+		return errors.New("failed to migrate context")
+	}
+	if _, exist := m.migrated[key]; exist {
+		m.migrated[key].insert(item)
+	} else {
+		newSet := migrationSet{}
+		newSet.insert(item)
+		m.migrated[key] = newSet
+	}
+	return nil
+}
+
+func newfakeKubeClient() fakeKubeClient {
+	return fakeKubeClient{
+		errors:  sets.NewString(),
+		created: []kube.ProwJobSpec{},
+	}
+}
+
+type fakeKubeClient struct {
+	errors  sets.String
+	created []kube.ProwJobSpec
+}
+
+func (c *fakeKubeClient) CreateProwJob(j kube.ProwJob) (kube.ProwJob, error) {
+	if c.errors.Has(j.Name) {
+		return j, errors.New("failed to create prow job")
+	}
+	c.created = append(c.created, j.Spec)
+	return j, nil
+}
+
+func newFakeGitHubClient(key orgRepo) fakeGitHubClient {
+	return fakeGitHubClient{
+		prErrors:  orgRepoSet{},
+		refErrors: map[orgRepo]sets.String{key: sets.NewString()},
+		prs:       map[orgRepo][]github.PullRequest{key: {}},
+		refs:      map[orgRepo]map[string]string{key: {}},
+	}
+}
+
+type fakeGitHubClient struct {
+	prErrors  orgRepoSet
+	refErrors map[orgRepo]sets.String
+
+	prs  map[orgRepo][]github.PullRequest
+	refs map[orgRepo]map[string]string
+}
+
+func (c *fakeGitHubClient) GetPullRequests(org, repo string) ([]github.PullRequest, error) {
+	key := orgRepo{org: org, repo: repo}
+	if c.prErrors.has(key) {
+		return nil, errors.New("failed to get PRs")
+	}
+	return c.prs[key], nil
+}
+
+func (c *fakeGitHubClient) GetRef(org, repo, ref string) (string, error) {
+	key := orgRepo{org: org, repo: repo}
+	if refs, exist := c.refErrors[key]; exist && refs.Has(ref) {
+		return "", errors.New("failed to get ref")
+	}
+	return c.refs[key][ref], nil
+}
+
+type prAuthor struct {
+	pr     int
+	author string
+}
+
+type prAuthorSet map[prAuthor]interface{}
+
+func (s prAuthorSet) has(item prAuthor) bool {
+	_, contained := s[item]
+	return contained
+}
+
+func newFakeTrustedChecker(key orgRepo) fakeTrustedChecker {
+	return fakeTrustedChecker{
+		errors:  map[orgRepo]prAuthorSet{key: {}},
+		trusted: map[orgRepo]map[prAuthor]bool{key: {}},
+	}
+}
+
+type fakeTrustedChecker struct {
+	errors map[orgRepo]prAuthorSet
+
+	trusted map[orgRepo]map[prAuthor]bool
+}
+
+func (c *fakeTrustedChecker) trustedPullRequest(author, org, repo string, num int) (bool, error) {
+	key := orgRepo{org: org, repo: repo}
+	item := prAuthor{pr: num, author: author}
+	if errs, exist := c.errors[key]; exist && errs.has(item) {
+		return false, errors.New("failed to check trusted")
+	}
+	return c.trusted[key][item], nil
+}
+
+func TestControllerReconcile(t *testing.T) {
+	// the diff from these configs causes:
+	//  - deletion (required-job),
+	//  - creation (new-required-job)
+	//  - migration (other-required-job)
+	oldConfigData := `presubmits:
+  "org/repo":
+  - name: required-job
+    context: required-job
+  - name: other-required-job
+    context: other-required-job`
+	newConfigData := `presubmits:
+  "org/repo":
+  - name: other-required-job
+    context: new-context
+  - name: new-required-job
+    context: new-required-context`
+
+	var oldConfig, newConfig config.Config
+	if err := yaml.Unmarshal([]byte(oldConfigData), &oldConfig); err != nil {
+		t.Fatalf("could not unmarshal old config: %v", err)
+	}
+	if err := yaml.Unmarshal([]byte(newConfigData), &newConfig); err != nil {
+		t.Fatalf("could not unmarshal new config: %v", err)
+	}
+	delta := config.ConfigDelta{Before: oldConfig, After: newConfig}
+	migrate := migration{from: "other-required-job", to: "new-context"}
+	org, repo := "org", "repo"
+	orgRepoKey := orgRepo{org: org, repo: repo}
+	prNumber := 1
+	author := "user"
+	prAuthorKey := prAuthor{author: author, pr: prNumber}
+	baseRef := "base"
+	baseSha := "abc"
+	pr := github.PullRequest{
+		User: github.User{
+			Login: author,
+		},
+		Number: prNumber,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: org,
+				},
+				Name: repo,
+			},
+			Ref: baseRef,
+		},
+		Head: github.PullRequestBranch{
+			SHA: "prsha",
+		},
+	}
+	var testCases = []struct {
+		name string
+		// generator creates the controller and a func that checks
+		// the internal state of the fakes in the controller
+		generator func() (Controller, func(*testing.T))
+		expectErr bool
+	}{
+		{
+			name: "no errors and trusted PR means we should see a trigger, retire and migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fkc := newfakeKubeClient()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = true
+				return Controller{
+						continueOnError: true, kubeClient: &fkc, githubClient: &fghc, statusMigrator: &fsm, trustedChecker: &ftc,
+					}, func(t *testing.T) {
+						expectedProwJob := pjutil.NewPresubmit(pr, baseSha, config.Presubmit{
+							JobBase: config.JobBase{Name: "new-required-job"},
+							Context: "new-required-context",
+						}, "none").Spec
+						if actual, expected := fkc.created, []kube.ProwJobSpec{expectedProwJob}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not create expected ProwJob: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.retired, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not retire correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.migrated, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not migrate correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+					}
+			},
+		},
+		{
+			name: "no errors and untrusted PR means we should see no trigger, a retire and a migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fkc := newfakeKubeClient()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = false
+				return Controller{
+						continueOnError: true, kubeClient: &fkc, githubClient: &fghc, statusMigrator: &fsm, trustedChecker: &ftc,
+					}, func(t *testing.T) {
+						if actual, expected := fkc.created, []kube.ProwJobSpec{}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not create expected ProwJob: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.retired, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not retire correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.migrated, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not migrate correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+					}
+			},
+		},
+		{
+			name: "trust check error means we should see no trigger, a retire and a migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fkc := newfakeKubeClient()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.errors = map[orgRepo]prAuthorSet{orgRepoKey: {prAuthorKey: nil}}
+				return Controller{
+						continueOnError: true, kubeClient: &fkc, githubClient: &fghc, statusMigrator: &fsm, trustedChecker: &ftc,
+					}, func(t *testing.T) {
+						if actual, expected := fkc.created, []kube.ProwJobSpec{}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not create expected ProwJob: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.retired, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not retire correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.migrated, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not migrate correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+					}
+			},
+			expectErr: true,
+		},
+		{
+			name: "retire errors and trusted PR means we should see a trigger and migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fkc := newfakeKubeClient()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				fsm.retireErrors = map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = true
+				return Controller{
+						continueOnError: true, kubeClient: &fkc, githubClient: &fghc, statusMigrator: &fsm, trustedChecker: &ftc,
+					}, func(t *testing.T) {
+						expectedProwJob := pjutil.NewPresubmit(pr, baseSha, config.Presubmit{
+							JobBase: config.JobBase{Name: "new-required-job"},
+							Context: "new-required-context",
+						}, "none").Spec
+						if actual, expected := fkc.created, []kube.ProwJobSpec{expectedProwJob}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not create expected ProwJob: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.retired, map[orgRepo]sets.String{orgRepoKey: sets.NewString()}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not retire correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.migrated, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not migrate correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+					}
+			},
+			expectErr: true,
+		},
+		{
+			name: "migrate errors and trusted PR means we should see a trigger and retire",
+			generator: func() (Controller, func(*testing.T)) {
+				fkc := newfakeKubeClient()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				fsm.migrateErrors = map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}}
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = true
+				return Controller{
+						continueOnError: true, kubeClient: &fkc, githubClient: &fghc, statusMigrator: &fsm, trustedChecker: &ftc,
+					}, func(t *testing.T) {
+						expectedProwJob := pjutil.NewPresubmit(pr, baseSha, config.Presubmit{
+							JobBase: config.JobBase{Name: "new-required-job"},
+							Context: "new-required-context",
+						}, "none").Spec
+						if actual, expected := fkc.created, []kube.ProwJobSpec{expectedProwJob}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not create expected ProwJob: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.retired, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not retire correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+						if actual, expected := fsm.migrated, map[orgRepo]migrationSet{orgRepoKey: {}}; !reflect.DeepEqual(actual, expected) {
+							t.Errorf("did not migrate correct statuses: %s", diff.ObjectReflectDiff(actual, expected))
+						}
+					}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			controller, check := testCase.generator()
+			err := controller.reconcile(delta)
+			if err == nil && testCase.expectErr {
+				t.Errorf("expected an error, but got none")
+			}
+			if err != nil && !testCase.expectErr {
+				t.Errorf("expected no error, but got one: %v", err)
+			}
+			check(t)
+		})
+	}
+}

--- a/prow/statusreconciler/doc.go
+++ b/prow/statusreconciler/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package statusreconciler ensures that changes to required presubmits
+// do not cause PRs in flight to get stuck in the merge queue
+package statusreconciler


### PR DESCRIPTION
A new component, the `status-reconciler`, is created that subscribes to
changes in the Prow configuration in order to ensure that changes to the
configuration do not cause pull requests in flight to get stuck in the
Tide queues. In order to do this, the controller determines if any
changes to the configuration edit the set of blocking presubmits for any
repo. There are three types of change, for each of which the
`status-reconciler` will make the appropriate action:

 - a new blocking presubmit context is added; a ProwJob is created for
   every trusted pull request in flight to populate the new status
 - a current blocking presubmit is removed; the GitHub statuses on any
   pull requests in flight are updated to mark the status as retired
 - a current blocking presubmit is migrated to a new status; the GitHub
   statuses on any pull requests in flight are updated to mark the new
   status that was migrated to

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @BenTheElder @krzyzacy 
/assign @cjwagner @fejta 