### PR TITLE
Allow status migration to filter on target branch

### DIFF
--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -35,6 +37,8 @@ type options struct {
 	descriptionURL                                       string
 	continueOnError, dryRun                              bool
 	github                                               prowflagutil.GitHubOptions
+	branchFilterRaw                                      string
+	branchFilter                                         *regexp.Regexp
 }
 
 func gatherOptions() options {
@@ -51,6 +55,8 @@ func gatherOptions() options {
 	fs.StringVar(&o.retireContext, "retire", "", "Indicates retire mode and specifies the context to retire.")
 	fs.StringVar(&o.destContext, "dest", "", "The destination context to copy or move to. For retire mode this is the context that replaced the retired context.")
 	fs.StringVar(&o.descriptionURL, "description", "", "A URL to a page explaining why a context was migrated or retired. (Optional)")
+
+	fs.StringVar(&o.branchFilterRaw, "branch-filter", "", "A regular expression which the PR target branch must match to be modified. (Optional)")
 
 	o.github.AddFlags(fs)
 	fs.Parse(os.Args[1:])
@@ -90,6 +96,13 @@ func (o *options) Validate() error {
 	if err := o.github.Validate(o.dryRun); err != nil {
 		return err
 	}
+
+	expr, err := regexp.Compile(o.branchFilterRaw)
+	if err != nil {
+		return fmt.Errorf("invalid --branch-filter regular expression: %v", err)
+	}
+	o.branchFilter = expr
+
 	return nil
 }
 
@@ -128,7 +141,7 @@ func main() {
 
 	// Note that continueOnError is false by default so that errors can be addressed when they occur
 	// instead of blindly continuing to the next PR, possibly continuing to error.
-	m := migrator.New(*mode, githubClient, o.org, o.repo, o.continueOnError)
+	m := migrator.New(*mode, githubClient, o.org, o.repo, o.branchFilter.MatchString, o.continueOnError)
 	if err := m.Migrate(); err != nil {
 		logrus.WithError(err).Fatal("Error during status migration")
 	}

--- a/maintenance/migratestatus/migrator/BUILD.bazel
+++ b/maintenance/migratestatus/migrator/BUILD.bazel
@@ -10,7 +10,10 @@ go_test(
     name = "go_default_test",
     srcs = ["migrator_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/github:go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+    ],
 )
 
 go_library(

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -447,7 +447,7 @@ type fakeMigrator struct {
 	migrated map[orgRepo]migrationSet
 }
 
-func (m *fakeMigrator) retire(org, repo, context string) error {
+func (m *fakeMigrator) retire(org, repo, context string, targetBranchFilter func(string) bool) error {
 	key := orgRepo{org: org, repo: repo}
 	if contexts, exist := m.retireErrors[key]; exist && contexts.Has(context) {
 		return errors.New("failed to retire context")
@@ -460,7 +460,7 @@ func (m *fakeMigrator) retire(org, repo, context string) error {
 	return nil
 }
 
-func (m *fakeMigrator) migrate(org, repo, from, to string) error {
+func (m *fakeMigrator) migrate(org, repo, from, to string, targetBranchFilter func(string) bool) error {
 	key := orgRepo{org: org, repo: repo}
 	item := migration{from: from, to: to}
 	if contexts, exist := m.migrateErrors[key]; exist && contexts.has(item) {


### PR DESCRIPTION
When a status is being migrated, more often than not this is due to a
specific change in a specific presubmit. As presubmits provide statuses
only to a specific subset of branches, migration of a status across all
branches indiscriminately is not the correct behavior.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
/cc @cjwagner @BenTheElder 