### PR TITLE
config/.../eks: update "aws/aws-k8s-tester" to 0.1.9

### DIFF
--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 # Run Kubernetes 1.11 branch e2e tests with EKS prod build 1.11
-- interval: 2h
+- interval: 3h
   name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"
@@ -26,7 +26,7 @@ periodics:
 
 # Run Kubernetes 1.11 branch e2e tests with EKS prod build 1.11
 # run conformance tests
-- interval: 2h
+- interval: 3h
   name: ci-kubernetes-e2e-1-11-aws-eks-1-11-prod-conformance
   labels:
     preset-service-account: "true"
@@ -51,7 +51,7 @@ periodics:
       - --timeout=180m
 
 # Run Kubernetes stable e2e tests with EKS prod build 1.11
-- interval: 2h
+- interval: 3h
   name: ci-kubernetes-e2e-stable-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"
@@ -76,7 +76,7 @@ periodics:
       - --timeout=180m
 
 # Run Kubernetes latest e2e tests with EKS prod build 1.11
-- interval: 2h
+- interval: 3h
   name: ci-kubernetes-e2e-latest-aws-eks-1-11-prod
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
@@ -5,6 +5,10 @@ presets:
     value: yes
   - name: KUBERNETES_CONFORMANCE_PROVIDER
     value: eks
+  # configure worker node private key path to "~/.ssh/kube_aws_rsa"
+  # see https://godoc.org/k8s.io/kubernetes/test/e2e/framework#GetSigner
+  - name: AWS_SSH_KEY
+    value: kube_aws_rsa
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
     value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.9/aws-k8s-tester-0.1.9-linux-amd64

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
@@ -7,7 +7,7 @@ presets:
     value: eks
   # URL to download the latest 'aws-k8s-tester' release
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_URL
-    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.8/aws-k8s-tester-0.1.8-linux-amd64
+    value: https://github.com/aws/aws-k8s-tester/releases/download/0.1.9/aws-k8s-tester-0.1.9-linux-amd64
   - name: AWS_K8S_TESTER_EKS_AWS_K8S_TESTER_DOWNLOAD_PATH
     value: /tmp/aws-k8s-tester/aws-k8s-tester
   - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_PATH


### PR DESCRIPTION
To pick up worker node private key path change.
Now it sets to "~/.ssh/kube_aws_rsa".

ref. https://github.com/kubernetes/kubernetes/pull/72317

/cc @shyamjvs 

@karinnainiguez will update `eksconfig` vendor after Christmas, in the following PR.