### PR TITLE
encoding/json expects omitempty, not omit_empty

### DIFF
--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -177,8 +177,8 @@ func (o Options) doUpload(spec *downwardapi.JobSpec, passed, aborted bool, metad
 		Timestamp int64                  `json:"timestamp"`
 		Passed    bool                   `json:"passed"`
 		Result    string                 `json:"result"`
-		Metadata  map[string]interface{} `json:"metadata,omit_empty"`
-		Revision  string                 `json:"revision,omit_empty"`
+		Metadata  map[string]interface{} `json:"metadata,omitempty"`
+		Revision  string                 `json:"revision,omitempty"`
 	}{
 		Timestamp: time.Now().Unix(),
 		Passed:    passed,


### PR DESCRIPTION
This is causing gubernator to crash when viewing builds where this field is empty, and is also not what was intended.

I'm disappointed some sort of linter/checker/something didn't notice this.

/cc @krzyzacy @cjwagner @stevekuznetsov 