### PR TITLE
Add option to only report knative agent jobs

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -59,7 +59,8 @@ type options struct {
 	pubsubWorkers int
 	githubWorkers int
 
-	dryrun bool
+	dryrun      bool
+	reportAgent string
 }
 
 func (o *options) validate() error {
@@ -98,6 +99,7 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 	fs.IntVar(&o.gerritWorkers, "gerrit-workers", 0, "Number of gerrit report workers (0 means disabled)")
 	fs.IntVar(&o.pubsubWorkers, "pubsub-workers", 0, "Number of pubsub report workers (0 means disabled)")
 	fs.IntVar(&o.githubWorkers, "github-workers", 0, "Number of github report workers (0 means disabled)")
+	fs.StringVar(&o.reportAgent, "report-agent", "", "Only report specified agent - empty means report to all agents (effective for github only)")
 
 	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
@@ -205,7 +207,7 @@ func main() {
 				prowjobClient,
 				queue,
 				prowjobInformerFactory.Prow().V1().ProwJobs(),
-				githubreporter.NewReporter(githubClient, configAgent),
+				githubreporter.NewReporter(githubClient, configAgent, o.reportAgent),
 				o.githubWorkers,
 				wg))
 	}

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -30,15 +30,17 @@ type configAgent interface {
 
 // Client is a github reporter client
 type Client struct {
-	gc report.GithubClient
-	ca configAgent
+	gc          report.GithubClient
+	ca          configAgent
+	reportAgent string
 }
 
 // NewReporter returns a reporter client
-func NewReporter(gc report.GithubClient, ca configAgent) *Client {
+func NewReporter(gc report.GithubClient, ca configAgent, reportAgent string) *Client {
 	return &Client{
-		gc: gc,
-		ca: ca,
+		gc:          gc,
+		ca:          ca,
+		reportAgent: reportAgent,
 	}
 }
 
@@ -52,6 +54,11 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 
 	if !pj.Spec.Report || pj.Spec.Type != v1.PresubmitJob {
 		// Only report presubmit github jobs for github reporter
+		return false
+	}
+
+	if c.reportAgent != "" && string(pj.Spec.Agent) != c.reportAgent {
+		// Only report for specified agent
 		return false
 	}
 

--- a/prow/github/reporter/reporter_test.go
+++ b/prow/github/reporter/reporter_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestShouldReport(t *testing.T) {
 	var testcases = []struct {
-		name   string
-		pj     *v1.ProwJob
-		report bool
+		name        string
+		pj          *v1.ProwJob
+		report      bool
+		reportAgent string
 	}{
 		{
 			name: "should not report skip report job",
@@ -78,11 +79,34 @@ func TestShouldReport(t *testing.T) {
 			},
 			report: true,
 		},
+		{
+			name: "knative only, don't report kubernetes agent job",
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PresubmitJob,
+					Agent:  v1.KubernetesAgent,
+					Report: true,
+				},
+			},
+			report:      false,
+			reportAgent: v1.KnativeBuildAgent,
+		},
+		{
+			name: "knative only, report knative agent job",
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PresubmitJob,
+					Agent:  v1.KnativeBuildAgent,
+					Report: true,
+				},
+			},
+			report:      true,
+			reportAgent: v1.KnativeBuildAgent,
+		},
 	}
 
-	c := NewReporter(nil, nil)
-
 	for _, tc := range testcases {
+		c := NewReporter(nil, nil, tc.reportAgent)
 		r := c.ShouldReport(tc.pj)
 
 		if r != tc.report {


### PR DESCRIPTION
I don't want to break the world by switching everything to crier yet, how about we do this for knative agent first, if everything works then I'm more confident to lift the floodgate.

/area prow/crier
/assign @fejta @cjwagner 