### PR TITLE
Use run_if_changed for godeps job

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1996,17 +1996,22 @@ presubmits:
     name: pull-security-kubernetes-godeps
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-godeps
+    run_if_changed: ^((build\/|Godeps\/|vendor\/|hack\/lib\/|hack\/.*godep|staging\/).*)$
     spec:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
         - verify
         - WHAT="godeps staging-godeps godep-licenses"
-        - KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
         command:
         - make
+        env:
+        - name: KUBE_FORCE_VERIFY_CHECKS
+          value: "Y"
+        - name: KUBE_JUNIT_REPORT_DIR
+          value: ${WORKSPACE}/_artifacts
         image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-master
-        name: test
+        name: main
         resources: {}
         volumeMounts:
         - mountPath: /etc/ssh-security

--- a/config/jobs/kubernetes/sig-testing/godeps.yaml
+++ b/config/jobs/kubernetes/sig-testing/godeps.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-godeps
+    run_if_changed: '^((build\/|Godeps\/|vendor\/|hack\/lib\/|hack\/.*godep|staging\/).*)$'
     path_alias: "k8s.io/kubernetes"
     decorate: true
     always_run: false
@@ -9,11 +10,15 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - name: test
+      - name: main
         command:
         - make
         image: gcr.io/k8s-testimages/kubekins-e2e:v20181205-915278e90-master
         args:
         - verify
         - WHAT="godeps staging-godeps godep-licenses"
-        - KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
+        env:
+        - name: KUBE_FORCE_VERIFY_CHECKS
+          value: "Y"
+        - name: KUBE_JUNIT_REPORT_DIR
+          value: "${WORKSPACE}/_artifacts"


### PR DESCRIPTION
Because of the way that podutils is checking out the code, the built in bash to check if it should run godeps isn't working. However, we can skip that if we force godeps, but only run the job sometimes using `run_if_changed`.