### PR TITLE
use UnmarshalStrict for prow config

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -40,6 +40,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *January 17, 2019* config loading now uses `UnmarshalStrict` to ensure that all
+   keys are for valid fields. This may break deployments using invalid prow configs.
  - *November 29, 2018* `plank` will no longer default jobs with `decorate: true`
    to have `automountServiceAccountToken: false` in their PodSpec if unset, if the
    job explicitly sets `serviceAccountName`

--- a/prow/cmd/mkpod/main.go
+++ b/prow/cmd/mkpod/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	var job kube.ProwJob
-	if err := yaml.Unmarshal(rawJob, &job); err != nil {
+	if err := yaml.UnmarshalStrict(rawJob, &job); err != nil {
 		logrus.WithError(err).Fatal("Could not unmarshal ProwJob YAML.")
 	}
 

--- a/prow/cmd/tot/fallbackcheck/main.go
+++ b/prow/cmd/tot/fallbackcheck/main.go
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	cfg := &config.Config{}
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(data, &cfg); err != nil {
 		logrus.Fatalf("cannot unmarshal data from prow: %v", err)
 	}
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -410,7 +410,7 @@ func yamlToConfig(path string, nc interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error reading %s: %v", path, err)
 	}
-	if err := yaml.Unmarshal(b, nc); err != nil {
+	if err := yaml.UnmarshalStrict(b, nc); err != nil {
 		return fmt.Errorf("error unmarshaling %s: %v", path, err)
 	}
 	var jc *JobConfig


### PR DESCRIPTION
/hold
~this will fail because we have known invalid config fields xref #10811, and some more that I am currently fixing...~ second commit fixes all of these, including invalid configuration in our unit tests.

NOTE: this is a breaking change, and is listed as such in the announcements.