### PR TITLE
Add area/deflake label to repos

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -157,6 +157,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="kind/kep" href="#kind/kep">`kind/kep`</a> | Categorizes issues related to KEPs and PRs modifying the KEP directory| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes/enhancements, for both issues and PRs
@@ -170,6 +171,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues
 
@@ -199,6 +201,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/boskos" href="#area/boskos">`area/boskos`</a> | Issues or PRs related to code in /boskos| label | |
 | <a id="area/config" href="#area/config">`area/config`</a> | Issues or PRs related to code in /config| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/ghproxy" href="#area/ghproxy">`area/ghproxy`</a> | Issues or PRs related to code in /ghproxy| label | |
 | <a id="area/gopherage" href="#area/gopherage">`area/gopherage`</a> | Issues or PRs related to code in /gopherage| humans | |
 | <a id="area/greenhouse" href="#area/greenhouse">`area/greenhouse`</a> | Issues or PRs related to code in /greenhouse (our remote bazel cache)| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -632,6 +632,11 @@ repos:
         name: area/conformance
         target: both
         addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to deflaking kubernetes tests
+        name: area/deflake
+        target: both
+        addedBy: label
       - color: cc99ff
         description: Categorizes issues related to KEPs and PRs modifying the KEP directory
         name: kind/kep
@@ -661,6 +666,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to kubernetes conformance tests
         name: area/conformance
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to deflaking kubernetes tests
+        name: area/deflake
         target: both
         addedBy: label
       - color: ededed
@@ -701,6 +711,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to kubernetes conformance tests
         name: area/conformance
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to deflaking kubernetes tests
+        name: area/deflake
         target: both
         addedBy: label
       - color: 0052cc

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -28,6 +28,11 @@
     color: #ffffff;
 }
 
+.areax00002fdeflake {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fghproxy {
     background-color: #0052cc;
     color: #ffffff;


### PR DESCRIPTION
I'd like to be able to group / triage issues related to deflaking
kubernetes tests across a couple of repos. If there is sufficient
interested to staff this effort, I would rather convert this to a
wg/ label but let's start here just so I have something to query

/sig testing
/sig release

FYI @mariantalla