### PR TITLE
Clarify that org/repo must be explicitly set in clone_uri

### DIFF
--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -86,7 +86,7 @@ the `exta_refs` field.
   decoration_config:
     ssh_key_secrets:
     - ssh-secret
-  clone_uri: "git@github.com:{{.Org}}/{{.Repo}}.git"
+  clone_uri: "git@github.com:<YOUR_ORG>/<YOUR_REPO>.git"
   extra_refs:
   - org: kubernetes
     repo: other-repo


### PR DESCRIPTION
I am not sure if this is actually a documentation bug or a bug in the code. I copied the line from the docs (`clone_uri: "git@github.com:{{.Org}}/{{.Repo}}.git"`) to my prowjob, then `clonerefs` failed like this:

```
{"component":"clonerefs","level":"info","msg":"Started SSH agent","time":"2018-12-02T11:48:14Z"}
{"component":"clonerefs","level":"info","msg":"Added SSH key at /secrets/ssh/ssh-key/id_rsa","time":"2018-12-02T11:48:14Z"}
{"component":"clonerefs","level":"info","msg":"Cloning refs","refs":{"org":"kubermatic","repo":"reponame-redacted","base_ref":"master","base_sha":"ac7d732bf0c7f868616782dc87a0cc6c37352e0f","pulls":[{"number":5,"author":"alvaroaleman","sha":"3b20c680e6c3473d59cb63eabf9dc84178b47343"}],"clone_uri":"git@github.com:{{.Org}}/{{.Repo}}.git"},"time":"2018-12-02T11:48:14Z"}
{"command":"mkdir -p /home/prow/go/src/github.com/kubermatic/reponame-redacted","component":"clonerefs","error":null,"level":"info","msg":"Ran command","output":"","time":"2018-12-02T11:48:14Z"}
{"command":"git init","component":"clonerefs","error":null,"level":"info","msg":"Ran command","output":"Initialized empty Git repository in /home/prow/go/src/github.com/kubermatic/reponame-redacted/.git/\n","time":"2018-12-02T11:48:14Z"}
{"command":"git config user.name ci-robot","component":"clonerefs","error":null,"level":"info","msg":"Ran command","output":"","time":"2018-12-02T11:48:14Z"}
{"command":"git config user.email ci-robot@k8s.io","component":"clonerefs","error":null,"level":"info","msg":"Ran command","output":"","time":"2018-12-02T11:48:14Z"}
{"command":"git fetch git@github.com:{{.Org}}/{{.Repo}}.git --tags --prune","component":"clonerefs","error":"exit status 128","level":"info","msg":"Ran command","output":"Warning: Permanently added 'github.com,192.30.253.112' (RSA) to the list of known hosts.\r\nfatal: remote error: \n   is not a valid repository name\n  Email support@github.com for help\n","time":"2018-12-02T11:48:15Z"}
{"component":"clonerefs","level":"info","msg":"Finished cloning refs","time":"2018-12-02T11:48:15Z"}
```