### PR TITLE
Remove duplicate key in pull-test-infra-verify-config

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -104,7 +104,6 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-experimental
-        args:
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The `args` key is present twice. This works now because the last key wins, but we should remove the first one to have syntactically correct yaml.

/assign @krzyzacy 
/kind cleanup
/shrug