### PR TITLE
kubetest/eks: fix EKS test plugin downloader

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -3,7 +3,7 @@ presets:
 - env:
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.3/aws-k8s-tester-0.1.3-linux-amd64
+    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.4/aws-k8s-tester-0.1.4-linux-amd64
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
     value: /tmp/aws-k8s-tester/aws-k8s-tester
   # URL to download 'kubectl', required for 'kubectl' calls to EKS

--- a/kubetest/eks/eks.go
+++ b/kubetest/eks/eks.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -77,6 +78,9 @@ func NewDeployer(timeout time.Duration, verbose bool) (ekstester.Deployer, error
 	}
 
 	if err = os.RemoveAll(cfg.AWSK8sTesterPath); err != nil {
+		return nil, err
+	}
+	if err = os.MkdirAll(filepath.Dir(cfg.AWSK8sTesterPath), 0700); err != nil {
 		return nil, err
 	}
 	f, err = os.Create(cfg.AWSK8sTesterPath)


### PR DESCRIPTION
Fix

```
W1204 01:37:36.186] 2018/12/04 01:37:36 process.go:96: Saved XML output to /workspace/_artifacts/junit_runner.xml.
W1204 01:37:36.187] 2018/12/04 01:37:36 main.go:313: Something went wrong: error creating deployer: failed to create "/tmp/aws-k8s-tester/aws-k8s-tester" (open /tmp/aws-k8s-tester/aws-k8s-tester: no such file or directory)
...
```

`os.Create` was failing when `filepath.Dir(binary-path)` did not exist. This calls `os.MkdirAll` to make sure the parental directory exists before we download test plugin binaries.

Thanks!

/cc @BenTheElder @krzyzacy 