### PR TITLE
Fix coreos-alpha image for ci-kubernetes-node-kubelet-conformance

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -150,21 +150,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   coreosalpha-resource1:
-    image: coreos-alpha-1478-0-0-v20170719
+    image: coreos-alpha-2016-0-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   coreosalpha-resource2:
-    image: coreos-alpha-1478-0-0-v20170719
+    image: coreos-alpha-2016-0-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   coreosalpha-resource3:
-    image: coreos-alpha-1478-0-0-v20170719
+    image: coreos-alpha-2016-0-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1

--- a/jobs/e2e_node/image-config-1-10.yaml
+++ b/jobs/e2e_node/image-config-1-10.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image: coreos-alpha-2016-0-0-v20190108 # docker 18.06.1
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-11.yaml
+++ b/jobs/e2e_node/image-config-1-11.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image: coreos-alpha-2016-0-0-v20190108 # docker 18.06.1
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-9.yaml
+++ b/jobs/e2e_node/image-config-1-9.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image: coreos-alpha-2016-0-0-v20190108 # docker 18.06.1
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    image: coreos-alpha-2016-0-0-v20190108 # docker 18.06.1
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable2:


### PR DESCRIPTION
The job has been failing for a while, latest errors indicate the
following error:

```
I0114 19:26:38.350] unable to create gce instance with running docker daemon for image coreos-alpha-1478-0-0-v20170719.  could not create instance n1-standard-1-coreos-alpha-1478-0-0-v20170719-4f9f54d1: API error: googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.sourceImage': 'projects/coreos-cloud/global/images/coreos-alpha-1478-0-0-v20170719'. The referenced image resource cannot be found., invalid
```

Change-Id: Ia41d98998adc04e0c711d0a8475337c9d74554a4