### PR TITLE
Only dump sidecar-errors if there's any

### DIFF
--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -130,7 +130,10 @@ func (o Options) Run(ctx context.Context) error {
 			metadata[k] = v // TODO(fejta): consider deeper merge
 		}
 	}
-	metadata["sidecar-errors"] = errors
+
+	if len(errors) > 0 {
+		metadata["sidecar-errors"] = errors
+	}
 
 	return o.doUpload(spec, passed, aborted, metadata, io.MultiReader(readers...))
 }


### PR DESCRIPTION
it's always showing up now, aka, https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/test-infra/10773/pull-test-infra-lint/9290

/assign @stevekuznetsov @ibzib 