### PR TITLE
Make Tide log timing info about GitHub queries.

### DIFF
--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
@@ -131,6 +132,7 @@ func parseBranches(str string) []string {
 }
 
 func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) ([]Issue, error) {
+	requestStart := time.Now()
 	var ret []Issue
 	vars := map[string]interface{}{
 		"query":        githubql.String(q),
@@ -153,7 +155,9 @@ func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) 
 		}
 		vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
 	}
-	log.Debugf("Search for query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
+	log.WithField(
+		"duration", time.Since(requestStart).String(),
+	).Debugf("Search for blocker query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
 	return ret, nil
 }
 

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -31,6 +31,7 @@ type searchExecutor func(start, end time.Time) ([]PullRequest, int /*true match 
 
 func newSearchExecutor(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) searchExecutor {
 	return func(start, end time.Time) ([]PullRequest, int, error) {
+		requestStart := time.Now()
 		datedQuery := fmt.Sprintf("%s %s", q, dateToken(start, end))
 		vars := map[string]interface{}{
 			"query":        githubql.String(datedQuery),
@@ -60,9 +61,10 @@ func newSearchExecutor(ctx context.Context, ghc githubClient, log *logrus.Entry,
 			vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
 		}
 		log.WithFields(logrus.Fields{
-			"query": datedQuery,
-			"start": start.String(),
-			"end":   start.String(),
+			"query":    datedQuery,
+			"start":    start.String(),
+			"end":      end.String(),
+			"duration": time.Since(requestStart).String(),
 		}).Debugf("Query returned %d PRs and cost %d point(s). %d remaining.", len(ret), totalCost, remaining)
 		return ret, totalMatches, nil
 	}

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -435,6 +435,9 @@ func (sc *statusController) search() []PullRequest {
 			allPRs = append(allPRs, prs...)
 		}
 	}
+	sc.logger.WithField(
+		"duration", time.Since(queryStartTime).String(),
+	).Debugf("Found %d open PRs.", len(allPRs))
 
 	// We were able to find all open PRs so update the last successful query time.
 	sc.lastSuccessfulQueryStart = queryStartTime

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -282,6 +282,9 @@ func (c *Controller) Sync() error {
 			prs[prKey(&pr)] = pr
 		}
 	}
+	c.logger.WithField(
+		"duration", time.Since(start).String(),
+	).Debugf("Found %d (unfiltered) pool PRs.", len(prs))
 
 	var pjs []kube.ProwJob
 	var blocks blockers.Blockers


### PR DESCRIPTION
I'd like to collect some more data about query durations (both individual queries and time spent querying per sync loop).

/assign @stevekuznetsov @ibzib