### PR TITLE
refer e2e scripts from main repo instead of personal repo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -82,12 +82,6 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    # TODO: move this to clusterapi-vsphere main repo 
-    extra_refs:
-    - org: figo
-      repo: cluster-api-provider-vsphere-ci
-      base_ref: master
-      path_alias: figo/cluster-api-provider-vsphere-ci
     max_concurrency: 1
     spec:
       containers:
@@ -95,7 +89,7 @@ presubmits:
         command:
         - runner.sh
         args:
-        - ./../../figo/cluster-api-provider-vsphere-ci/prow/e2e.sh
+        - ./scripts/e2e/e2e.sh
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
since we have moved the e2e code to main repo, we need to update
Prow job definition to refer to the main repo.