### PR TITLE
Skip archived repos in case label_sync autodiscovers repos

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -326,6 +326,9 @@ func loadRepos(org string, gc client) ([]string, error) {
 	}
 	var rl []string
 	for _, r := range repos {
+		if r.Archived == true {
+			continue
+		}
 		rl = append(rl, r.Name)
 	}
 	return rl, nil


### PR DESCRIPTION
Archived repos can't be synchronized or updated. Skip them, if they were
not explicitly metioned.

If a repo is explicitly mentioned via `--only`, it will not be skipped. If an org is selected with `--org`, then archived repos will be skipped.

Without this, a label_sync cron-job repeatedly fails when new archives are archived in an organization.