### PR TITLE
Migrating ci-kubernetes-kubemark-gce-scale to clusterloader

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -453,7 +453,9 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190110-49573aea5-master
       args:
-      - --bare
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
       - --timeout=1100
       - --scenario=kubernetes_e2e
       - --
@@ -468,7 +470,15 @@ periodics:
       - --kubemark-nodes=5000
       - --provider=gce
       - --test=false
-      - --test_args=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=5000
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-name=ClusterLoaderV2
       - --timeout=1080m
       - --use-logexporter
       # docker-in-docker needs privilged mode


### PR DESCRIPTION
Migrating ci-kubernetes-kubemark-gce-scale to clusterloader.