### PR TITLE
Add side-effect import to allow for plugin config load

### DIFF
--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/flagutil:go_default_library",
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/hook:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/statusreconciler:go_default_library",

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	_ "k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/statusreconciler"


### PR DESCRIPTION
When loading the plugin configuration, all of the plugins must be
side-effect imported into the binary so that they will all be linked and
will be able to self-register for configuration validation at load-time.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 

Would be awesome if it were impossible to make this mistake -.-