### PR TITLE
Trim trailing periods on label values

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -76,7 +76,7 @@ func LabelsAndAnnotationsForSpec(spec kube.ProwJobSpec, extraLabels, extraAnnota
 	jobNameForLabel := spec.Job
 	if len(jobNameForLabel) > validation.LabelValueMaxLength {
 		// TODO(fejta): consider truncating middle rather than end.
-		jobNameForLabel = strings.TrimRight(spec.Job[:validation.LabelValueMaxLength], "-")
+		jobNameForLabel = strings.TrimRight(spec.Job[:validation.LabelValueMaxLength], ".-")
 		logrus.WithFields(logrus.Fields{
 			"job":       spec.Job,
 			"key":       kube.ProwJobAnnotation,


### PR DESCRIPTION
A trailing period is not valid for a k8s label value, so we should make
sure our truncated label values do not end with one.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 