### PR TITLE
Update cluster-api-make image to v20181205-915278e90-1.12

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-1.10
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-1.12
         resources:
           requests:
             memory: "6Gi"


### PR DESCRIPTION
This PR updates the image for `cluster-api-make` presubmit CI task. Related to https://github.com/kubernetes-sigs/cluster-api/pull/630, the CI fails when running against dependencies that rely on Kubernetes v1.12.

Signed-off-by: Vince Prignano <vince@vincepri.com>