### PR TITLE
spyglass: cosmetic touches to JUnit output

### DIFF
--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -25,8 +25,9 @@ import (
 
 	"fmt"
 	"html/template"
-	"k8s.io/test-infra/prow/spyglass/lenses"
 	"path/filepath"
+
+	"k8s.io/test-infra/prow/spyglass/lenses"
 )
 
 const (
@@ -127,6 +128,10 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		}
 		jvd.NumTests = len(jvd.Passed) + len(jvd.Failed) + len(jvd.Skipped)
 
+	}
+
+	if jvd.NumTests == 0 {
+		return "Failed to parse any JUnit test results"
 	}
 
 	junitTemplate, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -9,13 +9,7 @@
       color: #e8e8e8;
     }
     .noselect {
-      -webkit-touch-callout: none; /* iOS Safari */
-      -webkit-user-select: none; /* Safari */
-      -khtml-user-select: none; /* Konqueror HTML */
-      -moz-user-select: none; /* Firefox */
-      -ms-user-select: none; /* Internet Explorer/Edge */
-      user-select: none; /* Non-prefixed version, currently
-                            supported by Chrome and Opera */
+      user-select: none;
     }
     .expander {
       background-color: #333333;
@@ -57,6 +51,7 @@
     {{end}}
     </tbody>
   {{end}}
+  {{if gt $numP 0}}
     <thead id="passed-theader" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
     <tr>
       <td class="mdl-data-table__cell--non-numeric expander" style="color: #00FF00" colspan="3"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
@@ -75,6 +70,7 @@
     </tr>
     {{end}}
     </tbody>
+  {{end}}
   {{if gt $numS 0}}
     <thead id="skipped-theader" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
     <tr>

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -3,6 +3,29 @@
     .hidden-tests {
         visibility: collapse;
     }
+    .mdl-data-table__cell--non-numeric {
+      font-family: monospace;
+      background-color: #212121;
+      color: #e8e8e8;
+    }
+    .noselect {
+      -webkit-touch-callout: none; /* iOS Safari */
+      -webkit-user-select: none; /* Safari */
+      -khtml-user-select: none; /* Konqueror HTML */
+      -moz-user-select: none; /* Firefox */
+      -ms-user-select: none; /* Internet Explorer/Edge */
+      user-select: none; /* Non-prefixed version, currently
+                            supported by Chrome and Opera */
+    }
+    .expander {
+      background-color: #333333;
+      font-weight:bold;
+      font-size:1.5em;
+    }
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
 </style>
 
 <script type="text/javascript" src="script_bundle.min.js"></script>
@@ -16,21 +39,18 @@
   <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="white-space: pre-wrap;">
   {{if gt $numF 0}}
     <thead id="failed-theader" onclick="toggleExpansion('failed-tbody', 'failed-expander')">
-    <tr style="background-color:#FF0000;color:white;font-weight:bold;font-size:1.5em;">
-      <td class="mdl-data-table__cell--non-numeric" colspan="4"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
-      <td>&nbsp;</td>
-      <td class="mdl-data-table__cell">
-        <i id="failed-expander" class="icon-button material-icons arrow-icon">expand_less</i>
-      </td>
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric expander" style="color: #FF0000;" colspan="3"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     </thead>
     <tbody id="failed-tbody">
     {{range $ix, $test := .Failed}}
-    <tr onclick="toggleExpansion('failed-test-body-{{$ix}}', 'failed-test-expander-{{$ix}}')">
-      <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Name}}</td>
-      <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Status}}</td>
+    <tr class="dark" onclick="toggleExpansion('failed-test-body-{{$ix}}', 'failed-test-expander-{{$ix}}')">
+      <td class="mdl-data-table__cell--non-numeric"><a href="{{$test.Link}}">{{$test.Junit.Name}}</a></td>
+      <td class="mdl-data-table__cell--non-numeric" style="color: #FF0000">{{$test.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"><a href="{{$test.Link}}">Link</a></td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Error.Message}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Error.Body}}</td>
     </tr>
@@ -38,21 +58,18 @@
     </tbody>
   {{end}}
     <thead id="passed-theader" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
-    <tr style="background-color:#00FF00;color:black;font-weight:bold;font-size:1.5em;">
-      <td class="mdl-data-table__cell--non-numeric" colspan="4"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
-      <td>&nbsp;</td>
-      <td class="mdl-data-table__cell">
-        <i id="passed-expander" class="icon-button material-icons arrow-icon">expand_more</i>
-      </td>
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric expander" style="color: #00FF00" colspan="3"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i id="passed-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     </thead>
     <tbody id="passed-tbody" class="hidden-tests">
     {{range .Passed}}
     <tr>
-      <td class="mdl-data-table__cell--non-numeric">{{.Junit.Name}}</td>
-      <td class="mdl-data-table__cell--non-numeric">{{.Junit.Status}}</td>
+      <td class="mdl-data-table__cell--non-numeric"><a href="{{.Link}}">{{.Junit.Name}}</a></td>
+      <td class="mdl-data-table__cell--non-numeric" style="color: #00FF00">{{.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"><a href="{{.Link}}">Link</a></td>
       <td class="mdl-data-table__cell--non-numeric"></td>
       <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
@@ -60,21 +77,18 @@
     </tbody>
   {{if gt $numS 0}}
     <thead id="skipped-theader" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
-    <tr style="font-weight:bold;font-size:1.5em;">
-      <td class="mdl-data-table__cell--non-numeric" colspan="4"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
-      <td>&nbsp;</td>
-      <td class="mdl-data-table__cell">
-        <i id="skipped-expander" class="icon-button material-icons arrow-icon">expand_more</i>
-      </td>
+    <tr>
+      <td class="mdl-data-table__cell--non-numeric expander" style="color: rgba(255, 224, 0, 1.0);" colspan="3"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i id="skipped-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     </thead>
     <tbody id="skipped-tbody" class="hidden-tests">
     {{range .Skipped}}
     <tr>
-      <td class="mdl-data-table__cell--non-numeric">{{.Junit.Name}}</td>
-      <td class="mdl-data-table__cell--non-numeric">{{.Junit.Status}}</td>
+      <td class="mdl-data-table__cell--non-numeric"><a href="{{.Link}}">{{.Junit.Name}}</a></td>
+      <td class="mdl-data-table__cell--non-numeric" style="color: rgba(255, 224, 0, 1.0);">{{.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"><a href="{{.Link}}">Link</a></td>
       <td class="mdl-data-table__cell--non-numeric"></td>
       <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>


### PR DESCRIPTION
- Make output monospace so things like hyphens actually readable
- Replace full-width full-saturation screaming colors
- Don't allow an empty table saying "0/0 Tests Passed!" that expands into nothing
- Links are in the test name instead of occupying their own column
- Dark mode all the things!

![screenshot from 2018-12-11 17-21-51](https://user-images.githubusercontent.com/16039734/49841056-ef6c1a00-fd6a-11e8-8cdb-579dc0ed4a52.png)
