### PR TITLE
Also build the commenter and label_sync on merge

### DIFF
--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -34,7 +34,7 @@ docker_push(
 # bazel-bin/.../label_sync loads the image into docker
 # bazel-bin/.../label_sync.binary is the binary
 go_image(
-    name = "label_sync-image",
+    name = "image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
     goarch = "amd64",

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -35,6 +35,10 @@ container_bundle(
         prefix("cherrypicker"): "//prow/external-plugins/cherrypicker:image",
     }) + image_tags(**{
         prefix("refresh"): "//prow/external-plugins/refresh:image",
+    }) + image_tags(**{
+        prefix("label_sync"): "//label_sync:image",
+    }) + image_tags(**{
+        prefix("commenter"): "//robots/commenter:image",
     }),
     stamp = True,
 )

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -27,7 +27,7 @@ load(
 )
 
 go_image(
-    name = "commenter-image",
+    name = "image",
     base = "@distroless-base//image",
     embed = [":go_default_library"],
 )


### PR DESCRIPTION
There are a number of other tools from test-infra that are useful to
consume the latest revision from, that most deployments of Prow will be
using to ensure that they have a mature ecosystem.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
These are super useful for Prow deployments but aren't "technically" part of Prow ...