### PR TITLE
Shuffle trigger state into pending when report to github

### DIFF
--- a/prow/report/BUILD.bazel
+++ b/prow/report/BUILD.bazel
@@ -23,8 +23,8 @@ go_library(
     srcs = ["report.go"],
     importpath = "k8s.io/test-infra/prow/report",
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/github:go_default_library",
-        "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/plugins:go_default_library",
     ],

--- a/prow/report/report_test.go
+++ b/prow/report/report_test.go
@@ -279,7 +279,7 @@ func TestReportStatus(t *testing.T) {
 		expectedStatuses []string
 	}{
 		{
-			name: "successful_job-report_true",
+			name: "Successful prowjob with report true and children should set status for itself but not its children",
 
 			children: 3,
 			state:    kube.SuccessState,
@@ -288,7 +288,7 @@ func TestReportStatus(t *testing.T) {
 			expectedStatuses: []string{"success"},
 		},
 		{
-			name: "successful_job-report_false",
+			name: "Successful prowjob with report false and children should not set status for itself and its children",
 
 			children: 3,
 			state:    kube.SuccessState,
@@ -297,7 +297,7 @@ func TestReportStatus(t *testing.T) {
 			expectedStatuses: []string{},
 		},
 		{
-			name: "pending_job-report_true",
+			name: "Pending prowjob with report true and children should set status for itself and its children",
 
 			children: 3,
 			state:    kube.PendingState,
@@ -306,7 +306,7 @@ func TestReportStatus(t *testing.T) {
 			expectedStatuses: []string{"pending", "pending", "pending", "pending"},
 		},
 		{
-			name: "pending_job-report_false",
+			name: "Pending prowjob with report false and children should not set status for itself, but still cover children jobs",
 
 			children: 3,
 			state:    kube.PendingState,
@@ -315,12 +315,20 @@ func TestReportStatus(t *testing.T) {
 			expectedStatuses: []string{"pending", "pending", "pending"},
 		},
 		{
-			name: "aborted_job-report_true",
+			name: "Aborted prowjob with report true should set failure status",
 
 			state:  kube.AbortedState,
 			report: true,
 
 			expectedStatuses: []string{"failure"},
+		},
+		{
+			name: "Triggered prowjob with report true should set pending status",
+
+			state:  kube.TriggeredState,
+			report: true,
+
+			expectedStatuses: []string{"pending"},
 		},
 	}
 


### PR DESCRIPTION
looks like plank handles description already in https://github.com/kubernetes/test-infra/blob/91186ea67814300ed42df1188bdd2357d1d86bb2/prow/plank/controller.go#L466-L473

/assign @cjwagner 