### PR TITLE
Add links to more Prow users in Prow README.

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -53,12 +53,20 @@ For a brief overview of how Prow runs jobs take a look at ["Life of a Prow Job"]
 
 ## Prow in the wild
 
-Prow is used by the following organizations:
+Prow is used by the following organizations and projects:
 - [Kubernetes](https://prow.k8s.io)
+  - This includes [kubernetes](https://github.com/kubernetes), [kubernetes-client](https://github.com/kubernetes-client), [kubernetes-csi](https://github.com/kubernetes-csi), [kubernetes-incubator](https://github.com/kubernetes-incubator), and [kubernetes-sigs](https://github.com/kubernetes-sigs).
 - [OpenShift](https://deck-ci.svc.ci.openshift.org/)
 - [Istio](https://prow.istio.io/)
 - [Knative](https://prow.knative.dev/)
 - [Jetstack](https://prow.build-infra.jetstack.net/)
+- [Kyma](https://status.build.kyma-project.io/)
+- [Prometheus](http://prombench.prometheus.io/)
+- [Caicloud](https://github.com/caicloud)
+- [Kubeflow](https://github.com/kubeflow)
+- [Azure acs-engine](https://github.com/Azure/acs-engine/tree/master/.prowci)
+- [tensorflow/minigo](https://github.com/tensorflow/minigo#automated-tests)
+- [helm/charts](https://github.com/helm/charts)
 
 [Jenkins X](https://jenkins-x.io/) uses [Prow as part of Serverless Jenkins](https://medium.com/@jdrawlings/serverless-jenkins-with-jenkins-x-9134cbfe6870).
 


### PR DESCRIPTION
Not all of these instances expose a public `Deck` so I linked to the org or repo in those cases.

/assign @mithrav @spiffxp @krzyzacy 