### PR TITLE
Update kubekins tag for eks jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -37,7 +37,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-correctness
         - --timeout=180m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aws-eks-1-11-correctness
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
         imagePullPolicy: Always
         name: ""
         resources: {}

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -33,7 +33,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -58,7 +58,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
       imagePullPolicy: Always
       args:
       - --timeout=200

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kubernetes-e2e-aws-eks-1-11: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
         imagePullPolicy: Always
         args:
           - --root=/go/src


### PR DESCRIPTION
Similar to all other jobs. We shouldn't rely on ambiguous latest tag.

/cc @gyuho 

