### PR TITLE
Prow: unify started|finished|metadata structs

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -100,6 +100,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
+        "//prow/pod-utils/gcs:go_default_library",
         "//prow/prstatus:go_default_library",
         "//prow/spyglass:go_default_library",
         "//prow/spyglass/lenses:go_default_library",

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -297,9 +297,7 @@ func getBuildData(bucket storageBucket, dir string) (buildData, error) {
 		return b, fmt.Errorf("failed to read started.json: %v", err)
 	}
 	b.Started = time.Unix(started.Timestamp, 0)
-	if started.Revision != "" {
-		b.commitHash = started.Revision
-	} else if commitHash, err := getPullCommitHash(started.Pull); err == nil {
+	if commitHash, err := getPullCommitHash(started.Pull); err == nil {
 		b.commitHash = commitHash
 	}
 	finished := gcs.Finished{}

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -33,7 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/deck/jobs"
+	"k8s.io/test-infra/prow/pod-utils/gcs"
 )
 
 const (
@@ -291,7 +291,7 @@ func getBuildData(bucket storageBucket, dir string) (buildData, error) {
 		Result:     "Unknown",
 		commitHash: "Unknown",
 	}
-	started := jobs.Started{}
+	started := gcs.Started{}
 	err := readJSON(bucket, path.Join(dir, "started.json"), &started)
 	if err != nil {
 		return b, fmt.Errorf("failed to read started.json: %v", err)
@@ -302,7 +302,7 @@ func getBuildData(bucket storageBucket, dir string) (buildData, error) {
 	} else if commitHash, err := getPullCommitHash(started.Pull); err == nil {
 		b.commitHash = commitHash
 	}
-	finished := jobs.Finished{}
+	finished := gcs.Finished{}
 	err = readJSON(bucket, path.Join(dir, "finished.json"), &finished)
 	if err != nil {
 		logrus.Infof("failed to read finished.json (job might be unfinished): %v", err)

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -205,7 +205,7 @@ var testBucket = fakeBucket{
 		}`,
 		"pr-logs/pull/123/build-snowman/789/started.json": `{
 			"timestamp": 98765,
-			"revision": "bbdebedaf24c03f9e2eeb88e8ea4bb10c9e1fbfc"
+			"pull": "master:d0c3cd182cffb3e722b14322fd1ca854a8bf62b0,69848:bbdebedaf24c03f9e2eeb88e8ea4bb10c9e1fbfc"
 		}`,
 		"pr-logs/pull/765/eat-bread/999/started.json": `{
 			"timestamp": 12345,

--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -2,10 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "jobs.go",
-        "metadata.go",
-    ],
+    srcs = ["jobs.go"],
     importpath = "k8s.io/test-infra/prow/deck/jobs",
     visibility = ["//visibility:public"],
     deps = [

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -36,9 +36,7 @@ func (o Options) Run() error {
 		return fmt.Errorf("could not resolve job spec: %v", err)
 	}
 
-	started := struct {
-		Timestamp int64 `json:"timestamp"`
-	}{
+	started := gcs.Started{
 		Timestamp: time.Now().Unix(),
 	}
 	startedData, err := json.Marshal(&started)
@@ -90,11 +88,7 @@ func processCloneLog(logfile string, uploadTargets map[string]gcs.UploadFunc) (b
 	if failed {
 		uploadTargets["build-log.txt"] = gcs.DataUpload(bytes.NewReader(cloneLog.Bytes()))
 
-		finished := struct {
-			Timestamp int64  `json:"timestamp"`
-			Passed    bool   `json:"passed"`
-			Result    string `json:"result"`
-		}{
+		finished := gcs.Finished{
 			Timestamp: time.Now().Unix(),
 			Passed:    false,
 			Result:    "FAILURE",

--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "metadata.go",
         "target.go",
         "upload.go",
     ],

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -27,8 +27,6 @@ type Started struct {
 	Repos map[string]string `json:"repos"`
 	// Pull is deprecated.
 	Pull string `json:"pull"`
-	// Revision is deprecated.
-	Revision string `json:"revision"`
 }
 
 // Finished is used to mirror the finished.json artifact.

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package jobs
+package gcs
 
 // Started is used to mirror the started.json artifact.
 type Started struct {
@@ -25,22 +25,13 @@ type Started struct {
 	Revision  string            `json:"revision"`
 }
 
-// Metadata is used to mirror the metadata in the finished.json artifact.
-type Metadata struct {
-	InfraCommit string            `json:"infra-commit"`
-	Pod         string            `json:"pod"`
-	Repo        string            `json:"repo"`
-	RepoCommit  string            `json:"repo-commit"`
-	Repos       map[string]string `json:"repos"`
-}
-
 // Finished is used to mirror the finished.json artifact.
 type Finished struct {
-	Timestamp  int64  `json:"timestamp"`
-	Version    string `json:"version"`
-	JobVersion string `json:"job-version"`
-	Passed     bool   `json:"passed"`
-	Result     string `json:"result"`
-	Metadata   `json:"metadata"`
-	Revision   string `json:"revision"`
+	Timestamp  int64                  `json:"timestamp"`
+	Version    string                 `json:"version"`
+	JobVersion string                 `json:"job-version"`
+	Passed     bool                   `json:"passed"`
+	Result     string                 `json:"result"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+	Revision   string                 `json:"revision,omitempty"`
 }

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -17,21 +17,40 @@ limitations under the License.
 package gcs
 
 // Started is used to mirror the started.json artifact.
+// All fields in Started beside Timestamp are deprecated.
 type Started struct {
-	Timestamp int64             `json:"timestamp"`
-	Node      string            `json:"node"`
-	Repos     map[string]string `json:"repos"`
-	Pull      string            `json:"pull"`
-	Revision  string            `json:"revision"`
+	// Timestamp is the time in epoch seconds recorded when started.json is created.
+	Timestamp int64 `json:"timestamp"`
+	// Node is deprecated.
+	Node string `json:"node"`
+	// Repos is deprecated.
+	Repos map[string]string `json:"repos"`
+	// Pull is deprecated.
+	Pull string `json:"pull"`
+	// Revision is deprecated.
+	Revision string `json:"revision"`
 }
 
 // Finished is used to mirror the finished.json artifact.
 type Finished struct {
-	Timestamp  int64                  `json:"timestamp"`
-	Version    string                 `json:"version"`
-	JobVersion string                 `json:"job-version"`
-	Passed     bool                   `json:"passed"`
-	Result     string                 `json:"result"`
-	Metadata   map[string]interface{} `json:"metadata,omitempty"`
-	Revision   string                 `json:"revision,omitempty"`
+	// Timestamp is the time in epoch seconds recorded when finished.json is created.
+	Timestamp int64 `json:"timestamp"`
+	// Version is deprecated.
+	// TODO: Version should be removed in favor of Revision.
+	Version string `json:"version"`
+	// JobVersion is deprecated.
+	// TODO: JobVersion should be removed in favor of Revision.
+	JobVersion string `json:"job-version"`
+	// Revision identifies the revision of the code the build tested.
+	// Revision can be either a SHA or a ref.
+	// TODO: resolve https://github.com/kubernetes/test-infra/issues/10359
+	Revision string `json:"revision,omitempty"`
+	// Passed is true when the job has passed, else false.
+	Passed bool `json:"passed"`
+	// Result is the result of the job ("SUCCESS", "ABORTED", or "FAILURE").
+	Result string `json:"result"`
+	// Metadata is any additional metadata uploaded by the job.
+	// Keys typically include infra-commit, repos, repo, repo-commit.
+	// Values typically have type string or map[string]string.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -162,14 +162,7 @@ func (o Options) doUpload(spec *downwardapi.JobSpec, passed, aborted bool, metad
 		result = "FAILURE"
 	}
 
-	// TODO(krzyzacy): Unify with downstream spyglass definition
-	finished := struct {
-		Timestamp int64                  `json:"timestamp"`
-		Passed    bool                   `json:"passed"`
-		Result    string                 `json:"result"`
-		Metadata  map[string]interface{} `json:"metadata,omitempty"`
-		Revision  string                 `json:"revision,omitempty"`
-	}{
+	finished := gcs.Finished{
 		Timestamp: time.Now().Unix(),
 		Passed:    passed,
 		Result:    result,

--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/spyglass/lenses/metadata",
     visibility = ["//visibility:public"],
     deps = [
-        "//prow/deck/jobs:go_default_library",
+        "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -4,6 +4,7 @@
 {{end}}
 
 {{define "body"}}
+{{$len := len .Metadata}}
 {{$passed := eq .Status "SUCCESS"}}
 {{$failed := eq .Status "FAILURE" "FAILED"}}
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp metadata-table">
@@ -22,7 +23,7 @@
       <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
     </tr>
-    <tbody id="supplementary_data" class="{{if gt .MetadataLen 1}}hidden{{end}}">
+    <tbody id="supplementary_data" class="{{if gt $len 1}}hidden{{end}}">
     {{range $key, $value := .Metadata}}
     {{if $value}}
       <tr>
@@ -32,7 +33,7 @@
     {{end}}
     {{end}}
     </tbody>
-    {{if gt .MetadataLen 1}}
+    {{if gt $len 1}}
     <tr class="expander" onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
       <td id="expand_text" class="mdl-data-table__cell--non-numeric expander">Show more</td>
       <td class="mdl-data-table__cell--non-numeric expander">


### PR DESCRIPTION
Unified redundant Go definitions (upstream and downstream). We still might want to move to just uploading the pod spec rather than these special structs in the future, but this change makes the status quo a little less ugly. I didn't touch one definition outside of Prow: https://github.com/ibzib/test-infra/blob/5b57a7ea791e09620380eae53cd51870390ecf2f/testgrid/cmd/updater/main.go#L117-L142

fixes #10699
/cc @stevekuznetsov @krzyzacy @fejta 