### PR TITLE
Add / update a bunch of OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
 - amwat
 - BenTheElder
@@ -11,3 +13,6 @@ approvers:
 - shyamjvs
 - spiffxp
 - stevekuznetsov
+
+labels:
+- sig/testing

--- a/boskos/OWNERS
+++ b/boskos/OWNERS
@@ -3,5 +3,6 @@
 approvers:
 - krzyzacy
 - sebastienvas
+
 labels:
 - area/boskos

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,8 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- BenTheElder
-- ixdy
+- cblecker
+- mithrav
+- spiffxp
 
-labels:
-- area/planter

--- a/gopherage/OWNERS
+++ b/gopherage/OWNERS
@@ -1,4 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
 - Katharine
+- spiffxp
+
 labels:
 - area/gopherage

--- a/greenhouse/OWNERS
+++ b/greenhouse/OWNERS
@@ -2,5 +2,7 @@
 
 approvers:
 - BenTheElder
+- ixdy
+
 labels:
 - area/greenhouse

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,10 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- bentheelder
+- ixdy
+- krzyzacy
 
 labels:
-- area/gubernator
+- area/images

--- a/jenkins/OWNERS
+++ b/jenkins/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- bentheelder
+- cjwagner
+- fejta
+- krzyzacy
 
 labels:
-- area/gubernator
+- area/jenkins

--- a/kettle/OWNERS
+++ b/kettle/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
 - Katharine
-- rmmh
-- stevekuznetsov
+- spiffxp
 
 labels:
-- area/gubernator
+- area/kettle

--- a/kubetest/OWNERS
+++ b/kubetest/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- BenTheElder
+- krzyzacy
 
 labels:
-- area/gubernator
+- area/kubetest

--- a/metrics/OWNERS
+++ b/metrics/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- cjwagner
+- spiffxp
 
 labels:
-- area/gubernator
+- area/metrics

--- a/prow/pod-utils/OWNERS
+++ b/prow/pod-utils/OWNERS
@@ -1,4 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
+- cjwagner
 - stevekuznetsov
+
 labels:
  - area/prow/pod-utilities

--- a/prow/pod-utils/clone/OWNERS
+++ b/prow/pod-utils/clone/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/pod-utils/decorate/OWNERS
+++ b/prow/pod-utils/decorate/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/pod-utils/downwardapi/OWNERS
+++ b/prow/pod-utils/downwardapi/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/pod-utils/gcs/OWNERS
+++ b/prow/pod-utils/gcs/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/pod-utils/options/OWNERS
+++ b/prow/pod-utils/options/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/pod-utils/wrapper/OWNERS
+++ b/prow/pod-utils/wrapper/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-- stevekuznetsov

--- a/prow/test/OWNERS
+++ b/prow/test/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- cjwagner
-- spxtr
-- stevekuznetsov

--- a/robots/OWNERS
+++ b/robots/OWNERS
@@ -1,10 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
+- cjwagner
+- fejta
 - stevekuznetsov
 
 labels:
-- area/gubernator
+- area/robots

--- a/scenarios/OWNERS
+++ b/scenarios/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- bentheelder
+- cjwagner
+- fejta
+- krzyzacy
 
 labels:
-- area/gubernator
+- area/scenarios

--- a/triage/OWNERS
+++ b/triage/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
 - Katharine
-- rmmh
-- stevekuznetsov
+- spiffxp
 
 labels:
-- area/gubernator
+- area/triage

--- a/velodrome/OWNERS
+++ b/velodrome/OWNERS
@@ -1,10 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ibzib
-- Katharine
-- rmmh
-- stevekuznetsov
+- cjwagner
+- krzyzacy
+- spiffxp
 
 labels:
-- area/gubernator
+- area/velodrome


### PR DESCRIPTION
Let's have less PRs hit the root OWNERS file

If it's important enough to merit its own github label, it's important enough
to have at least two people who can /approve its changes

Also I'm very sorry to the jenkins/ and scenarios/ OWNERS, those all seem
tied up with rewriting kubetest, moving away from bootstrap, and making
pod-utils nicer, so that's the list I ended up with.