### PR TITLE
Deck: make Gerrit links

### DIFF
--- a/prow/cmd/deck/static/api/prow.ts
+++ b/prow/cmd/deck/static/api/prow.ts
@@ -21,5 +21,12 @@ export interface Job {
   url: string;
   pod_name: string;
   agent: string;
+  pr_refs: number[];
+  pr_ref_links: string[];
   prow_job: string;
+  repo_link: string;
+  pull_link: string;
+  pull_commit_link: string;
+  push_commit_link: string;
+  author_link: string;
 }

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -502,11 +502,8 @@ function redraw(fz: FuzzySearch): void {
 
             if (build.type === "periodic") {
                 r.appendChild(createTextCell(""));
-            } else if (build.repo.startsWith("http://") || build.repo.startsWith("https://") ) {
-                r.appendChild(createLinkCell(build.repo, build.repo, ""));
             } else {
-                r.appendChild(createLinkCell(build.repo, "https://github.com/"
-                    + build.repo, ""));
+                r.appendChild(createLinkCell(build.repo, build.repo_link, ""));
             }
             if (build.type === "presubmit") {
                 r.appendChild(prRevisionCell(build));
@@ -698,15 +695,13 @@ function stateCell(state: JobState): HTMLTableDataCellElement {
 
 function batchRevisionCell(build: Job): HTMLTableDataCellElement {
     const c = document.createElement("td");
-    const prRefs = build.refs.split(",");
-    for (let i = 1; i < prRefs.length; i++) {
-        if (i != 1) {
+    for (let i = 0; i < build.pr_refs.length; i++) {
+        if (i != 0) {
             c.appendChild(document.createTextNode(", "));
         }
-        const pr = prRefs[i].split(":")[0];
         const l = document.createElement("a");
-        l.href = "https://github.com/" + build.repo + "/pull/" + pr;
-        l.text = pr;
+        l.href = build.pr_ref_links[i];
+        l.text = String(build.pr_refs[i]);
         c.appendChild(document.createTextNode("#"));
         c.appendChild(l);
     }
@@ -716,7 +711,7 @@ function batchRevisionCell(build: Job): HTMLTableDataCellElement {
 function pushRevisionCell(build: Job): HTMLTableDataCellElement {
     const c = document.createElement("td");
     const bl = document.createElement("a");
-    bl.href = "https://github.com/" + build.repo + "/commit/" + build.base_sha;
+    bl.href = build.push_commit_link;
     bl.text = build.base_ref + " (" + build.base_sha.slice(0, 7) + ")";
     c.appendChild(bl);
     return c;
@@ -726,18 +721,17 @@ function prRevisionCell(build: Job): HTMLTableDataCellElement {
     const c = document.createElement("td");
     c.appendChild(document.createTextNode("#"));
     const pl = document.createElement("a");
-    pl.href = "https://github.com/" + build.repo + "/pull/" + build.number;
+    pl.href = build.pull_link;
     pl.text = build.number.toString();
     c.appendChild(pl);
     c.appendChild(document.createTextNode(" ("));
     const cl = document.createElement("a");
-    cl.href = "https://github.com/" + build.repo + "/pull/" + build.number
-        + '/commits/' + build.pull_sha;
+    cl.href = build.pull_commit_link;
     cl.text = build.pull_sha.slice(0, 7);
     c.appendChild(cl);
     c.appendChild(document.createTextNode(") by "));
     const al = document.createElement("a");
-    al.href = "https://github.com/" + build.author;
+    al.href = build.author_link;
     al.text = build.author;
     c.appendChild(al);
     return c;

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -25,7 +25,11 @@ go_test(
         "refs_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//prow/kube:go_default_library"],
+    deps = [
+        "//prow/gerrit/client:go_default_library",
+        "//prow/kube:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -5,11 +5,13 @@ go_library(
     srcs = [
         "jobs.go",
         "metadata.go",
+        "refs.go",
     ],
     importpath = "k8s.io/test-infra/prow/deck/jobs",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
@@ -18,7 +20,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["jobs_test.go"],
+    srcs = [
+        "jobs_test.go",
+        "refs_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -46,13 +46,6 @@ var (
 // TODO(#5216): Remove this, and all associated machinery.
 type Job struct {
 	Type        string            `json:"type"`
-	Repo        string            `json:"repo"`
-	Refs        string            `json:"refs"`
-	BaseRef     string            `json:"base_ref"`
-	BaseSHA     string            `json:"base_sha"`
-	PullSHA     string            `json:"pull_sha"`
-	Number      int               `json:"number"`
-	Author      string            `json:"author"`
 	Job         string            `json:"job"`
 	BuildID     string            `json:"build_id"`
 	Context     string            `json:"context"`
@@ -65,6 +58,7 @@ type Job struct {
 	PodName     string            `json:"pod_name"`
 	Agent       kube.ProwJobAgent `json:"agent"`
 	ProwJob     string            `json:"prow_job"`
+	RefData
 
 	st time.Time
 	ft time.Time
@@ -292,15 +286,7 @@ func (ja *JobAgent) update() error {
 			nj.Duration = duration.String()
 		}
 		if j.Spec.Refs != nil {
-			nj.Repo = fmt.Sprintf("%s/%s", j.Spec.Refs.Org, j.Spec.Refs.Repo)
-			nj.Refs = j.Spec.Refs.String()
-			nj.BaseRef = j.Spec.Refs.BaseRef
-			nj.BaseSHA = j.Spec.Refs.BaseSHA
-			if len(j.Spec.Refs.Pulls) == 1 {
-				nj.Number = j.Spec.Refs.Pulls[0].Number
-				nj.Author = j.Spec.Refs.Pulls[0].Author
-				nj.PullSHA = j.Spec.Refs.Pulls[0].SHA
-			}
+			nj.RefData = getRefData(j)
 		}
 		njs = append(njs, nj)
 		if nj.PodName != "" {

--- a/prow/deck/jobs/refs.go
+++ b/prow/deck/jobs/refs.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"fmt"
+
+	"k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/kube"
+)
+
+// RefData is a wrapper for information derived from a job's refs
+type RefData struct {
+	Repo           string   `json:"repo"`
+	Refs           string   `json:"refs"`
+	BaseRef        string   `json:"base_ref"`
+	BaseSHA        string   `json:"base_sha"`
+	PullSHA        string   `json:"pull_sha"`
+	Number         int      `json:"number"`
+	Author         string   `json:"author"`
+	RepoLink       string   `json:"repo_link"`
+	PullLink       string   `json:"pull_link"`
+	PullCommitLink string   `json:"pull_commit_link"`
+	PushCommitLink string   `json:"push_commit_link"`
+	AuthorLink     string   `json:"author_link"`
+	PRRefs         []int    `json:"pr_refs"`
+	PRRefLinks     []string `json:"pr_ref_links"`
+}
+
+func hasGerritMetadata(job kube.ProwJob) bool {
+	return job.ObjectMeta.Annotations[client.GerritID] != "" &&
+		job.ObjectMeta.Annotations[client.GerritInstance] != "" &&
+		job.ObjectMeta.Labels[client.GerritRevision] != ""
+}
+
+func getRefData(j kube.ProwJob) RefData {
+	if hasGerritMetadata(j) {
+		return gerritRefData(j)
+	}
+	return githubRefData(j)
+}
+
+func githubRefData(job kube.ProwJob) RefData {
+	const github = "https://github.com"
+	ref := RefData{
+		Repo:    fmt.Sprintf("%s/%s", job.Spec.Refs.Org, job.Spec.Refs.Repo),
+		Refs:    job.Spec.Refs.String(),
+		BaseRef: job.Spec.Refs.BaseRef,
+		BaseSHA: job.Spec.Refs.BaseSHA,
+	}
+	for _, pull := range job.Spec.Refs.Pulls {
+		ref.PRRefs = append(ref.PRRefs, pull.Number)
+		link := fmt.Sprintf("%s/%s/pull/%d", github, ref.Repo, pull.Number)
+		ref.PRRefLinks = append(ref.PRRefLinks, link)
+	}
+
+	ref.RepoLink = fmt.Sprintf("%s/%s", github, ref.Repo)
+	ref.PushCommitLink = fmt.Sprintf("%s/%s/commit/%s", github, ref.Repo, ref.BaseSHA)
+	if len(job.Spec.Refs.Pulls) == 1 {
+		ref.Number = job.Spec.Refs.Pulls[0].Number
+		ref.Author = job.Spec.Refs.Pulls[0].Author
+		ref.PullSHA = job.Spec.Refs.Pulls[0].SHA
+
+		ref.AuthorLink = fmt.Sprintf("%s/%s", github, ref.Author)
+		ref.PullLink = fmt.Sprintf("%s/%s/pull/%d", github, ref.Repo, ref.Number)
+		ref.PullCommitLink = fmt.Sprintf("%s/commits/%s", ref.PullLink, ref.PullSHA)
+	}
+	return ref
+}
+
+func gerritRefData(job kube.ProwJob) RefData {
+	return RefData{} // TODO(ibzib)
+}

--- a/prow/deck/jobs/refs.go
+++ b/prow/deck/jobs/refs.go
@@ -105,7 +105,7 @@ func gerritRefData(job kube.ProwJob) RefData {
 		ref.Author = job.Spec.Refs.Pulls[0].Author
 		ref.PullSHA = job.Spec.Refs.Pulls[0].SHA
 
-		ref.AuthorLink = fmt.Sprintf("mailto:%s", ref.Author)
+		ref.AuthorLink = fmt.Sprintf("%s/q/%s", reviewHost, ref.Author)
 		ref.PullLink = fmt.Sprintf("%s/c/%s/+/%d", reviewHost, ref.Repo, ref.Number)
 		ref.PullCommitLink = fmt.Sprintf("%s/%s/+/%s", codeHost, ref.Repo, ref.PullSHA)
 	}

--- a/prow/deck/jobs/refs_test.go
+++ b/prow/deck/jobs/refs_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/kube"
 )
@@ -152,8 +153,7 @@ func TestGetRefData(t *testing.T) {
 	for _, tc := range cases {
 		refData := getRefData(tc.job)
 		if !reflect.DeepEqual(refData, tc.exp) {
-			t.Errorf("%s\nexpected: %v\n"+
-				"got:      %v", tc.name, tc.exp, refData)
+			t.Errorf("ref data mismatch:\n%s", diff.ObjectReflectDiff(tc.exp, refData))
 		}
 	}
 }

--- a/prow/deck/jobs/refs_test.go
+++ b/prow/deck/jobs/refs_test.go
@@ -145,7 +145,7 @@ func TestGetRefData(t *testing.T) {
 				PullLink:       "https://fhqwhgads-review.example.com/c/trogdor/dragonman/+/23",
 				PullCommitLink: "https://fhqwhgads.example.com/trogdor/dragonman/+/99999",
 				PushCommitLink: "https://fhqwhgads.example.com/trogdor/dragonman/+/12345",
-				AuthorLink:     "mailto:strongbad@example.com",
+				AuthorLink:     "https://fhqwhgads-review.example.com/q/strongbad@example.com",
 			},
 		},
 	}

--- a/prow/deck/jobs/refs_test.go
+++ b/prow/deck/jobs/refs_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/kube"
+)
+
+func TestGetRefData(t *testing.T) {
+	cases := []struct {
+		name string
+		job  kube.ProwJob
+		exp  RefData
+	}{
+		{
+			name: "github presubmit (1 PR)",
+			job: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Refs: &kube.Refs{
+						Org:     "kubernetes",
+						Repo:    "prow",
+						BaseRef: "master",
+						BaseSHA: "12345",
+						Pulls: []kube.Pull{
+							{
+								Number: 23,
+								Author: "ibzib",
+								SHA:    "99999",
+							},
+						},
+					},
+				},
+			},
+			exp: RefData{
+				Repo:           "kubernetes/prow",
+				Refs:           "master:12345,23:99999",
+				BaseRef:        "master",
+				BaseSHA:        "12345",
+				PullSHA:        "99999",
+				Number:         23,
+				Author:         "ibzib",
+				RepoLink:       "https://github.com/kubernetes/prow",
+				PullLink:       "https://github.com/kubernetes/prow/pull/23",
+				PullCommitLink: "https://github.com/kubernetes/prow/pull/23/commits/99999",
+				PushCommitLink: "https://github.com/kubernetes/prow/commit/12345",
+				AuthorLink:     "https://github.com/ibzib",
+				PRRefs:         []int{23},
+				PRRefLinks:     []string{"https://github.com/kubernetes/prow/pull/23"},
+			},
+		},
+		{
+			name: "github batch job",
+			job: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Refs: &kube.Refs{
+						Org:     "kubernetes",
+						Repo:    "prow",
+						BaseRef: "master",
+						BaseSHA: "12345",
+						Pulls: []kube.Pull{
+							{
+								Number: 23,
+								Author: "ibzib",
+								SHA:    "99999",
+							},
+							{
+								Number: 24,
+								Author: "k8s-ci-robot",
+								SHA:    "nomorehumans",
+							},
+						},
+					},
+				},
+			},
+			exp: RefData{
+				Repo:           "kubernetes/prow",
+				Refs:           "master:12345,23:99999,24:nomorehumans",
+				BaseRef:        "master",
+				BaseSHA:        "12345",
+				RepoLink:       "https://github.com/kubernetes/prow",
+				PushCommitLink: "https://github.com/kubernetes/prow/commit/12345",
+				PRRefs:         []int{23, 24},
+				PRRefLinks: []string{
+					"https://github.com/kubernetes/prow/pull/23",
+					"https://github.com/kubernetes/prow/pull/24",
+				},
+			},
+		},
+		{
+			name: "gerrit presubmit",
+			job: kube.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						client.GerritInstance: "https://fhqwhgads-review.example.com",
+						client.GerritID:       "trogdor%2Fdragonman~I12345",
+					},
+					Labels: map[string]string{
+						client.GerritRevision: "12345",
+					},
+				},
+				Spec: kube.ProwJobSpec{
+					Refs: &kube.Refs{
+						Org:     "fhqwhgads-review.example.com",
+						Repo:    "trogdor/dragonman",
+						BaseRef: "master",
+						BaseSHA: "12345",
+						Pulls: []kube.Pull{
+							{
+								Number: 23,
+								Author: "strongbad@example.com",
+								SHA:    "99999",
+							},
+						},
+					},
+				},
+			},
+			exp: RefData{
+				Repo:           "trogdor/dragonman",
+				Refs:           "master:12345,23:99999",
+				BaseRef:        "master",
+				BaseSHA:        "12345",
+				PullSHA:        "99999",
+				Number:         23,
+				Author:         "strongbad@example.com",
+				RepoLink:       "https://fhqwhgads.example.com/trogdor/dragonman",
+				PullLink:       "https://fhqwhgads-review.example.com/c/trogdor/dragonman/+/23",
+				PullCommitLink: "https://fhqwhgads.example.com/trogdor/dragonman/+/99999",
+				PushCommitLink: "https://fhqwhgads.example.com/trogdor/dragonman/+/12345",
+				AuthorLink:     "mailto:strongbad@example.com",
+			},
+		},
+	}
+	for _, tc := range cases {
+		refData := getRefData(tc.job)
+		if !reflect.DeepEqual(refData, tc.exp) {
+			t.Errorf("%s\nexpected: %v\n"+
+				"got:      %v", tc.name, tc.exp, refData)
+		}
+	}
+}

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -223,7 +223,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		Pulls: []kube.Pull{
 			{
 				Number: change.Number,
-				Author: rev.Commit.Author.Name,
+				Author: rev.Commit.Author.Email,
 				SHA:    change.CurrentRevision,
 				Ref:    rev.Ref,
 			},


### PR DESCRIPTION
Deck links currently are hardcoded to Github. This PR adds logic to make Gerrit links work as well. Related changes:

1. Moving existing Github link construction to the server code (which is a mess per #5216 but out of scope for this fix).
2. Using Gerrit annotations/labels to identify jobs triggered by Gerrit. This way we can avoid adding extra metadata to jobs for now, although if Prow's going to continue to add support for different SCMs that might become necessary at some point.
3. Using `Email` instead of `Name` for Gerrit authors. `Name` isn't necessarily unique.

/assign @krzyzacy 
/cc @ixdy