### PR TITLE
spyglass: fetch pod log for /gcs/ endpoint

### DIFF
--- a/prow/spyglass/podlogartifact_fetcher.go
+++ b/prow/spyglass/podlogartifact_fetcher.go
@@ -18,7 +18,6 @@ package spyglass
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/test-infra/prow/spyglass/lenses"
 )
@@ -33,14 +32,8 @@ func NewPodLogArtifactFetcher(ja jobAgent) *PodLogArtifactFetcher {
 	return &PodLogArtifactFetcher{jobAgent: ja}
 }
 
-// artifact constructs an artifact handle from the given key
-func (af *PodLogArtifactFetcher) artifact(key string, sizeLimit int64) (lenses.Artifact, error) {
-	parsed := strings.Split(key, "/")
-	if len(parsed) != 2 {
-		return nil, fmt.Errorf("Could not fetch artifact: key %q incorrectly formatted", key)
-	}
-	jobName := parsed[0]
-	buildID := parsed[1]
+// artifact constructs an artifact handle for the given job build
+func (af *PodLogArtifactFetcher) artifact(jobName, buildID string, sizeLimit int64) (lenses.Artifact, error) {
 
 	podLog, err := NewPodLogArtifact(jobName, buildID, sizeLimit, af.jobAgent)
 	if err != nil {

--- a/prow/spyglass/podlogartifact_fetcher_test.go
+++ b/prow/spyglass/podlogartifact_fetcher_test.go
@@ -26,27 +26,31 @@ func TestFetchArtifacts_Prow(t *testing.T) {
 	maxSize := int64(500e6)
 	testCases := []struct {
 		name      string
-		src       string
+		job       string
+		buildID   string
 		expectErr bool
 	}{
 		{
-			name: "Fetch build-log.txt from valid src",
-			src:  "BFG/435",
+			name:    "Fetch build-log.txt from valid src",
+			job:     "BFG",
+			buildID: "435",
 		},
 		{
 			name:      "Fetch log from empty src",
-			src:       "",
+			job:       "",
+			buildID:   "",
 			expectErr: true,
 		},
 		{
 			name:      "Fetch log from incomplete src",
-			src:       "BFG",
+			job:       "BFG",
+			buildID:   "",
 			expectErr: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		artifact, err := goodFetcher.artifact(tc.src, maxSize)
+		artifact, err := goodFetcher.artifact(tc.job, tc.buildID, maxSize)
 		if err != nil && !tc.expectErr {
 			t.Errorf("%s: failed unexpectedly for artifact %s, err: %v", tc.name, artifact.JobPath(), err)
 		}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -576,19 +576,29 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 	fakeGCSClient := fakeGCSServer.Client()
 
 	sg := New(fakeJa, fakeConfigAgent, fakeGCSClient)
+	testKeys := []string{
+		"prowjob/job/123",
+		"gcs/kubernetes-jenkins/logs/job/123/",
+		"gcs/kubernetes-jenkins/logs/job/123",
+	}
 
-	result, err := sg.FetchArtifacts("prowjob/job/123", "", 500e6, []string{"build-log.txt"})
-	if err != nil {
-		t.Fatalf("Unexpected error grabbing pod log: %v", err)
-	}
-	if len(result) != 1 {
-		t.Fatalf("Expected 1 result, got %d", len(result))
-	}
-	content, err := result[0].ReadAll()
-	if err != nil {
-		t.Fatalf("Unexpected error reading pod log: %v", err)
-	}
-	if string(content) != "clusterA" {
-		t.Fatalf("Bad pod log content: %q (expected 'clusterA')", content)
+	for _, key := range testKeys {
+		result, err := sg.FetchArtifacts(key, "", 500e6, []string{"build-log.txt"})
+		if err != nil {
+			t.Errorf("Unexpected error grabbing pod log for %s: %v", key, err)
+			continue
+		}
+		if len(result) != 1 {
+			t.Errorf("Expected 1 artifact for %s, got %d", key, len(result))
+			continue
+		}
+		content, err := result[0].ReadAll()
+		if err != nil {
+			t.Errorf("Unexpected error reading pod log for %s: %v", key, err)
+			continue
+		}
+		if string(content) != "clusterA" {
+			t.Errorf("Bad pod log content for %s: %q (expected 'clusterA')", key, content)
+		}
 	}
 }


### PR DESCRIPTION
The `/gcs/` endpoint now does pretty much the same stuff as `/prowjob/` (the original intent was for them to be different ways of arriving at the same information).

This also means more path manipulation (bleh). I moved path splitting from `podlogartifact_fetcher.go` to `artifacts.go` to prevent having to take apart, reassemble, and again take apart the job/build id from gcs keys. Most everything else is unchanged, just reordered in a way diff doesn't recognize.

/assign @Katharine 
/cc @BenTheElder 