### PR TITLE
Update ubuntu/gke image for ci-kubernetes-node-kubelet-conformance

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -194,19 +194,19 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable2-resource2:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable2-resource3:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -160,21 +160,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable2-resource2:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable2-resource3:
-    image: ubuntu-gke-1604-xenial-v20170816-1
+    image: ubuntu-gke-1804-d1703-0-v20181113
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"


### PR DESCRIPTION
tests are now failing with:
```
failed to run Kubelet: failed to create kubelet: docker API version is older than 1.26.0
```

So let's bump to newer ubuntu image listed in:
https://cloud.google.com/kubernetes-engine/release-notes

Change-Id: Ie21bdb4c464105a112d9e2c9726f8b0a8c633cf8