### PR TITLE
Mount SA secret by default if SA name is given

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -32,6 +32,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 29, 2018* `plank` will no longer default jobs with `decorate: true`
+   to have `automountServiceAccountToken: false` in their PodSpec if unset, if the
+   job explicitly sets `serviceAccountName`
  - *November 26, 2018* job names must now match `^[A-Za-z0-9-._]+$`. Jobs that did not
    match this before were allowed but did not provide a good user experience.
  - *November 15, 2018* the `hook` service account now requires RBAC privileges

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -149,9 +149,11 @@ func ProwJobToPod(pj kube.ProwJob, buildID string) (*v1.Pod, error) {
 	spec.RestartPolicy = "Never"
 	spec.Containers[0].Name = kube.TestContainerName
 
-	// we treat this as false if unset, while kubernetes treats it as true if
-	// unset because it was added in v1.6
-	if spec.AutomountServiceAccountToken == nil {
+	// if the user has not provided a serviceaccount to use or explicitly
+	// requested mounting the default token, we treat the unset value as
+	// false, while kubernetes treats it as true if it is unset because
+	// it was added in v1.6
+	if spec.AutomountServiceAccountToken == nil && spec.ServiceAccountName == "" {
 		myFalse := false
 		spec.AutomountServiceAccountToken = &myFalse
 	}


### PR DESCRIPTION
When a user provides a service account name for their PodSpec in a job,
they are clearly requesting that their service account have it's
credentials mounted into the pod and we should not make them explicitly
request that as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @BenTheElder @cjwagner 
/cc @fejta 