### PR TITLE
Fix status-reconciler image name

### DIFF
--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/statusreconciler:v20181129-31c544b
+        image: gcr.io/k8s-prow/status-reconciler:v20190109-6897efb
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
Also bumped the tag as the old one doesn't seem to exist anymore (taken from prow/cluster/deck_deployment.yaml)

/assign @stevekuznetsov 