### PR TITLE
Don't trigger postsubmits on branch deletion

### DIFF
--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -43,6 +43,10 @@ func listPushEventChanges(pe github.PushEvent) []string {
 }
 
 func handlePE(c client, pe github.PushEvent) error {
+	if pe.Deleted {
+		// we should not trigger jobs for a branch deletion
+		return nil
+	}
 	for _, j := range c.Config.Postsubmits[pe.Repo.FullName] {
 		if !j.RunsAgainstBranch(pe.Branch()) {
 			continue

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -26,41 +26,22 @@ import (
 )
 
 func TestHandlePE(t *testing.T) {
-	g := &fakegithub.FakeClient{}
-	kc := &fkc{}
-	c := client{
-		GitHubClient: g,
-		KubeClient:   kc,
-		Config:       &config.Config{},
-		Logger:       logrus.WithField("plugin", pluginName),
-	}
-	postsubmits := map[string][]config.Postsubmit{
-		"org/repo": {
-			{
-				JobBase: config.JobBase{
-					Name: "pass-butter",
-				},
-				RegexpChangeMatcher: config.RegexpChangeMatcher{
-					RunIfChanged: "\\.sh$",
-				},
-			},
-		},
-		"org2/repo2": {
-			{
-				JobBase: config.JobBase{
-					Name: "pass-salt",
-				},
-			},
-		},
-	}
-	if err := c.Config.SetPostsubmits(postsubmits); err != nil {
-		t.Fatalf("failed to set postsubmits: %v", err)
-	}
 	testCases := []struct {
 		name      string
 		pe        github.PushEvent
 		jobsToRun int
 	}{
+		{
+			name: "branch deleted",
+			pe: github.PushEvent{
+				Ref: "master",
+				Repo: github.Repo{
+					FullName: "org/repo",
+				},
+				Deleted: true,
+			},
+			jobsToRun: 0,
+		},
 		{
 			name: "no matching files",
 			pe: github.PushEvent{
@@ -106,19 +87,38 @@ func TestHandlePE(t *testing.T) {
 			},
 			jobsToRun: 1,
 		},
-		{
-			name: "branch deleted",
-			pe: github.PushEvent{
-				Ref: "master",
-				Repo: github.Repo{
-					FullName: "org/repo",
-				},
-				Deleted: true,
-			},
-			jobsToRun: 0,
-		},
 	}
 	for _, tc := range testCases {
+		g := &fakegithub.FakeClient{}
+		kc := &fkc{}
+		c := client{
+			GitHubClient: g,
+			KubeClient:   kc,
+			Config:       &config.Config{},
+			Logger:       logrus.WithField("plugin", pluginName),
+		}
+		postsubmits := map[string][]config.Postsubmit{
+			"org/repo": {
+				{
+					JobBase: config.JobBase{
+						Name: "pass-butter",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "\\.sh$",
+					},
+				},
+			},
+			"org2/repo2": {
+				{
+					JobBase: config.JobBase{
+						Name: "pass-salt",
+					},
+				},
+			},
+		}
+		if err := c.Config.SetPostsubmits(postsubmits); err != nil {
+			t.Fatalf("failed to set postsubmits: %v", err)
+		}
 		err := handlePE(c, tc.pe)
 		if err != nil {
 			t.Errorf("test %q: handlePE returned unexpected error %v", tc.name, err)

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -106,6 +106,17 @@ func TestHandlePE(t *testing.T) {
 			},
 			jobsToRun: 1,
 		},
+		{
+			name: "branch deleted",
+			pe: github.PushEvent{
+				Ref: "master",
+				Repo: github.Repo{
+					FullName: "org/repo",
+				},
+				Deleted: true,
+			},
+			jobsToRun: 0,
+		},
 	}
 	for _, tc := range testCases {
 		err := handlePE(c, tc.pe)


### PR DESCRIPTION
It is not appropriate to trigger postsubmits on a branch deletion event.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner
/cc @BenTheElder @fejta @smarterclayton @cblecker 
supersedes https://github.com/kubernetes/test-infra/pull/9799