### PR TITLE
Fix tide-history time handling.

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
     deps = [
         ":api",
         ":common",
+        "@npm//:moment",
     ],
 )
 
@@ -93,6 +94,7 @@ ts_library(
     deps = [
         ":api",
         ":common",
+        "@npm//:moment",
     ],
 )
 

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -10,16 +10,15 @@ export namespace cell {
 		return c;
 	};
 
-	export function time(id: string, time: number): HTMLTableDataCellElement {
-		const momentTime = moment.unix(time);
+	export function time(id: string, time: moment.Moment): HTMLTableDataCellElement {
 		const tid = "time-cell-" + id;
 		const main = document.createElement("div");
-		const isADayOld = momentTime.isBefore(moment().startOf('day'));
-		main.textContent = momentTime.format(isADayOld ? 'MMM DD HH:mm:ss' : 'HH:mm:ss');
+		const isADayOld = time.isBefore(moment().startOf('day'));
+		main.textContent = time.format(isADayOld ? 'MMM DD HH:mm:ss' : 'HH:mm:ss');
 		main.id = tid;
 
 		const tooltip = document.createElement("div");
-		tooltip.textContent = momentTime.format('MMM DD YYYY, HH:mm:ss [UTC]ZZ');
+		tooltip.textContent = time.format('MMM DD YYYY, HH:mm:ss [UTC]ZZ');
 		tooltip.setAttribute("data-mdl-for", tid);
 		tooltip.classList.add("mdl-tooltip", "mdl-tooltip--large");
 

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,6 +1,7 @@
 import {FuzzySearch} from './fuzzy-search';
 import {Job, JobState, JobType} from "../api/prow";
 import {cell} from "../common/common";
+import moment from "moment";
 
 
 
@@ -536,7 +537,7 @@ function redraw(fz: FuzzySearch): void {
             r.appendChild(cell.link(build.job, build.url));
         }
 
-        r.appendChild(cell.time(i.toString(), parseInt(build.started)));
+        r.appendChild(cell.time(i.toString(), moment.unix(parseInt(build.started))));
         r.appendChild(cell.text(build.duration));
         builds.appendChild(r);
     }

--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -1,6 +1,7 @@
 import {cell} from "../common/common";
 import {JobState} from "../api/prow";
 import {HistoryData, Record, PRMeta} from "../api/tide-history";
+import moment from "moment";
 
 declare const tideHistory: HistoryData;
 
@@ -229,7 +230,7 @@ function redraw(): void {
     }
   }
   // Sort by descending time.
-  filteredRecs = filteredRecs.sort((a, b) => parseInt(b.time) - parseInt(a.time));
+  filteredRecs = filteredRecs.sort((a, b) => moment(b.time).unix() - moment(a.time).unix());
   redrawRecords(filteredRecs);
 }
 
@@ -272,7 +273,7 @@ function redrawRecords(recs: FilteredRecord[]): void {
     }
     r.appendChild(cell.text(rec.action));
     r.appendChild(targetCell(rec));
-    r.appendChild(cell.time(nextID(), parseInt(rec.time)));
+    r.appendChild(cell.time(nextID(), moment(rec.time)));
     r.appendChild(cell.text(rec.err || ""));
     records.appendChild(r);
   }


### PR DESCRIPTION
The timestamp in the json payload is in `YYYY-MM-DDThh:mm:ssZ` time format, not unix time. 
I tested the fix with runlocal using the real data that is now available at https://prow.k8s.io/tide-history.js

/kind bug
/assign @Katharine 