### PR TITLE
kubetest: make "KUBECTL" and "listNodes" kubectl commands configurable

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -48,15 +48,21 @@ func argFields(args, dump, ipRange string) []string {
 }
 
 func run(deploy deployer, o options) error {
-	if o.checkSkew {
-		os.Setenv("KUBECTL", "./cluster/kubectl.sh --match-server-version")
-	} else {
-		os.Setenv("KUBECTL", "./cluster/kubectl.sh")
+	cmd, err := deploy.KubectlCommand()
+	if err != nil {
+		return err
 	}
+	if cmd == nil {
+		cmd = exec.Command("./cluster/kubectl.sh")
+	}
+	if o.checkSkew {
+		cmd.Args = append(cmd.Args, "--match-server-version")
+	}
+	os.Setenv("KUBECTL", strings.Join(cmd.Args, " "))
+
 	os.Setenv("KUBE_CONFIG_FILE", "config-test.sh")
 	os.Setenv("KUBE_RUNTIME_CONFIG", o.runtimeConfig)
 
-	var err error
 	var errs []error
 
 	dump, err := util.OptionalAbsPath(o.dump)
@@ -150,7 +156,7 @@ func run(deploy deployer, o options) error {
 			errs = util.AppendError(errs, control.XMLWrap(&suite, "Check APIReachability", func() error { return getKubectlVersion(deploy) }))
 			if dump != "" {
 				errs = util.AppendError(errs, control.XMLWrap(&suite, "list nodes", func() error {
-					return listNodes(dump)
+					return listNodes(deploy, dump)
 				}))
 			}
 		}
@@ -381,16 +387,32 @@ func dumpRemoteLogs(deploy deployer, o options, path, reason string) []error {
 	return errs
 }
 
-func listNodes(dump string) error {
-	b, err := control.Output(exec.Command("./cluster/kubectl.sh", "--match-server-version=false", "get", "nodes", "-oyaml"))
+func listNodes(dp deployer, dump string) error {
+	cmd, err := dp.KubectlCommand()
+	if err != nil {
+		return err
+	}
+	if cmd == nil {
+		cmd = exec.Command("./cluster/kubectl.sh")
+	}
+	cmd.Args = append(cmd.Args, "--match-server-version=false", "get", "nodes", "-oyaml")
+	b, err := control.Output(cmd)
 	if err != nil {
 		return err
 	}
 	return ioutil.WriteFile(filepath.Join(dump, "nodes.yaml"), b, 0644)
 }
 
-func listKubemarkNodes(dump string) error {
-	b, err := control.Output(exec.Command("./cluster/kubectl.sh", "--match-server-version=false", "--kubeconfig=./test/kubemark/resources/kubeconfig.kubemark", "get", "nodes", "-oyaml"))
+func listKubemarkNodes(dp deployer, dump string) error {
+	cmd, err := dp.KubectlCommand()
+	if err != nil {
+		return err
+	}
+	if cmd == nil {
+		cmd = exec.Command("./cluster/kubectl.sh")
+	}
+	cmd.Args = append(cmd.Args, "--match-server-version=false", "--kubeconfig=./test/kubemark/resources/kubeconfig.kubemark", "get", "nodes", "-oyaml")
+	b, err := control.Output(cmd)
 	if err != nil {
 		return err
 	}
@@ -628,7 +650,7 @@ func kubemarkTest(testArgs []string, dump string, o options, deploy deployer) er
 	// Check kubemark apiserver reachability by listing all nodes.
 	if dump != "" {
 		control.XMLWrap(&suite, "list kubemark nodes", func() error {
-			return listKubemarkNodes(dump)
+			return listKubemarkNodes(deploy, dump)
 		})
 	}
 


### PR DESCRIPTION
Still see failures such as

```
W1205 04:08:30.485] 2018/12/05 04:08:30 process.go:155: Step '/tmp/aws-k8s-tester/aws-k8s-tester eks --path=/tmp/aws-k8s-tester-config843003272 create cluster' finished in 16m1.068073491s
W1205 04:08:30.487] 2018/12/05 04:08:30 process.go:153: Running: /tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig --match-server-version=false version
W1205 04:08:30.917] 2018/12/05 04:08:30 process.go:155: Step '/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig --match-server-version=false version' finished in 429.441201ms
W1205 04:08:30.917] 2018/12/05 04:08:30 process.go:153: Running: ./cluster/kubectl.sh --match-server-version=false get nodes -oyaml
W1205 04:08:31.373] The connection to the server localhost:8080 was refused - did you specify the right host or port?
W1205 04:08:31.377] 2018/12/05 04:08:31 process.go:155: Step './cluster/kubectl.sh --match-server-version=false get nodes -oyaml' finished in 459.793472ms
W1205 04:08:31.378] 2018/12/05 04:08:31 process.go:153: Running: /tmp/aws-k8s-tester/aws-k8s-tester eks --path=/tmp/aws-k8s-tester-config843003272 check cluster
...
Something went wrong: encountered 2 errors: [error during ./cluster/kubectl.sh --match-server-version=false get nodes -oyaml: exit status 1 error during ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8 --report-dir=/workspace/_artifacts --disable-log-dump=true: exit status 1]
```

Hope this helps debug!
