### PR TITLE
Update to golang 1.10.7 and 1.11.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,15 +15,15 @@ versions.check(minimum_bazel_version = "0.18.0")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz"],
+    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.11.2")
+go_register_toolchains(go_version = "1.11.4")
 
 http_archive(
     name = "io_bazel_rules_docker",

--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Includes go and gcloud
-FROM golang:1.10.2
+FROM golang:1.10.7
 LABEL maintainer="senlu@google.com"
 
 # add env we can debug with the image name:tag

--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -17,7 +17,7 @@ TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # kubernetes master branch config
 K8S ?= master
-GO ?= 1.11.2
+GO ?= 1.11.4
 BAZEL ?= 0.18.1
 UPGRADE_DOCKER ?=false
 # TODO(bentheelder,cblecker): this is aging and bad
@@ -25,7 +25,7 @@ CFSSL ?= R1.2
 
 # config for testing prior to rolling out to master / ongoing release
 ifeq ($(K8S), experimental)
-	GO = 1.11.2
+	GO = 1.11.4
 	BAZEL = 0.20.0
 	CFSSL = R1.2
 	UPGRADE_DOCKER = true
@@ -33,19 +33,19 @@ endif
 
 # kubernetes release-X branch configs
 ifeq ($(K8S), 1.13)
-	GO = 1.11.2
+	GO = 1.11.4
 	BAZEL = 0.18.1
 	CFSSL = R1.2
 endif
 
 ifeq ($(K8S), 1.12)
-	GO = 1.10.4
+	GO = 1.10.7
 	BAZEL = 0.18.1
 	CFSSL = R1.2
 endif
 
 ifeq ($(K8S), 1.11)
-	GO = 1.10.2
+	GO = 1.10.7
 	BAZEL = 0.14.0
 	CFSSL = R1.2
 endif

--- a/images/kubekins-test/Dockerfile-1.11
+++ b/images/kubekins-test/Dockerfile-1.11
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.10.2
+FROM golang:1.10.7
 LABEL maintainer="Sen Lu <senlu@google.com>"
 
 # Setup workspace and symlink to gopath

--- a/images/kubekins-test/Dockerfile-1.12
+++ b/images/kubekins-test/Dockerfile-1.12
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.10.4
+FROM golang:1.10.7
 LABEL maintainer="Sen Lu <senlu@google.com>"
 
 # Setup workspace and symlink to gopath

--- a/images/kubekins-test/Dockerfile-1.13
+++ b/images/kubekins-test/Dockerfile-1.13
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.11.2
+FROM golang:1.11.4
 LABEL maintainer="Sen Lu <senlu@google.com>"
 
 # Setup workspace and symlink to gopath


### PR DESCRIPTION
I can't actually build new `kubekins-test` and `kubekins-e2e` images yet because docker hasn't published updated golang images.

We can either wait for those to go in before merging this, or we can merge this and then bump the images later once the upstream base images are available.

x-ref https://github.com/kubernetes/kubernetes/issues/72032

/assign @BenTheElder @krzyzacy 
cc @cblecker 