### PR TITLE
Add post job to build canary build on latest master

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -1,0 +1,45 @@
+postsubmits:
+  kubernetes-sigs/sig-storage-local-static-provisioner:
+  # A postsubmit job to build canary build on master.
+  - name: post-sig-storage-local-static-provisioner-build-canary
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190108-eadd44c98-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - e2e
+        - release
+        env:
+        - name: PROVIDER
+          value: gce
+        - name: EXTRACT_STRATEGY
+          value: ci/latest
+        - name: VERSION
+          value: canary
+        - name: ALLOW_UNSTABLE
+          value: "true"
+        - name: CONFIRM
+          value: "yes"
+        - name: DOCKER_CONFIG
+          value: /etc/pusher-docker-config
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: pusher-docker-config
+          mountPath: /etc/pusher-docker-config
+      volumes:
+      - name: pusher-docker-config
+        secret:
+          secretName: sig-storage-local-static-provisioner-pusher

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -18,13 +18,8 @@ postsubmits:
         - runner.sh
         args:
         - make
-        - e2e
         - release
         env:
-        - name: PROVIDER
-          value: gce
-        - name: EXTRACT_STRATEGY
-          value: ci/latest
         - name: VERSION
           value: canary
         - name: ALLOW_UNSTABLE

--- a/config/tests/jobs/BUILD.bazel
+++ b/config/tests/jobs/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//prow/kube:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3393,6 +3393,9 @@ test_groups:
 - name: ci-sig-storage-local-static-provisioner-master-gke-default
   gcs_prefix: kubernetes-jenkins/logs/ci-sig-storage-local-static-provisioner-master-gke-default
 
+- name: post-sig-storage-local-static-provisioner-build-canary
+  gcs_prefix: kubernetes-jenkins/logs/post-sig-storage-local-static-provisioner-build-canary
+
 
 #
 # Start dashboards
@@ -6651,6 +6654,9 @@ dashboards:
   - name: master-gke-default
     test_group_name: ci-sig-storage-local-static-provisioner-master-gke-default
     description: E2E tests against default kubernetes on GKE
+  - name: master-canary-build
+    test_group_name: post-sig-storage-local-static-provisioner-build-canary
+    description: Canary image build against latest master
 
 - name: sig-testing-maintenance
   dashboard_tab:


### PR DESCRIPTION
It also adds unit test to restrict usage of secrets.

xref: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/9