### PR TITLE
Use top level .gitattributes in size computation

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -116,6 +116,7 @@ filegroup(
         "//prow/gerrit/client:all-srcs",
         "//prow/gerrit/reporter:all-srcs",
         "//prow/git:all-srcs",
+        "//prow/gitattributes:all-srcs",
         "//prow/github:all-srcs",
         "//prow/githuboauth:all-srcs",
         "//prow/hook:all-srcs",

--- a/prow/gitattributes/BUILD.bazel
+++ b/prow/gitattributes/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gitattributes.go",
+        "pattern.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/gitattributes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "gitattributes_test.go",
+        "pattern_test.go",
+    ],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/gitattributes/gitattributes.go
+++ b/prow/gitattributes/gitattributes.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitattributes
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+// Pattern defines a single gitattributes pattern.
+type Pattern interface {
+	// Match matches the given path to the pattern.
+	Match(path string) bool
+}
+
+// Group is a logical collection of files. Check for a file's
+// inclusion in the group using the Match method.
+type Group struct {
+	LinguistGeneratedPatterns []Pattern
+}
+
+// NewGroup reads the .gitattributes file in the root of the repository only.
+func NewGroup(gitAttributesContent func() ([]byte, error)) (*Group, error) {
+	g := &Group{
+		LinguistGeneratedPatterns: []Pattern{},
+	}
+
+	bs, err := gitAttributesContent()
+	if err != nil {
+		switch err.(type) {
+		case *github.FileNotFound:
+			return g, nil
+		default:
+			return nil, fmt.Errorf("could not get .gitattributes: %v", err)
+		}
+	}
+
+	if err := g.load(bytes.NewBuffer(bs)); err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+// Use load to read a .gitattributes file, and populate g with the commands.
+// Each line in gitattributes file is of form:
+//   pattern	attr1 attr2 ...
+// That is, a pattern followed by an attributes list, separated by whitespaces.
+func (g *Group) load(r io.Reader) error {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		// Leading and trailing whitespaces are ignored.
+		l := strings.TrimSpace(s.Text())
+		// Lines that begin with # are ignored.
+		if l == "" || l[0] == '#' {
+			continue
+		}
+
+		fs := strings.Fields(l)
+		if len(fs) < 2 {
+			continue
+		}
+
+		// When the pattern matches the path in question, the attributes listed on the line are given to the path.
+		attributes := sets.NewString(fs[1:]...)
+		if attributes.Has("linguist-generated=true") {
+			p, err := parsePattern(fs[0])
+			if err != nil {
+				return fmt.Errorf("error parsing pattern: %v", err)
+			}
+			g.LinguistGeneratedPatterns = append(g.LinguistGeneratedPatterns, p)
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return fmt.Errorf("scan error: %v", err)
+	}
+
+	return nil
+}
+
+// IsLinguistGenerated determines whether a file, given here by its full path
+// is included in the .gitattributes linguist-generated group.
+// These files are excluded from language stats and suppressed in diffs.
+// https://github.com/github/linguist/#generated-code
+// Unmarked paths (linguist-generated=false) are not supported.
+func (g *Group) IsLinguistGenerated(path string) bool {
+	for _, p := range g.LinguistGeneratedPatterns {
+		if p.Match(path) {
+			return true
+		}
+	}
+	return false
+}

--- a/prow/gitattributes/gitattributes_test.go
+++ b/prow/gitattributes/gitattributes_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitattributes
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	var cases = []struct {
+		name                        string
+		src                         string
+		nbLinguistGeneratedPatterns int
+		expectError                 bool
+	}{
+		{
+			name: "kubernetes",
+			src: `hack/verify-flags/known-flags.txt merge=union
+test/test_owners.csv merge=union
+
+**/zz_generated.*.go linguist-generated=true
+**/types.generated.go linguist-generated=true
+**/generated.pb.go linguist-generated=true
+**/generated.proto
+**/types_swagger_doc_generated.go linguist-generated=true
+docs/api-reference/** linguist-generated=true
+api/swagger-spec/*.json linguist-generated=true
+api/openapi-spec/*.json linguist-generated=true`,
+			nbLinguistGeneratedPatterns: 7,
+		},
+		{
+			name: "mholt/caddy",
+			src: `# shell scripts should not use tabs to indent!
+*.bash    text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+*.sh      text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+
+# files for systemd (shell-similar)
+*.path    text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+*.service text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+*.timer   text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+
+# go fmt will enforce this, but in case a user has not called "go fmt" allow GIT to catch this:
+*.go      text eol=lf core.whitespace whitespace=indent-with-non-tab,trailing-space,tabwidth=4
+
+*.yml     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
+.git*     text eol=auto core.whitespace whitespace=trailing-space`,
+		},
+		{
+			name: "opencontainers/runtime-spec",
+			src: `# https://tools.ietf.org/html/rfc5545#section-3.1
+*.ics text eol=crlf`,
+		},
+		{
+			name: "test-infra/prow/cmd/phony/examples",
+			src: `# Treat webhook fixtures as generated so they don't clutter PRs
+*.json linguist-generated=true`,
+			nbLinguistGeneratedPatterns: 1,
+		},
+		{
+			name:        "wrong pattern",
+			src:         `abc/ linguist-generated=true`,
+			expectError: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g := &Group{
+				LinguistGeneratedPatterns: []Pattern{},
+			}
+			if err := g.load(bytes.NewBufferString(c.src)); err != nil && !c.expectError {
+				t.Fatalf("load error: %v", err)
+			}
+			if got := len(g.LinguistGeneratedPatterns); got != c.nbLinguistGeneratedPatterns {
+				t.Fatalf("len(g.LinguistGeneratedPatterns) mismatch: got %d, want %d", got, c.nbLinguistGeneratedPatterns)
+			}
+		})
+	}
+}
+
+func TestIsLinguistGenerated(t *testing.T) {
+	var src = `hack/verify-flags/known-flags.txt merge=union
+test/test_owners.csv merge=union
+
+**/zz_generated.*.go linguist-generated=true
+**/types.generated.go linguist-generated=true
+**/generated.pb.go linguist-generated=true
+**/generated.proto
+**/types_swagger_doc_generated.go linguist-generated=true
+docs/api-reference/** linguist-generated=true
+api/swagger-spec/*.json linguist-generated=true
+api/openapi-spec/*.json linguist-generated=true`
+	var cases = []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "known-flags.txt",
+			path: "hack/verify-flags/known-flags.txt",
+			want: false,
+		},
+		{
+			name: "generated.proto",
+			path: "a/generated.proto",
+			want: false,
+		},
+		{
+			name: "generated.pb.go",
+			path: "a/b/generated.pb.go",
+			want: true,
+		},
+		{
+			name: "abc.xml",
+			path: "docs/api-reference/a/b/c/abc.xml",
+			want: true,
+		},
+		{
+			name: "abc.json",
+			path: "api/openapi-spec/abc.json",
+			want: true,
+		},
+	}
+	for _, c := range cases {
+		g := &Group{
+			LinguistGeneratedPatterns: []Pattern{},
+		}
+		if err := g.load(bytes.NewBufferString(src)); err != nil {
+			t.Fatalf("load error: %v", err)
+		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := g.IsLinguistGenerated(c.path); got != c.want {
+				t.Fatalf("IsLinguistGenerated mismatch: got %t, want %t", got, c.want)
+			}
+		})
+	}
+}

--- a/prow/gitattributes/pattern.go
+++ b/prow/gitattributes/pattern.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitattributes
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	negativePrefix = "!"
+	patternDirSep  = "/"
+	zeroToManyDirs = "**"
+)
+
+type pattern struct {
+	pattern []string
+	isPath  bool
+}
+
+// parsePattern parses a gitattributes pattern string into the Pattern structure.
+// The rules by which the pattern matches paths are the same as in .gitignore files (see https://git-scm.com/docs/gitignore), with a few exceptions:
+//   - negative patterns are forbidden
+//   - patterns that match a directory do not recursively match paths inside that directory
+// https://git-scm.com/docs/gitattributes
+func parsePattern(p string) (Pattern, error) {
+	res := pattern{}
+
+	// negative patterns are forbidden
+	if strings.HasPrefix(p, negativePrefix) {
+		return nil, fmt.Errorf("negative patterns are forbidden: <%s>", p)
+	}
+
+	// trailing spaces are ignored unless they are quoted with backslash
+	if !strings.HasSuffix(p, `\ `) {
+		p = strings.TrimRight(p, " ")
+	}
+
+	// patterns that match a directory do not recursively match paths inside that directory
+	if strings.HasSuffix(p, patternDirSep) {
+		return nil, fmt.Errorf("directory patterns are not matched recursively, use path/** instead: <%s>", p)
+	}
+
+	if strings.Contains(p, patternDirSep) {
+		res.isPath = true
+	}
+
+	res.pattern = strings.Split(p, patternDirSep)
+	return &res, nil
+}
+
+func (p *pattern) Match(path string) bool {
+	pathElements := strings.Split(path, "/")
+	if p.isPath && p.pathMatch(pathElements) {
+		return true
+	} else if !p.isPath && p.nameMatch(pathElements) {
+		return true
+	}
+	return false
+}
+
+func (p *pattern) nameMatch(path []string) bool {
+	for _, name := range path {
+		if match, err := filepath.Match(p.pattern[0], name); err != nil {
+			return false
+		} else if !match {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (p *pattern) pathMatch(path []string) bool {
+	matched := false
+	canTraverse := false
+	for i, pattern := range p.pattern {
+		if pattern == "" {
+			canTraverse = false
+			continue
+		}
+		if pattern == zeroToManyDirs {
+			if i == len(p.pattern)-1 {
+				break
+			}
+			canTraverse = true
+			continue
+		}
+		if strings.Contains(pattern, zeroToManyDirs) {
+			return false
+		}
+		if len(path) == 0 {
+			return false
+		}
+		if canTraverse {
+			canTraverse = false
+			for len(path) > 0 {
+				e := path[0]
+				path = path[1:]
+				if match, err := filepath.Match(pattern, e); err != nil {
+					return false
+				} else if match {
+					matched = true
+					break
+				} else if len(path) == 0 {
+					// if nothing left then fail
+					matched = false
+				}
+			}
+		} else {
+			if match, err := filepath.Match(pattern, path[0]); err != nil || !match {
+				return false
+			}
+			matched = true
+			path = path[1:]
+		}
+	}
+	return matched
+}

--- a/prow/gitattributes/pattern_test.go
+++ b/prow/gitattributes/pattern_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitattributes
+
+import (
+	"testing"
+)
+
+func TestParsePattern(t *testing.T) {
+	var cases = []struct {
+		name        string
+		pattern     string
+		expectError bool
+	}{
+		{
+			name:        "file",
+			pattern:     `abc.json`,
+			expectError: false,
+		},
+		{
+			name:        "negative file",
+			pattern:     `!abc.json`,
+			expectError: true,
+		},
+		{
+			name:        "directory",
+			pattern:     `abc/`,
+			expectError: true,
+		},
+		{
+			name:        "directory recursive",
+			pattern:     `abc/**`,
+			expectError: false,
+		},
+		{
+			name:        "glob",
+			pattern:     `a/*/c`,
+			expectError: false,
+		},
+		{
+			name:        "needs trim",
+			pattern:     `abc.json `,
+			expectError: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parsePattern(c.pattern); err != nil && !c.expectError {
+				t.Fatalf("load error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	var cases = []struct {
+		name        string
+		pattern     string
+		path        string
+		shouldMatch bool
+	}{
+		{
+			name:        "file",
+			pattern:     `abc.json`,
+			path:        "abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "file in dir",
+			pattern:     `abc.json`,
+			path:        "a/abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "file fail",
+			pattern:     `abc.js`,
+			path:        "abc.json",
+			shouldMatch: false,
+		},
+		{
+			name:        "glob",
+			pattern:     `*.json`,
+			path:        "abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "glob in dir",
+			pattern:     `a/*.json`,
+			path:        "a/abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "glob dir",
+			pattern:     `*/abc.json`,
+			path:        "a/abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "glob dir fail",
+			pattern:     `*/abc.json`,
+			path:        "a/b/abc.json",
+			shouldMatch: false,
+		},
+		{
+			name:        "recursive file",
+			pattern:     `**/abc.json`,
+			path:        "a/b/abc.json",
+			shouldMatch: true,
+		},
+		{
+			name:        "recursive file fail",
+			pattern:     `**/abc.js`,
+			path:        "a/b/abc.json",
+			shouldMatch: false,
+		},
+		{
+			name:        "recursive dir",
+			pattern:     `a/**`,
+			path:        "a/b/abc.json",
+			shouldMatch: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, _ := parsePattern(c.pattern)
+			if p.Match(c.path) != c.shouldMatch {
+				t.Fatalf("mismatch")
+			}
+		})
+	}
+}

--- a/prow/plugins/size/BUILD.bazel
+++ b/prow/plugins/size/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//prow/genfiles:go_default_library",
+        "//prow/gitattributes:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/size/size_test.go
+++ b/prow/plugins/size/size_test.go
@@ -227,6 +227,69 @@ func TestHandlePR(t *testing.T) {
 			sizes: defaultSizes,
 		},
 		{
+			name: "simple size/M, with .gitattributes",
+			client: &ghc{
+				labels: map[github.Label]bool{},
+				files: map[string][]byte{
+					".gitattributes": []byte(`
+						# comments
+						foobar linguist-generated=true
+						generated/**/*.txt linguist-generated=true
+					`),
+				},
+				prChanges: []github.PullRequestChange{
+					{
+						SHA:       "abcd",
+						Filename:  "foobar",
+						Additions: 10,
+						Deletions: 10,
+						Changes:   20,
+					},
+					{
+						SHA:       "abcd",
+						Filename:  "barfoo",
+						Additions: 50,
+						Deletions: 0,
+						Changes:   50,
+					},
+					{
+						SHA:       "abcd",
+						Filename:  "generated/what.txt",
+						Additions: 30,
+						Deletions: 0,
+						Changes:   30,
+					},
+					{
+						SHA:       "abcd",
+						Filename:  "generated/my/file.txt",
+						Additions: 300,
+						Deletions: 0,
+						Changes:   300,
+					},
+				},
+			},
+			event: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				Number: 101,
+				PullRequest: github.PullRequest{
+					Number: 101,
+					Base: github.PullRequestBranch{
+						SHA: "abcd",
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "kubernetes",
+							},
+							Name: "kubernetes",
+						},
+					},
+				},
+			},
+			finalLabels: []github.Label{
+				{Name: "size/M"},
+			},
+			sizes: defaultSizes,
+		},
+		{
 			name: "simple size/XS, with .generated_files and paths-from-repo",
 			client: &ghc{
 				labels: map[github.Label]bool{},


### PR DESCRIPTION
Fixes #9003
I have used an existing .gitignore implementation for the pattern matching, I hope it's ok...