### PR TITLE
config/jobs/.../eks: add non-blocking presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3,6 +3,49 @@
 presubmits:
   kubernetes-security/kubernetes:
   - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    labels:
+      preset-eks-common: "true"
+      preset-kubernetes-e2e-aws-eks-1-10: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    rerun_command: /test pull-security-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --timeout=200
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-version-skew=false
+        - --deployment=eks
+        - --provider=eks
+        - --gce-ssh=
+        - --extract=local
+        - --ginkgo-parallel=30
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+        - --timeout=180m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-e2e-kops-aws

--- a/config/jobs/kubernetes/sig-aws/eks/OWNERS
+++ b/config/jobs/kubernetes/sig-aws/eks/OWNERS
@@ -1,3 +1,6 @@
 approvers:
 - gyuho
-- d-nishi
+- shyamjvs
+reviewers:
+- gyuho
+- shyamjvs

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-1.10.yaml
@@ -1,83 +1,121 @@
-
 presets:
-- env:
-  # URL to download the latest 'aws-k8s-tester' release
-  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.4/aws-k8s-tester-0.1.4-linux-amd64
-  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/aws-k8s-tester
-  # URL to download 'kubectl', required for 'kubectl' calls to EKS
-  # TODO: use upstream 'kubectl'
-  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
-  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/kubectl
-  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
-  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
-  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/aws-iam-authenticator
-  # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
-  - name: AWS_K8S_TESTER_EKS_TEST_MODE
-    value: "embedded"
-  # configure EKS Kubernetes version
-  - name: AWS_K8S_TESTER_EKS_KUBERNETES_VERSION
-    value: "1.10"
-  # duration to wait before destroying EKS cluster, useful to add wait time before collecting AWS ALB access logs
-  - name: AWS_K8S_TESTER_EKS_WAIT_BEFORE_DOWN
-    value: 1m0s
-  # 'true' to destroying all AWS resources when it calls "Down"
-  - name: AWS_K8S_TESTER_EKS_DOWN
-    value: "true"
-  # 'true' to assign worker nodes across all available subnets
-  - name: AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA
-    value: "true"
-  # 'true' to open port 22 in security group, and enable SSH for log dumper
-  - name: AWS_K8S_TESTER_EKS_ENABLE_NODE_SSH
-    value: "true"
-  # 'true' to enable S3 Access Logs and AWS ALB Access Logs
-  # use it for debug, dump cluster log already handles log artifacts
-  - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
-    value: "false"
-  # 'true' to upload 'aws-k8s-tester' logs to S3 buckets, in addition to log dumper
-  # use it for debug, dump cluster log already handles log artifacts
-  - name: AWS_K8S_TESTER_EKS_UPLOAD_TESTER_LOGS
-    value: "false"
-  # 'true' to upload worker node logs to S3, in addition to log dumper
-  # use it for debug, dump cluster log already handles worker node logs
-  - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
-    value: "false"
-  # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
-    value: ami-0f54a2f7d2e9c88b3
-  # worker node EC2 instance type
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_INSTANCE_TYPE
-    value: m3.xlarge
-  # worker node auto-scaling group minimum number of nodes
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MIN
-    value: "1"
-  # worker node auto-scaling group maximum number of nodes
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MAX
-    value: "1"
-  # 'true' to enable debug level logs
-  - name: AWS_K8S_TESTER_EKS_LOG_DEBUG
-    value: "false"
-  # 'true' to create AWS ALB
-  - name: AWS_K8S_TESTER_EKS_ALB_ENABLE
-    value: "false"
-  # AWS test account credential mounted path, required for AWS API call
-  - name: AWS_SHARED_CREDENTIALS_FILE
-    value: /etc/eks-aws-credentials/eks-aws-credentials
-  labels:
-    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
-  volumeMounts:
-  - mountPath: /etc/eks-aws-credentials
-    name: eks-aws-credentials
-    readOnly: true
-  volumes:
-  - name: eks-aws-credentials
-    secret:
-      secretName: eks-aws-credentials
+  # common configuration for EKS e2e tests
+  - labels:
+      preset-eks-common: "true"
+    env:
+      # URL to download the latest 'aws-k8s-tester' release
+      - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
+        value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.4/aws-k8s-tester-0.1.4-linux-amd64
+      - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
+        value: /tmp/aws-k8s-tester/aws-k8s-tester
+      - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
+        value: /tmp/aws-k8s-tester/kubectl
+      - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
+        value: /tmp/aws-k8s-tester/aws-iam-authenticator
+      # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
+      - name: AWS_K8S_TESTER_EKS_TEST_MODE
+        value: "embedded"
+      # duration to wait before destroying EKS cluster, useful to add wait time before collecting AWS ALB access logs
+      - name: AWS_K8S_TESTER_EKS_WAIT_BEFORE_DOWN
+        value: 1m0s
+      # 'true' to destroying all AWS resources when it calls "Down"
+      - name: AWS_K8S_TESTER_EKS_DOWN
+        value: "true"
+      # 'true' to assign worker nodes across all available subnets
+      - name: AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA
+        value: "true"
+      # 'true' to open port 22 in security group, and enable SSH for log dumper
+      - name: AWS_K8S_TESTER_EKS_ENABLE_NODE_SSH
+        value: "true"
+      # 'true' to enable S3 Access Logs and AWS ALB Access Logs
+      # use it for debug, dump cluster log already handles log artifacts
+      - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
+        value: "false"
+      # 'true' to upload 'aws-k8s-tester' logs to S3 buckets, in addition to log dumper
+      # use it for debug, dump cluster log already handles log artifacts
+      - name: AWS_K8S_TESTER_EKS_UPLOAD_TESTER_LOGS
+        value: "false"
+      # 'true' to upload worker node logs to S3, in addition to log dumper
+      # use it for debug, dump cluster log already handles worker node logs
+      - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
+        value: "false"
+      # 'true' to enable debug level logs
+      - name: AWS_K8S_TESTER_EKS_LOG_DEBUG
+        value: "false"
+      # 'true' to create AWS ALB
+      - name: AWS_K8S_TESTER_EKS_ALB_ENABLE
+        value: "false"
+      # AWS test account credential mounted path, required for AWS API call
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: /etc/eks-aws-credentials/eks-aws-credentials
+    volumeMounts:
+      - mountPath: /etc/eks-aws-credentials
+        name: eks-aws-credentials
+        readOnly: true
+    volumes:
+      - name: eks-aws-credentials
+        secret:
+          secretName: eks-aws-credentials
+
+  # configuration for EKS Kubernetes e2e tests with 1.10
+  - labels:
+      preset-kubernetes-e2e-aws-eks-1-10: "true"
+    env:
+      # URL to download 'kubectl', required for 'kubectl' calls to EKS
+      - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
+        value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
+      # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
+      - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
+        value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      # configure EKS Kubernetes version
+      - name: AWS_K8S_TESTER_EKS_KUBERNETES_VERSION
+        value: "1.10"
+      # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+      - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
+        value: ami-0f54a2f7d2e9c88b3
+      # worker node EC2 instance type
+      - name: AWS_K8S_TESTER_EKS_WORKER_NODE_INSTANCE_TYPE
+        value: m3.xlarge
+      # worker node auto-scaling group minimum number of nodes
+      - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MIN
+        value: "1"
+      # worker node auto-scaling group maximum number of nodes
+      - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MAX
+        value: "1"
+
+presubmits:
+  # Run Kubernetes 1.10 branch e2e tests with EKS prod build 1.10
+  # run conformance tests
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    # run tests from master branch (for now)
+    branch:
+    - master
+    # non-blocking, only triggered manually
+    always_run: false
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+      preset-eks-common: "true"
+      preset-kubernetes-e2e-aws-eks-1-10: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        args:
+        - --timeout=200
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-version-skew=false
+        - --deployment=eks
+        - --provider=eks
+        - --gce-ssh=
+        - --extract=local
+        - --ginkgo-parallel=30
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+        - --timeout=180m
 
 periodics:
 # Run Kubernetes 1.10 branch e2e tests with EKS prod build 1.10
@@ -85,7 +123,8 @@ periodics:
   name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
+    preset-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -110,7 +149,8 @@ periodics:
   name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
+    preset-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -134,7 +174,8 @@ periodics:
   name: ci-kubernetes-e2e-stable-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
+    preset-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -158,7 +199,8 @@ periodics:
   name: ci-kubernetes-e2e-latest-aws-eks-1-10-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-10: "true"
+    preset-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2174,6 +2174,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-manifest-lists
 
 # EKS e2e results
+- name: pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+  gcs_prefix: kubernetes-jenkins/logs/pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
 - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-1-10-aws-eks-1-10-prod
 - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
@@ -5787,6 +5789,11 @@ dashboards:
     test_group_name: pull-aws-ebs-csi-driver-sanity
     description: aws ebs csi driver sanity test
 
+- name: sig-aws-eks-presubmits
+  dashboard_tab:
+  - name: pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    test_group_name: pull-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
+    description: Kubernetes 1.10 branch e2e tests with EKS prod build 1.10, Conformance tests
 - name: sig-aws-eks-ci-kubernetes-e2e-1-10
   dashboard_tab:
   - name: ci-kubernetes-e2e-1-10-aws-eks-1-10-prod


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/sig-aws-eks-ci-kubernetes-e2e-1-10#ci-kubernetes-e2e-1-10-aws-eks-1-10-prod-conformance
and others are still failing:

> error during ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8 --report-dir=/workspace/_artifacts --disable-log-dump=true: exit status 1

We want to create a test PR in kubernetes/kubernetes to debug around "hack/ginkgo-e2e.sh" script.
In order to do that, we need a presubmit job that can be manually triggered.

/cc @shyamjvs @krzyzacy @BenTheElder 