### PR TITLE
Set --node-killer-jitter-factor=25 in scalability killer job.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -52,7 +52,7 @@ periodics:
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --minStartupPods=8 --vmodule=request=4 --node-killer=true
+      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --minStartupPods=8 --vmodule=request=4 --node-killer=true --node-killer-jitter-factor=25
       - --timeout=120m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181122-a5bf59311-master


### PR DESCRIPTION
The test runs approx. ~25 minutes in test code, so we set 25 to kill ~1  node per test run.

/assign @wojtek-t 