### PR TITLE
Implicit self-approval and consider github review state by default

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,10 @@
 # Announcements
 
 New features added to each component:
+ - *Jan 7, 2019* `implicit_self_approve` will become `require_self_approval` in
+   the second half of this year.
+ - *Jan 7, 2019* `review_acts_as_approve` will become `ignore_review_state` in
+   the second half of this year.
  - *October 10, 2018* `tide` now supports the `-repo:foo/bar` tag in queries via
    the `excludedRepos` YAML field.
  - *October 3, 2018* `welcome` now supports a configurable message on a per-org,

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -14,7 +14,10 @@ go_test(
         "respond_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//prow/github:go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
 )
 
 go_library(

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1019,10 +1019,10 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			fr,
 			&plugins.Approve{
 				Repos:               []string{"org/repo"},
-				ImplicitSelfApprove: test.selfApprove,
+				RequireSelfApproval: !test.selfApprove,
 				IssueRequired:       test.needsIssue,
 				LgtmActsAsApprove:   test.lgtmActsAsApprove,
-				ReviewActsAsApprove: test.reviewActsAsApprove,
+				IgnoreReviewState:   !test.reviewActsAsApprove,
 			},
 			&state{
 				org:       "org",
@@ -1505,9 +1505,9 @@ func TestHandleReview(t *testing.T) {
 		test.reviewEvent.PullRequest = pr
 		config := &plugins.Configuration{}
 		config.Approve = append(config.Approve, plugins.Approve{
-			Repos:               []string{test.reviewEvent.Repo.Owner.Login},
-			LgtmActsAsApprove:   test.lgtmActsAsApprove,
-			ReviewActsAsApprove: test.reviewActsAsApprove,
+			Repos:             []string{test.reviewEvent.Repo.Owner.Login},
+			LgtmActsAsApprove: test.lgtmActsAsApprove,
+			IgnoreReviewState: !test.reviewActsAsApprove,
 		})
 		err := handleReview(
 			logrus.WithField("plugin", "approve"),


### PR DESCRIPTION
Maintain backwards compatibility with current config values (which have the opposite defaults) for 6 months.