### PR TITLE
Treat unknown succeeded status as still running

### DIFF
--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20181218-8eb6f41
+        image: gcr.io/k8s-prow/build:v20181219-932f7b14e
         args:
         - --all-contexts
         - --tot-url=http://tot

--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -453,9 +453,10 @@ func prowJobStatus(bs buildv1alpha1.BuildStatus) (prowjobv1.ProwJobState, string
 		return prowjobv1.FailureState, description(cond, descFailed)
 	case started.IsZero():
 		return prowjobv1.TriggeredState, description(cond, descInitializing)
-	case finished.IsZero():
+	case cond.Status == untypedcorev1.ConditionUnknown, finished.IsZero():
 		return prowjobv1.PendingState, description(cond, descRunning)
 	}
+	logrus.Warnf("Unknown condition %#v", cond)
 	return prowjobv1.ErrorState, description(cond, descUnknown) // shouldn't happen
 }
 

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -1023,7 +1023,7 @@ func TestProwJobStatus(t *testing.T) {
 			fallback: descRunning,
 		},
 		{
-			name: "expect a finished job to have a success status",
+			name: "builds with unknown success status are still running",
 			input: buildv1alpha1.BuildStatus{
 				StartTime:      now,
 				CompletionTime: later,
@@ -1035,12 +1035,12 @@ func TestProwJobStatus(t *testing.T) {
 					},
 				},
 			},
-			state:    prowjobv1.ErrorState,
+			state:    prowjobv1.PendingState,
 			desc:     "hola",
-			fallback: descUnknown,
+			fallback: descRunning,
 		},
 		{
-			name: "expect a finished job to have a condition",
+			name: "completed builds without a succeeded condition end in error",
 			input: buildv1alpha1.BuildStatus{
 				StartTime:      now,
 				CompletionTime: later,


### PR DESCRIPTION
Otherwise jobs end in error: https://prow.k8s.io/?job=ci-test-infra-build-smoke

Pin build controller to this commit for the day.

/assign @BenTheElder @krzyzacy @michelle192837 