### PR TITLE
istio: add non-mcp test variants to testgrid dashboard

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2908,6 +2908,10 @@ test_groups:
   gcs_prefix: istio-prow/pr-logs/directory/istio-pilot-e2e-envoyv2-v1alpha3-mcp
 - name: istio-e2e-mixer-no_auth-mcp-presubmit
   gcs_prefix: istio-prow/pr-logs/directory/e2e-mixer-no_auth-mcp
+- name: istio-pilot-e2e-envoyv2-v1alpha3-non-mcp-presubmit
+  gcs_prefix: istio-prow/pr-logs/directory/istio-pilot-e2e-envoyv2-v1alpha3-non-mcp
+- name: istio-e2e-mixer-no_auth-non-mcp-presubmit
+  gcs_prefix: istio-prow/pr-logs/directory/e2e-mixer-no_auth-non-mcp
 # Istio Prow Postsubmits
 - name: istio-postsubmit
   gcs_prefix: istio-prow/logs/istio-postsubmit
@@ -2938,6 +2942,9 @@ test_groups:
   num_failures_to_alert: 1
 - name: istio-e2e-simpleTests-mcp
   gcs_prefix: istio-prow/logs/e2e-simpleTests-mcp
+  num_failures_to_alert: 1
+- name: istio-e2e-simpleTests-non-mcp
+  gcs_prefix: istio-prow/logs/e2e-simpleTests-non-mcp
   num_failures_to_alert: 1
 - name: istio-e2e-simpleTests-minProfile
   gcs_prefix: istio-prow/logs/e2e-simpleTestsMinProfile
@@ -2973,6 +2980,10 @@ test_groups:
   gcs_prefix: istio-circleci/presubmit/e2e-mixer-noauth-v1alpha3-v2-mcp
 - name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-mcp-presubmit
   gcs_prefix: istio-circleci/presubmit/e2e-pilot-auth-v1alpha3-v2-mcp
+- name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp-presubmit
+  gcs_prefix: istio-circleci/presubmit/e2e-mixer-noauth-v1alpha3-v2-non-mcp
+- name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp-presubmit
+  gcs_prefix: istio-circleci/presubmit/e2e-pilot-auth-v1alpha3-v2-non-mcp
 # Istio CircleCI Postsubmits
 - name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2
   gcs_prefix: istio-circleci/e2e-mixer-noauth-v1alpha3-v2
@@ -3017,6 +3028,21 @@ test_groups:
   num_failures_to_alert: 5
 - name: istio-circleci-e2e-pilot-noauth-v1alpha3-v2-mcp
   gcs_prefix: istio-circleci/e2e-pilot-noauth-v1alpha3-v2-mcp
+  num_failures_to_alert: 5
+- name: istio-circleci-e2e-simple-non-mcp
+  gcs_prefix: istio-circleci/e2e-simple-non-mcp
+  num_failures_to_alert: 5
+- name: istio-circleci-e2e-dashboard-non-mcp
+  gcs_prefix: istio-circleci/e2e-dashboard-non-mcp
+  num_failures_to_alert: 5
+- name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp
+  gcs_prefix: istio-circleci/e2e-mixer-noauth-v1alpha3-v2-non-mcp
+  num_failures_to_alert: 5
+- name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp
+  gcs_prefix: istio-circleci/e2e-pilot-auth-v1alpha3-v2-non-mcp
+  num_failures_to_alert: 5
+- name: istio-circleci-e2e-pilot-noauth-v1alpha3-v2-non-mcp
+  gcs_prefix: istio-circleci/e2e-pilot-noauth-v1alpha3-v2-non-mcp
   num_failures_to_alert: 5
 # Istio daily releases
 - name: istio-daily-unit-tests
@@ -7271,6 +7297,15 @@ dashboards:
     test_group_name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-mcp-presubmit
   - name: circleci-e2e-pilot-auth-v1alpha3-v2-mcp
     test_group_name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-mcp-presubmit
+  - name: pilot-e2e-envoyv2-v1alpha3-non-mcp
+    test_group_name: istio-pilot-e2e-envoyv2-v1alpha3-non-mcp-presubmit
+  - name: e2e-mixer-no_auth-non-mcp
+    test_group_name: istio-e2e-mixer-no_auth-non-mcp-presubmit
+  - name: circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp
+    test_group_name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp-presubmit
+  - name: circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp
+    test_group_name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp-presubmit
+
 
 - name: istio-postsubmits
   dashboard_tab:
@@ -7312,6 +7347,10 @@ dashboards:
       alert_mail_to_addresses: istio-oncall@googlegroups.com
   - name: e2e-simpleTests-mcp
     test_group_name: istio-e2e-simpleTests-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: e2e-simpleTests-non-mcp
+    test_group_name: istio-e2e-simpleTests-non-mcp
     alert_options:
       alert_mail_to_addresses: istio-oncall@googlegroups.com
   - name: e2e-simpleTests-minProfile
@@ -7372,6 +7411,26 @@ dashboards:
       alert_mail_to_addresses: istio-oncall@googlegroups.com
   - name: circleci-e2e-pilot-noauth-v1alpha3-v2-mcp
     test_group_name: istio-circleci-e2e-pilot-noauth-v1alpha3-v2-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp
+    test_group_name: istio-circleci-e2e-mixer-noauth-v1alpha3-v2-non-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: circleci-e2e-simple-non-mcp
+    test_group_name: istio-circleci-e2e-simple-non-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: circleci-e2e-dashboard-non-mcp
+    test_group_name: istio-circleci-e2e-dashboard-non-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp
+    test_group_name: istio-circleci-e2e-pilot-auth-v1alpha3-v2-non-mcp
+    alert_options:
+      alert_mail_to_addresses: istio-oncall@googlegroups.com
+  - name: circleci-e2e-pilot-noauth-v1alpha3-v2-non-mcp
+    test_group_name: istio-circleci-e2e-pilot-noauth-v1alpha3-v2-non-mcp
     alert_options:
       alert_mail_to_addresses: istio-oncall@googlegroups.com
 


### PR DESCRIPTION
Istio is switching to MCP by default. During the transition we'd like
to retain testing a subset of the non-mcp. We'd also like to retain
the previous mcp specific test results in testgrid for a few weeks
until the cutover completed.