### PR TITLE
Add labels in github template metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug encountered with test-infra
+labels: kind/bug
 
 ---
 
@@ -16,6 +17,3 @@ about: Report a bug encountered with test-infra
 **Please provide links to example occurrences, if any**:
 
 **Anything else we need to know?**:
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind bug

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,7 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to the test-infra tooling
+labels: kind/feature
 
 ---
 <!-- Please only use this template for submitting enhancement requests -->
@@ -8,6 +9,3 @@ about: Suggest an enhancement to the test-infra tooling
 **What would you like to be added**:
 
 **Why is this needed**:
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind feature


### PR DESCRIPTION
GitHub now allows you to specify labels by default as a part of the template. This PR updates our templates to use this.

Ref: https://help.github.com/articles/creating-issue-templates-for-your-repository/

Similar PR for kubernetes/org: https://github.com/kubernetes/org/pull/329

/assign @cblecker @spiffxp 