### PR TITLE
Correctly create singleton for repoowners cache

### DIFF
--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pluginhelp/hook:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/test-infra/prow/metrics"
 	pluginhelp "k8s.io/test-infra/prow/pluginhelp/hook"
 	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/repoowners"
 	"k8s.io/test-infra/prow/slack"
 )
 
@@ -146,17 +147,29 @@ func main() {
 		slackClient = slack.NewFakeClient()
 	}
 
+	pluginAgent := &plugins.ConfigAgent{}
+	if err := pluginAgent.Start(o.pluginConfig); err != nil {
+		logrus.WithError(err).Fatal("Error starting plugins.")
+	}
+
+	mdYAMLEnabled := func(org, repo string) bool {
+		return pluginAgent.Config().MDYAMLEnabled(org, repo)
+	}
+	skipCollaborators := func(org, repo string) bool {
+		return pluginAgent.Config().SkipCollaborators(org, repo)
+	}
+	ownersDirBlacklist := func() config.OwnersDirBlacklist {
+		return configAgent.Config().OwnersDirBlacklist
+	}
+	ownersClient := repoowners.NewClient(gitClient, githubClient, mdYAMLEnabled, skipCollaborators, ownersDirBlacklist)
+
 	clientAgent := &plugins.ClientAgent{
 		GitHubClient:     githubClient,
 		ProwJobClient:    prowJobClient,
 		KubernetesClient: infrastructureClient,
 		GitClient:        gitClient,
 		SlackClient:      slackClient,
-	}
-
-	pluginAgent := &plugins.ConfigAgent{}
-	if err := pluginAgent.Start(o.pluginConfig); err != nil {
-		logrus.WithError(err).Fatal("Error starting plugins.")
+		OwnersClient:     ownersClient,
 	}
 
 	promMetrics := hook.NewMetrics()

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -119,6 +119,19 @@ type OwnersDirBlacklist struct {
 	Default []string `json:"default"`
 }
 
+// DirBlacklist returns directories which are used to ignore when
+// searching for OWNERS{,_ALIAS} files in a repo.
+func (ownersDirBlacklist OwnersDirBlacklist) DirBlacklist(org, repo string) (blacklist []string) {
+	blacklist = append(blacklist, ownersDirBlacklist.Default...)
+	if bl, ok := ownersDirBlacklist.Repos[org]; ok {
+		blacklist = append(blacklist, bl...)
+	}
+	if bl, ok := ownersDirBlacklist.Repos[org+"/"+repo]; ok {
+		blacklist = append(blacklist, bl...)
+	}
+	return
+}
+
 // PushGateway is a prometheus push gateway.
 type PushGateway struct {
 	// Endpoint is the location of the prometheus pushgateway

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -18,6 +18,8 @@ limitations under the License.
 package git
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -335,4 +337,18 @@ func retryCmd(l *logrus.Entry, dir, cmd string, arg ...string) ([]byte, error) {
 		break
 	}
 	return b, err
+}
+
+func (r *Repo) Diff(head, sha string) (changes []string, err error) {
+	r.logger.Infof("Diff head with %s'.", sha)
+	output, err := r.gitCommand("diff", head, sha, "--name-only").CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	scan := bufio.NewScanner(bytes.NewReader(output))
+	scan.Split(bufio.ScanLines)
+	for scan.Scan() {
+		changes = append(changes, scan.Text())
+	}
+	return
 }

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -162,14 +162,10 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 		ProwJobClient:    clientAgent.ProwJobClient,
 		GitClient:        clientAgent.GitClient,
 		SlackClient:      clientAgent.SlackClient,
-		OwnersClient: repoowners.NewClient(
-			clientAgent.GitClient, clientAgent.GitHubClient,
-			prowConfig, pluginConfig.MDYAMLEnabled,
-			pluginConfig.SkipCollaborators,
-		),
-		Config:       prowConfig,
-		PluginConfig: pluginConfig,
-		Logger:       logger,
+		OwnersClient:     clientAgent.OwnersClient,
+		Config:           prowConfig,
+		PluginConfig:     pluginConfig,
+		Logger:           logger,
 	}
 }
 
@@ -198,6 +194,7 @@ type ClientAgent struct {
 	KubernetesClient kubernetes.Interface
 	GitClient        *git.Client
 	SlackClient      *slack.Client
+	OwnersClient     *repoowners.Client
 }
 
 // ConfigAgent contains the agent mutex and the Agent configuration.

--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -22,7 +22,7 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",
-        "//prow/github/fakegithub:go_default_library",
+        "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],


### PR DESCRIPTION
**What happened**:
The `NewAgent #prow/plugins/plugins.go`  will create new OwnersClient, but the cache in repoowner is not singleton, it will cause cache is useless
![image](https://user-images.githubusercontent.com/26948962/51313284-20392080-1a88-11e9-978f-e32f445c2298.png)
![image](https://user-images.githubusercontent.com/26948962/51313347-4494fd00-1a88-11e9-8944-9a2f56aa405e.png)

**other changes**
1. add git diff before sync entry
2. delete update entry sha when only sync aliases