### PR TITLE
spyglass: clean up metadata viewer

### DIFF
--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 go_library(
     name = "go_default_library",
@@ -12,6 +14,22 @@ go_library(
     ],
 )
 
+ts_library(
+    name = "script",
+    srcs = ["metadata.ts"],
+    deps = [
+        "//prow/spyglass/lenses:lens_api",
+    ],
+)
+
+rollup_bundle(
+    name = "script_bundle",
+    entry_point = "prow/spyglass/lenses/metadata/metadata",
+    deps = [
+        ":script",
+    ],
+)
+
 filegroup(
     name = "template",
     srcs = ["template.html"],
@@ -20,7 +38,10 @@ filegroup(
 
 filegroup(
     name = "resources",
-    srcs = ["style.css"],
+    srcs = [
+        "style.css",
+        ":script_bundle",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/spyglass/lenses/metadata/metadata.ts
+++ b/prow/spyglass/lenses/metadata/metadata.ts
@@ -1,0 +1,16 @@
+function toggleExpansion(dataId: string, textId: string, iconId: string): void {
+  const body = document.getElementById(dataId)!;
+  body.classList.toggle('hidden');
+  const icon = document.getElementById(iconId)!;
+  const textElem = document.getElementById(textId)!;
+  if (body.classList.contains('hidden')) {
+    icon.innerHTML = 'expand_more';
+    textElem.innerText = 'Show more'
+  } else {
+    icon.innerHTML = 'expand_less';
+    textElem.innerText = 'Show less'
+  }
+  spyglass.contentUpdated();
+}
+
+(window as any).toggleExpansion = toggleExpansion;

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -2,14 +2,6 @@
     font-weight: bold;
     font-size: 1.1em;
 }
-.failed-row {
-    background-color: #FF0000;
-    color: white;
-}
-.passed-row {
-    background-color:#00FF00;
-    color: black;
-}
 .mdl-data-table .metadata-header th {
     font-size: 1.2em;
     color: black;
@@ -29,4 +21,14 @@
 
 .hidden {
     visibility: collapse;
+}
+
+.mdl-data-table__cell--non-numeric {
+    font-family: monospace;
+    background-color: #212121;
+    color: #e8e8e8;
+}
+
+.mdl-data-table__cell--non-numeric.expander {
+    background-color: #333333;
 }

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -12,6 +12,7 @@
 }
 .mdl-data-table .metadata-header th {
     font-size: 1.2em;
+    color: black;
 }
 .metadata-table {
     height: unset;
@@ -24,5 +25,4 @@
     border-radius: 2px;
     box-shadow: 0 0 4px #e0e0e0;
     border-collapse: collapse;
-    width: 100%;
 }

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -26,3 +26,7 @@
     box-shadow: 0 0 4px #e0e0e0;
     border-collapse: collapse;
 }
+
+.hidden {
+    visibility: collapse;
+}

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -1,10 +1,12 @@
 {{define "header"}}
 <link rel="stylesheet" href="style.css">
+<script type="text/javascript" src="script_bundle.min.js"></script>
 {{end}}
 
 {{define "body"}}
 {{$passed := eq .Status "SUCCESS"}}
 {{$failed := eq .Status "FAILURE" "FAILED"}}
+{{$length := len .Metadata}}
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
   <thead>
     <tr class="test-row {{if $passed}}passed-row{{else if $failed}}failed-row{{end}}">
@@ -21,11 +23,23 @@
       <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
     </tr>
+    <tbody id="supplementary_data" class="{{if gt $length 1}}hidden{{end}}">
     {{range $key, $value := .Metadata}}
-    <tr>
-      <td class="mdl-data-table__cell--non-numeric">{{$key}}</td>
-      <td class="mdl-data-table__cell--non-numeric">{{$value}}</td>
-    </tr>
+    {{if $value}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">{{$key}}</td>
+        <td class="mdl-data-table__cell--non-numeric">{{$value}}</td>
+      </tr>
+    {{end}}
+    {{end}}
+    </tbody>
+    {{if gt $length 1}}
+    <tr onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
+      <td id="expand_text" class="mdl-data-table__cell--non-numeric">Show more</td>
+      <td class="mdl-data-table__cell--non-numeric">
+        <i id="expand_icon" class="icon-button material-icons arrow-icon">expand_more</i>
+      </td>
+      </tr>
     {{end}}
   </tbody>
 </table>

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -3,90 +3,30 @@
 {{end}}
 
 {{define "body"}}
-{{$passed := eq .Finished.Result "SUCCESS"}}
-{{$failed := eq .Finished.Result "FAILURE" "FAILED"}}
-<div class="mdl-grid">
-  <div class="mdl-cell mdl-cell--6-col">
-    <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
-      <thead class="metadata-header">
-      <tr>
-        <th class="mdl-data-table__cell--non-numeric">Prow Metadata</td>
-        <th class="mdl-data-table__cell--non-numeric">&nbsp</td>
-      </tr>
-      </thead>
-      <tbody>
-      {{if $passed}}
-      <tr class="test-row passed-row">
-      {{else if $failed}}
-      <tr class="test-row failed-row">
-      {{else}}
-      <tr class="test-row">
-      {{end}}
-        <td class="mdl-data-table__cell--non-numeric">Status</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Derived.Status}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Started</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Derived.StartTime}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Derived.Elapsed}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Node</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Started.Node}}</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-{{if .Derived.Done}}
-  <div class="mdl-cell mdl-cell--6-col">
-    <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="height:unset;">
-      <thead class="metadata-header">
-      <tr>
-        <th class="mdl-data-table__cell--non-numeric">Job-Provided Metadata</td>
-        <th class="mdl-data-table__cell--non-numeric">&nbsp</td>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Repo</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Finished.Metadata.Repo}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Repo Commit</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Finished.Metadata.RepoCommit}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Infra Commit</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Finished.Metadata.InfraCommit}}</td>
-      </tr>
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">Pod</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Finished.Metadata.Pod}}</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="mdl-cell mdl-cell--6-col">
-    <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="height:unset;">
-      <thead class="metadata-header">
-      <tr>
-        <th class="mdl-data-table__cell--non-numeric">Package</td>
-        <th class="mdl-data-table__cell--non-numeric">Version</td>
-      </tr>
-      </thead>
-      <tbody>
-      {{range $k, $v := .Finished.Metadata.Repos}}
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">{{$k}}</td>
-        <td class="mdl-data-table__cell--non-numeric">{{$v}}</td>
-      </tr>
-      {{end}}
-      </tbody>
-    </table>
-  </div>
-{{end}}
-</div>
+{{$passed := eq .Status "SUCCESS"}}
+{{$failed := eq .Status "FAILURE" "FAILED"}}
+<table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
+  <thead>
+    <tr class="test-row {{if $passed}}passed-row{{else if $failed}}failed-row{{end}}">
+      <td class="mdl-data-table__cell--non-numeric">Status</td>
+      <td class="mdl-data-table__cell--non-numeric">{{.Status}}</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric">Started</td>
+      <td class="mdl-data-table__cell--non-numeric">{{.StartTime}}</td>
+    </tr>
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
+      <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
+    </tr>
+    {{range $key, $value := .Metadata}}
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric">{{$key}}</td>
+      <td class="mdl-data-table__cell--non-numeric">{{$value}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
 {{end}}

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -9,9 +9,9 @@
 {{$length := len .Metadata}}
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
   <thead>
-    <tr class="test-row {{if $passed}}passed-row{{else if $failed}}failed-row{{end}}">
+    <tr class="test-row">
       <td class="mdl-data-table__cell--non-numeric">Status</td>
-      <td class="mdl-data-table__cell--non-numeric">{{.Status}}</td>
+      <td class="mdl-data-table__cell--non-numeric" style="color: {{if $passed}}#00FF00{{else if $failed}}#FF0000{{end}}">{{.Status}}</td>
     </tr>
   </thead>
   <tbody>
@@ -34,9 +34,9 @@
     {{end}}
     </tbody>
     {{if gt $length 1}}
-    <tr onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
-      <td id="expand_text" class="mdl-data-table__cell--non-numeric">Show more</td>
-      <td class="mdl-data-table__cell--non-numeric">
+    <tr class="expander" onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
+      <td id="expand_text" class="mdl-data-table__cell--non-numeric expander">Show more</td>
+      <td class="mdl-data-table__cell--non-numeric expander">
         <i id="expand_icon" class="icon-button material-icons arrow-icon">expand_more</i>
       </td>
       </tr>


### PR DESCRIPTION
- Use monospace font
- Don't gray out the colored status row on hover
- Put everything in one table rather than up to 3 different tables with just a few rows each
- Don't display keys for empty fields
- Dark mode all the things
![screenshot from 2018-12-14 13-52-27](https://user-images.githubusercontent.com/16039734/50029444-94733680-ffa7-11e8-8163-5c088ee74cab.png)
![screenshot from 2018-12-14 13-52-39](https://user-images.githubusercontent.com/16039734/50029446-963cfa00-ffa7-11e8-9391-8dcf6d87fc43.png)
