### PR TITLE
Fixing kubemark 5000 ci job resources

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -652,6 +652,10 @@ periodics:
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
 
 - name: ci-kubernetes-kubemark-high-density-100-gce
   tags:


### PR DESCRIPTION
Bumping up kubemark 5000 nodes job resources to 6 cpu and 16Gi memory.

/cc @mborsz 