### PR TITLE
Remove logging for no current approvers as this is noise

### DIFF
--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -342,9 +342,6 @@ func (ap Approvers) GetCurrentApproversSet() sets.String {
 		currentApprovers.Insert(approver)
 	}
 
-	if len(currentApprovers) == 0 {
-		ap.owners.log.Debug("There are no current approvers, but approvers were requested. Does this repo have OWNERS files?")
-	}
 	return currentApprovers
 }
 
@@ -356,9 +353,6 @@ func (ap Approvers) GetCurrentApproversSetCased() sets.String {
 		currentApprovers.Insert(approval.Login)
 	}
 
-	if len(currentApprovers) == 0 {
-		ap.owners.log.Debug("There are no current approvers, but approvers were requested. Does this repo have OWNERS files?")
-	}
 	return currentApprovers
 }
 


### PR DESCRIPTION
It is normal in the course of PR approval to have no current approvers,
but not normal to have no potential approvers. We should remove the logs
for the former case as it is just spam.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 

These were incorrectly added. The owners code is a little hard to follow it turns out. And of course  I can't find any reproducers for the bug I was trying to track down with the logging in the first place ..