### PR TITLE
tide: fix panic if contexts are not specified in required_status_contexts

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -444,7 +444,7 @@ func (c Config) GetTideContextPolicy(org, repo, branch string) (*TideContextPoli
 			logrus.WithError(err).Warningf("Error getting branch protection for %s/%s+%s", org, repo, branch)
 		} else if bp == nil {
 			logrus.Warningf("branch protection not set for %s/%s+%s", org, repo, branch)
-		} else if bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil {
+		} else if bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil && bp.RequiredStatusChecks.Contexts != nil {
 			required.Insert(bp.RequiredStatusChecks.Contexts...)
 		}
 	}


### PR DESCRIPTION
If `Contexts` are not specified in `RequiredStatusChecks`, `required.Insert(bp.RequiredStatusChecks.Contexts...)` will panic.