### PR TITLE
Don't trigger new blocking optional presubmits

### DIFF
--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -114,6 +114,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
-	c := statusreconciler.NewController(o.continueOnError, kubeClient, githubClient, pluginAgent)
+	c := statusreconciler.NewController(o.continueOnError, kubeClient, githubClient, configAgent, pluginAgent)
 	c.Run(sig, changes)
 }

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -29,7 +29,7 @@ var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 var testAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
 var retestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 
-func handleGenericComment(c client, trigger *plugins.Trigger, gc github.GenericCommentEvent) error {
+func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericCommentEvent) error {
 	org := gc.Repo.Owner.Login
 	repo := gc.Repo.Name
 	number := gc.Number
@@ -146,5 +146,5 @@ func handleGenericComment(c client, trigger *plugins.Trigger, gc github.GenericC
 		requestedJobs = append(requestedJobs, retests...)
 	}
 
-	return runOrSkipRequested(c, pr, requestedJobs, forceRunContexts, gc.Body, gc.GUID)
+	return RunOrSkipRequested(c, pr, requestedJobs, forceRunContexts, gc.Body, gc.GUID)
 }

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -621,7 +621,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 		}
 		kc := &fkc{}
-		c := client{
+		c := Client{
 			GitHubClient: g,
 			KubeClient:   kc,
 			Config:       &config.Config{},

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-func handlePR(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
+func handlePR(c Client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
 	org, repo, a := orgRepoAuthor(pr.PullRequest)
 	author := string(a)
 	num := pr.PullRequest.Number
@@ -113,7 +113,7 @@ func orgRepoAuthor(pr github.PullRequest) (string, string, login) {
 	return org, repo, login(author)
 }
 
-func buildAllIfTrusted(c client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
+func buildAllIfTrusted(c Client, trigger *plugins.Trigger, pr github.PullRequestEvent) error {
 	// When a PR is updated, check that the user is in the org or that an org
 	// member has said "/ok-to-test" before building. There's no need to ask
 	// for "/ok-to-test" because we do that once when the PR is created.
@@ -240,12 +240,12 @@ func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 	return l, false, nil
 }
 
-func buildAll(c client, pr *github.PullRequest, eventGUID string) error {
+func buildAll(c Client, pr *github.PullRequest, eventGUID string) error {
 	var matchingJobs []config.Presubmit
 	for _, job := range c.Config.Presubmits[pr.Base.Repo.FullName] {
 		if job.AlwaysRun || job.RunIfChanged != "" {
 			matchingJobs = append(matchingJobs, job)
 		}
 	}
-	return runOrSkipRequested(c, pr, matchingJobs, nil, "", eventGUID)
+	return RunOrSkipRequested(c, pr, matchingJobs, nil, "", eventGUID)
 }

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -277,7 +277,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 		}
 		kc := &fkc{}
-		c := client{
+		c := Client{
 			GitHubClient: g,
 			KubeClient:   kc,
 			Config:       &config.Config{},

--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -42,7 +42,7 @@ func listPushEventChanges(pe github.PushEvent) []string {
 	return changedFiles
 }
 
-func handlePE(c client, pe github.PushEvent) error {
+func handlePE(c Client, pe github.PushEvent) error {
 	if pe.Deleted {
 		// we should not trigger jobs for a branch deletion
 		return nil

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -91,7 +91,7 @@ func TestHandlePE(t *testing.T) {
 	for _, tc := range testCases {
 		g := &fakegithub.FakeClient{}
 		kc := &fkc{}
-		c := client{
+		c := Client{
 			GitHubClient: g,
 			KubeClient:   kc,
 			Config:       &config.Config{},

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -106,7 +106,7 @@ type kubeClient interface {
 	CreateProwJob(kube.ProwJob) (kube.ProwJob, error)
 }
 
-type client struct {
+type Client struct {
 	GitHubClient githubClient
 	KubeClient   kubeClient
 	Config       *config.Config
@@ -118,8 +118,8 @@ type trustedUserClient interface {
 	IsMember(org, user string) (bool, error)
 }
 
-func getClient(pc plugins.Agent) client {
-	return client{
+func getClient(pc plugins.Agent) Client {
+	return Client{
 		GitHubClient: pc.GitHubClient,
 		Config:       pc.Config,
 		KubeClient:   pc.KubeClient,
@@ -203,7 +203,7 @@ func allContexts(parent config.Presubmit) []string {
 	return contexts
 }
 
-func runOrSkipRequested(c client, pr *github.PullRequest, requestedJobs []config.Presubmit, forceRunContexts map[string]bool, body, eventGUID string) error {
+func RunOrSkipRequested(c Client, pr *github.PullRequest, requestedJobs []config.Presubmit, forceRunContexts map[string]bool, body, eventGUID string) error {
 	org := pr.Base.Repo.Owner.Login
 	repo := pr.Base.Repo.Name
 	number := pr.Number

--- a/prow/statusreconciler/BUILD.bazel
+++ b/prow/statusreconciler/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//prow/errorutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
-        "//prow/pjutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
@@ -28,8 +27,6 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
-        "//prow/kube:go_default_library",
-        "//prow/pjutil:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",


### PR DESCRIPTION
When a new required presubmit is added that's optionally run on PRs, we
should not trigger new runs of the job on PRs in flight.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta @cjwagner
/cc @BenTheElder @krzyzacy
/kind bug