### PR TITLE
Add backwards compatibility for new spyglass lens names.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -27,12 +27,13 @@ deck:
   spyglass:
     size_limit: 500000000 # 500MB
     viewers:
+      # TODO(Katharine, #10274): These names are deprecated, rename after deploy.
       "started.json|finished.json":
-      - "metadata"
+      - "metadata-viewer"
       "build-log.txt":
-      - "buildlog"
+      - "build-log-viewer"
       "artifacts/junit.*\\.xml":
-      - "junit"
+      - "junit-viewer"
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -828,6 +828,22 @@ func parseProwConfig(c *Config) error {
 		c.Deck.Spyglass.RegexCache[k] = r
 	}
 
+	// Map old viewer names to the new ones for backwards compatibility.
+	// TODO(Katharine, #10274): remove this, eventually.
+	oldViewers := map[string]string{
+		"build-log-viewer": "buildlog",
+		"metadata-viewer":  "metadata",
+		"junit-viewer":     "junit",
+	}
+
+	for re, viewers := range c.Deck.Spyglass.Viewers {
+		for i, v := range viewers {
+			if rename, ok := oldViewers[v]; ok {
+				c.Deck.Spyglass.Viewers[re][i] = rename
+			}
+		}
+	}
+
 	if c.PushGateway.IntervalString == "" {
 		c.PushGateway.Interval = time.Minute
 	} else {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -127,6 +127,33 @@ deck:
     size_limit: 500e6
     viewers:
       "started.json|finished.json":
+      - "metadata"
+      "build-log.txt":
+      - "buildlog"
+      "artifacts/junit.*\\.xml":
+      - "junit"
+`,
+			expectedViewers: map[string][]string{
+				"started.json|finished.json": {"metadata"},
+				"build-log.txt":              {"buildlog"},
+				"artifacts/junit.*\\.xml":    {"junit"},
+			},
+			expectedRegexMatches: map[string][]string{
+				"started.json|finished.json": {"started.json", "finished.json"},
+				"build-log.txt":              {"build-log.txt"},
+				"artifacts/junit.*\\.xml":    {"artifacts/junit01.xml", "artifacts/junit_runner.xml"},
+			},
+			expectedSizeLimit: 500e6,
+			expectError:       false,
+		},
+		{
+			name: "Backwards compatibility",
+			spyglassConfig: `
+deck:
+  spyglass:
+    size_limit: 500e+6
+    viewers:
+      "started.json|finished.json":
       - "metadata-viewer"
       "build-log.txt":
       - "build-log-viewer"
@@ -134,14 +161,9 @@ deck:
       - "junit-viewer"
 `,
 			expectedViewers: map[string][]string{
-				"started.json|finished.json": {"metadata-viewer"},
-				"build-log.txt":              {"build-log-viewer"},
-				"artifacts/junit.*\\.xml":    {"junit-viewer"},
-			},
-			expectedRegexMatches: map[string][]string{
-				"started.json|finished.json": {"started.json", "finished.json"},
-				"build-log.txt":              {"build-log.txt"},
-				"artifacts/junit.*\\.xml":    {"artifacts/junit01.xml", "artifacts/junit_runner.xml"},
+				"started.json|finished.json": {"metadata"},
+				"build-log.txt":              {"buildlog"},
+				"artifacts/junit.*\\.xml":    {"junit"},
 			},
 			expectedSizeLimit: 500e6,
 			expectError:       false,


### PR DESCRIPTION
Add backwards compatibility for the new names, and change our config back to reference the old ones (because spyglass is going to be broken until the new code is deployed).

Reverting this is tracked by #10274.
