### PR TITLE
Allow override of org config with repo config

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -585,13 +585,24 @@ func addApprovers(approversHandler *approvers.Approvers, approveComments []*comm
 // optionsForRepo gets the plugins.Approve struct that is applicable to the indicated repo.
 func optionsForRepo(config *plugins.Configuration, org, repo string) *plugins.Approve {
 	fullName := fmt.Sprintf("%s/%s", org, repo)
+
+	// First search for repo config
 	for i := range config.Approve {
-		if !strInSlice(org, config.Approve[i].Repos) && !strInSlice(fullName, config.Approve[i].Repos) {
+		if !strInSlice(fullName, config.Approve[i].Repos) {
 			continue
 		}
 		return &config.Approve[i]
 	}
-	// Default to no issue required and no implicit self approval.
+
+	// If you don't find anything, loop again looking for an org config
+	for i := range config.Approve {
+		if !strInSlice(org, config.Approve[i].Repos) {
+			continue
+		}
+		return &config.Approve[i]
+	}
+
+	// Return an empty config, and use plugin defaults
 	return &plugins.Approve{}
 }
 

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -587,19 +587,19 @@ func optionsForRepo(config *plugins.Configuration, org, repo string) *plugins.Ap
 	fullName := fmt.Sprintf("%s/%s", org, repo)
 
 	// First search for repo config
-	for i := range config.Approve {
-		if !strInSlice(fullName, config.Approve[i].Repos) {
+	for _, c := range config.Approve {
+		if !strInSlice(fullName, c.Repos) {
 			continue
 		}
-		return &config.Approve[i]
+		return &c
 	}
 
 	// If you don't find anything, loop again looking for an org config
-	for i := range config.Approve {
-		if !strInSlice(org, config.Approve[i].Repos) {
+	for _, c := range config.Approve {
+		if !strInSlice(org, c.Repos) {
 			continue
 		}
-		return &config.Approve[i]
+		return &c
 	}
 
 	// Return an empty config, and use plugin defaults

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -141,19 +141,19 @@ func optionsForRepo(config *plugins.Configuration, org, repo string) *plugins.We
 	fullName := fmt.Sprintf("%s/%s", org, repo)
 
 	// First search for repo config
-	for i := range config.Welcome {
-		if !strInSlice(fullName, config.Welcome[i].Repos) {
+	for _, c := range config.Welcome {
+		if !strInSlice(fullName, c.Repos) {
 			continue
 		}
-		return &config.Welcome[i]
+		return &c
 	}
 
 	// If you don't find anything, loop again looking for an org config
-	for i := range config.Welcome {
-		if !strInSlice(org, config.Welcome[i].Repos) {
+	for _, c := range config.Welcome {
+		if !strInSlice(org, c.Repos) {
 			continue
 		}
-		return &config.Welcome[i]
+		return &c
 	}
 
 	// Return an empty config, and default to defaultWelcomeMessage


### PR DESCRIPTION
This uses similar logic to what I used for the welcome plugin. Using this, we can layer config priorities.. a repo config will always be used first, then an org config, and lastly, fall through to defaults.