### PR TITLE
[WIP] peribolos: support managing repo collaborators

### DIFF
--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -39,9 +39,10 @@ type Metadata struct {
 // Config declares org metadata as well as its people and teams.
 type Config struct {
 	Metadata
-	Teams   map[string]Team `json:"teams,omitempty"`
-	Members []string        `json:"members,omitempty"`
 	Admins  []string        `json:"admins,omitempty"`
+	Members []string        `json:"members,omitempty"`
+	Teams   map[string]Team `json:"teams,omitempty"`
+	Repos   map[string]Repo `json:"repos,omitempty"`
 }
 
 // TeamMetadata declares metadata about the github team.
@@ -60,6 +61,21 @@ type Team struct {
 	Children    map[string]Team `json:"teams,omitempty"`
 
 	Previously []string `json:"previously,omitempty"`
+}
+
+// Repo declares metadata about who has access to a repo.
+// Members denotes members of the organization with direct collaborator access.
+type Repo struct {
+	Members              UserPermissionLevel `json:"members,omitempty"`
+	OutsideCollaborators UserPermissionLevel `json:"outside_collaborators,omitempty"`
+	Teams                UserPermissionLevel `json:"teams,omitempty"`
+}
+
+// UserPermissionLevel declares the level of access to a repo.
+type UserPermissionLevel struct {
+	Admin []string `json:"admin,omitempty"`
+	Write []string `json:"write,omitempty"`
+	Read  []string `json:"read,omitempty"`
 }
 
 // RepoPermissionLevel is admin, write, read or none.

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -374,7 +374,7 @@ func (f *FakeClient) IsCollaborator(org, repo, login string) (bool, error) {
 }
 
 // ListCollaborators lists the collaborators.
-func (f *FakeClient) ListCollaborators(org, repo string) ([]github.User, error) {
+func (f *FakeClient) ListCollaborators(org, repo, affiliation string) ([]github.User, error) {
 	result := make([]github.User, 0, len(f.Collaborators))
 	for _, login := range f.Collaborators {
 		result = append(result, github.User{Login: login})

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -701,6 +701,7 @@ type Team struct {
 	Name         string `json:"name"`
 	Description  string `json:"description,omitempty"`
 	Privacy      string `json:"privacy,omitempty"`
+	Permission   string `json:"permission,omitempty"`
 	Parent       *Team  `json:"parent,omitempty"`         // Only present in responses
 	ParentTeamID *int   `json:"parent_team_id,omitempty"` // Only valid in creates/edits
 }
@@ -765,6 +766,15 @@ type OrgInvitation struct {
 	Email   string     `json:"email"`
 	Inviter TeamMember `json:"inviter"`
 }
+
+const (
+	// AffiliationAll lists all collaborators for a repo.
+	AffiliationAll = "all"
+	// AffiliationOutside lists all outside collaborators for a repo.
+	AffiliationOutside = "outside"
+	// AffiliationDirect lists all direct collaborators with permissions to a repo, regardless of organization membership status.
+	AffiliationDirect = "direct"
+)
 
 // GenericCommentEventAction coerces multiple actions into its generic equivalent.
 type GenericCommentEventAction string

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -74,7 +74,7 @@ type FullConfig struct {
 }
 
 type githubClient interface {
-	ListCollaborators(org, repo string) ([]github.User, error)
+	ListCollaborators(org, repo, affiliation string) ([]github.User, error)
 	GetRef(org, repo, ref string) (string, error)
 }
 
@@ -255,7 +255,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 	var owners *RepoOwners
 	// Filter collaborators. We must filter the RepoOwners struct even if it came from the cache
 	// because the list of collaborators could have changed without the git SHA changing.
-	collaborators, err := c.ghc.ListCollaborators(org, repo)
+	collaborators, err := c.ghc.ListCollaborators(org, repo, "")
 	if err != nil {
 		log.WithError(err).Errorf("Failed to list collaborators while loading RepoOwners. Skipping collaborator filtering.")
 		owners = entry.owners

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -40,7 +40,7 @@ type client interface {
 	AddLabel(org, repo string, number int, label string) error
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	GetPullRequests(org, repo string) ([]github.PullRequest, error)
-	ListCollaborators(org, repo string) ([]github.User, error)
+	ListCollaborators(org, repo, affiliation string) ([]github.User, error)
 	ListOrgMembers(org, role string) ([]github.TeamMember, error)
 }
 
@@ -120,7 +120,7 @@ func main() {
 
 	// eventually also skip collaborators
 	if o.trustCollaborators {
-		collaborators, err := c.ListCollaborators(o.org, o.repo)
+		collaborators, err := c.ListCollaborators(o.org, o.repo, "")
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/10501

This PR adds support for managing repo collaborators in peribolos. The repo collaborator data has information about both membership-level and permission-level granularity.

/sig contributor-experience
/kind feature
/assign @fejta @cblecker 