### PR TITLE
Create postsubmit job for kops build

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -320,3 +320,34 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+
+postsubmits:
+  kubernetes/kops:
+  - name: kops-postsubmit
+    branches:
+    - master
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-experimental
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--timeout=60"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--" # end bootstrap args, scenario args below
+        - "make"
+        - "prow-postsubmit"
+        - "UPLOAD_DEST=gs://kubernetes-release-dev/kops/ci"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "2Gi"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2232,6 +2232,8 @@ test_groups:
   - configuration_value: node_os_image
   - configuration_value: Commit
   - configuration_value: infra-commit
+- name: kops-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/kops-postsubmit
 - name: ci-kubernetes-e2e-kops-aws-channelalpha
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-channelalpha
 - name: ci-kubernetes-e2e-kops-aws-ena-nvme
@@ -7498,6 +7500,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
   - name: kops-gce-ha
     test_group_name: ci-kubernetes-e2e-kops-gce-ha
+  - name: kops-postsubmit
+    test_group_name: kops-postsubmit
 
 # Gardener Dashboard
 - name: conformance-gardener


### PR DESCRIPTION
This runs a postsubmit makefile target in kops, which is responsible
for uploading a version that we could potentially release.

Part of the work to automate kops release publishing.