### PR TITLE
Gubernator: actually enable spyglass link in config

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -3,6 +3,7 @@ default_external_services:
   gcs_bucket: kubernetes-jenkins/
   gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
   prow_url: prow.k8s.io
+  spyglass: true
 default_org: kubernetes
 default_repo: kubernetes
 external_services:


### PR DESCRIPTION
Actually enable the Spyglass link added in #10349 (and no, there is no reason these needed to be separate PRs).

/assign @BenTheElder 
/cc @Katharine 