### PR TITLE
Deck: fix gerrit links

### DIFF
--- a/prow/cmd/deck/static/api/prow.ts
+++ b/prow/cmd/deck/static/api/prow.ts
@@ -1,5 +1,6 @@
 export type JobType = "presubmit" | "postsubmit" | "batch" | "periodic";
 export type JobState = "triggered" | "pending" | "success" | "failure" | "aborted" | "error" | "unknown" | "";
+export type HostType = "github" | "gerrit" | "";
 
 export interface Job {
   type: JobType;
@@ -22,4 +23,7 @@ export interface Job {
   pod_name: string;
   agent: string;
   prow_job: string;
+  host_type: HostType;
+  code_host: string;
+  review_host: string;
 }

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -89,18 +89,21 @@ export namespace cell {
 		}
 	};
 
-	export function commitRevision(repo: string, ref: string, SHA: string): HTMLTableDataCellElement {
+	export function commitRevision(repo: string, ref: string, SHA: string, hostType: string, codeHost: string): HTMLTableDataCellElement {
 		const c = document.createElement("td");
 		const bl = document.createElement("a");
 		bl.href = "https://github.com/" + repo + "/commit/" + SHA;
+		if (hostType === "gerrit") {
+			bl.href = codeHost + "/" + repo + "/+/" + SHA;
+		}
 		bl.text = ref + " (" + SHA.slice(0, 7) + ")";
 		c.appendChild(bl);
 		return c;
 	}
 
-	export function prRevision(repo: string, num: number, author: string, title: string, SHA: string): HTMLTableDataCellElement {
+	export function prRevision(repo: string, num: number, author: string, title: string, SHA: string, hostType: string, codeHost: string, reviewHost: string): HTMLTableDataCellElement {
 		const td = document.createElement("td");
-		addPRRevision(td, repo, num, author, title, SHA);
+		addPRRevision(td, repo, num, author, title, SHA, hostType, codeHost, reviewHost);
 		return td;
 	}
 
@@ -110,10 +113,13 @@ export namespace cell {
 	  return "tipID-" + String(idCounter);
 	};
 
-	export function addPRRevision(elem: Node, repo: string, num: number, author: string, title: string, SHA: string): void {
+	export function addPRRevision(elem: Node, repo: string, num: number, author: string, title: string, SHA: string, hostType: string, codeHost: string, reviewHost: string): void {
 		elem.appendChild(document.createTextNode("#"));
 		const pl = document.createElement("a");
 		pl.href = "https://github.com/" + repo + "/pull/" + num;
+		if (hostType === "gerrit") {
+			pl.href = reviewHost + "/c/" + repo + "/+/" + num;
+		}
 		pl.text = num.toString();
 		if (title) {
 			pl.id = "pr-" + repo + "-" + num + "-" + nextID();
@@ -126,6 +132,9 @@ export namespace cell {
 			const cl = document.createElement("a");
 			cl.href = "https://github.com/" + repo + "/pull/" + num
 					+ '/commits/' + SHA;
+			if (hostType === "gerrit") {
+				cl.href = codeHost + "/" + repo + "/+/" + SHA;
+			}
 			cl.text = SHA.slice(0, 7);
 			elem.appendChild(cl);
 			elem.appendChild(document.createTextNode(")"));
@@ -134,6 +143,9 @@ export namespace cell {
 			elem.appendChild(document.createTextNode(" by "))
 			const al = document.createElement("a");
 			al.href = "https://github.com/" + author;
+			if (hostType === "gerrit") {
+				al.href = reviewHost + "/q/" + author;
+			}		
 			al.text = author;
 			elem.appendChild(al);
 		}

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -496,15 +496,20 @@ function redraw(fz: FuzzySearch): void {
             } else if (build.repo.startsWith("http://") || build.repo.startsWith("https://") ) {
                 r.appendChild(cell.link(build.repo, build.repo));
             } else {
-                r.appendChild(cell.link(build.repo, "https://github.com/"
-                    + build.repo));
+                let link = "https://github.com/" + build.repo;
+                if (build.host_type === "gerrit") {
+                    link = build.code_host + "/" + build.repo;
+                }
+                r.appendChild(cell.link(build.repo, link));
             }
             if (build.type === "presubmit") {
-                r.appendChild(cell.prRevision(build.repo, build.number, build.author, "", build.pull_sha));
+                r.appendChild(cell.prRevision(build.repo, build.number, build.author, "", build.pull_sha,
+                    build.host_type, build.code_host, build.review_host));
             } else if (build.type === "batch") {
                 r.appendChild(batchRevisionCell(build));
             } else if (build.type === "postsubmit") {
-                r.appendChild(cell.commitRevision(build.repo, build.base_ref, build.base_sha));
+                r.appendChild(cell.commitRevision(build.repo, build.base_ref, build.base_sha,
+                    build.host_type, build.code_host));
             } else if (build.type === "periodic") {
                 r.appendChild(cell.text(""));
             }

--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -288,13 +288,13 @@ function targetCell(rec: FilteredRecord): HTMLTableDataCellElement {
       return cell.text("");
     case 1:
       let pr = target[0];
-      return cell.prRevision(rec.repo, pr.num, pr.author, pr.title, pr.SHA);
+      return cell.prRevision(rec.repo, pr.num, pr.author, pr.title, pr.SHA, "", "", "");
     default:
       // Multiple PRs in 'target'. Add them all to the cell, but on separate lines.
       let td = document.createElement("td");
       td.style.whiteSpace = "pre";
       for (const pr of target) {
-        cell.addPRRevision(td, rec.repo, pr.num, pr.author, pr.title, pr.SHA);
+        cell.addPRRevision(td, rec.repo, pr.num, pr.author, pr.title, pr.SHA, "", "", "");
         td.appendChild(document.createTextNode("\n"));
       }
       return td;

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
@@ -20,7 +21,13 @@ go_test(
     name = "go_default_test",
     srcs = ["jobs_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/kube:go_default_library"],
+    deps = [
+        "//prow/gerrit/client:go_default_library",
+        "//prow/kube:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -223,7 +223,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		Pulls: []kube.Pull{
 			{
 				Number: change.Number,
-				Author: rev.Commit.Author.Name,
+				Author: rev.Commit.Author.Email,
 				SHA:    change.CurrentRevision,
 				Ref:    rev.Ref,
 			},


### PR DESCRIPTION
Simplest possible re-implementation of #10433. Sticks to generating links in the client. Long term, a couple related issues to be addressed:
- There should probably be a better way to identify whether a Prow job was run against Github, Gerrit, etc.
- Github Enterprise links are still not supported by Deck.

/assign @stevekuznetsov @krzyzacy 