### PR TITLE
Update Boskos Binary with in memory storage for local testing

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -27,21 +27,26 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/crds"
 	"k8s.io/test-infra/boskos/ranch"
 )
 
 var (
-	configPath  = flag.String("config", "config.yaml", "Path to init resource file")
-	storagePath = flag.String("storage", "", "Path to persistent volume to load the state")
+	configPath        = flag.String("config", "config.yaml", "Path to init resource file")
+	storagePath       = flag.String("storage", "", "Path to persistent volume to load the state")
+	kubeClientOptions crds.KubernetesClientOptions
 )
 
 func main() {
+	kubeClientOptions.AddFlags(flag.CommandLine)
 	flag.Parse()
+	kubeClientOptions.Validate()
+
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 
-	rc, err := crds.NewResourceClient()
+	rc, err := kubeClientOptions.Client(crds.ResourceType)
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to create a CRD client")
 	}

--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -39,19 +39,21 @@ const (
 	version = "v1"
 )
 
+// KubernetesClientOptions are flag options used to create a kube client.
 type KubernetesClientOptions struct {
 	inMemory   bool
 	kubeConfig string
 	namespace  string
 }
 
+// AddFlags adds kube client flags to existing FlagSet.
 func (o *KubernetesClientOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.namespace, "namespace", v1.NamespaceDefault, "namespace to install on")
 	fs.StringVar(&o.kubeConfig, "kubeconfig", "", "absolute path to the kubeConfig file")
 	fs.BoolVar(&o.inMemory, "in_memory", false, "Use in memory client instead of CRD")
 }
 
-// Validate validates Kubernetes options.
+// Validate validates Kubernetes client options.
 func (o *KubernetesClientOptions) Validate() error {
 	if o.kubeConfig != "" {
 		if _, err := os.Stat(o.kubeConfig); err != nil {
@@ -61,6 +63,7 @@ func (o *KubernetesClientOptions) Validate() error {
 	return nil
 }
 
+// Client returns a ClientInterface based on the flags provided.
 func (o *KubernetesClientOptions) Client(t Type) (ClientInterface, error) {
 	if o.inMemory {
 		return newDummyClient(t), nil

--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -19,6 +19,7 @@ package crds
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"k8s.io/test-infra/boskos/common"
 
@@ -38,10 +39,55 @@ const (
 	version = "v1"
 )
 
-var (
-	kubeConfig = flag.String("kubeconfig", "", "absolute path to the kubeConfig file")
-	namespace  = flag.String("namespace", v1.NamespaceDefault, "namespace to install on")
-)
+type KubernetesClientOptions struct {
+	inMemory   bool
+	kubeConfig string
+	namespace  string
+}
+
+func (o *KubernetesClientOptions) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&o.namespace, "namespace", v1.NamespaceDefault, "namespace to install on")
+	fs.StringVar(&o.kubeConfig, "kubeconfig", "", "absolute path to the kubeConfig file")
+	fs.BoolVar(&o.inMemory, "in_memory", false, "Use in memory client instead of CRD")
+}
+
+// Validate validates Kubernetes options.
+func (o *KubernetesClientOptions) Validate() error {
+	if o.kubeConfig != "" {
+		if _, err := os.Stat(o.kubeConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *KubernetesClientOptions) Client(t Type) (ClientInterface, error) {
+	if o.inMemory {
+		return newDummyClient(t), nil
+	}
+	return o.newCRDClient(t)
+}
+
+// newClientFromFlags creates a CRD rest client from provided flags.
+func (o *KubernetesClientOptions) newCRDClient(t Type) (*Client, error) {
+	config, scheme, err := createRESTConfig(o.kubeConfig, t)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = registerResource(config, t); err != nil {
+		return nil, err
+	}
+	// creates the client
+	var restClient *rest.RESTClient
+	restClient, err = rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+	rc := Client{cl: restClient, ns: o.namespace, t: t,
+		codec: runtime.NewParameterCodec(scheme)}
+	return &rc, nil
+}
 
 // Type defines a Custom Resource Definition (CRD) Type.
 type Type struct {
@@ -113,9 +159,8 @@ func registerResource(config *rest.Config, t Type) error {
 			Name: fmt.Sprintf("%s.%s", t.Plural, group),
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   group,
-			Version: version,
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Group: group,
+			Scope: apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Singular: t.Singular,
 				Plural:   t.Plural,
@@ -130,12 +175,6 @@ func registerResource(config *rest.Config, t Type) error {
 	return nil
 }
 
-// NewClient creates a CRD client for a given resource type.
-func NewClient(cl *rest.RESTClient, scheme *runtime.Scheme, namespace string, t Type) Client {
-	return Client{cl: cl, ns: namespace, t: t,
-		codec: runtime.NewParameterCodec(scheme)}
-}
-
 // newDummyClient creates a in memory client representation for testing, such that we do not need to use a kubernetes API Server.
 func newDummyClient(t Type) *dummyClient {
 	c := &dummyClient{
@@ -143,26 +182,6 @@ func newDummyClient(t Type) *dummyClient {
 		objects: make(map[string]Object),
 	}
 	return c
-}
-
-// newClientFromFlags creates a CRD rest client from provided flags.
-func newClientFromFlags(t Type) (*Client, error) {
-	config, scheme, err := createRESTConfig(*kubeConfig, t)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = registerResource(config, t); err != nil {
-		return nil, err
-	}
-	// creates the client
-	var restClient *rest.RESTClient
-	restClient, err = rest.RESTClientFor(config)
-	if err != nil {
-		return nil, err
-	}
-	rc := NewClient(restClient, scheme, *namespace, t)
-	return &rc, nil
 }
 
 // ClientInterface is used for testing.

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -17,17 +17,17 @@ limitations under the License.
 package crds
 
 import (
+	"reflect"
 	"time"
 
 	"k8s.io/test-infra/boskos/common"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 )
 
 var (
-	resourceType = Type{
+	ResourceType = Type{
 		Kind:       reflect.TypeOf(ResourceObject{}).Name(),
 		ListKind:   reflect.TypeOf(ResourceCollection{}).Name(),
 		Singular:   "resource",
@@ -37,14 +37,9 @@ var (
 	}
 )
 
-// NewResourceClient creates a CRD rest client for common.Resource
-func NewResourceClient() (ClientInterface, error) {
-	return newClientFromFlags(resourceType)
-}
-
 // NewTestResourceClient creates a fake CRD rest client for common.Resource
 func NewTestResourceClient() ClientInterface {
-	return newDummyClient(resourceType)
+	return newDummyClient(ResourceType)
 }
 
 // ResourceObject represents common.ResourceObject. It implements the Object interface.

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -27,6 +27,7 @@ import (
 )
 
 var (
+	// ResourceType is the ResourceObject CRD type
 	ResourceType = Type{
 		Kind:       reflect.TypeOf(ResourceObject{}).Name(),
 		ListKind:   reflect.TypeOf(ResourceCollection{}).Name(),

--- a/boskos/crds/resources_config_crd.go
+++ b/boskos/crds/resources_config_crd.go
@@ -17,14 +17,16 @@ limitations under the License.
 package crds
 
 import (
+	"reflect"
+
+	"k8s.io/test-infra/boskos/common"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/test-infra/boskos/common"
-	"reflect"
 )
 
 var (
-	resourcesConfigType = Type{
+	ResourcesConfigType = Type{
 		Kind:       reflect.TypeOf(ResourcesConfigObject{}).Name(),
 		ListKind:   reflect.TypeOf(ResourcesConfigCollection{}).Name(),
 		Singular:   "resourcesconfig",
@@ -34,14 +36,9 @@ var (
 	}
 )
 
-// NewResourceConfigClient creates a CRD rest client for common.Resource
-func NewResourceConfigClient() (ClientInterface, error) {
-	return newClientFromFlags(resourcesConfigType)
-}
-
 // NewTestResourceConfigClient creates a fake CRD rest client for common.Resource
 func NewTestResourceConfigClient() ClientInterface {
-	return newDummyClient(resourcesConfigType)
+	return newDummyClient(ResourcesConfigType)
 }
 
 // ResourcesConfigObject holds generalized configuration information about how the

--- a/boskos/crds/resources_config_crd.go
+++ b/boskos/crds/resources_config_crd.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	// ResourcesConfigType is the ResourceObject CRD type
 	ResourcesConfigType = Type{
 		Kind:       reflect.TypeOf(ResourcesConfigObject{}).Name(),
 		ListKind:   reflect.TypeOf(ResourcesConfigCollection{}).Name(),


### PR DESCRIPTION
In order to be able to start Boskos locally, I added a flag to start an in memory storage.

Note that the crd package was setting its own flags, and I updated this to be an option as we do in Prow.

For testing use the following
$ go run boskos.go --config=resources.yaml --in_memory 