### PR TITLE
Non blocking eks jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3,6 +3,51 @@
 presubmits:
   kubernetes-security/kubernetes:
   - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-aws-eks-1-11-prod-conformance
+    labels:
+      preset-kubernetes-e2e-aws-eks-1-11: "true"
+      preset-kubernetes-e2e-aws-eks-common: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-aws-eks-1-11-prod-conformance
+    rerun_command: /test pull-security-kubernetes-e2e-aws-eks-1-11-prod-conformance
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --timeout=200
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-version-skew=false
+        - --deployment=eks
+        - --provider=eks
+        - --gce-ssh=
+        - --extract=local
+        - --ginkgo-parallel=30
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
+        - --timeout=180m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aws-eks-1-11-prod-conformance
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-aws-eks-1-11-prod-conformance,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-e2e-kops-aws

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
@@ -1,91 +1,11 @@
-
-presets:
-- env:
-  # URL to download the latest 'aws-k8s-tester' release
-  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.5/aws-k8s-tester-0.1.5-linux-amd64
-  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/aws-k8s-tester
-  # URL to download 'kubectl', required for 'kubectl' calls to EKS
-  # TODO: use upstream 'kubectl'
-  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl
-  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/kubectl
-  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS
-  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator
-  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
-    value: /tmp/aws-k8s-tester/aws-iam-authenticator
-  # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
-  - name: AWS_K8S_TESTER_EKS_TEST_MODE
-    value: "embedded"
-  # configure EKS Kubernetes version
-  - name: AWS_K8S_TESTER_EKS_KUBERNETES_VERSION
-    value: "1.11"
-  # duration to wait before destroying EKS cluster, useful to add wait time before collecting AWS ALB access logs
-  - name: AWS_K8S_TESTER_EKS_WAIT_BEFORE_DOWN
-    value: 1m0s
-  # 'true' to destroying all AWS resources when it calls "Down"
-  - name: AWS_K8S_TESTER_EKS_DOWN
-    value: "true"
-  # 'true' to assign worker nodes across all available subnets
-  - name: AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA
-    value: "true"
-  # 'true' to open port 22 in security group, and enable SSH for log dumper
-  - name: AWS_K8S_TESTER_EKS_ENABLE_NODE_SSH
-    value: "true"
-  # 'true' to enable S3 Access Logs and AWS ALB Access Logs
-  # use it for debug, dump cluster log already handles log artifacts
-  - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
-    value: "false"
-  # 'true' to upload 'aws-k8s-tester' logs to S3 buckets, in addition to log dumper
-  # use it for debug, dump cluster log already handles log artifacts
-  - name: AWS_K8S_TESTER_EKS_UPLOAD_TESTER_LOGS
-    value: "false"
-  # 'true' to upload worker node logs to S3, in addition to log dumper
-  # use it for debug, dump cluster log already handles worker node logs
-  - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
-    value: "false"
-  # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
-    value: ami-094fa4044a2a3cf52
-  # worker node EC2 instance type
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_INSTANCE_TYPE
-    value: m3.xlarge
-  # worker node auto-scaling group minimum number of nodes
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MIN
-    value: "1"
-  # worker node auto-scaling group maximum number of nodes
-  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MAX
-    value: "1"
-  # 'true' to enable debug level logs
-  - name: AWS_K8S_TESTER_EKS_LOG_DEBUG
-    value: "false"
-  # 'true' to create AWS ALB
-  - name: AWS_K8S_TESTER_EKS_ALB_ENABLE
-    value: "false"
-  # AWS test account credential mounted path, required for AWS API call
-  - name: AWS_SHARED_CREDENTIALS_FILE
-    value: /etc/eks-aws-credentials/eks-aws-credentials
-  labels:
-    preset-ci-kubernetes-e2e-aws-eks-1-11: "true"
-  volumeMounts:
-  - mountPath: /etc/eks-aws-credentials
-    name: eks-aws-credentials
-    readOnly: true
-  volumes:
-  - name: eks-aws-credentials
-    secret:
-      secretName: eks-aws-credentials
-
 periodics:
 # Run Kubernetes 1.11 branch e2e tests with EKS prod build 1.11
 - interval: 2h
   name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-11: "true"
+    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -110,7 +30,8 @@ periodics:
   name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod-conformance
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-11: "true"
+    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -134,7 +55,8 @@ periodics:
   name: ci-kubernetes-e2e-stable-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-11: "true"
+    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
@@ -158,7 +80,8 @@ periodics:
   name: ci-kubernetes-e2e-latest-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"
-    preset-ci-kubernetes-e2e-aws-eks-1-11: "true"
+    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
@@ -1,0 +1,83 @@
+presets:
+- env:
+  # URL to download the latest 'aws-k8s-tester' release
+  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
+    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.7/aws-k8s-tester-0.1.7-linux-amd64
+  - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/aws-k8s-tester
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/kubectl
+  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
+    value: /tmp/aws-k8s-tester/aws-iam-authenticator
+  # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
+  - name: AWS_K8S_TESTER_EKS_TEST_MODE
+    value: "embedded"
+  # duration to wait before destroying EKS cluster, useful to add wait time before collecting AWS ALB access logs
+  - name: AWS_K8S_TESTER_EKS_WAIT_BEFORE_DOWN
+    value: 1m0s
+  # 'true' to destroying all AWS resources when it calls "Down"
+  - name: AWS_K8S_TESTER_EKS_DOWN
+    value: "true"
+  # 'true' to assign worker nodes across all available subnets
+  - name: AWS_K8S_TESTER_EKS_ENABLE_WORKER_NODE_HA
+    value: "true"
+  # 'true' to open port 22 in security group, and enable SSH for log dumper
+  - name: AWS_K8S_TESTER_EKS_ENABLE_NODE_SSH
+    value: "true"
+  # 'true' to enable S3 Access Logs and AWS ALB Access Logs
+  # use it for debug, dump cluster log already handles log artifacts
+  - name: AWS_K8S_TESTER_EKS_LOG_ACCESS
+    value: "false"
+  # 'true' to upload 'aws-k8s-tester' logs to S3 buckets, in addition to log dumper
+  # use it for debug, dump cluster log already handles log artifacts
+  - name: AWS_K8S_TESTER_EKS_UPLOAD_TESTER_LOGS
+    value: "false"
+  # 'true' to upload worker node logs to S3, in addition to log dumper
+  # use it for debug, dump cluster log already handles worker node logs
+  - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
+    value: "false"
+  # worker node auto-scaling group minimum number of nodes
+  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MIN
+    value: "1"
+  # worker node auto-scaling group maximum number of nodes
+  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MAX
+    value: "1"
+  # 'true' to enable debug level logs
+  - name: AWS_K8S_TESTER_EKS_LOG_DEBUG
+    value: "false"
+  # 'true' to create AWS ALB
+  - name: AWS_K8S_TESTER_EKS_ALB_ENABLE
+    value: "false"
+  # AWS test account credential mounted path, required for AWS API call
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: /etc/eks-aws-credentials/eks-aws-credentials
+  labels:
+    preset-kubernetes-e2e-aws-eks-common: "true"
+  volumeMounts:
+  - mountPath: /etc/eks-aws-credentials
+    name: eks-aws-credentials
+    readOnly: true
+  volumes:
+  - name: eks-aws-credentials
+    secret:
+      secretName: eks-aws-credentials
+
+- env:
+  # configure EKS Kubernetes version
+  - name: AWS_K8S_TESTER_EKS_KUBERNETES_VERSION
+    value: "1.11"
+  # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
+    value: ami-094fa4044a2a3cf52
+  # URL to download 'kubectl', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  # TODO: use upstream 'kubectl'
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl
+  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator
+  # worker node EC2 instance type
+  - name: AWS_K8S_TESTER_EKS_WORKER_NODE_INSTANCE_TYPE
+    value: m3.xlarge
+  labels:
+    preset-kubernetes-e2e-aws-eks-1-11: "true"

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
@@ -1,0 +1,33 @@
+presubmits:
+  # Run Kubernetes e2e tests with EKS prod build
+  # run conformance tests
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
+    # run tests from master branch (for now)
+    branches:
+    - master
+    # NON-BLOCKING; only triggered manually, use this for debug test script
+    always_run: false
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+      preset-kubernetes-e2e-aws-eks-common: "true"
+      preset-kubernetes-e2e-aws-eks-1-11: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        args:
+          - --timeout=200
+          - --bare
+          - --scenario=kubernetes_e2e
+          - --
+          - --check-version-skew=false
+          - --deployment=eks
+          - --provider=eks
+          - --gce-ssh=
+          - --extract=local
+          - --ginkgo-parallel=30
+          - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+          - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
+          - --timeout=180m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2144,6 +2144,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-manifest-lists
 
 # EKS e2e results
+- name: pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
+  gcs_prefix: kubernetes-jenkins/logs/pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
 - name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-1-11-aws-eks-1-11-prod
 - name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod-conformance
@@ -5692,6 +5694,11 @@ dashboards:
     test_group_name: pull-aws-ebs-csi-driver-sanity
     description: aws ebs csi driver sanity test
 
+- name: sig-aws-eks-presubmits
+  dashboard_tab:
+  - name: k8s-eks-1-11-prod-conformance
+    test_group_name: pull-kubernetes-e2e-aws-eks-1-11-prod-conformance
+    description: Kubernetes e2e tests with EKS prod build, Conformance tests
 - name: sig-aws-eks-ci-kubernetes-e2e-1-11
   dashboard_tab:
   - name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod


### PR DESCRIPTION
Some clean-up in how we define presets for EKS. And reattempt on https://github.com/kubernetes/test-infra/pull/10387.

/cc @shyamjvs @krzyzacy 

We are trying to debug ginkgo-e2e.sh script in kubernetes/kubernetes using **non-blocking** PRs to kubernetes.

https://testgrid.k8s.io/sig-aws-eks-ci-kubernetes-e2e-1-11#ci-kubernetes-e2e-1-11-aws-eks-1-11-prod-conformance has been failing. This would make it much easier to debug around the failures.

Thanks!