### PR TITLE
config/.../eks: set "KUBERNETES_CONFORMANCE_*", "KUBECTL"

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
@@ -1,12 +1,24 @@
 presets:
 - env:
+  # to prevent ginkgo-e2e.sh from using the cluster/eks functions
+  - name: KUBERNETES_CONFORMANCE_TEST
+    value: yes
+  - name: KUBERNETES_CONFORMANCE_PROVIDER
+    value: eks
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.7/aws-k8s-tester-0.1.7-linux-amd64
+    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.8/aws-k8s-tester-0.1.8-linux-amd64
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
     value: /tmp/aws-k8s-tester/aws-k8s-tester
   - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH
     value: /tmp/aws-k8s-tester/kubectl
+  - name: AWS_K8S_TESTER_EKS_KUBECONFIG_PATH
+    value: /tmp/aws-k8s-tester/kubeconfig
+  - name: KUBECONFIG
+    value: /tmp/aws-k8s-tester/kubeconfig
+  # upstream "kubernetes/kubernetes/hack/ginkgo-e2e.sh" requires this via "cluster/kubectl.sh"
+  - name: KUBECTL
+    value: "/tmp/aws-k8s-tester/kubectl --kubeconfig=/tmp/aws-k8s-tester/kubeconfig"
   - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_PATH
     value: /tmp/aws-k8s-tester/aws-iam-authenticator
   # test mode is either "embedded" or "aws-cli" ("embedded" uses native AWS Go client, "aws-cli" will use 'aws')
@@ -36,6 +48,9 @@ presets:
   # use it for debug, dump cluster log already handles worker node logs
   - name: AWS_K8S_TESTER_EKS_UPLOAD_WORKER_NODE_LOGS
     value: "false"
+  # "2" to add S3 bucket lifecycle of 2 days; let bucket be deleted in 2 days
+  - name: AWS_K8S_TESTER_EKS_UPLOAD_BUCKET_EXPIRE_DAYS
+    value: "2"
   # worker node auto-scaling group minimum number of nodes
   - name: AWS_K8S_TESTER_EKS_WORKER_NODE_ASG_MIN
     value: "1"


### PR DESCRIPTION
To follow GKE kubetest deployer pattern https://github.com/kubernetes/test-infra/blob/4feecf5851be192c738cec981962ee1594d2fb8f/kubetest/gke.go#L210-L229.

And upgrades "aws-k8s-tester" plugin to 0.1.8 to pick up S3 lifecycle policy change.
