### PR TITLE
Remove priority label as a merge requirement

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -243,11 +243,6 @@ require_matching_label:
 
     Note: Method 1 will trigger an email to the group. See the [group list](https://git.k8s.io/community/sig-list.md).
     The `<group-suffix>` in method 1 has to be replaced with one of these: _**bugs, feature-requests, pr-reviews, test-failures, proposals**_.
-- missing_label: needs-priority
-  org: kubernetes
-  repo: kubernetes
-  prs: true
-  regexp: ^priority/
 - missing_label: needs-kind
   org: kubernetes
   repo: cloud-provider-aws


### PR DESCRIPTION
This label is only required during code slush and code freeze as per
the docs: https://github.com/kubernetes/community/blob/master/contributors/devel/release.md#tldr

/assign @cjwagner @AishSundar 