### PR TITLE
Fix org queries being ignored in PR dashboard.

### DIFF
--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -67,7 +67,7 @@ class TideQuery {
         const isMatched =
             (this.repos && this.repos.indexOf(pr.Repository.NameWithOwner) !== -1) ||
             ((this.orgs && this.orgs.indexOf(pr.Repository.Owner.Login) !== -1) &&
-            (this.excludedRepos && this.excludedRepos.indexOf(pr.Repository.NameWithOwner) === -1));
+            (!this.excludedRepos || this.excludedRepos.indexOf(pr.Repository.NameWithOwner) === -1));
 
         if (!isMatched) {
             return false;


### PR DESCRIPTION
A logic error in the PR dashboard's handling of excluded repos caused Tide queries that exclude no repos to be considered to never match any org. Fix the error.

Reason #n+1 that this stuff should have some unit tests.

Fixes #10574.
/cc @cjwagner 
/kind bug