### PR TITLE
Setting clusterloader as default 100 nodes test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -13,11 +13,15 @@ periodics:
     preset-e2e-gci-gce-scalability: "true"
   spec:
     containers:
-    - args:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
       - --timeout=140
-      - --bare
       - --scenario=kubernetes_e2e
       - --
+      - --check-leaked-resources
       - --cluster=e2e-big
       - --extract=ci/latest
       - --gcp-node-image=gci
@@ -25,10 +29,17 @@ periodics:
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --minStartupPods=8 --vmodule=request=4
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-master
 
 # copy of ci-kubernetes-e2e-gci-gce-scalability with node killer enabled
 - interval: 1h


### PR DESCRIPTION
`ci-kubernetes-e2e-gci-gce-scalability` will be replaced with `ci-perf-tests-e2e-gce-clusterloader2`.