### PR TITLE
Prowjob crd: Add additionalPrinterColumns

### DIFF
--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -81,3 +81,8 @@ spec:
     type: date
     description: When the job finished running.
     JSONPath: .status.completionTime
+  - name: State
+    description: The state of the job.
+    name: state
+    type: string
+    JSONPath: .status.state

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -76,6 +76,44 @@ spec:
                   - "aborted"
           - required:
             - completionTime
+  additionalPrinterColumns:
+  - name: Job
+    type: string
+    description: The name of the job being run.
+    JSONPath: .spec.job
+  - name: BuildId
+    type: string
+    description: The ID of the job being run.
+    JSONPath: .status.build_id
+  - name: Type
+    type: string
+    description: The type of job being run.
+    JSONPath: .spec.type
+  - name: Org
+    type: string
+    description: The org for which the job is running.
+    JSONPath: .spec.refs.org
+  - name: Repo
+    type: string
+    description: The repo for which the job is running.
+    JSONPath: .spec.refs.repo
+  - name: Pulls
+    type: string
+    description: The pulls for which the job is running.
+    JSONPath: ".spec.refs.pulls[*].number"
+  - name: StartTime
+    type: date
+    description: When the job started running.
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    description: When the job finished running.
+    JSONPath: .status.completionTime
+  - name: State
+    description: The state of the job.
+    name: state
+    type: string
+    JSONPath: .status.state
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
After this change, Prowjobs are much nicer to look at:

```
$ k get prowjob|head -5
NAME                                   AGE       AGENT        JOB                                                        TYPE         STATE
00ebd902-19ec-11e9-9c99-0a580a28008b   1d        kubernetes   periodic-kubermatic-stale                                  periodic     success
00effa20-1805-11e9-b7f7-0a580a28008e   4d        kubernetes   pull-dashboard-dependencies                                presubmit    success
0143f55c-1805-11e9-b7f7-0a580a28008e   4d        kubernetes   pull-dashboard-static-check                                presubmit    success
01504290-1805-11e9-b7f7-0a580a28008e   4d        kubernetes   pull-dashboard-node-dist                                   presubmit    success
```