### PR TITLE
Remove no-longer used highspeed-common preset

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1240,7 +1240,6 @@ presubmits:
     labels:
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-highspeed-common: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 1
@@ -1298,7 +1297,6 @@ presubmits:
     labels:
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-highspeed-common: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 1

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -176,7 +176,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-highspeed-common: "true"
   spec:
     containers:
     - args:
@@ -213,7 +212,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-highspeed-common: "true"
   spec:
     containers:
     - args:
@@ -254,7 +252,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-highspeed-common: "true"
   spec:
     containers:
     - args:
@@ -291,7 +288,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-highspeed-common: "true"
   spec:
     containers:
     - args:
@@ -327,7 +323,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-highspeed-common: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -110,10 +110,3 @@ presets:
   # Increase delete collection parallelism.
   - name: TEST_CLUSTER_DELETE_COLLECTION_WORKERS
     value: --delete-collection-workers=16
-### Common env variables for all high-speed scalability suites.
-- labels:
-    preset-e2e-scalability-highspeed-common: "true"
-  env:
-  # Increase size of default subnetworks to enable large clusters.
-  - name: ENABLE_BIG_CLUSTER_SUBNETS
-    value: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -51,7 +51,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-highspeed-common: "true"
     spec:
       containers:
       - args:
@@ -93,7 +92,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-highspeed-common: "true"
     spec:
       containers:
       - args:


### PR DESCRIPTION
It was setting only ENABLE_BIG_CLUSTER_SUBNETS env var.
And that env-var is not used in connection with IP-aliases, which we use in all our tests.

With this PR, we are using the same config for all our real-cluster jobs
(modulo individual env-vars that are set in job definitions, but only in stable1 and stable2 ones).