### PR TITLE
Spyglass: Do not consider EOF on gcs files an error

### DIFF
--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -196,12 +197,12 @@ func logLinesAll(artifact lenses.Artifact) ([]string, error) {
 func logLines(artifact lenses.Artifact, offset, length int64) ([]string, error) {
 	b := make([]byte, length)
 	_, err := artifact.ReadAt(b, offset)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		if err != lenses.ErrGzipOffsetRead {
 			return nil, fmt.Errorf("couldn't read requested bytes: %v", err)
 		}
 		moreBytes, err := artifact.ReadAtMost(offset + length)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return nil, fmt.Errorf("couldn't handle reading gzipped file: %v", err)
 		}
 		b = moreBytes[offset:]


### PR DESCRIPTION
This surfaced on a spyglass GCS view where clicking on `Show all hidden lines` works perfectly fine but clicking on `Show 904 hidden lines` results in a `failed to retrieve log lines: couldn't read requested bytes: EOF`

/assign @Katharine 

CC @nikhita 