### PR TITLE
The repoowners cache is useless

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -18,6 +18,8 @@ limitations under the License.
 package git
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -335,4 +337,18 @@ func retryCmd(l *logrus.Entry, dir, cmd string, arg ...string) ([]byte, error) {
 		break
 	}
 	return b, err
+}
+
+func (r *Repo) Diff(head, sha string) (changes []string, err error) {
+	r.logger.Infof("Diff head with %s'.", sha)
+	output, err := r.gitCommand("diff", head, sha, "--name-only").CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	scan := bufio.NewScanner(bytes.NewReader(output))
+	scan.Split(bufio.ScanLines)
+	for scan.Scan() {
+		changes = append(changes, scan.Text())
+	}
+	return
 }


### PR DESCRIPTION
**What happened**:
The `NewAgent #prow/plugins/plugins.go`  will create new OwnersClient, but the cache in repoowner is not singleton, it will cause cache is useless
![image](https://user-images.githubusercontent.com/26948962/51313284-20392080-1a88-11e9-978f-e32f445c2298.png)
![image](https://user-images.githubusercontent.com/26948962/51313347-4494fd00-1a88-11e9-8944-9a2f56aa405e.png)

**other changes**
1. add git diff before sync entry
2. delete update entry sha when only sync aliases