### PR TITLE
Remove DecorationConfig from security jobs that use only default values

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1977,20 +1977,6 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-godeps
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: kubernetes-jenkins
-        default_org: kubernetes
-        default_repo: kubernetes
-        path_strategy: legacy
-      gcs_credentials_secret: service-account
-      grace_period: 15000000000
-      timeout: 7200000000000
-      utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20181207-201eb76
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20181207-201eb76
-        initupload: gcr.io/k8s-prow/initupload:v20181207-201eb76
-        sidecar: gcr.io/k8s-prow/sidecar:v20181207-201eb76
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes-security/genjobs.go
+++ b/config/jobs/kubernetes-security/genjobs.go
@@ -33,6 +33,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -120,7 +121,7 @@ func undoPresubmitPresets(presets []config.Preset, presubmit *config.Presubmit) 
 // dropLabels should be a set of "k: v" strings
 // xref: prow/config/config_test.go replace(...)
 // it will return the same job mutated, or nil if the job should be removed
-func convertJobToSecurityJob(j *config.Presubmit, dropLabels sets.String, podNamespace string) *config.Presubmit {
+func convertJobToSecurityJob(j *config.Presubmit, dropLabels sets.String, defaultDecoration *kube.DecorationConfig, podNamespace string) *config.Presubmit {
 	// if a GKE job, disable it
 	if strings.Contains(j.Name, "gke") {
 		return nil
@@ -146,6 +147,9 @@ func convertJobToSecurityJob(j *config.Presubmit, dropLabels sets.String, podNam
 	j.Context = strings.Replace(j.Context, "pull-kubernetes", "pull-security-kubernetes", -1)
 	if j.Namespace != nil && *j.Namespace == podNamespace {
 		j.Namespace = nil
+	}
+	if j.DecorationConfig != nil && reflect.DeepEqual(j.DecorationConfig, defaultDecoration) {
+		j.DecorationConfig = nil
 	}
 
 	// handle k8s job args, volumes etc
@@ -259,7 +263,7 @@ func convertJobToSecurityJob(j *config.Presubmit, dropLabels sets.String, podNam
 	if len(j.RunAfterSuccess) > 0 {
 		filteredRunAfterSucces := []config.Presubmit{}
 		for i := range j.RunAfterSuccess {
-			newJob := convertJobToSecurityJob(&j.RunAfterSuccess[i], dropLabels, podNamespace)
+			newJob := convertJobToSecurityJob(&j.RunAfterSuccess[i], dropLabels, defaultDecoration, podNamespace)
 			if newJob != nil {
 				filteredRunAfterSucces = append(filteredRunAfterSucces, *newJob)
 			}
@@ -359,7 +363,7 @@ func main() {
 		// undo merged presets, this needs to occur first!
 		undoPresubmitPresets(parsed.Presets, job)
 		// now convert the job
-		job = convertJobToSecurityJob(job, dropLabels, parsed.PodNamespace)
+		job = convertJobToSecurityJob(job, dropLabels, parsed.Plank.DefaultDecorationConfig, parsed.PodNamespace)
 		if job == nil {
 			continue
 		}


### PR DESCRIPTION
Bumping prow should not involve changing the security jobs.

However now that we have k/k presubmits that use decoration, every decorated security job includes the full decoration config.

Fix this by detecting when the decoration equals the default and replacing this with a nil value.

We should consider:
a) Whether we should move the logic to collate a bunch of config.yaml files into a single prow config somewhere before uploading the configmap
b) Whether we should leave defaulted values in that state, versus injecting the default value



/assign @Katharine @krzyzacy
/cc @cjwagner @stevekuznetsov 