### PR TITLE
make pr page support `revision` field from podutils

### DIFF
--- a/gubernator/pull_request.py
+++ b/gubernator/pull_request.py
@@ -28,11 +28,13 @@ def builds_to_table(jobs):
     """
     # pylint: disable=too-many-locals
 
-    def commit(started):
+    def commit(started, finished):
         if 'pull' in started:
             return started['pull'].split(':')[-1]
         if 'version' in started:
             return started['version'].split('+')[-1]
+        if 'revision' in finished:
+            return finished['revision']
         return 'unknown'
 
     # Compute the headings first -- versions and their maximum build counts.
@@ -43,7 +45,7 @@ def builds_to_table(jobs):
         for build, started, finished in builds:
             if not started:
                 continue
-            version = commit(started)
+            version = commit(started, finished)
             if not version:
                 continue
             versions.setdefault(version, {}).setdefault(job, 0)
@@ -68,10 +70,10 @@ def builds_to_table(jobs):
         row = []
         n = 0
         for build, started, finished in builds:
-            if not started or not commit(started):
+            if not started or not commit(started, finished):
                 minspan = 0
             else:
-                minspan = version_colstart[commit(started)]
+                minspan = version_colstart[commit(started, finished)]
             while n < minspan:
                 row.append(None)
                 n += 1

--- a/gubernator/pull_request_test.py
+++ b/gubernator/pull_request_test.py
@@ -25,6 +25,10 @@ def make(number, version, result, start_time=1000):
     finished = result and {'result': result}
     return (number, started, finished)
 
+def makePodutil(number, revision, result, start_time=1000):
+    started = {'timestamp': start_time}
+    finished = result and {'result': result, 'revision': revision}
+    return (number, started, finished)
 
 class TableTest(unittest.TestCase):
 
@@ -48,3 +52,13 @@ class TableTest(unittest.TestCase):
         jobs['J1'][0][1]['pull'] = 'master:1234,35:abcd'
         _, headings, _ = pull_request.builds_to_table(jobs)
         self.assertEqual(headings, [('abcd', 1, 9)])
+
+    def test_builds_to_table_podutils(self):
+        jobs = {'J1': [makePodutil(4, 'v2', 'A', 9), makePodutil(3, 'v2', 'B', 10)],
+                'J2': [makePodutil(5, 'v1', 'C', 7), makePodutil(4, 'v1', 'D', 6)]}
+        max_builds, headings, rows = pull_request.builds_to_table(jobs)
+
+        self.assertEqual(max_builds, 4)
+        self.assertEqual(headings, [('v2', 2, 9), ('v1', 2, 6)])
+        self.assertEqual(rows, [('J1', [(4, 'A'), (3, 'B')]),
+                                ('J2', [None, None, (5, 'C'), (4, 'D')])])


### PR DESCRIPTION
So that the pr page can support both started and finished.json. (ref https://gubernator.k8s.io/pr/test-infra/10677)

(@ibzib - indeed I need to fix this :joy: it is already broken.. haven't actually deployed a new gubernator yet but will do after this one)

/assign @cjwagner @ibzib 