### PR TITLE
Prevent blunderbuss from requesting reviews from authors with uppercase.

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -171,7 +171,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, reviewerCount,
 }
 
 func getReviewers(rc reviewersClient, author string, files []github.PullRequestChange, minReviewers int) ([]string, []string, error) {
-	authorSet := sets.NewString(author)
+	authorSet := sets.NewString(github.NormLogin(author))
 	reviewers := sets.NewString()
 	requiredReviewers := sets.NewString()
 	leafReviewers := sets.NewString()
@@ -260,7 +260,7 @@ func getPotentialReviewers(owners ownersClient, author string, files []github.Pu
 		}
 
 		for _, owner := range fileOwners.List() {
-			if owner == author {
+			if owner == github.NormLogin(author) {
 				continue
 			}
 			potentialReviewers[owner] = potentialReviewers[owner] + fileWeight

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -122,6 +122,7 @@ var (
 
 		"e.go":  sets.NewString("erick", "evan"),
 		"ee.go": sets.NewString("erick", "evan"),
+		"f.go":  sets.NewString("author", "non-author"),
 	}
 	requiredReviewers = map[string]sets.String{
 		"a.go": sets.NewString("ben"),
@@ -136,6 +137,7 @@ var (
 
 		"e.go":  sets.NewString("erick", "ellen"),
 		"ee.go": sets.NewString("erick", "ellen"),
+		"f.go":  sets.NewString("author"),
 	}
 	testcases = []struct {
 		name                       string
@@ -209,6 +211,12 @@ var (
 			expectedRequested:          []string{"alice", "ben"},
 			alternateExpectedRequested: []string{"ben", "bob"},
 		},
+		{
+			name:              "exclude author",
+			filesChanged:      []string{"f.go"},
+			reviewerCount:     1,
+			expectedRequested: []string{"non-author"},
+		},
 	}
 )
 
@@ -227,7 +235,7 @@ func TestHandleWithExcludeApproversOnlyReviewers(t *testing.T) {
 		fghc := newFakeGithubClient(tc.filesChanged)
 		pre := &github.PullRequestEvent{
 			Number:      5,
-			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
+			PullRequest: github.PullRequest{User: github.User{Login: "AUTHOR"}},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
 		if err := handle(fghc, foc, logrus.WithField("plugin", PluginName), &tc.reviewerCount, nil, tc.maxReviewerCount, true, pre); err != nil {
@@ -266,7 +274,7 @@ func TestHandleWithoutExcludeApproversNoReviewers(t *testing.T) {
 		fghc := newFakeGithubClient(tc.filesChanged)
 		pre := &github.PullRequestEvent{
 			Number:      5,
-			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
+			PullRequest: github.PullRequest{User: github.User{Login: "AUTHOR"}},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
 		if err := handle(fghc, foc, logrus.WithField("plugin", PluginName), &tc.reviewerCount, nil, tc.maxReviewerCount, false, pre); err != nil {
@@ -413,12 +421,14 @@ func TestHandleOld(t *testing.T) {
 			"c.go": sets.NewString("charles"),
 			"d.go": sets.NewString("dan"),
 			"e.go": sets.NewString("erick", "evan"),
+			"f.go": sets.NewString("author", "non-author"),
 		},
 		leafReviewers: map[string]sets.String{
 			"a.go": sets.NewString("alice"),
 			"b.go": sets.NewString("bob"),
 			"c.go": sets.NewString("cole", "carl", "chad"),
 			"e.go": sets.NewString("erick"),
+			"f.go": sets.NewString("author"),
 		},
 	}
 
@@ -470,12 +480,18 @@ func TestHandleOld(t *testing.T) {
 			reviewerCount:     2,
 			expectedRequested: []string{"erick", "evan"},
 		},
+		{
+			name:              "exclude author",
+			filesChanged:      []string{"f.go"},
+			reviewerCount:     1,
+			expectedRequested: []string{"non-author"},
+		},
 	}
 	for _, tc := range testcases {
 		fghc := newFakeGithubClient(tc.filesChanged)
 		pre := &github.PullRequestEvent{
 			Number:      5,
-			PullRequest: github.PullRequest{User: github.User{Login: "author"}},
+			PullRequest: github.PullRequest{User: github.User{Login: "AUTHOR"}},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}
 		if err := handle(fghc, foc, logrus.WithField("plugin", PluginName), nil, &tc.reviewerCount, 0, false, pre); err != nil {


### PR DESCRIPTION
```
  author:  "M00nF1sh"   
  error:  "could not request a PR review from the following user(s): m00nf1sh."   
```

Blunderbuss filters out the PR author when auto-requesting reviews, but fails to normalize the author's name first meaning that users with uppercases in their user names can still be requested even if they are the author.

/kind bug
/cc @ibzib @krzyzacy @stevekuznetsov 