### PR TITLE
Enable trigger plugin for sig-storage-local-static-provisioner.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -555,6 +555,9 @@ plugins:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - trigger
 
+  kubernetes-sigs/sig-storage-local-static-provisioner:
+  - trigger
+
   kubernetes-sigs/gcp-filestore-csi-driver:
   - trigger
 


### PR DESCRIPTION
It seems like I missed trigger plugin for kubernetes-sigs/sig-storage-local-static-provisioner.

xref: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/13
xref: https://github.com/kubernetes/test-infra/pull/10512