### PR TITLE
sig-storage: fix csi-lib-utils config

### DIFF
--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  github.com/kubernetes-csi/csi-lib-utils:
+  kubernetes-csi/csi-lib-utils:
   - name: pull-sig-storage-csi-lib-utils
     always_run: true
     decorate: true


### PR DESCRIPTION
The key was wrong (must not include github.com), therefore the job
wasn't triggered.