### PR TITLE
Revert rules_docker update due to broken docker_push

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "c0e9d27e6ca307e4ac0122d3dd1df001b9824373fb6fb8627cd2371068e51fef",
-    strip_prefix = "rules_docker-0.6.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.6.0.tar.gz"],
+    sha256 = "5235045774d2f40f37331636378f21fe11f69906c0386a790c5987a09211c3c4",
+    strip_prefix = "rules_docker-8010a50ef03d1e13f1bebabfc625478da075fa60",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/8010a50ef03d1e13f1bebabfc625478da075fa60.tar.gz"],
 )
 
 load(

--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -12,6 +12,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/ghproxy:latest": ":image",
         "{STABLE_DOCKER_REPO}/ghproxy:latest-{BUILD_USER}": ":image",
     },
+    stamp = True,
 )
 
 docker_push(

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -23,6 +23,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/label_sync:latest": ":label_sync-image",
         "{STABLE_DOCKER_REPO}/label_sync:latest-{BUILD_USER}": ":label_sync-image",
     },
+    stamp = True,
 )
 
 docker_push(

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -38,6 +38,7 @@ container_bundle(
     }) + image_tags(**{
         prefix("refresh"): "//prow/external-plugins/refresh:image",
     }),
+    stamp = True,
 )
 
 docker_push(

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -11,6 +11,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/commenter:latest": ":commenter-image",
         "{STABLE_DOCKER_REPO}/commenter:latest-{BUILD_USER}": ":commenter-image",
     },
+    stamp = True,
 )
 
 docker_push(

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -10,6 +10,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/issue-creator:latest": ":issue-creator-image",
         "{STABLE_DOCKER_REPO}/issue-creator:latest-{BUILD_USER}": ":issue-creator-image",
     },
+    stamp = True,
 )
 
 docker_push(

--- a/robots/pr-labeler/BUILD.bazel
+++ b/robots/pr-labeler/BUILD.bazel
@@ -11,6 +11,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/pr-labeler:latest": ":pr-labeler-image",
         "{STABLE_DOCKER_REPO}/pr-labeler:latest-{BUILD_USER}": ":pr-labeler-image",
     },
+    stamp = True,
 )
 
 docker_push(

--- a/testgrid/images/BUILD.bazel
+++ b/testgrid/images/BUILD.bazel
@@ -26,6 +26,7 @@ container_bundle(
         "gcr.io/fejta-prod/testgrid/updater": ":updater",
         "gcr.io/fejta-prod/testgrid/configurator": ":configurator",
     }),
+    stamp = True,
 )
 
 docker_push(


### PR DESCRIPTION
I updated rules_docker (along with a bunch of other dependencies) in https://github.com/kubernetes/test-infra/pull/10677, but it appears to have broken the `docker_push` rule we use with Prow:

https://gubernator.k8s.io/build/kubernetes-jenkins/logs/post-test-infra-push-prow/760/
```
...
  bazel-bin/prow/release-push
INFO: Elapsed time: 551.904s, Critical Path: 148.41s, Remote (0.00% of the time): [queue: 0.00%, setup: 0.00%, process: 0.00%]
INFO: 836 processes: 836 processwrapper-sandbox.
INFO: Build completed successfully, 2310 total actions
INFO: Running command line: bazel-bin/prow/release-push
INFO: Build completed successfully, 2310 total actions
usage: fast_pusher_.py [-h] --name NAME [--tarball TARBALL] [--config CONFIG]
                       [--manifest MANIFEST] [--digest DIGEST] [--layer LAYER]
                       [--stamp-info-file STAMP_INFO_FILE] [--oci]
                       [--client-config-dir CLIENT_CONFIG_DIR]
                       [--stderrthreshold STDERRTHRESHOLD]
usage: fast_pusher_.py [-h] --name NAME [--tarball TARBALL] [--config CONFIG]
                       [--manifest MANIFEST] [--digest DIGEST] [--layer LAYER]
                       [--stamp-info-file STAMP_INFO_FILE] [--oci]
                       [--client-config-dir CLIENT_CONFIG_DIR]
                       [--stderrthreshold STDERRTHRESHOLD]
fast_pusher_.py: error: argument --name is required
fast_pusher_.py: error: argument --name is required
usage: fast_pusher_.py [-h] --name NAME [--tarball TARBALL] [--config CONFIG]
                       [--manifest MANIFEST] [--digest DIGEST] [--layer LAYER]
                       [--stamp-info-file STAMP_INFO_FILE] [--oci]
                       [--client-config-dir CLIENT_CONFIG_DIR]
                       [--stderrthreshold STDERRTHRESHOLD]
fast_pusher_.py: error: argument --name is required
...
```
This appears to be https://github.com/bazelbuild/rules_docker/issues/609. Let's revert the `rules_docker` update until a fix is released.

/assign @fejta