### PR TITLE
fix invalid links to plugins in REAME.md

### DIFF
--- a/prow/jobs.md
+++ b/prow/jobs.md
@@ -4,8 +4,8 @@ For a brief overview of how Prow runs jobs take a look at ["Life of a Prow Job"]
 
 ## How to configure new jobs
 
-To configure a new job you'll need to add an entry into [config.yaml](config.yaml).
-If you have [update-config](plugins/updateconfig) plugin deployed then the
+To configure a new job you'll need to add an entry into [config.yaml](/prow/config.yaml).
+If you have [update-config](/prow/plugins/updateconfig) plugin deployed then the
 config will be automatically updated once the PR is merged, else you will need
 to run `make update-config`. This does not require redeploying any binaries,
 and will take effect within a minute.

--- a/prow/plugins/README.md
+++ b/prow/plugins/README.md
@@ -14,8 +14,8 @@ For an alternate view, please see https://prow.k8s.io/command-help to see all of
 
 ## How to enable a plugin on a repo
 
-Add an entry to [plugins.yaml](plugins.yaml). If you misspell the name then a
-unit test will fail. If you have [update-config](plugins/updateconfig) plugin
+Add an entry to [plugins.yaml](/prow/plugins.yaml). If you misspell the name then a
+unit test will fail. If you have [update-config](/prow/plugins/updateconfig) plugin
 deployed then the config will be automatically updated once the PR is merged,
 else you will need to run `make update-plugins`. This does not require
 redeploying the binaries, and will take effect within a minute.


### PR DESCRIPTION
There are a few links in `prow/plugins/README.md` files which caused 404. Updating the links, also use absolute path instead of relative path

- The links in `prow/plugins/README.md` are the ones that caused trouble
- The links in `prow/jobs.md` are still valid links, update with absolute paths just for consistency