### PR TITLE
Revamp scalability periodic test config

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -39,84 +39,6 @@ periodics:
       - --timeout=120m
       - --use-logexporter
 
-- cron: '1 6 * * 6' # Run at 22:01PST on Fri (06:01 UTC on Sat)
-  name: ci-kubernetes-e2e-gce-large-correctness
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-scalability-common: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=420
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=gce-scale-cluster
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-8
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-node-size=g1-small
-      - --gcp-nodes=2000
-      - --gcp-project=kubernetes-scale
-      - --gcp-zone=us-east1-b
-      - --ginkgo-parallel=40
-      - --provider=gce
-      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8
-      - --timeout=390m
-      - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
-      resources:
-        requests:
-          cpu: 6
-          memory: "16Gi"
-
-- cron: '1 13 * * 6' # Run at 5:01PST on Sat (13:01 UTC on Sat)
-  name: ci-kubernetes-e2e-gce-large-performance
-  tags:
-  - "perfDashPrefix: gce-2000Nodes"
-  - "perfDashJobType: performance"
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-scalability-common: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=540
-      - --repo=k8s.io/kubernetes=master
-      - --repo=k8s.io/perf-tests=master
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=gce-scale-cluster
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-8
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-nodes=2000
-      - --gcp-project=kubernetes-scale
-      - --gcp-zone=us-east1-b
-      - --provider=gce
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-      - --test-cmd-args=cluster-loader2
-      - --test-cmd-args=--nodes=2000
-      - --test-cmd-args=--provider=gce
-      - --test-cmd-args=--report-dir=/workspace/_artifacts
-      - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/density/2000_nodes/override.yaml
-      - --test-cmd-name=ClusterLoaderV2
-      - --timeout=510m
-      - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
-      resources:
-        requests:
-          cpu: 6
-          memory: "16Gi"
-
 # Temporary job for gce 5000 that runs on clusterloader.
 # If there are no problems spotted after few runs,
 # ci-kubernetes-e2e-gce-scale-performance will be migrated to clusterloader and this job will be removed.
@@ -132,7 +54,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=1320
+      - --timeout=1080
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -157,7 +79,7 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=1290m
+      - --timeout=1050m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
       resources:
@@ -278,7 +200,7 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
-- cron: '1 18 * * 0' # Run at 10:01PST (18:01 UTC) on sunday
+- cron: '1 3 * * 6' # Run at 19:01PST on Friday (03:01 UTC on Saturday)
   name: ci-kubernetes-e2e-gke-scale-correctness
   labels:
     preset-service-account: "true"
@@ -305,6 +227,42 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8
       - --timeout=210m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
+
+- cron: '1 8 * * 6' # Run at 00:01PST (8:01 UTC) on Sat
+  name: ci-kubernetes-e2e-gke-scale-performance
+  tags:
+  - "perfDashPrefix: gke-5000Nodes"
+  - "perfDashJobType: performance"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=1080
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=gke-scale-cluster
+      - --deployment=gke
+      # TODO(wojtek-t): get rid of this once GKE is fixed in master
+      - --extract=ci/latest-1.13
+      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
+      - --gcp-node-image=gci
+      - --gcp-project=kubernetes-scale
+      - --gcp-zone=us-east1-a
+      - --gke-create-command=container clusters create --quiet --enable-ip-alias --create-subnetwork name=ip-alias-subnet --cluster-ipv4-cidr=/11 --services-ipv4-cidr=/18 --timeout=2700
+      - --gke-environment=staging
+      - '--gke-shape={"default":{"Nodes":4999,"MachineType":"n1-standard-1"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-16"}}'
+      - --provider=gke
+      - --test_args=--ginkgo.focus=\[Feature:Performance\]
+      - --timeout=1030m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
       resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -1,6 +1,6 @@
 periodics:
 # This is a sig-release-master-blocking job.
-- cron: '1 22 * * 6' # Run at 14:01PST on Sat (22:01 UTC on Sat)
+- cron: '1 3 * * 1,2,3,4,5' # Run at 19:01PST on Sun-Thu (03:01 UTC on Mon-Fri)
   name: ci-kubernetes-e2e-gce-scale-correctness
   labels:
     preset-service-account: "true"
@@ -9,7 +9,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=600
+      - --timeout=240
       - --bare
       - --scenario=kubernetes_e2e
       - --
@@ -25,7 +25,7 @@ periodics:
       - --ginkgo-parallel=40
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
-      - --timeout=570m
+      - --timeout=210m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
       resources:
@@ -46,7 +46,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=1320
+      - --timeout=1080
       - --bare
       - --scenario=kubernetes_e2e
       - --
@@ -60,7 +60,7 @@ periodics:
       - --gcp-zone=us-east1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8 --node-schedulable-timeout=90m --gather-resource-usage=masteranddns --gather-metrics-at-teardown=master --vmodule=request=4
-      - --timeout=1290m
+      - --timeout=1050m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190119-7f748595c-master
       resources:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -341,16 +341,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-prometheus
 - name: ci-kubernetes-e2e-gce-influxdb
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-influxdb
-- name: ci-kubernetes-e2e-gce-large-correctness
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-large-correctness
-  days_of_results: 60
-  num_columns_recent: 3
-  num_failures_to_alert: 1
-- name: ci-kubernetes-e2e-gce-large-performance
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-large-performance
-  days_of_results: 60
-  num_columns_recent: 3
-  num_failures_to_alert: 1
 - name: ci-kubernetes-e2e-gce-scale-correctness
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness
   days_of_results: 60
@@ -550,6 +540,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-regional-slow
 - name: ci-kubernetes-e2e-gke-scale-correctness
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-scale-correctness
+  days_of_results: 60
+  num_columns_recent: 3
+  num_failures_to_alert: 1
+- name: ci-kubernetes-e2e-gke-scale-performance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-scale-performance
   days_of_results: 60
   num_columns_recent: 3
   num_failures_to_alert: 1
@@ -6393,10 +6388,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-stable1
   - name: gci-gce-scalability-1.13
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-beta
-  - name: gce-large-correctness
-    test_group_name: ci-kubernetes-e2e-gce-large-correctness
-  - name: gce-large-performance
-    test_group_name: ci-kubernetes-e2e-gce-large-performance
   - name: gce-scale-correctness
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
   - name: gce-scale-performance
@@ -6410,6 +6401,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-large-performance-regional
   - name: gke-scale-correctness
     test_group_name: ci-kubernetes-e2e-gke-scale-correctness
+  - name: gke-scale-performance
+    test_group_name: ci-kubernetes-e2e-gke-scale-performance
 
 - name: sig-scalability-kubemark
   dashboard_tab:


### PR DESCRIPTION
  * Run gce-scale-correctness Mon-Fri after gce-scale-performance tests
  * Retire gce-large-(correctness|performance) jobs
  * Run gke-scale-performance weekly on Saturday