### PR TITLE
add spyglass links to gubernator

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -38,4 +38,3 @@ jobs:
   - pull-kubernetes-typecheck
   - pull-kubernetes-verify
 recursive_artifacts: false
-spyglass: false

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -38,3 +38,4 @@ jobs:
   - pull-kubernetes-typecheck
   - pull-kubernetes-verify
 recursive_artifacts: false
+spyglass: false

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -16,7 +16,11 @@
 		{{job}}
 	% endif
 	#{{build}}</h1>
-	<p><a href="/builds{{job_dir}}">Recent runs</a><br>
+	<p><a href="/builds{{job_dir}}">Recent runs</a>
+	% if spyglass_link
+	|| <a href="{{spyglass_link}}">View in Spyglass</a>
+	% endif
+	</p><br>
 % endblock
 % block content
 <div id="summary">

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -257,7 +257,7 @@ class BuildHandler(view_base.BaseHandler):
         spyglass_link = ''
         external_config = get_build_config(prefix, self.app.config)
         if external_config is not None:
-            if self.app.config.get('spyglass'):
+            if external_config.get('spyglass'):
                 spyglass_link = 'https://' + external_config['prow_url'] + '/view/gcs/' + build_dir
             if '/pull/' in prefix:
                 pr, pr_path, pr_digest, repo = get_pr_info(prefix, self.app.config)

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -254,8 +254,11 @@ class BuildHandler(view_base.BaseHandler):
         pr, pr_path, pr_digest = None, None, None
         repo = '%s/%s' % (self.app.config['default_org'],
                           self.app.config['default_repo'])
+        spyglass_link = ''
         external_config = get_build_config(prefix, self.app.config)
         if external_config is not None:
+            if self.app.config.get('spyglass'):
+                spyglass_link = 'https://' + external_config['prow_url'] + '/view/gcs/' + build_dir
             if '/pull/' in prefix:
                 pr, pr_path, pr_digest, repo = get_pr_info(prefix, self.app.config)
             if want_build_log and not build_log:
@@ -283,7 +286,7 @@ class BuildHandler(view_base.BaseHandler):
             build_log=build_log, build_log_src=build_log_src,
             issues=issues_fut.get_result(), repo=repo,
             pr_path=pr_path, pr=pr, pr_digest=pr_digest,
-            testgrid_query=testgrid_query))
+            testgrid_query=testgrid_query, spyglass_link=spyglass_link))
 
 
 def get_build_config(prefix, config):


### PR DESCRIPTION
In order to make it easier to folks to try out Spyglass, I added the option to put Spyglass links on Gubernator `/build/*` pages. The Gubernated of the world can opt in to this feature per-org by setting `spyglass: true` under the desired `external_services` entry in their `config.yaml`. Otherwise, they will be unaffected.

/cc @Katharine @AishSundar