### PR TITLE
Update /pony to use documented pony endpoint

### DIFF
--- a/prow/plugins/pony/pony.go
+++ b/prow/plugins/pony/pony.go
@@ -46,7 +46,7 @@ type ponyRepresentations struct {
 }
 
 const (
-	ponyURL    = realHerd("https://theponyapi.com/pony.json")
+	ponyURL    = realHerd("https://theponyapi.com/api/v1/ponies/random")
 	pluginName = "pony"
 )
 
@@ -90,12 +90,7 @@ func formatURLs(small, full string) string {
 }
 
 func (h realHerd) readPony(tags string) (string, error) {
-	// Omit webm video (the only video type) and anything too far off square.
-	q := "-webm, aspect_ratio:1~0.5"
-	if tags != "" {
-		q += ", " + tags
-	}
-	uri := string(h) + "?q=" + url.QueryEscape(q)
+	uri := string(h) + "?q=" + url.QueryEscape(tags)
 	resp, err := client.Get(uri)
 	if err != nil {
 		return "", fmt.Errorf("failed to make request: %v", err)

--- a/prow/plugins/pony/pony_test.go
+++ b/prow/plugins/pony/pony_test.go
@@ -168,11 +168,8 @@ func TestHttpResponse(t *testing.T) {
 				return
 			}
 			q := r.URL.Query().Get("q")
-			if strings.HasSuffix(q, ",") {
-				t.Errorf("Expected query without trailing comma: %q", q)
-			}
-			if tc.expectTag != "" && !strings.HasSuffix(q, ", "+tc.expectTag) {
-				t.Errorf("Expected tag %q, but didn't find it in %q", tc.expectTag, q)
+			if tc.expectTag != "" && q != tc.expectTag {
+				t.Errorf("Expected tag %q, but got %q", tc.expectTag, q)
 			}
 			io.WriteString(w, tc.response)
 		} else {


### PR DESCRIPTION
theponyapi.com now actually has a [documented API](https://theponyapi.com/docs) that we should use.

/pony book