### PR TITLE
bootstrap image: set SOURCE_DATE_EPOCH based on latest git commit

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -99,6 +99,9 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 
+# Use a reproducible build date based on the most recent git commit timestamp.
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+
 # actually start bootstrap and the job
 "$@"
 EXIT_VALUE=$?


### PR DESCRIPTION
Another piece addressing #7760, enabling more reproducibility for Kubernetes builds run on Prow using pod-utils.

Based on discussion in https://github.com/kubernetes/test-infra/pull/10377#discussion_r243440756, this is not automatically enabled for all Prow jobs, but it should work well enough for our needs since we pretty much use this image (or a derivative of it) everywhere.