### PR TITLE
Fix ingress rule in starter.yaml

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -356,7 +356,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /*
+      - path: /
         backend:
           serviceName: deck
           servicePort: 80

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -139,7 +139,6 @@ kind: Service
 metadata:
   namespace: default
   name: hook
-  namespace: default
 spec:
   selector:
     app: hook
@@ -338,7 +337,6 @@ kind: Service
 metadata:
   namespace: default
   name: tide
-  namespace: default
 spec:
   selector:
     app: tide


### PR DESCRIPTION
The asterisk results for me in a 404 from the Ingress controller (Contour) and only applying the rule when using a literal asterisk in the url which in turn results in a 404 from Deck.

Not sure if there are ingress-controller implementations in which this works, a quick Google search did not turn up any sample in which this is used.

Removing the asterisk makes the Ingress work just fine.

Also I removed two redundant namespace properties