### PR TITLE
Don't warn when no branch protection is set

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -442,9 +442,7 @@ func (c Config) GetTideContextPolicy(org, repo, branch string) (*TideContextPoli
 		bp, err := c.GetBranchProtection(org, repo, branch)
 		if err != nil {
 			logrus.WithError(err).Warningf("Error getting branch protection for %s/%s+%s", org, repo, branch)
-		} else if bp == nil {
-			logrus.Warningf("branch protection not set for %s/%s+%s", org, repo, branch)
-		} else if bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil {
+		} else if bp != nil && bp.Protect != nil && *bp.Protect && bp.RequiredStatusChecks != nil {
 			required.Insert(bp.RequiredStatusChecks.Contexts...)
 		}
 	}


### PR DESCRIPTION
When `tide` is running and honoring branch protection settings, but some
repos don't have it turned on, no error or warning should occur. This is
normal and the operator should not be informed of it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner 
/assign @fejta 