### PR TITLE
escape branch names

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -21,6 +21,7 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"strings"
 	"time"
 
@@ -228,7 +229,7 @@ func (c *Client) GetBranchRevision(instance, project, branch string) (string, er
 		return "", fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	res, _, err := h.projectService.GetBranch(project, branch)
+	res, _, err := h.projectService.GetBranch(project, url.QueryEscape(branch))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
(upstream fix opened in https://github.com/andygrunwald/go-gerrit/pull/65 as well)

```
senlu@senlu:~$ curl https://kunit-review.googlesource.com/projects/linux/branches/kunit%2Falpha%2Fmaster
)]}'
{
  "web_links": [
    {
      "name": "gitiles",
      "url": "https://kunit.googlesource.com/linux/+/refs/heads/kunit/alpha/master",
      "target": "_blank"
    }
  ],
  "ref": "refs/heads/kunit/alpha/master",
  "revision": "c54af688ebcdc3c04a5d92bb2327cf5443b01842"
}
senlu@senlu:~$ curl https://kunit-review.googlesource.com/projects/linux/branches/kunit/alpha/master
Not found: kunit
```

/shrug
/assign @amwat @BenTheElder 
cc @AviKndr 