### PR TITLE
gubernator: things that exist may still be null

### DIFF
--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -67,7 +67,7 @@
 			<tr><td>{{k}}<td>{{v|maybe_linkify}}
 			% endfor
 		% endif
-		% if finished and 'metadata' in finished
+		% if finished and 'metadata' in finished and finished['metadata']
 			% for k, v in finished['metadata']|dictsort
 			<tr><td>{{k}}<td>{{v|maybe_linkify}}
 			% endfor


### PR DESCRIPTION
This is the other side of #10367, and fixes e.g. https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/447/pull-cluster-api-provider-aws-bazel-verify/52