### PR TITLE
Enable tide for cloud-provider-sample

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -343,6 +343,7 @@ tide:
     - kubernetes/cloud-provider-azure
     - kubernetes/cloud-provider-gcp
     - kubernetes/cloud-provider-openstack
+    - kubernetes/cloud-provider-sample
     - kubernetes/cloud-provider-vsphere
     - kubernetes/cluster-registry
     - kubernetes/community


### PR DESCRIPTION
cloud-provider-sample is a new repo in the Kubernetes org: https://github.com/kubernetes/org/issues/314.

This is required for https://github.com/kubernetes/cloud-provider-sample/pull/1 to merge.

/cc @cblecker @spiffxp 
