### PR TITLE
prow/plugins/size,lgtm: expose config through PluginHelp

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -99,13 +99,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		if b {
 			return ""
 		}
-		return "do not "
+		return "do not"
 	}
 	willNot := func(b bool) string {
 		if b {
-			return "will "
+			return "will"
 		}
-		return "will not "
+		return "will not"
 	}
 
 	approveConfig := map[string]string{}
@@ -115,7 +115,15 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			return nil, fmt.Errorf("invalid repo in enabledRepos: %q", repo)
 		}
 		opts := optionsForRepo(config, parts[0], parts[1])
-		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.HasSelfApproval()), willNot(opts.LgtmActsAsApprove), willNot(opts.ConsiderReviewState()))
+		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>"+
+			"Pull request authors %s implicitly approve their own PRs.<br>"+
+			"The /lgtm [cancel] command(s) %s act as approval.<br>"+
+			"A GitHub approved or changes requested review %s act as approval or cancel respectively.",
+			doNot(opts.IssueRequired),
+			doNot(opts.HasSelfApproval()),
+			willNot(opts.LgtmActsAsApprove),
+			willNot(opts.ConsiderReviewState()),
+		)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -60,9 +60,37 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
+	willNot := func(b bool) string {
+		if b {
+			return "will"
+		}
+		return "will not"
+	}
+	definedNot := func(s string) string {
+		if s != "" {
+			return "(not defined)"
+		}
+		return s
+	}
+	lgtmConfig := map[string]string{}
+	for _, repo := range enabledRepos {
+		parts := strings.Split(repo, "/")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid repo in enabledRepos: %q", repo)
+		}
+		opts := optionsForRepo(config, parts[0], parts[1])
+		lgtmConfig[repo] = fmt.Sprintf("Github reviews %s act as adding or removing the LGTM label.<br>"+
+			"Tree hash %s be stored in a comment to detect squashed commits before removing LGTM label.<br>"+
+			"Sticky LGTM team is: %s",
+			willNot(opts.ReviewActsAsLgtm),
+			willNot(opts.StoreTreeHash),
+			definedNot(opts.StickyLgtmTeam),
+		)
+
+	}
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
+		Config:      lgtmConfig,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/lgtm [cancel] or Github Review action",

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -48,17 +48,26 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	sizes := sizesOrDefault(config.Size)
-	return &pluginhelp.PluginHelp{
-			Description: fmt.Sprintf(`The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions):<ul>
+	configHelp := fmt.Sprintf(`Configured sizes:<ul>
 <li>size/XS:  0-%d</li>
 <li>size/S:   %d-%d</li>
 <li>size/M:   %d-%d</li>
 <li>size/L    %d-%d</li>
 <li>size/XL:  %d-%d</li>
 <li>size/XXL: %d+</li>
-</ul>`, sizes.S-1, sizes.S, sizes.M-1, sizes.M, sizes.L-1, sizes.L, sizes.Xl-1, sizes.Xl, sizes.Xxl-1, sizes.Xxl),
+</ul>`, sizes.S-1, sizes.S, sizes.M-1, sizes.M, sizes.L-1, sizes.L, sizes.Xl-1, sizes.Xl, sizes.Xxl-1, sizes.Xxl)
+	sizeConfig := map[string]string{
+		"": configHelp,
+	}
+	for _, repo := range enabledRepos {
+		sizeConfig[repo] = configHelp
+	}
+	return &pluginhelp.PluginHelp{
+			Description: "The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated." +
+				"Generated files identified by the config file '.generated_files' at the repo root are ignored." +
+				"Labels are applied based on the total number of lines of changes (additions and deletions)",
+			Config: sizeConfig,
 		},
 		nil
 }


### PR DESCRIPTION
The following plugins didn't expose their current config through `PluginHelp`:
* `lgtm`
* `size`

This PR update the plugins to expose this information.

Fixes: #10714 
