### PR TITLE
Blank out the src container name

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -554,6 +554,8 @@ func injectSource(b *buildv1alpha1.Build, pj prowjobv1.ProwJob) error {
 	}
 	if srcContainer == nil {
 		return nil
+	} else {
+		srcContainer.Name = "" // knative-build requirement
 	}
 
 	b.Spec.Source = &buildv1alpha1.SourceSpec{

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -857,6 +857,7 @@ func TestInjectSource(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to make clonerefs container: %v", err)
 				}
+				src.Name = ""
 				b.Spec.Volumes = append(b.Spec.Volumes, cloneVolumes...)
 				b.Spec.Source = &buildv1alpha1.SourceSpec{
 					Custom: src,


### PR DESCRIPTION
/assign @krzyzacy @BenTheElder 

Otherwise the build never schedules, with the build-controller printing messages like the following:

```console
{"level":"error","logger":"controller.build-controller","caller":"build/build.go:141","msg":"Failed to validate build: OmitName: custom source containers are expected to omit Name, got: clonerefs","knative.dev/controller":"controller","knative.dev/controller":"build-controller",
```