### PR TITLE
Build and push checkconfig on merge

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -14,6 +14,7 @@ container_bundle(
         "artifact-uploader",
         "branchprotector",
         "build",
+        "checkconfig",
         "clonerefs",
         "deck",
         "entrypoint",

--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -46,7 +47,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-container_image(
+prow_image(
     name = "image",
     base = "@git-base//image",
     directory = "/",


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign  @fejta @cjwagner 
Is it possible to push every image under `prow/` automatically so we can't accidentally miss something?