### PR TITLE
Make owners-label use fewer tokens if no labels could apply to the PR.

### DIFF
--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -72,6 +72,20 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 	repo := pre.Repo.Name
 	number := pre.Number
 
+	// First see if there are any labels requested based on the files changed.
+	changes, err := ghc.GetPullRequestChanges(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("error getting PR changes: %v", err)
+	}
+	neededLabels := sets.NewString()
+	for _, change := range changes {
+		neededLabels.Insert(oc.FindLabelsForFile(change.Filename).List()...)
+	}
+	if neededLabels.Len() == 0 {
+		// No labels requested for the given files. Return now to save API tokens.
+		return nil
+	}
+
 	repoLabels, err := ghc.GetRepoLabels(org, repo)
 	if err != nil {
 		return err
@@ -85,21 +99,12 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 	for _, label := range repoLabels {
 		RepoLabelsExisting.Insert(label.Name)
 	}
-	changes, err := ghc.GetPullRequestChanges(org, repo, number)
-	if err != nil {
-		return fmt.Errorf("error getting PR changes: %v", err)
-	}
 	currentLabels := sets.NewString()
 	for _, label := range issuelabels {
 		currentLabels.Insert(label.Name)
 	}
-	neededLabels := sets.NewString()
-	for _, change := range changes {
-		neededLabels.Insert(oc.FindLabelsForFile(change.Filename).List()...)
-	}
 
 	nonexistent := sets.NewString()
-
 	for _, labelToAdd := range neededLabels.Difference(currentLabels).List() {
 		if !RepoLabelsExisting.Has(labelToAdd) {
 			nonexistent.Insert(labelToAdd)


### PR DESCRIPTION
This just reorders the API calls so that we can return early if OWNERS files don't specify any labels for the PR, avoiding 2 API calls (one of which is likely free if using ghproxy).

This is a minor optimization, but it will be helpful for enabling the plugin across the org.

/assign @spiffxp @krzyzacy 