### PR TITLE
spyglass: fix bad junit table height calculation in Safari

### DIFF
--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -2,7 +2,13 @@
 <style>
     .hidden-tests {
         visibility: collapse;
+        display: none;
     }
+
+    table {
+      width: 100%;
+    }
+
     .mdl-data-table__cell--non-numeric {
       font-family: monospace;
       background-color: #212121;
@@ -16,6 +22,11 @@
       font-weight:bold;
       font-size:1.5em;
     }
+
+    .expander:last-of-type {
+      text-align: right;
+    }
+
     a {
       color: inherit;
       text-decoration: none;


### PR DESCRIPTION
This may also fix the issue in other non-Chrome browsers; I haven't checked.

This also locks the table to 100% width, which is also the old behaviour.

/cc @ibzib 
/kind bug