### PR TITLE
spyglass: don't 'show more' metadata when there isn't any

### DIFF
--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -86,6 +86,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		FinishedTime time.Time
 		Elapsed      time.Duration
 		Metadata     map[string]string
+		MetadataLen  int
 	}
 	metadataViewData := MetadataViewData{Status: "Pending"}
 	started := jobs.Started{}
@@ -127,6 +128,11 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 	}
 	for pkg, version := range finished.Metadata.Repos {
 		metadataViewData.Metadata[pkg] = version
+	}
+	for _, v := range metadataViewData.Metadata {
+		if v != "" {
+			metadataViewData.MetadataLen++
+		}
 	}
 
 	metadataTemplate, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -6,7 +6,6 @@
 {{define "body"}}
 {{$passed := eq .Status "SUCCESS"}}
 {{$failed := eq .Status "FAILURE" "FAILED"}}
-{{$length := len .Metadata}}
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
   <thead>
     <tr class="test-row">
@@ -23,7 +22,7 @@
       <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
     </tr>
-    <tbody id="supplementary_data" class="{{if gt $length 1}}hidden{{end}}">
+    <tbody id="supplementary_data" class="{{if gt .MetadataLen 1}}hidden{{end}}">
     {{range $key, $value := .Metadata}}
     {{if $value}}
       <tr>
@@ -33,7 +32,7 @@
     {{end}}
     {{end}}
     </tbody>
-    {{if gt $length 1}}
+    {{if gt .MetadataLen 1}}
     <tr class="expander" onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
       <td id="expand_text" class="mdl-data-table__cell--non-numeric expander">Show more</td>
       <td class="mdl-data-table__cell--non-numeric expander">


### PR DESCRIPTION
Fixes a dumb bug in the Spyglass metadata viewer (by only counting pairs that have non-empty values)

/assign @Katharine 
/pony twilight sparkle, derp