### PR TITLE
Switch verify/integration jobs to use kubekins-e2e image

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2069,7 +2069,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-test:1.13-v20181218-db74ab3f4
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
         name: ""
         resources:
           requests:
@@ -2505,7 +2505,7 @@ presubmits:
         - ./hack/jenkins/verify-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-test:1.13-v20181218-db74ab3f4
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -38,7 +38,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-test:1.13-v20181218-db74ab3f4
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -43,7 +43,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-test:1.13-v20181218-db74ab3f4
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
         command:
         - runner.sh
         args:


### PR DESCRIPTION
I'll handle golint either in the image or in k/k, and let's see what else will fail.

/assign @ixdy @BenTheElder @cblecker 