### PR TITLE
Explicitly specify artifacts dir

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -50,6 +50,10 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
+        - name: KUBE_JUNIT_REPORT_DIR
+          value: $(ARTIFACTS)
+        - name: ARTIFACTS_DIR
+          value: $(ARTIFACTS)
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -55,6 +55,10 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
+        - name: KUBE_JUNIT_REPORT_DIR
+          value: $(ARTIFACTS)
+        - name: ARTIFACTS_DIR
+          value: $(ARTIFACTS)
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Because cannot read the integration log 😢try to get some junit artifacts to debug instead...

the path is currently hard-coded in places like https://github.com/kubernetes/kubernetes/blob/master/hack/jenkins/test-dockerized.sh#L43-L44, will make that take in existing value as well.

/assign @ixdy @cblecker 
/pony shrug