### PR TITLE
Make some Prow components use the Retain deployment strategy.

### DIFF
--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -20,7 +20,9 @@ metadata:
   labels:
     app: horologium
 spec:
-  replicas: 1
+  replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -21,6 +21,8 @@ metadata:
     app: plank
 spec:
   replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -156,6 +156,8 @@ metadata:
     app: plank
 spec:
   replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -269,7 +271,9 @@ metadata:
   labels:
     app: horologium
 spec:
-  replicas: 1
+  replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -298,6 +302,8 @@ metadata:
     app: tide
 spec:
   replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -21,6 +21,8 @@ metadata:
     app: tide
 spec:
   replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -52,6 +52,8 @@ metadata:
     app: tot
 spec:
   replicas: 1  # one canonical source of build numbers
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Prow components that can only safely be run with a single instance in
the cluster need to explicitly specify the "Retain" deployment strategy
to avoid the default rolling update behavior.

Specifically `plank`, `horologium`, `tide`, and `tot` cannot safely have multiple instances running concurrently.

/cc @stevekuznetsov @fejta @krzyzacy @BenTheElder 