### PR TITLE
Changed the type of `timeout` and `grace_period` in `decoration_config`

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -20,7 +20,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/release
   decoration_config:
-    timeout: 10800000000000 # 3 hours
+    timeout: 3h
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
@@ -79,7 +79,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/release
   decoration_config:
-    timeout: 10800000000000 # 3 hours
+    timeout: 3h
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -140,7 +140,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   decorate: true
   decoration_config:
-    timeout: 14000000000000 # 140m
+    timeout: 233m
   spec:
     containers:
     - command:
@@ -193,7 +193,7 @@ periodics:
     preset-aws-credential: "true"
   decorate: true
   decoration_config:
-    timeout: 14000000000000 # 140m
+    timeout: 233m
   spec:
     containers:
     - command:
@@ -222,7 +222,7 @@ periodics:
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 14000000000000 # 140m
+    timeout: 233m
   spec:
     containers:
     - command:
@@ -281,7 +281,7 @@ periodics:
     preset-e2e-kubemark-common: "true"
   decorate: true
   decoration_config:
-    timeout: 26000000000000 # 260m
+    timeout: 433m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -30,6 +30,23 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *Jan 3, 2019* To unify the UX, the type of `timeout` and `grace_period`
+   in `decoration_config` has changed from `time.Duration` to `string`, e.g. from
+    ```yaml
+    - name: job-foo
+      decorate: true
+      decoration_config:
+        timeout: 1
+        grace_period: 1
+    ```
+    to
+    ```yaml
+    - name: job-foo
+      decorate: true
+      decoration_config:
+        timeout: 1ns
+        grace_period: 1ns
+    ```
  - *November 29, 2018* `plank` will no longer default jobs with `decorate: true`
    to have `automountServiceAccountToken: false` in their PodSpec if unset, if the
    job explicitly sets `serviceAccountName`

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4,8 +4,8 @@ plank:
   job_url_prefix: https://gubernator.k8s.io/build/
   pod_pending_timeout: 60m
   default_decoration_config:
-    timeout: 7200000000000 # 2h
-    grace_period: 15000000000 # 15s
+    timeout: 2h
+    grace_period: 15s
     utility_images:
       clonerefs: "gcr.io/k8s-prow/clonerefs:v20181220-899fabe"
       initupload: "gcr.io/k8s-prow/initupload:v20181220-899fabe"

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -727,6 +727,16 @@ func parseProwConfig(c *Config) error {
 		return fmt.Errorf("validating plank config: %v", err)
 	}
 
+	if c.Plank.DefaultDecorationConfig != nil {
+		c.Plank.DefaultDecorationConfig.CompileDurations()
+	}
+
+	for _, p := range c.Periodics {
+		if p.DecorationConfig != nil {
+			p.DecorationConfig.CompileDurations()
+		}
+	}
+
 	if c.Plank.PodPendingTimeoutString == "" {
 		c.Plank.PodPendingTimeout = 24 * time.Hour
 	} else {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -287,7 +287,7 @@ type Branding struct {
 	HeaderColor string `json:"header_color,omitempty"`
 }
 
-// PubSubSubscriptions maps GCP projects to a list of Topics.
+// PubsubSubscriptions maps GCP projects to a list of Topics.
 type PubsubSubscriptions map[string][]string
 
 // Load loads and parses the config at path.

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -298,8 +298,8 @@ periodics:
 			rawConfig: `
 plank:
   default_decoration_config:
-    timeout: 7200000000000 # 2h
-    grace_period: 15000000000 # 15s
+    timeout: 2h
+    grace_period: 15s
     utility_images:
       clonerefs: "clonerefs:default"
       initupload: "initupload:default"
@@ -324,8 +324,10 @@ periodics:
       - "test"
       - "./..."`,
 			expected: &kube.DecorationConfig{
-				Timeout:     2 * time.Hour,
-				GracePeriod: 15 * time.Second,
+				TimeoutString:     "2h",
+				Timeout:           2 * time.Hour,
+				GracePeriodString: "15s",
+				GracePeriod:       15 * time.Second,
 				UtilityImages: &kube.UtilityImages{
 					CloneRefs:  "clonerefs:default",
 					InitUpload: "initupload:default",
@@ -346,8 +348,8 @@ periodics:
 			rawConfig: `
 plank:
   default_decoration_config:
-    timeout: 7200000000000 # 2h
-    grace_period: 15000000000 # 15s
+    timeout: 2h
+    grace_period: 15s
     utility_images:
       clonerefs: "clonerefs:default"
       initupload: "initupload:default"
@@ -366,8 +368,8 @@ periodics:
   always_run: true
   decorate: true
   decoration_config:
-    timeout: 1
-    grace_period: 1
+    timeout: 1ns
+    grace_period: 1ns
     utility_images:
       clonerefs: "clonerefs:explicit"
       initupload: "initupload:explicit"
@@ -384,8 +386,10 @@ periodics:
       - "test"
       - "./..."`,
 			expected: &kube.DecorationConfig{
-				Timeout:     1 * time.Nanosecond,
-				GracePeriod: 1 * time.Nanosecond,
+				TimeoutString:     "1ns",
+				GracePeriodString: "1ns",
+				Timeout:           1 * time.Nanosecond,
+				GracePeriod:       1 * time.Nanosecond,
 				UtilityImages: &kube.UtilityImages{
 					CloneRefs:  "clonerefs:explicit",
 					InitUpload: "initupload:explicit",

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -23,8 +23,8 @@ spec:
       default_repo: kubernetes
       path_strategy: legacy
     gcs_credentials_secret: default-service-account
-    grace_period: 15000000000
-    timeout: 7200000000000
+    grace_period: 15s
+    timeout: 2h
     utility_images:
       clonerefs: clonerefs:default
       entrypoint: entrypoint:default

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -23,8 +23,8 @@ spec:
       default_repo: kubernetes
       path_strategy: explicit
     gcs_credentials_secret: explicit-service-account
-    grace_period: 1
-    timeout: 1
+    grace_period: 1ns
+    timeout: 1ns
     utility_images:
       clonerefs: clonerefs:explicit
       entrypoint: entrypoint:explicit

--- a/prow/test/data/test-config.yaml
+++ b/prow/test/data/test-config.yaml
@@ -1,7 +1,7 @@
 plank:
   default_decoration_config:
-    timeout: 7200000000000 # 2h
-    grace_period: 15000000000 # 15s
+    timeout: 2h
+    grace_period: 15s
     utility_images:
       clonerefs: "clonerefs:default"
       initupload: "initupload:default"
@@ -36,8 +36,8 @@ presubmits:
     always_run: true
     decorate: true
     decoration_config:
-      timeout: 1
-      grace_period: 1
+      timeout: 1ns
+      grace_period: 1ns
       utility_images:
         clonerefs: "clonerefs:explicit"
         initupload: "initupload:explicit"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/10470

To unify the UX, the type of these two fields has been changed from `time.Duration` to `string`, this change includes

- implementation
- test cases
- existing jobs
- changelog