### PR TITLE
Allow cuj, platform, community, and team labels to be set via bot.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -97,7 +97,7 @@ size:
   xxl: 1000
 
 label:
-  additionalLabels:
+  additional_labels:
     # These labels are used by Kubeflow
     # TODO(https://github.com/kubernetes/test-infra/issues/8648): Switch
     # to configuring prefixes and not individual labels once  that's supported.

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -96,6 +96,22 @@ size:
   xl:  500
   xxl: 1000
 
+label:
+  additionalLabels:
+    # These labels are used by Kubeflow
+    # TODO(https://github.com/kubernetes/test-infra/issues/8648): Switch
+    # to configuring prefixes and not individual labels once  that's supported.
+    - community/discussion
+    - community/maintenance
+    - community/question
+    - cuj/build-train-deploy
+    - cuj/multi-user
+    - platform/aws
+    - platform/azure
+    - platform/gcp
+    - platform/minikube
+    - platform/other
+
 lgtm:
 - repos:
   - bazelbuild


### PR DESCRIPTION
* The Kubeflow project would like to be able to use the K8s bot to add labels
  prefixed by cuj and platform

* cuj stands for critical user journey. We'd like to use this to group related
  issues to delivering a core user experience.

* We use platform to group issues by platform; e.g.
  /platform/gcp
  /platform/minikube.

* There is an open issue #8648 is fixed to allow whitelisting additional prefixes. In the interim we can whitelist individual labels for use with /label.