### PR TITLE
Switch to newer coreos-stable image in benchmark-config

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -172,21 +172,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   coreosstable-resource1:
-    image: coreos-stable-1409-7-0-v20170719
+    image: coreos-stable-1967-3-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   coreosstable-resource2:
-    image: coreos-stable-1409-7-0-v20170719
+    image: coreos-stable-1967-3-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   coreosstable-resource3:
-    image: coreos-stable-1409-7-0-v20170719
+    image: coreos-stable-1967-3-0-v20190108
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1


### PR DESCRIPTION
coreos-stable-1409-7-0-v20170719 no longer exists, we should switch to
using the latest stable available now.

Change-Id: I8adefc8bc282a5ef6c4d3332920d23873339fef1