### PR TITLE
Allow configuring prow to use deprecated approval defaults

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -2,7 +2,10 @@
 
 New features added to each component:
 
- - *January 12, 2018* `blunderbluss` plugin now provides a new command, `/auto-cc`,
+ - *January 15, 2019* `approve` now considers self-approval and github review
+   state by default. Configure with `require_self_approval` and
+   `ignore_review_state`. Temporarily revert to old defaults with `use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019` and `use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019`.
+ - *January 12, 2019* `blunderbluss` plugin now provides a new command, `/auto-cc`,
    that triggers automatic review requests.
  - *January 7, 2019* `implicit_self_approve` will become `require_self_approval` in
    the second half of this year.

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -37,6 +37,10 @@ owners:
   - kubernetes-sigs/contributor-playground
   - helm/charts
 
+# TODO(fejta): delete these in before April
+use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019: true
+use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019: true
+
 approve:
 - repos:
   - kubernetes/cloud-provider-aws
@@ -67,7 +71,7 @@ approve:
   - kubernetes/steering
   - kubernetes/utils
   - kubernetes-incubator/ip-masq-agent
-  implicit_self_approve: true
+  require_self_approval: false
   lgtm_acts_as_approve: true
 - repos:
   - kubernetes/kops
@@ -76,17 +80,17 @@ approve:
   - kubernetes-csi
   - kubernetes-sigs
   - client-go/unofficial-docs
-  implicit_self_approve: true
+  require_self_approval: false
 - repos:
   - bazelbuild
   - kubernetes/community
   - kubernetes/org
   - kubernetes/test-infra
-  implicit_self_approve: true
-  review_acts_as_approve: true
+  require_self_approval: false
+  ignore_review_state: false
 - repos:
   - helm/charts
-  implicit_self_approve: true
+  require_self_approval: false
   lgtm_acts_as_approve: true
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1013,16 +1013,18 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			branch = test.branch
 		}
 
+		rsa := !test.selfApprove
+		irs := !test.reviewActsAsApprove
 		if err := handle(
 			logrus.WithField("plugin", "approve"),
 			fghc,
 			fr,
 			&plugins.Approve{
 				Repos:               []string{"org/repo"},
-				RequireSelfApproval: !test.selfApprove,
+				RequireSelfApproval: &rsa,
 				IssueRequired:       test.needsIssue,
 				LgtmActsAsApprove:   test.lgtmActsAsApprove,
-				IgnoreReviewState:   !test.reviewActsAsApprove,
+				IgnoreReviewState:   &irs,
 			},
 			&state{
 				org:       "org",
@@ -1504,10 +1506,11 @@ func TestHandleReview(t *testing.T) {
 		test.reviewEvent.Repo = repo
 		test.reviewEvent.PullRequest = pr
 		config := &plugins.Configuration{}
+		irs := !test.reviewActsAsApprove
 		config.Approve = append(config.Approve, plugins.Approve{
 			Repos:             []string{test.reviewEvent.Repo.Owner.Login},
 			LgtmActsAsApprove: test.lgtmActsAsApprove,
-			IgnoreReviewState: !test.reviewActsAsApprove,
+			IgnoreReviewState: &irs,
 		})
 		err := handleReview(
 			logrus.WithField("plugin", "approve"),

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -51,24 +51,26 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
-	Approve              []Approve              `json:"approve,omitempty"`
-	Blockades            []Blockade             `json:"blockades,omitempty"`
-	Blunderbuss          Blunderbuss            `json:"blunderbuss,omitempty"`
-	Cat                  Cat                    `json:"cat,omitempty"`
-	CherryPickUnapproved CherryPickUnapproved   `json:"cherry_pick_unapproved,omitempty"`
-	ConfigUpdater        ConfigUpdater          `json:"config_updater,omitempty"`
-	Golint               *Golint                `json:"golint,omitempty"`
-	Heart                Heart                  `json:"heart,omitempty"`
-	Label                *Label                 `json:"label,omitempty"`
-	Lgtm                 []Lgtm                 `json:"lgtm,omitempty"`
-	RepoMilestone        map[string]Milestone   `json:"repo_milestone,omitempty"`
-	RequireMatchingLabel []RequireMatchingLabel `json:"require_matching_label,omitempty"`
-	RequireSIG           RequireSIG             `json:"requiresig,omitempty"`
-	Slack                Slack                  `json:"slack,omitempty"`
-	SigMention           SigMention             `json:"sigmention,omitempty"`
-	Size                 *Size                  `json:"size,omitempty"`
-	Triggers             []Trigger              `json:"triggers,omitempty"`
-	Welcome              []Welcome              `json:"welcome,omitempty"`
+	Approve                    []Approve              `json:"approve,omitempty"`
+	UseDeprecatedSelfApprove   bool                   `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`
+	UseDeprecatedReviewApprove bool                   `json:"use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019,omitempty"`
+	Blockades                  []Blockade             `json:"blockades,omitempty"`
+	Blunderbuss                Blunderbuss            `json:"blunderbuss,omitempty"`
+	Cat                        Cat                    `json:"cat,omitempty"`
+	CherryPickUnapproved       CherryPickUnapproved   `json:"cherry_pick_unapproved,omitempty"`
+	ConfigUpdater              ConfigUpdater          `json:"config_updater,omitempty"`
+	Golint                     *Golint                `json:"golint,omitempty"`
+	Heart                      Heart                  `json:"heart,omitempty"`
+	Label                      *Label                 `json:"label,omitempty"`
+	Lgtm                       []Lgtm                 `json:"lgtm,omitempty"`
+	RepoMilestone              map[string]Milestone   `json:"repo_milestone,omitempty"`
+	RequireMatchingLabel       []RequireMatchingLabel `json:"require_matching_label,omitempty"`
+	RequireSIG                 RequireSIG             `json:"requiresig,omitempty"`
+	Slack                      Slack                  `json:"slack,omitempty"`
+	SigMention                 SigMention             `json:"sigmention,omitempty"`
+	Size                       *Size                  `json:"size,omitempty"`
+	Triggers                   []Trigger              `json:"triggers,omitempty"`
+	Welcome                    []Welcome              `json:"welcome,omitempty"`
 }
 
 // Golint holds configuration for the golint plugin
@@ -232,7 +234,7 @@ type Approve struct {
 	DeprecatedImplicitSelfApprove *bool `json:"implicit_self_approve,omitempty"`
 	// RequireSelfApproval requires PR authors to explicitly approve their PRs.
 	// Otherwise the plugin assumes the author of the PR approves the changes in the PR.
-	RequireSelfApproval bool `json:"require_self_approval,omitempty"`
+	RequireSelfApproval *bool `json:"require_self_approval,omitempty"`
 
 	// LgtmActsAsApprove indicates that the lgtm command should be used to
 	// indicate approval
@@ -244,7 +246,7 @@ type Approve struct {
 	// IgnoreReviewState causes the approve plugin to ignore the GitHub review state. Otherwise:
 	// * an APPROVE github review is equivalent to leaving an "/approve" message.
 	// * A REQUEST_CHANGES github review is equivalent to leaving an /approve cancel" message.
-	IgnoreReviewState bool `json:"ignore_review_state,omitempty"`
+	IgnoreReviewState *bool `json:"ignore_review_state,omitempty"`
 }
 
 var (
@@ -276,16 +278,20 @@ func (a Approve) HasSelfApproval() bool {
 	if a.DeprecatedImplicitSelfApprove != nil {
 		warnDeprecated(&warnImplicitSelfApprove, 5*time.Minute, "Please update plugins.yaml to use require_self_approval instead of the deprecated implicit_self_approve before June 2019")
 		return *a.DeprecatedImplicitSelfApprove
+	} else if a.RequireSelfApproval != nil {
+		return !*a.RequireSelfApproval
 	}
-	return !a.RequireSelfApproval
+	return true
 }
 
 func (a Approve) ConsiderReviewState() bool {
 	if a.DeprecatedReviewActsAsApprove != nil {
 		warnDeprecated(&warnReviewActsAsApprove, 5*time.Minute, "Please update plugins.yaml to use ignore_review_state instead of the deprecated review_acts_as_approve before June 2019")
 		return *a.DeprecatedReviewActsAsApprove
+	} else if a.IgnoreReviewState != nil {
+		return !*a.IgnoreReviewState
 	}
-	return !a.IgnoreReviewState
+	return true
 }
 
 // Lgtm specifies a configuration for a single lgtm.


### PR DESCRIPTION
/assign @cblecker @Katharine @cjwagner 

Also update prow.k8s.io to use:
* non-deprecated names (require_self_approval and ignore_review_state)
* deprecated defaults when nothing is specified

/hold