### PR TITLE
procps is missing in debian:stretch

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mercurial \
     openssh-client \
     pkg-config \
+    procps \
     python \
     python-dev \
     python-openssl \


### PR DESCRIPTION
we are missing the `ps` command

```
[dims@dims-mac 10:42] ~/test ⟩ env | grep IMAGE
IMAGE=gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
[dims@dims-mac 10:42] ~/test ⟩ docker run --privileged -it --rm --entrypoint=/bin/bash $IMAGE -c bash
root@0cfb14bd5c60:/workspace# ps
bash: ps: command not found
```