### PR TITLE
add a version metadata Bandaid

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -102,6 +102,12 @@ fi
 # Use a reproducible build date based on the most recent git commit timestamp.
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
 
+# TODO(bentheelder): this is a band-aid! Delete this when we've exposed this data
+# in the pod-utils first-class.
+if [[ "${METADATA_BANDAID:-false}" == "true" ]]; then
+    echo "{\"job-version\": \"$(git rev-parse HEAD)\"}" >> "${ARTIFACTS}/metadata.json"
+fi
+
 # actually start bootstrap and the job
 "$@"
 EXIT_VALUE=$?

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -100,7 +100,8 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
 fi
 
 # Use a reproducible build date based on the most recent git commit timestamp.
-export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+export SOURCE_DATE_EPOCH
 
 # TODO(bentheelder): this is a band-aid! Delete this when we've exposed this data
 # in the pod-utils first-class.


### PR DESCRIPTION
to be clear I don't like this, but we have some tasks that reallly depend on being able to monitor against the version, this is simple, will be easy to remove later, and is opt-in.

also fixed a shellcheck while I was at it

/assign @krzyzacy @ixdy 