### PR TITLE
Create pull-, post- variants of build-smoke job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -2,6 +2,11 @@ periodics:
 - name: ci-test-infra-build-smoke
   interval: 2h
   agent: knative-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
   build_spec:
     steps:
     - name: first
@@ -10,6 +15,9 @@ periodics:
     - name: second
       image: busybox
       args: ["echo", "world"]
+    - name: third
+      image: busybox
+      args: ["cat", "config/jobs/kubernetes/test-infra/test-infra-periodics.yaml"]
 - name: ci-test-infra-bazel
   interval: 1h
   labels:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -1,5 +1,19 @@
 postsubmits:
   kubernetes/test-infra:
+  - name: post-test-infra-build-smoke
+    agent: knative-build
+    decorate: true
+    build_spec:
+      steps:
+      - name: first
+        image: busybox
+        args: ["echo", "hello"]
+      - name: second
+        image: busybox
+        args: ["echo", "world"]
+      - name: third
+        image: busybox
+        args: ["cat", "config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml"]
   - name: ci-test-infra-bazel
     branches:
     - master

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -1,5 +1,19 @@
 presubmits:
   kubernetes/test-infra:
+  - name: pull-test-infra-build-smoke
+    agent: knative-build
+    decorate: true
+    build_spec:
+      steps:
+      - name: first
+        image: busybox
+        args: ["echo", "hello"]
+      - name: second
+        image: busybox
+        args: ["echo", "world"]
+      - name: third
+        image: busybox
+        args: ["cat", "config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml"]
   - name: pull-test-infra-bazel
     branches:
     - master

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1009,9 +1009,9 @@ func validateAgent(v JobBase, podNamespace string) error {
 		return fmt.Errorf("job build_specs require agent: %s (found %q)", b, agent)
 	case agent == b && v.BuildSpec == nil:
 		return errors.New("knative-build jobs require a build_spec")
-	case v.DecorationConfig != nil && agent != k:
-		// TODO(fejta): support decoration
-		return fmt.Errorf("decoration requires agent: %s (found %q)", k, agent)
+	case v.DecorationConfig != nil && agent != k && agent != b:
+		// TODO(fejta): only source decoration supported...
+		return fmt.Errorf("decoration requires agent: %s or %s (found %q)", k, b, agent)
 	case v.ErrorOnEviction && agent != k:
 		return fmt.Errorf("error_on_eviction only applies to agent: %s (found %q)", k, agent)
 	case v.Namespace == nil || *v.Namespace == "":

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -778,6 +778,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1-13
 - name: ci-test-infra-build-smoke
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-build-smoke
+- name: pull-test-infra-build-smoke
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-build-smoke
+  num_columns_recent: 20
+- name: post-test-infra-build-smoke
+  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-build-smoke
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
 # Ubuntu node e2e tests (contact: @kubernetes/ubuntu-image on github)
@@ -6710,6 +6715,16 @@ dashboards:
   - name: build-smoke
     description: basic job to ensure build controller works correctly
     test_group_name: ci-test-infra-build-smoke
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: pull-build-smoke
+    description: basic presubmit to ensure build controller works correctly
+    test_group_name: pull-test-infra-build-smoke
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: post-build-smoke
+    description: basic postsubmit to ensure build controller works correctly
+    test_group_name: post-test-infra-build-smoke
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 


### PR DESCRIPTION
Also:
* Add extra_refs to ci job
* Allow knative-build agent jobs to set decorate: true (although this just clones source at the moment, uploading to testgrid will come later)

/assign @krzyzacy @amwat 