### PR TITLE
Allow creating aliases for labels, and include a starter alias for /sig contribex

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -255,6 +255,11 @@ require_matching_label:
   prs: true
   regexp: ^kind/
 
+label:
+  label_aliases:
+    sig:
+      contribex: contributor-experience
+
 
 plugins:
   # Enable the following for any bazelbuild repo (rules_k8s, rules_docker) that sends prow webhooks

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -55,6 +55,7 @@ func TestLabel(t *testing.T) {
 		expectedBotComment    bool
 		repoLabels            []string
 		issueLabels           []string
+		labelAliases          map[string]map[string]string
 	}
 	testcases := []testCase{
 		{
@@ -426,6 +427,34 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 		},
+		{
+			name:                  "Can add a SIG label using an alias",
+			body:                  "/sig contribex",
+			repoLabels:            []string{"sig/contributor-experience"},
+			issueLabels:           []string{},
+			expectedNewLabels:     formatLabels("sig/contributor-experience"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+			labelAliases: map[string]map[string]string{
+				"sig": {
+					"contribex": "contributor-experience",
+				},
+			},
+		},
+		{
+			name:                  "Aliases as case-insensitive",
+			body:                  "/sig ContribEx",
+			repoLabels:            []string{"sig/contributor-experience"},
+			issueLabels:           []string{},
+			expectedNewLabels:     formatLabels("sig/contributor-experience"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+			labelAliases: map[string]map[string]string{
+				"sig": {
+					"contribex": "contributor-experience",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -450,7 +479,7 @@ func TestLabel(t *testing.T) {
 			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 			User:   github.User{Login: tc.commenter},
 		}
-		err := handle(fakeClient, logrus.WithField("plugin", pluginName), tc.extraLabels, e)
+		err := handle(fakeClient, logrus.WithField("plugin", pluginName), tc.extraLabels, tc.labelAliases, e)
 		if err != nil {
 			t.Errorf("didn't expect error from label test: %v", err)
 			continue

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -428,6 +428,9 @@ type Label struct {
 	// AdditionalLabels is a set of additional labels enabled for use
 	// on top of the existing "kind/*", "priority/*", and "area/*" labels.
 	AdditionalLabels []string `json:"additional_labels"`
+	// LabelAliases is a mapping of the form {"labeltype": {"short": "long"}} for
+	// expanding short or alternate names for some labels.
+	LabelAliases map[string]map[string]string `json:"label_aliases"`
 }
 
 type Trigger struct {


### PR DESCRIPTION
This will still create the label using the fully expanded name of the label to keep things consistent. My hope is this will make things a bit more friendly and help avoid confusion when Prow just ignores commands with unknown labels, favoring a "do what I mean" approach.