### PR TITLE
Stop the bleeding for GKE scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -377,7 +377,8 @@ periodics:
       - --
       - --cluster=gke-scale-cluster
       - --deployment=gke
-      - --extract=ci/latest
+      # TODO(wojtek-t): get rid of this once GKE is fixed in master
+      - --extract=ci/latest-1.13
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=kubernetes-scale
@@ -413,7 +414,8 @@ periodics:
       - --
       - --cluster=gke-regional-cluster
       - --deployment=gke
-      - --extract=ci/latest
+      # TODO(wojtek-t): get rid of this once GKE is fixed in master
+      - --extract=ci/latest-1.13
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=kubernetes-scale
@@ -447,7 +449,8 @@ periodics:
       - --
       - --cluster=gke-scale-cluster
       - --deployment=gke
-      - --extract=ci/latest
+      # TODO(wojtek-t): get rid of this once GKE is fixed in master
+      - --extract=ci/latest-1.13
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=kubernetes-scale


### PR DESCRIPTION
Creating large GKE clusters is temporarily broken for k8s master branch (1.14).
To stop th bleeding, use 1.13 release.

This should be reverted once GKE is fixed.