### PR TITLE
Deck: pr history supports `revision` field from pod-utils

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//prow/tide/history:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -297,8 +297,9 @@ func getBuildData(bucket storageBucket, dir string) (buildData, error) {
 		return b, fmt.Errorf("failed to read started.json: %v", err)
 	}
 	b.Started = time.Unix(started.Timestamp, 0)
-	commitHash, err := getPullCommitHash(started.Pull)
-	if err == nil {
+	if started.Revision != "" {
+		b.commitHash = started.Revision
+	} else if commitHash, err := getPullCommitHash(started.Pull); err == nil {
 		b.commitHash = commitHash
 	}
 	finished := jobs.Finished{}

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -307,6 +307,9 @@ func getBuildData(bucket storageBucket, dir string) (buildData, error) {
 	if err != nil {
 		logrus.Infof("failed to read finished.json (job might be unfinished): %v", err)
 	}
+	if finished.Revision != "" {
+		b.commitHash = finished.Revision
+	}
 	if finished.Timestamp != 0 {
 		b.Duration = time.Unix(finished.Timestamp, 0).Sub(b.Started)
 	}

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -196,12 +196,12 @@ var testBucket = fakeBucket{
 	name: "chum-bucket",
 	objects: map[string]string{
 		"pr-logs/pull/123/build-snowman/456/started.json": `{
-			"timestamp": 55555,
-			"pull": "master:d0c3cd182cffb3e722b14322fd1ca854a8bf62b0,69848:1244ee66517bbe603d899bbd24458ebc0e185fd9"
+			"timestamp": 55555
 		}`,
 		"pr-logs/pull/123/build-snowman/456/finished.json": `{
 			"timestamp": 66666,
-			"result":    "SUCCESS"
+			"result":    "SUCCESS",
+			"revision":  "1244ee66517bbe603d899bbd24458ebc0e185fd9"
 		}`,
 		"pr-logs/pull/123/build-snowman/789/started.json": `{
 			"timestamp": 98765,

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
@@ -204,7 +205,7 @@ var testBucket = fakeBucket{
 		}`,
 		"pr-logs/pull/123/build-snowman/789/started.json": `{
 			"timestamp": 98765,
-			"pull": "master:d0c3cd182cffb3e722b14322fd1ca854a8bf62b0,69848:bbdebedaf24c03f9e2eeb88e8ea4bb10c9e1fbfc"
+			"revision": "bbdebedaf24c03f9e2eeb88e8ea4bb10c9e1fbfc"
 		}`,
 		"pr-logs/pull/765/eat-bread/999/started.json": `{
 			"timestamp": 12345,
@@ -295,9 +296,7 @@ func TestGetPRBuildData(t *testing.T) {
 	for _, build := range builds {
 		if expBuild, ok := expected[build.prefix]; ok {
 			if !reflect.DeepEqual(build, expBuild) {
-				t.Errorf("build %s\n"+
-					"expected: %v\n"+
-					"got:      %v", build.prefix, expBuild, build)
+				t.Errorf("build %s mismatch:\n%s", build.prefix, diff.ObjectReflectDiff(expBuild, build))
 			}
 		} else {
 			t.Errorf("found unexpected build %s", build.prefix)
@@ -381,7 +380,6 @@ func TestGetGCSDirsForPR(t *testing.T) {
 	}
 	for _, tc := range cases {
 		toSearch, err := getGCSDirsForPR(tc.config, tc.org, tc.repo, tc.pr)
-		fmt.Println(toSearch)
 		if (err != nil) != tc.expErr {
 			t.Errorf("%s: unexpected error %v", tc.name, err)
 		}

--- a/prow/deck/jobs/metadata.go
+++ b/prow/deck/jobs/metadata.go
@@ -42,4 +42,5 @@ type Finished struct {
 	Passed     bool   `json:"passed"`
 	Result     string `json:"result"`
 	Metadata   `json:"metadata"`
+	Revision   string `json:"revision"`
 }

--- a/prow/deck/jobs/metadata.go
+++ b/prow/deck/jobs/metadata.go
@@ -22,6 +22,7 @@ type Started struct {
 	Node      string            `json:"node"`
 	Repos     map[string]string `json:"repos"`
 	Pull      string            `json:"pull"`
+	Revision  string            `json:"revision"`
 }
 
 // Metadata is used to mirror the metadata in the finished.json artifact.


### PR DESCRIPTION
We will also probably have to add `revision` to the Spyglass metadata viewer.

/assign @krzyzacy 