### PR TITLE
Modify kubernetes_verify scenario to pass env vars into job

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2566,12 +2566,9 @@ presubmits:
         - --scenario=kubernetes_verify
         - --
         - --branch=${PULL_BASE_REF}
+        - --exclude-typecheck
+        - --exclude-godep
         - --script=./hack/jenkins/verify-dockerized.sh
-        env:
-        - name: EXCLUDE_TYPECHECK
-          value: "Y"
-        - name: EXCLUDE_GODEP
-          value: "Y"
         image: gcr.io/k8s-testimages/bootstrap:v20181219-899fabec7
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,13 +17,10 @@ presubmits:
         - --scenario=kubernetes_verify
         - --
         - "--branch=${PULL_BASE_REF}"
+        - --exclude-typecheck
+        - --exclude-godep
         - --script=./hack/jenkins/verify-dockerized.sh
         # docker-in-docker needs privileged mode
-        env:
-        - name: EXCLUDE_TYPECHECK
-          value: "Y"
-        - name: EXCLUDE_GODEP
-          value: "Y"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
I will be VERY HAPPY when we can get rid of this scenario. Until then, I had to modify it and create a couple new flags to be able to pass options into the job.

Extra eyes on the python might be required, as it's not my strongest language.

/assign @krzyzacy 