### PR TITLE
Drop build log error level from Error to Info

### DIFF
--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -137,7 +137,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		}
 		lines, err := logLinesAll(a)
 		if err != nil {
-			logrus.WithError(err).Error("Error reading log.")
+			logrus.WithError(err).Info("Error reading log.")
 			continue
 		}
 		av.LineGroups = groupLines(highlightLines(lines, 0))


### PR DESCRIPTION
Drop the error level when we can't turn up a build-log.txt from Error to Info: this failure doesn't really have much to do with prow, deck, or spyglass (it'll generally either be a pod that's still initialising or a job that failed to upload a build-log.txt).

I'm not happy with this solution as the actual solution. We blindly assert elsewhere that all jobs will definitely have some form of accessible `build-log.txt` at all times, which is not actually true. Sanely changing this assumption is a bunch of work, though (we currently lack the tools to determine it ~efficiently), so I'm punting to the future: #10771.

/cc @stevekuznetsov 