### PR TITLE
PR test results are not updated by testgrid/updater

### DIFF
--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -69,7 +69,9 @@ func (o Options) assembleTargets(spec *downwardapi.JobSpec, extra map[string]gcs
 	// job we're uploading artifacts for
 	if alias := gcs.AliasForSpec(spec); alias != "" {
 		fullBasePath := "gs://" + path.Join(o.Bucket, jobBasePath)
-		uploadTargets[alias] = gcs.DataUpload(strings.NewReader(fullBasePath))
+		uploadTargets[alias] = gcs.DataUploadWithMetadata(strings.NewReader(fullBasePath), map[string]string{
+			"x-goog-meta-link": fullBasePath,
+		})
 	}
 
 	if latestBuilds := gcs.LatestBuildForSpec(spec, builder); len(latestBuilds) > 0 {

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -90,3 +90,17 @@ func DataUpload(src io.Reader) UploadFunc {
 		return errorutil.NewAggregate(copyErr, closeErr)
 	}
 }
+
+// DataUploadWithMetadata returns an UploadFunc which copies all
+// data from src reader into GCS and also sets the provided metadata
+// fields onto the object.
+func DataUploadWithMetadata(src io.Reader, metadata map[string]string) UploadFunc {
+	return func(obj *storage.ObjectHandle) error {
+		writer := obj.NewWriter(context.Background())
+		writer.Metadata = metadata
+		_, copyErr := io.Copy(writer, src)
+		closeErr := writer.Close()
+
+		return errorutil.NewAggregate(copyErr, closeErr)
+	}
+}


### PR DESCRIPTION
The updater does not know how to handle the `.../directory/*/NUM.txt` entries and omits those results in `listBuilds()`. Have the updater read `x-goog-meta-link` and resolve those entries as builds.

At the same time, correct gcsupload to set `x-goog-meta-link` as bootstrap.py does. This ensures jobs that switch to using gcsupload to set metadata can be scraped for the testgrid.

After discussion with Erick he confirmed that we don't do uploading of PR jobs, even though we have dashboards like https://testgrid.k8s.io/presubmits-cloud-provider-vsphere-blocking#pull-cloud-provider-vsphere-test (differently provided?)