### PR TITLE
Fix ghproxy URL for periobolos jobs.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
         - run
         - //admin:update
         - --
-        - --github-endpoint=ghproxy.default.svc.cluster.local
+        - --github-endpoint=http://ghproxy.default.svc.cluster.local
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github-token/oauth
         - --confirm
@@ -86,7 +86,7 @@ periodics:
       - run
       - //admin:update
       - --
-      - --github-endpoint=ghproxy.default.svc.cluster.local
+      - --github-endpoint=http://ghproxy.default.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --github-token-path=/etc/github-token/oauth
       - --confirm


### PR DESCRIPTION
From: https://gubernator.k8s.io/build/kubernetes-jenkins/logs/post-org-peribolos/91 
```json
{
  "component":"peribolos",
  "level":"fatal",
  "msg":"Invalid flags: invalid -github-endpoint URI: \"ghproxy.default.svc.cluster.local\"",
  "time":"2019-01-14T23:09:25Z"
}
```

Should have `http://` prefix like hook: https://github.com/kubernetes/test-infra/blob/68d3329f88f03314ac026dfed0d6e5e1fe1490cd/prow/cluster/hook_deployment.yaml#L43-L44

/kind bug
/assign @fejta 