### PR TITLE
Update sig-storage testgrid

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6550,7 +6550,7 @@ dashboards:
     base_options: include-filter-by-regex=sig-scheduling
     description: scheduling gce statefulset e2e tests for master branch
 
-- name: sig-storage
+- name: sig-storage-kubernetes
   dashboard_tab:
   - name: gce
     test_group_name: ci-kubernetes-e2e-gci-gce
@@ -6640,8 +6640,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-regional-slow
     base_options: include-filter-by-regex=Volume%7Cstorage
     description: storage gke regional slow e2e tests for master branch
-  dashboard_names:
-  - sig-storage-local-static-provisioner
 
 - name: sig-storage-local-static-provisioner
   dashboard_tab:
@@ -7773,6 +7771,11 @@ dashboard_groups:
   - sig-autoscaling-cluster-autoscaler
   - sig-autoscaling-hpa
   - sig-autoscaling-vpa
+
+- name: sig-storage
+  dashboard_names:
+  - sig-storage-kubernetes
+  - sig-storage-local-static-provisioner
 
 - name: conformance
   dashboard_names:


### PR DESCRIPTION
- rename current sig-storage dashboard to sig-storage-kubernetes
- add new sig-storage dashboard group

xref: https://github.com/kubernetes/test-infra/pull/10630#discussion_r246890113