### PR TITLE
Sets k/org approve settings to match k/community

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -80,6 +80,7 @@ approve:
 - repos:
   - bazelbuild
   - kubernetes/community
+  - kubernetes/org
   - kubernetes/test-infra
   implicit_self_approve: true
   review_acts_as_approve: true


### PR DESCRIPTION
This sets the approve plugin settings to match k/community. Let's us test the github UI workflow as this is also a contribex repo.

cc: @kubernetes/sig-contributor-experience-pr-reviews @kubernetes/owners @justaugustus @mrbobbytables 