### PR TITLE
Use CREATE_CUSTOM_NETWORK for all scalability jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1133,7 +1133,6 @@ presubmits:
     context: pull-security-kubernetes-e2e-gce-100-performance
     labels:
       preset-bazel-scratch-dir: "true"
-      preset-e2e-gci-gce-scalability: "true"
       preset-e2e-scalability-common: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -10,7 +10,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-gci-gce-scalability: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
@@ -49,7 +48,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-gci-gce-scalability: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -81,6 +81,8 @@ presets:
   # Use IP-aliases for scalability tests.
   - name: KUBE_GCE_ENABLE_IP_ALIASES
     value: "true"
+  - name: CREATE_CUSTOM_NETWORK
+    value: "true"
   # Ensure good enough architecture for master machines.
   - name: MASTER_MIN_CPU_ARCHITECTURE
     value: "Intel Broadwell"
@@ -115,11 +117,3 @@ presets:
   # Increase size of default subnetworks to enable large clusters.
   - name: ENABLE_BIG_CLUSTER_SUBNETS
     value: "true"
-# Create a project k8s-jenkins-scalability-head and move this test there
-- labels:
-    preset-e2e-gci-gce-scalability: "true"
-  env:
-  # Override GCE defaults.
-  - name: CREATE_CUSTOM_NETWORK
-    value: "true"
-   

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -11,7 +11,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-gci-gce-scalability: "true"
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -138,7 +138,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-gci-gce-scalability: "true"
   decorate: true
   decoration_config:
     timeout: 14000000000000 # 140m


### PR DESCRIPTION
@shyamjvs - I think in the past you fixed all the problems with that - is that true?
Is this supposed to work also in case of presubmits?

/hold