### PR TITLE
Use PodUtils in cloud-provider-aws

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -2,37 +2,29 @@ presubmits:
   kubernetes/cloud-provider-aws:
   - name: pull-cloud-provider-aws-check
     always_run: true
-    branches:
-    - master
+    decorate: true
     labels:
       preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181203-a441fa430-master
+        command:
+        - runner.sh
         args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
         - make
         - check
 
   - name: pull-cloud-provider-aws-test
     always_run: true
-    branches:
-    - master
+    decorate: true
     labels:
       preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181203-a441fa430-master
+        command:
+        - runner.sh
         args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
         - make
         - test
 


### PR DESCRIPTION
This is a followup to #10151 that converts cloud-provider-aws to use PodUtils as requested by @BenTheElder (apologies for the delay).

/assign @BenTheElder 
/kind feature
/sig aws
/sig cloud-provider