### PR TITLE
Enable periodic tests on the Kubeflow 0-4 branch.

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -1,5 +1,20 @@
 periodics:
-- name: kubeflow-periodic-release-branch
+- name: kubeflow-periodic-0-4-branch
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.4-branch
+- name: kubeflow-periodic-0-3-branch
   interval: 8h
   labels:
     preset-service-account: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2310,8 +2310,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new-parallel
 - name: ci-kubernetes-multicluster-ingress-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-multicluster-ingress-test
-- name: kubeflow-periodic-release-branch
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic-release-branch
+- name: kubeflow-periodic-0-4-branch
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic-0-4-branch
+- name: kubeflow-periodic-0-3-branch
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic-0-3-branch
 - name: kubeflow-periodic-master
   gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic-master
 - name: kubeflow-presubmit
@@ -5498,9 +5500,12 @@ dashboards:
 
 - name: sig-big-data
   dashboard_tab:
-  - name: kubeflow-periodic-release-branch
-    description: Periodic testing of Kubeflow on the latest release branch.
-    test_group_name: kubeflow-periodic-release-branch
+  - name: kubeflow-periodic-0-4-branch
+    description: Periodic testing of Kubeflow on the 0-4 release branch.
+    test_group_name: kubeflow-periodic-0-3-branch
+  - name: kubeflow-periodic-0-3-branch
+    description: Periodic testing of Kubeflow on the 0-3 release branch.
+    test_group_name: kubeflow-periodic-0-3-branch
   - name: kubeflow-periodic-master
     description: Periodic testing of Kubeflow on the latest master branch.
     test_group_name: kubeflow-periodic-master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5502,7 +5502,7 @@ dashboards:
   dashboard_tab:
   - name: kubeflow-periodic-0-4-branch
     description: Periodic testing of Kubeflow on the 0-4 release branch.
-    test_group_name: kubeflow-periodic-0-3-branch
+    test_group_name: kubeflow-periodic-0-4-branch
   - name: kubeflow-periodic-0-3-branch
     description: Periodic testing of Kubeflow on the 0-3 release branch.
     test_group_name: kubeflow-periodic-0-3-branch


### PR DESCRIPTION
* Rename the existing test to 0-3; we want to keep running the periodic
  tests on older releases to ensure they don't break.

* Define separate testgrid databases for each branch.

Related to kubeflow/kubeflow#2098