### PR TITLE
Move the deck readme link from the header logo to the sidebar

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -38,6 +38,7 @@
         <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
       {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
+      <a class="mdl-navigation__link" href="https://github.com/kubernetes/test-infra/blob/master/prow/README.md">Documentation</a>
     </nav>
   </div>
   <div id="loading-progress" class="mdl-progress mdl-js-progress mdl-progress__indeterminate hidden"></div>

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -21,7 +21,7 @@
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
   <header class="mdl-layout__header"{{if branding.HeaderColor}} style="background-color: {{branding.HeaderColor}};"{{end}}>
     <div class="mdl-layout__header-row">
-      <a href="https://github.com/kubernetes/test-infra/tree/master/prow#prow"
+      <a href="/"
          class="logo"><img src="/static/{{or branding.Logo "logo.svg"}}" alt="kubernetes logo" class="logo"/></a>
       <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
     </div>


### PR DESCRIPTION
The logo in the header of basically anything goes back to the homepage (try clicking the octocat in to the top left here, for instance). Prow doesn't do this, instead leaving the site entirely to point to a readme that is almost certainly not what you wanted to get to.

Conform to the universal standard by changing where the logo link goes, and put the readme link in the sidebar.

because I can imagine this being plausibly controversial:
/hold