### PR TITLE
Job is tested successfully, remove skip_report

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -45,7 +45,6 @@ presubmits:
   - name: pull-sig-storage-local-static-provisioner-e2e
     always_run: true
     decorate: true
-    skip_report: true # Remove it after job is tested successfully.
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"


### PR DESCRIPTION
`pull-sig-storage-local-static-provisioner-e2e` succeeds now, see https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_sig-storage-local-static-provisioner/21/pull-sig-storage-local-static-provisioner-e2e/3 and https://prow.k8s.io/?job=pull-sig-storage-local-static-provisioner-e2e.