### PR TITLE
Allow config-bootstrapper to work out of cluster

### DIFF
--- a/prow/cmd/config-bootstrapper/BUILD.bazel
+++ b/prow/cmd/config-bootstrapper/BUILD.bazel
@@ -10,10 +10,18 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/updateconfig:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
 


### PR DESCRIPTION
In order to allow the config bootstrapper to work with out-of-cluster
configuration, the upstream client is used and an adapter shim allows
for no downstream changes.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 
/cc @fejta 

I may use a similar shim approach to get us through the client transitions for the rest of the codebase as we move away from the hand-written k8s client.