### PR TITLE
add ginkgo-parallel for single-flake-attempt CI job

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -291,9 +291,11 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
+      - --gcp-nodes=4
       - --gcp-zone=us-central1-f
+      - --ginkgo-parallel=30
       - --provider=gce
-      - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181218-134e718ec-master
 


### PR DESCRIPTION
This job consistently times out, trying to tweak it to look more like
the ci-kubernetes-e2e-gci-gce job

/assign @spiffxp 

Change-Id: I68e4f6095fe0701e59f50c6cada88b7c47168c4e