### PR TITLE
Match resources for local-e2e-containerized and local-e2e jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2341,7 +2341,10 @@ presubmits:
         - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190116-8e0f20924-master
         name: ""
-        resources: {}
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
         securityContext:
           privileged: true
         volumeMounts:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -33,6 +33,13 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
 
 periodics:
 - name: ci-kubernetes-local-e2e
@@ -59,3 +66,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m


### PR DESCRIPTION
local-e2e-containerized is no longer timing out (it has a couple of
other intermittent failures, which we can deal with elsewhere). However
in this change, we make sure we use the same cpu/mem for the
(ci|pull)-kubernetes-local-e2e jobs so they stop timing out as well.

Change-Id: If561d34c9440c79202140295b91ce70b5b64ad52