### PR TITLE
Prevent tide from crashing when there are no RequiredStatusChecks

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -444,7 +444,7 @@ func (c Config) GetTideContextPolicy(org, repo, branch string) (*TideContextPoli
 			logrus.WithError(err).Warningf("Error getting branch protection for %s/%s+%s", org, repo, branch)
 		} else if bp == nil {
 			logrus.Warningf("branch protection not set for %s/%s+%s", org, repo, branch)
-		} else if bp.Protect != nil && *bp.Protect {
+		} else if bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil {
 			required.Insert(bp.RequiredStatusChecks.Contexts...)
 		}
 	}


### PR DESCRIPTION
Currently tide crashloops when activated on a repo that has no Presubmits configured:

```
{"client":"github","component":"tide","level":"info","msg":"Throttle(800, 39)","time":"2018-12-01T22:07:17Z"}
{"client":"github","component":"tide","level":"info","msg":"Throttle(400, 200)","time":"2018-12-01T22:07:17Z"}
{"component":"tide","controller":"sync","duration":"613.132559ms","level":"info","msg":"Synced","time":"2018-12-01T22:07:18Z"}
{"component":"tide","controller":"status-update","duration":"769.68268ms","level":"info","msg":"Statuses synced.","time":"2018-12-01T22:07:19Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae98ae]

goroutine 5 [running]:
k8s.io/test-infra/prow/config.Config.GetTideContextPolicy(0xc0001bcc00, 0x9, 0x9, 0xc00002f3e0, 0xc00002ecf0, 0xc0000c8480, 0x1, 0x4, 0x0, 0x0, ...)
	prow/config/tide.go:448 +0x4ce
k8s.io/test-infra/prow/tide.(*statusController).setStatuses.func1(0xc0001a76c0)
	prow/tide/status.go:270 +0x506
k8s.io/test-infra/prow/tide.(*statusController).setStatuses(0xc000342100, 0xc0001f4000, 0x8, 0x8, 0xc000308450)
	prow/tide/status.go:309 +0x1fe
k8s.io/test-infra/prow/tide.(*statusController).sync(0xc000342100, 0xc000308450)
	prow/tide/status.go:371 +0x95
k8s.io/test-infra/prow/tide.(*statusController).waitSync(0xc000342100)
	prow/tide/status.go:353 +0x1c0
k8s.io/test-infra/prow/tide.(*statusController).run(0xc000342100)
	prow/tide/status.go:335 +0x2d
created by k8s.io/test-infra/prow/tide.NewController
	prow/tide/tide.go:195 +0x1cc
```

This Pull fixes that