### PR TITLE
Fix plugin help selection box default text.

### DIFF
--- a/prow/cmd/deck/template/plugins.html
+++ b/prow/cmd/deck/template/plugins.html
@@ -12,7 +12,7 @@
     <ul class="noBullets">
       <li>Plugin help for</li>
       <li><select id="repo">
-        <option>All plugins</option>
+        <option>All repos</option>
       </select></li>
     </ul>
   </div>


### PR DESCRIPTION
This is a selection from a list of repos not a list of plugins so the previous default text is somewhat misleading.

/assign @alvaroaleman