### PR TITLE
Scheduler benchmark - increasing timeout from 10m to 20m

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -685,6 +685,8 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+      - name: KUBE_TIMEOUT
+        value: --timeout 20m
 
 - name: ci-benchmark-kube-dns-master
   interval: 2h


### PR DESCRIPTION
After adding 5k nodes tests, more time is required to run scheduler benchmark.