### PR TITLE
Kops - Change it so that "/lgtm" does not imply "/approve"

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -52,7 +52,6 @@ approve:
   - kubernetes/ingress-gce
   - kubernetes/ingress-nginx
   - kubernetes/klog
-  - kubernetes/kops
   - kubernetes/kube-deploy
   - kubernetes/kubeadm
   - kubernetes/kubectl
@@ -72,6 +71,7 @@ approve:
   implicit_self_approve: true
   lgtm_acts_as_approve: true
 - repos:
+  - kubernetes/kops
   - kubernetes/kubernetes
   - kubernetes-client
   - kubernetes-csi


### PR DESCRIPTION
Change it so that "/lgtm" does not imply "/approve" for anyone on the approvers list for Kops.

This is in order to prevent things such as https://github.com/kubernetes/kops/pull/6179 where the PR was supposed to be held but landed.

/assign @justinsb @mikesplain 