### PR TITLE
make kubetest write version to `revision` instead of `job-version` as well

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -545,7 +545,8 @@ func writeMetadata(path, metadataSources string) error {
 	}
 
 	ver := findVersion()
-	m["job-version"] = ver
+	m["job-version"] = ver // TODO(krzyzacy): retire
+	m["revision"] = ver
 	re := regexp.MustCompile(`^BUILD_METADATA_(.+)$`)
 	for _, e := range os.Environ() {
 		p := strings.SplitN(e, "=", 2)

--- a/kubetest/main_test.go
+++ b/kubetest/main_test.go
@@ -42,6 +42,11 @@ func TestWriteMetadata(t *testing.T) {
 			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
 		},
 		{
+			sources: nil,
+			key:     "revision",
+			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
+		},
+		{
 			sources: map[string]mdata{"images.json": {"imgkey": "imgval"}},
 			key:     "imgkey",
 			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",


### PR DESCRIPTION
This is got from k8s cluster, and testgrid still want to honor this if `revision` from finished.json is missing. Since we decided `job-version` is not explicit enough (https://github.com/kubernetes/test-infra/pull/10059#discussion_r236414310), let's unify it to `revision` instead.

We can get rid of `job-version` when we get rid of bootstrap.

/assign @BenTheElder @cjwagner @stevekuznetsov 