### PR TITLE
Revert "Migrating kubemark 500 to clusterloader"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -405,9 +405,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
       args:
-      - --repo=k8s.io/kubernetes=master
-      - --repo=k8s.io/perf-tests=master
-      - --root=/go/src
+      - --bare
       - --timeout=140
       - --scenario=kubernetes_e2e
       - --
@@ -423,15 +421,7 @@ periodics:
       - --kubemark-nodes=500
       - --provider=gce
       - --test=false
-      - --test_args=--ginkgo.focus=xxxx
-      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-      - --test-cmd-args=cluster-loader2
-      - --test-cmd-args=--nodes=500
-      - --test-cmd-args=--provider=kubemark
-      - --test-cmd-args=--report-dir=/workspace/_artifacts
-      - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-name=ClusterLoaderV2
+      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true
       - --timeout=70m
       # docker-in-docker needs privilged mode
       securityContext:


### PR DESCRIPTION
Reverts kubernetes/test-infra#10617

Reverting due to problem with test timeout.