### PR TITLE
Capture and expose GitHub webhook event GUIDs in more places.

### DIFF
--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -51,6 +51,7 @@ class GithubWebhookRaw(ndb.Model):
     repo = ndb.StringProperty()
     number = ndb.IntegerProperty(indexed=False)
     event = ndb.StringProperty()
+    guid = ndb.StringProperty()
     timestamp = ndb.DateTimeProperty(auto_now_add=True)
     body = ndb.TextProperty(compressed=True)
 

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -149,6 +149,8 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		srcRepo = se.Repo.FullName
 		s.wg.Add(1)
 		go s.handleStatusEvent(l, se)
+	default:
+		l.Debug("Ignoring unhandled event type. (Might still be handled by external plugins.)")
 	}
 	// Demux events only to external plugins that require this event.
 	if external := s.needDemux(eventType, srcRepo); len(external) > 0 {
@@ -165,16 +167,7 @@ func (s *Server) needDemux(eventType, srcRepo string) []plugins.ExternalPlugin {
 
 	for repo, plugins := range s.Plugins.Config().ExternalPlugins {
 		// Make sure the repositories match
-		var matchesRepo bool
-		if repo == srcRepo {
-			matchesRepo = true
-		}
-		// If repo is an org, we need to compare orgs.
-		if !matchesRepo && !strings.Contains(repo, "/") && repo == srcOrg {
-			matchesRepo = true
-		}
-		// No need to continue if the repos don't match.
-		if !matchesRepo {
+		if repo != srcRepo && repo != srcOrg {
 			continue
 		}
 


### PR DESCRIPTION
The event GUID is the value of the `X-Github-Delivery` request header and is used to trace webhook delivery by GitHub internally (and by us).
This PR:
- Makes Gubernator store the event GUID as part of the data it stores for all webhooks and updates Gubernator's timeline page to display the GUIDs next to the event type.
- Makes Prow log receipt of webhooks with unhandled event types and their event GUIDs.

This data will help GitHub support next time we encounter an issue.

/assign @stevekuznetsov @BenTheElder @Katharine 