### PR TITLE
Show the running test-infra commit on the deck UI

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/deck",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/cmd/deck/version:go_default_library",
         "//prow/config:go_default_library",
         "//prow/deck/jobs:go_default_library",
         "//prow/gcsupload:go_default_library",
@@ -128,6 +129,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//prow/cmd/deck/static:all-srcs",
+        "//prow/cmd/deck/version:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -6,6 +6,15 @@ body {
     font-size: 16px !important;
 }
 
+.mdl-layout__drawer footer {
+    text-align: center;
+    color: darkgray;
+    position: absolute;
+    bottom: 10px;
+    width: 100%;
+    font-size: small;
+}
+
 code {
     background-color: #EEEEEE;
     border-radius: 3px;

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -39,6 +39,9 @@
       {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
     </nav>
+    <footer>
+      {{deckVersion}}
+    </footer>
   </div>
   <div id="loading-progress" class="mdl-progress mdl-js-progress mdl-progress__indeterminate hidden"></div>
   <main class="mdl-layout__content">

--- a/prow/cmd/deck/templates.go
+++ b/prow/cmd/deck/templates.go
@@ -19,6 +19,7 @@ package main
 import (
 	"github.com/sirupsen/logrus"
 	"html/template"
+	"k8s.io/test-infra/prow/cmd/deck/version"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/deck/jobs"
 	"net/http"
@@ -66,6 +67,7 @@ func prepareBaseTemplate(o options, ca jobs.ConfigAgent, t *template.Template) (
 		"sections":         getConcreteSectionFunction(o),
 		"mobileFriendly":   func() bool { return true },
 		"mobileUnfriendly": func() bool { return false },
+		"deckVersion":      func() string { return version.Version },
 	}).ParseFiles(path.Join(o.templateFilesLocation, "base.html"))
 }
 

--- a/prow/cmd/deck/version/BUILD.bazel
+++ b/prow/cmd/deck/version/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["version.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/deck/version",
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "Version": "{STABLE_BUILD_GIT_COMMIT}",
+    },
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/deck/version/version.go
+++ b/prow/cmd/deck/version/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// This is filled in by bazel at link time. If bazel is not used, it will be empty.
+var Version string


### PR DESCRIPTION
This is relatively frequently something I would like to know.

No idea if this is the right way to go about this sort of thing, but it appears to work. Appears at the bottom of the drawer like this:

![image](https://user-images.githubusercontent.com/110792/50718648-a5fbab80-1046-11e9-918b-201854dd9d31.png)

/cc @ixdy @ibzib 