### PR TITLE
Update `/milestone|/status` error for non-members

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -368,8 +368,9 @@ type Milestone struct {
 	// You can curl the following endpoint in order to determine the github ID of your team
 	// responsible for maintaining the milestones:
 	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
-	MaintainersID   int    `json:"maintainers_id,omitempty"`
-	MaintainersTeam string `json:"maintainers_team,omitempty"`
+	MaintainersID           int    `json:"maintainers_id,omitempty"`
+	MaintainersTeam         string `json:"maintainers_team,omitempty"`
+	MaintainersFriendlyName string `json:"maintainers_friendly_name,omitempty"`
 }
 
 // Slack contains the configuration for the slack plugin.
@@ -673,6 +674,11 @@ func (c *Configuration) setDefaults() {
 	}
 	if c.Owners.LabelsBlackList == nil {
 		c.Owners.LabelsBlackList = []string{labels.Approved, labels.LGTM}
+	}
+	for _, milestone := range c.RepoMilestone {
+		if milestone.MaintainersFriendlyName == "" {
+			milestone.MaintainersFriendlyName = "SIG Chairs/TLs"
+		}
 	}
 	if c.CherryPickUnapproved.BranchRegexp == "" {
 		c.CherryPickUnapproved.BranchRegexp = `^release-.*$`

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -35,7 +35,7 @@ const pluginName = "milestone"
 
 var (
 	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
-	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your SIG Chairs/TLs and have them propose you as an additional delegate for this responsibility."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
 	clearKeyword     = "clear"
@@ -126,7 +126,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
 	}
 

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -35,7 +35,7 @@ const pluginName = "milestone"
 
 var (
 	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
-	mustBeSigLead    = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your SIG Chairs/TLs and have them propose you as an additional delegate for this responsibility."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
 	clearKeyword     = "clear"
@@ -126,7 +126,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeSigLead, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
 	}
 

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -34,7 +34,7 @@ const pluginName = "milestonestatus"
 
 var (
 	statusRegex      = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
-	mustBeSigLead    = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to add status labels."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to add status labels. If you believe you should be able to issue the /status command, please contact your SIG Chairs/TLs and have them propose you as an additional delegate for this responsibility."
 	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
 	statusMap        = map[string]string{
 		"approved-for-milestone": "status/approved-for-milestone",
@@ -119,7 +119,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeSigLead, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
 		return gc.CreateComment(org, repo, e.Number, msg)
 	}
 

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -34,7 +34,7 @@ const pluginName = "milestonestatus"
 
 var (
 	statusRegex      = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
-	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to add status labels. If you believe you should be able to issue the /status command, please contact your SIG Chairs/TLs and have them propose you as an additional delegate for this responsibility."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to add status labels. If you believe you should be able to issue the /status command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
 	statusMap        = map[string]string{
 		"approved-for-milestone": "status/approved-for-milestone",
@@ -119,7 +119,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
 		return gc.CreateComment(org, repo, e.Number, msg)
 	}
 


### PR DESCRIPTION
Provides additional context for non-milestone-maintainers about how to request access to issue `/milestone` and `/status` commands.

Related: https://github.com/kubernetes/sig-release/issues/241#issuecomment-452034571

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @spiffxp @tpepper 