### PR TITLE
Update cert-manager to v0.5.2

### DIFF
--- a/prow/cluster/cert-manager.yaml
+++ b/prow/cluster/cert-manager.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -44,7 +44,7 @@ spec:
     shortNames:
       - cert
       - certs
-
+      
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -55,7 +55,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -75,7 +75,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -93,7 +93,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -113,7 +113,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -133,7 +133,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -152,7 +152,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.5.2"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)


### PR DESCRIPTION
Bump cert-manager deployment to v0.5.2 - this contains a number of important fixes which you can see on the [releases](https://github.com/jetstack/cert-manager/releases) page.

v0.5.1 release notes:
```
This is a bugfix release for the v0.5 release series

It resolves an issue relating to our 'retry policies' when processing an Issuer resource fails.

In some edge cases, a misconfigured client will attempt to re-verify ACME accounts at a high rate, potentially causing issues for the ACME server.

All users should upgrade to this release as soon as possible - there have been no significant or breaking changes as this is a patch release!

Don't re-verify ACME accounts after they have been registered already (jetstack/cert-manager#1032, @munnerz)
Fix concurrent map write race condition in ACME solver (jetstack/cert-manager#1033, @munnerz)
Increase time between retries for failing issuers and clusterissuers (jetstack/cert-manager#981, @munnerz)
```

v0.5.2:
```
Two releases in one day!

This release contains a single additional patch over v0.5.1.

In cases where you have defined Ingress resources with multiple different hostnames, that only enable TLS for a subset of those hostnames - if ingress-shim is enabled for these Ingress resources, the hosts that did not have TLS enabled would be removed from the Ingress resource.

Fix bug when cleaning up ingress resources after performing ACME HTTP01 validation (jetstack/cert-manager#1082, @munnerz)
```

/cc @cjwagner 