### PR TITLE
Add custom fields to the CRD definition for better admin UX

### DIFF
--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -48,3 +48,36 @@ spec:
                   - "aborted"
           - required:
             - completionTime
+  additionalPrinterColumns:
+  - name: Job
+    type: string
+    description: The name of the job being run.
+    JSONPath: .spec.job
+  - name: BuildId
+    type: string
+    description: The ID of the job being run.
+    JSONPath: .status.build_id
+  - name: Type
+    type: string
+    description: The type of job being run.
+    JSONPath: .spec.type
+  - name: Org
+    type: string
+    description: The org for which the job is running.
+    JSONPath: .spec.refs.org
+  - name: Repo
+    type: string
+    description: The repo for which the job is running.
+    JSONPath: .spec.refs.repo
+  - name: Pulls
+    type: string
+    description: The pulls for which the job is running.
+    JSONPath: ".spec.refs.pulls[*].number"
+  - name: StartTime
+    type: date
+    description: When the job started running.
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    description: When the job finished running.
+    JSONPath: .status.completionTime


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Example:

```
$ kubectl get prowjobs --selector prow.k8s.io/type=presubmit | head -n 5
NAME                                   JOB                                                                               BUILDID               TYPE        ORG                  REPO                                       PULLS     STARTTIME   COMPLETIONTIME
03cb700a-0e9a-11e9-a792-0a58ac104abf   pull-ci-openshift-openshift-ansible-3.11-gcp-major-upgrade                        791                   presubmit   openshift            openshift-ansible                          10934     1h          32m
03ce7d1c-0e9a-11e9-a792-0a58ac104abf   pull-ci-openshift-openshift-ansible-release-3.11-e2e-aws                          637                   presubmit   openshift            openshift-ansible                          10934     1h          1h
03cfce29-0e9a-11e9-a792-0a58ac104abf   pull-ci-openshift-openshift-ansible-release-3.11-e2e-gcp                          815                   presubmit   openshift            openshift-ansible                          10934     1h          56m
03d0fc61-0e9a-11e9-a792-0a58ac104abf   pull-ci-openshift-openshift-ansible-release-3.11-images                           488                   presubmit   openshift            openshift-ansible                          10934     1h          1h
```

Fixes https://github.com/kubernetes/test-infra/issues/10564
/assign @jglick @cjwagner @fejta 
/cc @BenTheElder 
/kind enhancement