### PR TITLE
Spyglass: display errors to user instead of empty page

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -501,7 +501,8 @@ func handleRequestJobViews(sg *spyglass.Spyglass, ca *config.Agent, o options) h
 		page, err := renderSpyglass(sg, ca, src, o)
 		if err != nil {
 			logrus.WithError(err).Error("error rendering spyglass page")
-			http.Error(w, "error getting views for job", http.StatusInternalServerError)
+			message := fmt.Sprintf("error rendering spyglass page: %v", err)
+			http.Error(w, message, http.StatusInternalServerError)
 			return
 		}
 
@@ -521,6 +522,9 @@ func renderSpyglass(sg *spyglass.Spyglass, ca *config.Agent, src string, o optio
 	artifactNames, err := sg.ListArtifacts(src)
 	if err != nil {
 		return "", fmt.Errorf("error listing artifacts: %v", err)
+	}
+	if len(artifactNames) == 0 {
+		return "", fmt.Errorf("found no artifacts for %s", src)
 	}
 
 	viewerCache := map[string][]string{}


### PR DESCRIPTION
Current behavior for Spyglass after encountering an internal error is to serve the frustratingly vague message "error getting views for job" (the actual error is logged, but not displayed to the user).
1. The actual error should be shown so the user hopefully has at least some idea what is going on. 
2. When Spyglass finds no artifacts, that should be treated as an error state and reported to the user instead of just serving the Deck header above an empty webpage.

/cc @Katharine 