### PR TITLE
cherrypicker: don't add release note block if note is NONE

### DIFF
--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/releasenote:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -389,7 +389,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 
 	// Open a PR in Github.
 	title = fmt.Sprintf("[%s] %s", targetBranch, title)
-	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d", num)
+	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d on %s", num, targetBranch)
 	if s.prowAssignments {
 		cherryPickBody = fmt.Sprintf("%s\n\n/assign %s", cherryPickBody, requestor)
 	}

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -202,7 +202,7 @@ func TestCherryPickIC(t *testing.T) {
 	botName := "ci-robot"
 	expectedRepo := "foo/bar"
 	expectedTitle := "[stage] This is a fix for X"
-	expectedBody := "This is an automated cherry-pick of #2\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
+	expectedBody := "This is an automated cherry-pick of #2 on stage\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
 	expectedBase := "stage"
 	expectedHead := fmt.Sprintf(botName+":"+cherryPickBranchFmt, 2, expectedBase)
 	expected := fmt.Sprintf(expectedFmt, expectedRepo, expectedTitle, expectedBody, expectedHead, expectedBase, true)
@@ -353,7 +353,7 @@ func TestCherryPickPR(t *testing.T) {
 	var expectedFn = func(branch string) string {
 		expectedRepo := "foo/bar"
 		expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
-		expectedBody := "This is an automated cherry-pick of #2"
+		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #2 on %s", branch)
 		expectedHead := fmt.Sprintf(botName+":"+cherryPickBranchFmt, 2, branch)
 		return fmt.Sprintf(expectedFmt, expectedRepo, expectedTitle, expectedBody, expectedHead, branch, true)
 	}

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -139,7 +139,7 @@ index 1ea52dc..5bd70a9 100644
  }
 `)
 
-var body = "This PR updates the magic number.\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
+const body = "This PR updates the magic number.\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
 
 func TestCherryPickIC(t *testing.T) {
 	lg, c, err := localgit.New()
@@ -324,6 +324,7 @@ func TestCherryPickPR(t *testing.T) {
 			Merged:   true,
 			MergeSHA: new(string),
 			Title:    "This is a fix for Y",
+			Body:     "This is a fix for Y.\n\n```release-note\nNONE\n```",
 		},
 	}
 

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -49,7 +49,7 @@ var (
 	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
 
 	NoteMatcherRe = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
-	cpRe          = regexp.MustCompile(`Cherry pick of #([[:digit:]]+) on release-([[:digit:]]+\.[[:digit:]]+).`)
+	cpRe          = regexp.MustCompile(`(?:Cherry pick|cherry-pick) of #([[:digit:]]+) on release-([[:digit:]]+\.[[:digit:]]+).`)
 	NoneRe        = regexp.MustCompile(`(?i)^\W*NONE\W*$`)
 
 	allRNLabels = []string{

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -48,9 +48,9 @@ var (
 	releaseNoteBody       = fmt.Sprintf(releaseNoteFormat, ReleaseNoteLabelNeeded)
 	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
 
-	noteMatcherRE = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
+	NoteMatcherRe = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 	cpRe          = regexp.MustCompile(`Cherry pick of #([[:digit:]]+) on release-([[:digit:]]+\.[[:digit:]]+).`)
-	noneRe        = regexp.MustCompile(`(?i)^\W*NONE\W*$`)
+	NoneRe        = regexp.MustCompile(`(?i)^\W*NONE\W*$`)
 
 	allRNLabels = []string{
 		releaseNoteNone,
@@ -307,7 +307,7 @@ func determineReleaseNoteLabel(body string) string {
 	if composedReleaseNote == "" {
 		return ReleaseNoteLabelNeeded
 	}
-	if noneRe.MatchString(composedReleaseNote) {
+	if NoneRe.MatchString(composedReleaseNote) {
 		return releaseNoteNone
 	}
 	if strings.Contains(composedReleaseNote, actionRequiredNote) {
@@ -319,7 +319,7 @@ func determineReleaseNoteLabel(body string) string {
 // getReleaseNote returns the release note from a PR body
 // assumes that the PR body followed the PR template
 func getReleaseNote(body string) string {
-	potentialMatch := noteMatcherRE.FindStringSubmatch(body)
+	potentialMatch := NoteMatcherRe.FindStringSubmatch(body)
 	if potentialMatch == nil {
 		return ""
 	}


### PR DESCRIPTION
Addresses follow up comments from https://github.com/kubernetes/test-infra/pull/10460

This PR modifies the cherrypicker plugin to _not_ add a release note block to the cherrypick PR if the parent PR has the release note as `NONE`. This is done because we require cherrypicks to have a non-`NONE` release note. Example: https://github.com/kubernetes/kubernetes/pull/72127#issuecomment-447985619.

/cc @stevekuznetsov @kargakis @alvaroaleman @cblecker 