### PR TITLE
Make the Prow autobump job run at 7:05am PST Mon-Fri instead every day around 6pm.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -93,7 +93,7 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
-- interval: 24h
+- cron: "05 15 * * 1-5"  # Run at 7:05 PST (15:05 UTC) Mon-Fri
   name: ci-test-infra-autobump-prow
   cluster: test-infra-trusted
   decorate: true


### PR DESCRIPTION
This may be an unpopular opinion, but I'm not a fan of deploying Prow at 6pm or on weekend 😃 

/cc @fejta @krzyzacy @BenTheElder @stevekuznetsov 
/area prow