### PR TITLE
Revert "Bump prow from v20190117-81934b1 to v20190118-977be68"

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190118-977be68
+            image: gcr.io/k8s-prow/branchprotector:v20190117-81934b1
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20190118-977be68
+        image: gcr.io/k8s-prow/build:v20190117-81934b1
         args:
         - --all-contexts
         - --tot-url=http://tot

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190118-977be68
+        image: gcr.io/k8s-prow/crier:v20190117-81934b1
         args:
         - --github-workers=1
         - --report-agent=knative-build

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190118-977be68
+        image: gcr.io/k8s-prow/deck:v20190117-81934b1
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190118-977be68
+        image: gcr.io/k8s-prow/grandmatriarch:v20190117-81934b1
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190118-977be68
+        image: gcr.io/k8s-prow/hook:v20190117-81934b1
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190118-977be68
+        image: gcr.io/k8s-prow/horologium:v20190117-81934b1
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190118-977be68
+        image: gcr.io/k8s-prow/needs-rebase:v20190117-81934b1
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190118-977be68
+        image: gcr.io/k8s-prow/plank:v20190117-81934b1
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20190118-977be68
+        image: gcr.io/k8s-prow/sinker:v20190117-81934b1
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -100,7 +100,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190118-977be68
+        image: gcr.io/k8s-prow/hook:v20190117-81934b1
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -165,7 +165,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190118-977be68
+        image: gcr.io/k8s-prow/plank:v20190117-81934b1
         args:
         - --dry-run=false
         volumeMounts:
@@ -200,7 +200,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190118-977be68
+        image: gcr.io/k8s-prow/sinker:v20190117-81934b1
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -233,7 +233,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190118-977be68
+        image: gcr.io/k8s-prow/deck:v20190117-81934b1
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
@@ -282,7 +282,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190118-977be68
+        image: gcr.io/k8s-prow/horologium:v20190117-81934b1
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -311,7 +311,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190118-977be68
+        image: gcr.io/k8s-prow/tide:v20190117-81934b1
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20190118-977be68
+        image: gcr.io/k8s-prow/status-reconciler:v20190117-81934b1
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190118-977be68
+        image: gcr.io/k8s-prow/tide:v20190117-81934b1
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190118-977be68
+        image: gcr.io/k8s-prow/tot:v20190117-81934b1
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,10 +7,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190118-977be68"
-      initupload: "gcr.io/k8s-prow/initupload:v20190118-977be68"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190118-977be68"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190118-977be68"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190117-81934b1"
+      initupload: "gcr.io/k8s-prow/initupload:v20190117-81934b1"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190117-81934b1"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190117-81934b1"
     gcs_configuration:
       bucket: "kubernetes-jenkins"
       path_strategy: "legacy"


### PR DESCRIPTION
Reverts kubernetes/test-infra#10825

Seems to break pod-utils