### PR TITLE
Make clear that "Documentation" leaves Prow.

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -15,6 +15,10 @@ body {
     font-size: small;
 }
 
+.mdl-navigation__link .material-icons {
+    font-size: 14px;
+}
+
 code {
     background-color: #EEEEEE;
     border-radius: 3px;

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -38,7 +38,7 @@
         <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
       {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
-      <a class="mdl-navigation__link" href="https://github.com/kubernetes/test-infra/blob/master/prow/README.md">Documentation</a>
+      <a class="mdl-navigation__link" href="https://github.com/kubernetes/test-infra/blob/master/prow/README.md" target="_blank">Documentation <span class="material-icons">open_in_new</span></a>
     </nav>
     <footer>
       {{deckVersion}}


### PR DESCRIPTION
Use the standard icon to indicate that the "documentation" link behaves differently to the others.

![image](https://user-images.githubusercontent.com/110792/51212953-ac074d00-18ce-11e9-91c0-286ee96a1404.png)

/cc @ibzib 
