### PR TITLE
Setting 5000 nodes clusterloader test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -284,7 +284,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: '1 8 * * 1,2,3,4,5' # Run at 00:01PST (8:01 UTC) from Mon to Fri
+- cron: '1 8 * * 1,3,5' # Run at 00:01PST (8:01 UTC) on Mon, Wed and Fri
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -309,6 +309,51 @@ periodics:
       - --gcp-zone=us-east1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8 --node-schedulable-timeout=90m --gather-resource-usage=masteranddns --gather-metrics-at-teardown=master --vmodule=request=4
+      - --timeout=1290m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
+
+# Temporary job for gce 5000 that runs on clusterloader.
+# If there are no problems spotted after few runs,
+# ci-kubernetes-e2e-gce-scale-performance will be migrated to clusterloader and this job will be removed.
+- cron: '1 8 * * 2,4' # Run at 00:01PST (8:01 UTC) on Tue and Thu
+  name: ci-kubernetes-e2e-gce-scale-performance-cl
+  tags:
+  - "perfDashPrefix: {clusterloader} gce-5000Nodes"
+  - "perfDashJobType: performance"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-highspeed-common: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=1320
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=gce-scale-cluster
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
+      - --extract=ci/latest
+      - --gcp-nodes=5000
+      - --gcp-project=kubernetes-scale
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+       - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=5000
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
       - --timeout=1290m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -361,6 +361,8 @@ test_groups:
   days_of_results: 60
   num_columns_recent: 3
   num_failures_to_alert: 1
+- name: ci-kubernetes-e2e-gce-scale-performance-cl
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance-cl
 - name: ci-kubernetes-e2e-gci-gce-es-logging
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-es-logging
 - name: ci-kubernetes-e2e-gci-gce-sd-logging
@@ -6469,6 +6471,8 @@ dashboards:
     test_group_name: ci-perf-tests-kubemark-100-benchmark
   - name: cluster-loader
     test_group_name: ci-perf-tests-e2e-gce-clusterloader
+  - name: ci-kubernetes-e2e-gce-scale-performance-cl
+    test_group_name: ci-kubernetes-e2e-gce-scale-performance-cl
 
 - name: sig-scalability-benchmarks
   dashboard_tab:


### PR DESCRIPTION
Temporary job for gce 5000 that runs on clusterloader.
If there are no problems spotted after few runs, ci-kubernetes-e2e-gce-scale-performance will be migrated to clusterloader and this job will be removed.