### PR TITLE
prow/pluggins/*: Clarify where commands can be called

### DIFF
--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package cat adds cat images to issues in response to a /meow comment
+// Package cat adds cat images to an issue or PR in response to a /meow comment
 package cat
 
 import (
@@ -54,11 +54,11 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The cat plugin adds a cat image to an issue in response to the `/meow` command.",
+		Description: "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/meow(vie) [CATegory]",
-		Description: "Add a cat image to the issue",
+		Description: "Add a cat image to the issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
 		Examples:    []string{"/meow", "/meow caturday", "/meowvie clothes"},

--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dog adds dog images to issues in response to a /woof comment
+// Package dog adds dog images to the issue or PR in response to a /woof comment
 package dog
 
 import (
@@ -55,11 +55,11 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The dog plugin adds a (famous.)dog image to an issue in response to the `/woof` command.",
+		Description: "The dog plugin adds a (famous.)dog image to an issue or PR in response to the `/woof` command.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(woof|bark|this-is-{fine|not-fine|unbearable})",
-		Description: "Add a (famous.)dog image to the issue",
+		Description: "Add a (famous.)dog image to the issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
 		Examples:    []string{"/woof", "/bark", "this-is-{fine|not-fine|unbearable}"},

--- a/prow/plugins/pony/pony.go
+++ b/prow/plugins/pony/pony.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package pony adds pony images to issues in response to a /pony comment
+// Package pony adds pony images to the issue or PR in response to a /pony comment
 package pony
 
 import (
@@ -61,11 +61,11 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The pony plugin adds a pony image to an issue in response to the `/pony` command.",
+		Description: "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(pony) [pony]",
-		Description: "Add a little pony image to the issue. A particular pony can optionally be named for a picture of that specific pony.",
+		Description: "Add a little pony image to the issue or PR. A particular pony can optionally be named for a picture of that specific pony.",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
 		Examples:    []string{"/pony", "/pony Twilight Sparkle"},


### PR DESCRIPTION
The commands meow, pony or woof can be called from a PR as well and it
works in the same way as in an issue, this makes that more clear to the
user.