### PR TITLE
spyglass: don't show junit error body after all

### DIFF
--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -46,7 +46,7 @@
       <td class="mdl-data-table__cell--non-numeric" style="color: #FF0000">{{$test.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Duration}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Error.Message}}</td>
-      <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Error.Body}}</td>
+      <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}
     </tbody>

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -35,7 +35,6 @@
     <thead id="failed-theader" onclick="toggleExpansion('failed-tbody', 'failed-expander')">
     <tr>
       <td class="mdl-data-table__cell--non-numeric expander" style="color: #FF0000;" colspan="3"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
-      <td class="mdl-data-table__cell--non-numeric expander"></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     </thead>
@@ -46,7 +45,6 @@
       <td class="mdl-data-table__cell--non-numeric" style="color: #FF0000">{{$test.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Duration}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Error.Message}}</td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}
     </tbody>
@@ -55,7 +53,6 @@
     <thead id="passed-theader" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
     <tr>
       <td class="mdl-data-table__cell--non-numeric expander" style="color: #00FF00" colspan="3"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
-      <td class="mdl-data-table__cell--non-numeric expander"></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="passed-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     </thead>
@@ -66,7 +63,6 @@
       <td class="mdl-data-table__cell--non-numeric" style="color: #00FF00">{{.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
       <td class="mdl-data-table__cell--non-numeric"></td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}
     </tbody>
@@ -75,7 +71,6 @@
     <thead id="skipped-theader" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
     <tr>
       <td class="mdl-data-table__cell--non-numeric expander" style="color: rgba(255, 224, 0, 1.0);" colspan="3"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
-      <td class="mdl-data-table__cell--non-numeric expander"></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="skipped-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     </thead>
@@ -85,7 +80,6 @@
       <td class="mdl-data-table__cell--non-numeric"><a href="{{.Link}}">{{.Junit.Name}}</a></td>
       <td class="mdl-data-table__cell--non-numeric" style="color: rgba(255, 224, 0, 1.0);">{{.Junit.Status}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
       <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}


### PR DESCRIPTION
Undoes #9490 as it was a terrible idea (not enough space in the table for it and the same information is displayed in the build log viewer anyway, which is intended for this usage).

Before:
![screenshot from 2018-12-17 12-26-10](https://user-images.githubusercontent.com/16039734/50117561-34c49780-0202-11e9-8a90-1c22e2fa2277.png)

After:
![screenshot from 2018-12-17 15-28-35](https://user-images.githubusercontent.com/16039734/50122258-74927b80-0210-11e9-99d5-ec16eae2657a.png)
