### PR TITLE
Adding issue state proto

### DIFF
--- a/testgrid/BUILD.bazel
+++ b/testgrid/BUILD.bazel
@@ -6,6 +6,11 @@ proto_library(
 )
 
 proto_library(
+    name = "issue_state_proto",
+    srcs = ["issue_state.proto"],
+)
+
+proto_library(
     name = "config_proto",
     srcs = ["config.proto"],
 )
@@ -14,6 +19,13 @@ go_proto_library(
     name = "state",
     importpath = "k8s.io/test-infra/testgrid/state",
     proto = ":state_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "issue_state",
+    importpath = "k8s.io/test-infra/testgrid/issue_state",
+    proto = ":issue_state_proto",
     visibility = ["//visibility:public"],
 )
 

--- a/testgrid/issue_state.proto
+++ b/testgrid/issue_state.proto
@@ -1,0 +1,19 @@
+// Backing state for issues associated with a TestGrid test group.
+
+syntax = "proto3";
+
+message IssueInfo {
+  string issue_id = 1;
+  string title = 2;  // Issue title or description.
+
+  reserved 3, 4;
+
+  repeated string row_ids = 5;  // Associated row IDs (mentioned in the issue).
+
+  reserved 6, 7;
+}
+
+message IssueState {
+  // List of collected info for bugs.
+  repeated IssueInfo issue_info = 1;
+}


### PR DESCRIPTION
TestGrid uses this to add linked issues to tests.