### PR TITLE
Add and run unit some gopherage typescript unit tests.

### DIFF
--- a/gopherage/cmd/html/static/BUILD.bazel
+++ b/gopherage/cmd/html/static/BUILD.bazel
@@ -1,15 +1,46 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle", "jasmine_node_test")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
-    name = "browser",
-    srcs = glob(
-        ["*.ts"],
-        exclude = ["*_test.ts"],
-    ),
+    name = "utils",
+    srcs = ["utils.ts"],
+)
+
+ts_library(
+    name = "utils_test_lib",
+    srcs = ["utils_test.ts"],
     deps = [
+        ":utils",
+        "@npm//:@types/jasmine",
+    ],
+)
+
+jasmine_node_test(
+    name = "utils_test",
+    srcs = [
+        ":utils_test_lib",
+    ],
+    deps = [
+        "@npm//:jasmine",
+    ],
+)
+
+ts_library(
+    name = "parser",
+    srcs = ["parser.ts"],
+    deps = [
+        ":utils",
+    ],
+)
+
+ts_library(
+    name = "browser",
+    srcs = ["browser.ts"],
+    deps = [
+        ":parser",
+        ":utils",
         "@npm//:@types/google.visualization",
     ],
 )
@@ -27,6 +58,13 @@ filegroup(
     srcs = [
         "browser.html",
         ":browser_bundle.es6.js",
+    ],
+)
+
+test_suite(
+    name = "unit_tests",
+    tests = [
+        ":utils_test",
     ],
 )
 

--- a/gopherage/cmd/html/static/utils_test.ts
+++ b/gopherage/cmd/html/static/utils_test.ts
@@ -1,0 +1,135 @@
+import "jasmine";
+import {enumerate, filter, map, reduce} from './utils';
+
+describe('map', () => {
+  it('should map over an array', () => {
+    expect(Array.from(map([1, 3, 5], (x) => 2 * x))).toEqual([2, 6, 10]);
+  });
+
+  it('should call the function lazily', () => {
+    const spy = jasmine.createSpy('mapper').and.callFake((x: number) => 2 * x);
+
+    const [generatorSpy, input] = iterableSpy([1, 3]);
+    const iterable = map(input, spy);
+    const iterator = iterable[Symbol.iterator]();
+    expect(generatorSpy).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+
+    let next = iterator.next();
+    expect(next.value).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(generatorSpy).toHaveBeenCalledTimes(1);
+
+    next = iterator.next();
+    expect(next.value).toBe(6);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(3);
+    expect(generatorSpy).toHaveBeenCalledTimes(2);
+
+    next = iterator.next();
+    expect(next.done).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(generatorSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should accept non-array iterables', () => {
+    function* generator(): Iterable<number> {
+      yield 1;
+      yield 3;
+    }
+    expect(Array.from(map(generator(), (x) => x * 2))).toEqual([2, 6]);
+  });
+
+  it('should do nothing with empty input', () => {
+    expect(Array.from(map([], (x) => x))).toEqual([]);
+  });
+});
+
+describe('reduce', () => {
+  it('should reduce non-array iterators', () => {
+    function* generator(): Iterable<number> {
+      yield 1;
+      yield 2;
+    }
+    expect(reduce(generator(), (acc, x) => acc + x, 0)).toBe(3);
+  });
+});
+
+describe('filter', () => {
+  it('should accept and produce iterables', () => {
+    const [inputSpy, input] = iterableSpy([1, 2, 3, 4]);
+
+    const f = jasmine.createSpy('f').and.callFake((x: number) => x % 2 === 0);
+    const iterable = filter(input, f);
+    const iterator = iterable[Symbol.iterator]();
+
+    expect(f).not.toHaveBeenCalled();
+    let value = iterator.next();
+    expect(value.value).toBe(2);
+    expect(f).toHaveBeenCalledTimes(2);
+    expect(inputSpy).toHaveBeenCalledTimes(2);
+
+    value = iterator.next();
+    expect(value.value).toBe(4);
+    expect(f).toHaveBeenCalledTimes(4);
+    expect(inputSpy).toHaveBeenCalledTimes(4);
+
+    value = iterator.next();
+    expect(value.done).toBe(true);
+    expect(f).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('enumerate', () => {
+  it('should count up', () => {
+    expect(Array.from(enumerate(['hello', 'world']))).toEqual([
+      [0, 'hello'], [1, 'world']
+    ]);
+  });
+
+  it('should accept and produce iterables', () => {
+    const [inputSpy, input] = iterableSpy(['hello', 'world']);
+
+    const iterable = enumerate(input);
+    const iterator = iterable[Symbol.iterator]();
+
+    expect(inputSpy).not.toHaveBeenCalled();
+
+    let value = iterator.next();
+    expect(value.value).toEqual([0, 'hello']);
+    expect(inputSpy).toHaveBeenCalledTimes(1);
+
+    value = iterator.next();
+    expect(value.value).toEqual([1, 'world']);
+    expect(inputSpy).toHaveBeenCalledTimes(2);
+
+    value = iterator.next();
+    expect(value.done).toBe(true);
+    expect(inputSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+// Given an array, returns an iterable that yields the values one at a time,
+// and also a Spy that lets you observe the usage of that iterable.
+function iterableSpy<T>(output: T[]): [jasmine.Spy, Iterable<T>] {
+  const iterator = {
+    next(): IteratorResult<T> {
+      if (output.length > 0) {
+        return {value: output.shift()!, done: false};
+      } else {
+        // IteratorResult<T> is incorrect for finished iterators, apparently.
+        return {done: true} as IteratorResult<T>;
+      }
+    }
+  };
+
+  const iterable = {
+    [Symbol.iterator]() {
+      return iterator;
+    }
+  };
+
+  const spy = spyOn(iterator, 'next').and.callThrough();
+  return [spy, iterable];
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@bazel/typescript": "^0.18.0",
     "@types/google.visualization": "^0.0.43",
+    "@types/jasmine": "~2.8.0",
     "jasmine": "~2.8.0",
     "typescript": ">=2.8 <2.9"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,10 @@
   version "0.0.43"
   resolved "https://registry.yarnpkg.com/@types/google.visualization/-/google.visualization-0.0.43.tgz#d4172f94292b68a49a5666033386ce177f0ead9d"
 
+"@types/jasmine@~2.8.0":
+  version "2.8.14"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.14.tgz#42a87032418b7d70f427d1df16a9921fca28d8c7"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
I wrote these tests months ago, but we couldn't actually run them so I never committed them.

Use rules_nodejs' `jasmine_node_test` to execute some unit tests for gopherage without also downloading a copy of Chrome.

This is pretty verbose because we need to produce a `ts_library` with the unit tests first to avoid jasmine attempting to build the typescript without going through bazel. It also doesn't support generating coverage information.

This is also doubling as a proof-of-concept for doing the same thing to deck.