### PR TITLE
Always ignore 404 on label deletion calls

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1468,18 +1468,6 @@ func (c *Client) AddLabel(org, repo string, number int, label string) error {
 	return err
 }
 
-// LabelNotFound indicates that a label is not attached to an issue. For example, removing a
-// label from an issue, when the issue does not have that label.
-type LabelNotFound struct {
-	Owner, Repo string
-	Number      int
-	Label       string
-}
-
-func (e *LabelNotFound) Error() string {
-	return fmt.Sprintf("label %q does not exist on %s/%s/%d", e.Label, e.Owner, e.Repo, e.Number)
-}
-
 type githubError struct {
 	Message string `json:"message,omitempty"`
 }
@@ -1515,14 +1503,10 @@ func (c *Client) RemoveLabel(org, repo string, number int, label string) error {
 		return err
 	}
 
-	// If the error was because the label was not found, annotate that error with type information.
+	// If the error was because the label was not found, we don't really
+	// care since the label won't exist anyway.
 	if ge.Message == "Label does not exist" {
-		return &LabelNotFound{
-			Owner:  org,
-			Repo:   repo,
-			Number: number,
-			Label:  label,
-		}
+		return nil
 	}
 
 	// Otherwise we got some other 404 error.

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -493,9 +493,6 @@ func TestRemoveLabelFailsOnOtherThan404(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error but got none")
 	}
-	if _, ok := err.(*LabelNotFound); ok {
-		t.Fatalf("Expected error not to be a 404: %v", err)
-	}
 }
 
 func TestRemoveLabelNotFound(t *testing.T) {
@@ -506,12 +503,8 @@ func TestRemoveLabelNotFound(t *testing.T) {
 	c := getClient(ts.URL)
 	err := c.RemoveLabel("any", "old", 3, "label")
 
-	if err == nil {
-		t.Fatalf("RemoveLabel expected an error, got none")
-	}
-
-	if _, ok := err.(*LabelNotFound); !ok {
-		t.Fatalf("RemoveLabel expected LabelNotFound error, got %v", err)
+	if err != nil {
+		t.Fatalf("RemoveLabel expected no error, got one: %v", err)
 	}
 }
 

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -422,22 +422,14 @@ func handlePullRequest(log *logrus.Entry, gc githubClient, config *plugins.Confi
 		}
 	}
 
-	var labelNotFound bool
 	if err := gc.RemoveLabel(org, repo, number, LGTMLabel); err != nil {
-		if _, labelNotFound = err.(*github.LabelNotFound); !labelNotFound {
-			return fmt.Errorf("failed removing lgtm label: %v", err)
-		}
-		// If the error is indeed *github.LabelNotFound, consider it a success.
+		return fmt.Errorf("failed removing lgtm label: %v", err)
 	}
 
 	// Create a comment to inform participants that LGTM label is removed due to new
 	// pull request changes.
-	if !labelNotFound {
-		log.Infof("Commenting with an LGTM removed notification to %s/%s#%d with a message: %s", org, repo, number, removeLGTMLabelNoti)
-		return gc.CreateComment(org, repo, number, removeLGTMLabelNoti)
-	}
-
-	return nil
+	log.Infof("Commenting with an LGTM removed notification to %s/%s#%d with a message: %s", org, repo, number, removeLGTMLabelNoti)
+	return gc.CreateComment(org, repo, number, removeLGTMLabelNoti)
 }
 
 func skipCollaborators(config *plugins.Configuration, org, repo string) bool {

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -211,12 +211,8 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 	} else {
 		// Don't bother checking if it has the label...it's a race, and we'll have
 		// to handle failure due to not being labeled anyway.
-		labelNotFound := true
 		if err := ghc.RemoveLabel(org, repo, pre.Number, labels.InvalidOwners); err != nil {
-			if _, labelNotFound = err.(*github.LabelNotFound); !labelNotFound {
-				return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
-			}
-			// If the error is indeed *github.LabelNotFound, consider it a success.
+			return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When we are calling the GitHub API to remove a label from an issue or
PR, we do not care that the label existed in the first place and if we
try to verify that we have written racy code regardless.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 