### PR TITLE
Update ubuntu/gke image for ci-kubernetes-node-kubelet-conformance - Take #2

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -213,19 +213,19 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable1-resource2:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable1-resource3:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -182,21 +182,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable1-resource2:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable1-resource3:
-    image: ubuntu-gke-1604-xenial-v20171108-1
+    image: ubuntu-gke-1804-bionic-20180921
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"


### PR DESCRIPTION
In ea21255b43f97b48ba8562b5d303a7658cea483b we changed one set of
images, here we are changing the other set of ubuntu/gke images as these
have an older version of docker that is unsupported by kubelet as well.

Change-Id: I969b425475220e109495826369abed9c8b2297ee