### PR TITLE
Unify ratelimiter interface between build & crier

### DIFF
--- a/prow/cmd/build/BUILD.bazel
+++ b/prow/cmd/build/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "//vendor/github.com/knative/build/pkg/client/informers/externalversions/build/v1alpha1:go_default_library",
         "//vendor/github.com/knative/pkg/apis/duck/v1alpha1:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/golang.org/x/time/rate:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -132,6 +132,9 @@ type fakeLimiter struct {
 }
 
 func (fl *fakeLimiter) ShutDown() {}
+func (fl *fakeLimiter) ShuttingDown() bool {
+	return false
+}
 func (fl *fakeLimiter) Get() (interface{}, bool) {
 	return "not implemented", true
 }
@@ -139,6 +142,18 @@ func (fl *fakeLimiter) Done(interface{})   {}
 func (fl *fakeLimiter) Forget(interface{}) {}
 func (fl *fakeLimiter) AddRateLimited(a interface{}) {
 	fl.added = a.(string)
+}
+func (fl *fakeLimiter) Add(a interface{}) {
+	fl.added = a.(string)
+}
+func (fl *fakeLimiter) AddAfter(a interface{}, d time.Duration) {
+	fl.added = a.(string)
+}
+func (fl *fakeLimiter) Len() int {
+	return 0
+}
+func (fl *fakeLimiter) NumRequeues(item interface{}) int {
+	return 0
 }
 
 func TestEnqueueKey(t *testing.T) {

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -15,11 +15,10 @@ go_library(
         "//prow/gerrit/client:go_default_library",
         "//prow/gerrit/reporter:go_default_library",
         "//prow/github/reporter:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pubsub/reporter:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/golang.org/x/time/rate:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
     ],
 )
 

--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -91,7 +91,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 				logrus.WithError(err).Error("Cannot get key from object meta")
 				return
 			}
-			c.queue.Add(key)
+			c.queue.AddRateLimited(key)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(newObj)
@@ -100,7 +100,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 				logrus.WithError(err).Error("Cannot get key from object meta")
 				return
 			}
-			c.queue.Add(key)
+			c.queue.AddRateLimited(key)
 		},
 	})
 

--- a/prow/kube/BUILD.bazel
+++ b/prow/kube/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "cluster.go",
         "metrics.go",
         "prowjob.go",
+        "ratelimiter.go",
         "types.go",
     ],
     importpath = "k8s.io/test-infra/prow/kube",
@@ -31,6 +32,7 @@ go_library(
         "//prow/client/clientset/versioned:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/golang.org/x/time/rate:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
@@ -38,6 +40,7 @@ go_library(
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/prow/kube/ratelimiter.go
+++ b/prow/kube/ratelimiter.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// RateLimiter creates a ratelimiting queue for a given prow controller.
+func RateLimiter(controllerName string) workqueue.RateLimitingInterface {
+	rl := workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 120*time.Second),
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(1000), 50000)},
+	)
+	return workqueue.NewNamedRateLimitingQueue(rl, controllerName)
+}
+
+// for testing
+
+type fakeLimiter struct {
+	added string
+}
+
+func (fl *fakeLimiter) ShutDown() {}
+func (fl *fakeLimiter) Get() (interface{}, bool) {
+	return "not implemented", true
+}
+func (fl *fakeLimiter) Done(interface{})   {}
+func (fl *fakeLimiter) Forget(interface{}) {}
+func (fl *fakeLimiter) AddRateLimited(a interface{}) {
+	fl.added = a.(string)
+}
+func (fl *fakeLimiter) Add(a interface{}) {
+	fl.added = a.(string)
+}
+func (fl *fakeLimiter) AddAfter(a interface{}, d time.Duration) {
+	fl.added = a.(string)
+}
+func (fl *fakeLimiter) Len() {
+	return
+}
+func (fl *fakeLimiter) NumRequeues(item interface{}) int {
+	return 0
+}


### PR DESCRIPTION
An attempt towards https://github.com/kubernetes/test-infra/issues/10602, since I was guessing the existing ratelimit is too strict which causes keys got dropped? Copied the one from build controller which  has a wider limit.

/assign @munnerz @stevekuznetsov @fejta 