### PR TITLE
Add short_text_metric to testgrid config proto

### DIFF
--- a/testgrid/README.md
+++ b/testgrid/README.md
@@ -254,6 +254,16 @@ test_groups:
   ignore_pending: true
 ```
 
+### Showing a metric in the cells
+Specify `short_text_metric` to display a custom numeric metric in the TestGrid cells. Example:
+
+```
+test_groups:
+- name: ci-kubernetes-coverage-conformance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-conformance
+  short_text_metric: coverage
+```
+
 ## Using the client
 
 Here are some quick tips and clarifications for using the TestGrid site!

--- a/testgrid/config.proto
+++ b/testgrid/config.proto
@@ -111,6 +111,10 @@ message TestGroup {
 
   // The number of consecutive test passes to close the alert.
   int32 num_passes_to_disable_alert = 38;
+
+  // Numeric property metric value to be used for short text. If this property
+  // is present, it will override all the other short text values.
+  string short_text_metric = 43;
 }
 
 


### PR DESCRIPTION
So our many squares can contain many numbers.

/cc @michelle192837 