### PR TITLE
Enable /pony for kubernetes

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -319,6 +319,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - pony
   - shrug
   - sigmention
   - size

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -434,6 +434,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - pony
   - shrug
   - size
   - skip
@@ -454,6 +455,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - pony
   - shrug
   - size
   - skip
@@ -477,6 +479,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - pony
   - shrug
   - size
   - skip
@@ -506,6 +509,7 @@ plugins:
   - label
   - lgtm
   - lifecycle
+  - pony
   - shrug
   - size
   - skip


### PR DESCRIPTION
Enable the pony plugin for the kubernetes org.

(Or maybe we want to restrict it to test-infra or something first?)

/cc @krzyzacy 