### PR TITLE
Automate release process for sig-storage-local-static-provisioner

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -1,6 +1,6 @@
 postsubmits:
   kubernetes-sigs/sig-storage-local-static-provisioner:
-  # A postsubmit job to build canary build on master.
+  # A postsubmit job to build canary image on master.
   - name: post-sig-storage-local-static-provisioner-build-canary
     branches:
     - master
@@ -24,6 +24,45 @@ postsubmits:
           value: canary
         - name: ALLOW_UNSTABLE
           value: "true"
+        - name: CONFIRM
+          value: "yes"
+        - name: DOCKER_CONFIG
+          value: /etc/pusher-docker-config
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: pusher-docker-config
+          mountPath: /etc/pusher-docker-config
+      volumes:
+      - name: pusher-docker-config
+        secret:
+          secretName: sig-storage-local-static-provisioner-pusher
+  # A postsubmit job to build release image on release tags.
+  - name: post-sig-storage-local-static-provisioner-build-release
+    branches:
+    - ^v\d+\.\d+\.\d+$
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190108-eadd44c98-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - e2e
+        - release
+        env:
+        - name: PROVIDER
+          value: gce
+        - name: EXTRACT_STRATEGY
+          value: ci/latest
         - name: CONFIRM
           value: "yes"
         - name: DOCKER_CONFIG

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -91,6 +91,8 @@ periodics:
         value: gce
       - name: EXTRACT_STRATEGY
         value: ci/latest
+      - NAME: PROVISIONER_E2E_IMAGE
+        value: quay.io/external_storage/local-volume-provisioner:canary
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -121,6 +123,8 @@ periodics:
         value: prod
       - name: EXTRACT_STRATEGY
         value: gke-default
+      - NAME: PROVISIONER_E2E_IMAGE
+        value: quay.io/external_storage/local-volume-provisioner:canary
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3362,6 +3362,9 @@ test_groups:
 - name: post-sig-storage-local-static-provisioner-build-canary
   gcs_prefix: kubernetes-jenkins/logs/post-sig-storage-local-static-provisioner-build-canary
 
+- name: post-sig-storage-local-static-provisioner-build-release
+  gcs_prefix: kubernetes-jenkins/logs/post-sig-storage-local-static-provisioner-build-release
+
 
 #
 # Start dashboards
@@ -6660,6 +6663,9 @@ dashboards:
   - name: master-canary-build
     test_group_name: post-sig-storage-local-static-provisioner-build-canary
     description: Canary image build against latest master
+  - name: release-build
+    test_group_name: post-sig-storage-local-static-provisioner-build-release
+    description: Release image build against tagged releases
 
 - name: sig-testing-maintenance
   dashboard_tab:


### PR DESCRIPTION
- update periodical jobs to run against latest canary image
- add postsubmit jobs to build image for tagged releases

https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/9#issuecomment-454254367