### PR TITLE
Typo fixed: "satisty" -> "satisfy"

### DIFF
--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -353,7 +353,7 @@ func TestFulfillOne(t *testing.T) {
 		fulfillment: common.TypeToResources{},
 	}
 	if err = m.fulfillOne(context.Background(), &req); err != nil {
-		t.Errorf("could not satisty requirements ")
+		t.Errorf("could not satisfy requirements ")
 	}
 	if len(req.fulfillment) != 1 {
 		t.Errorf("there should be only one type")


### PR DESCRIPTION
Fix typo in line 356.