### PR TITLE
Fix up godeps logging and disable godeps checks in main verify job

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2094,8 +2094,6 @@ presubmits:
         env:
         - name: KUBE_FORCE_VERIFY_CHECKS
           value: "Y"
-        - name: KUBE_JUNIT_REPORT_DIR
-          value: /logs/artifacts
         - name: WHAT
           value: godeps staging-godeps godep-licenses
         image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master

--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2567,7 +2567,7 @@ presubmits:
         - name: EXCLUDE_TYPECHECK
           value: "Y"
         - name: EXCLUDE_GODEPS
-          value: "N"
+          value: "Y"
         image: gcr.io/k8s-testimages/bootstrap:v20181219-899fabec7
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/godeps.yaml
+++ b/config/jobs/kubernetes/sig-testing/godeps.yaml
@@ -26,10 +26,6 @@ presubmits:
         # bash/git checks to work.
         - name: KUBE_FORCE_VERIFY_CHECKS
           value: "Y"
-        # podutils will set $ARTIFACTS, so we just need to set the junit report
-        # variable to use it too.
-        - name: KUBE_JUNIT_REPORT_DIR
-          value: "/logs/artifacts"
         # Space separated list of the checks to run
         - name: WHAT
           value: "godeps staging-godeps godep-licenses"

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -23,7 +23,7 @@ presubmits:
         - name: EXCLUDE_TYPECHECK
           value: "Y"
         - name: EXCLUDE_GODEPS
-          value: "N"
+          value: "Y"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
/assign @krzyzacy 

Now that https://github.com/kubernetes/kubernetes/pull/72218 is in, we don't need to manually set the `KUBE_JUNIT_REPORT_DIR`.