### PR TITLE
Honor the Retry-After header on 403s from GitHub

### DIFF
--- a/prow/scaling.md
+++ b/prow/scaling.md
@@ -45,7 +45,12 @@ allowing multiple files to loaded into a single configmap under different keys
 [`ghproxy`](/ghproxy/) is a reverse proxy HTTP cache optimized for the GitHub API.
 It takes advantage of how GitHub responds to E-tags in order to fulfill repeated
 requests without spending additional API tokens. Check out this tool if you find
-that your GitHub bot is consuming or approaching it's token limit.
+that your GitHub bot is consuming or approaching it's token limit. Similarly,
+re-deploying Prow components may trigger a large amount of API requests to GitHub
+which may trip the abuse detection mechanisms. At scale, the `tide` deployment
+itself may create enough API throughput to trigger this on its own. Deploying the
+GitHub proxy cache is critical to ensuring that Prow does not trip this mechanism
+when operating at scale.
 
 ### Config Driven GitHub Org Management
 


### PR DESCRIPTION
When GitHub is using an abuse rate limit, not a normal API rate limit,
they will send a 403 and a suggested retry-after time. We need to honor
that header in order to not cause our clients to continue to exacerbate
the issue causing the abuse rate limit in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 