### PR TITLE
Enure that decorated containers have valid options

### DIFF
--- a/prow/pod-utils/decorate/BUILD.bazel
+++ b/prow/pod-utils/decorate/BUILD.bazel
@@ -45,7 +45,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/clonerefs:go_default_library",
+        "//prow/entrypoint:go_default_library",
+        "//prow/initupload:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/sidecar:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -18,7 +18,9 @@ package sidecar
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
@@ -27,8 +29,8 @@ import (
 // NewOptions returns an empty Options with no nil fields
 func NewOptions() *Options {
 	return &Options{
-		GcsOptions:     gcsupload.NewOptions(),
-		WrapperOptions: &wrapper.Options{},
+		GcsOptions: gcsupload.NewOptions(),
+		// Do not instantiate DeprecatedWrapperOptions by default
 	}
 }
 
@@ -36,8 +38,8 @@ func NewOptions() *Options {
 // for defining the process being watched and
 // where in GCS an upload will land.
 type Options struct {
-	GcsOptions     *gcsupload.Options `json:"gcs_options"`
-	WrapperOptions *wrapper.Options   `json:"wrapper_options,omitempty"` // TODO(fejta): remove july 2019
+	GcsOptions               *gcsupload.Options `json:"gcs_options"`
+	DeprecatedWrapperOptions *wrapper.Options   `json:"wrapper_options,omitempty"` // TODO(fejta): remove july 2019
 
 	// Additional entries to wait for if set
 	Entries []wrapper.Options `json:"entries,omitempty"`
@@ -45,8 +47,8 @@ type Options struct {
 
 func (o Options) entries() []wrapper.Options {
 	var e []wrapper.Options
-	if o.WrapperOptions != nil {
-		e = append(e, *o.WrapperOptions)
+	if o.DeprecatedWrapperOptions != nil {
+		e = append(e, *o.DeprecatedWrapperOptions)
 	}
 	return append(e, o.Entries...)
 }
@@ -54,8 +56,14 @@ func (o Options) entries() []wrapper.Options {
 // Validate ensures that the set of options are
 // self-consistent and valid
 func (o *Options) Validate() error {
-	if err := o.WrapperOptions.Validate(); err != nil {
-		return err
+	ents := o.entries()
+	if len(ents) == 0 {
+		return errors.New("no wrapper.Option entries")
+	}
+	for i, e := range ents {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("entry %d: %v", i, err)
+		}
 	}
 
 	return o.GcsOptions.Validate()
@@ -82,7 +90,7 @@ func (o *Options) LoadConfig(config string) error {
 // AddFlags binds flags to options
 func (o *Options) AddFlags(flags *flag.FlagSet) {
 	o.GcsOptions.AddFlags(flags)
-	o.WrapperOptions.AddFlags(flags)
+	// DeprecatedWrapperOptions flags should be unused, remove immediately
 }
 
 // Complete internalizes command line arguments

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -82,7 +82,7 @@ func (o Options) Run(ctx context.Context) error {
 		}
 	}()
 
-	if o.WrapperOptions != nil {
+	if o.DeprecatedWrapperOptions != nil {
 		// This only fires if the prowjob controller and sidecar are at different commits
 		logrus.Warnf("Using deprecated wrapper_options instead of entries. Please update prow/pod-utils/decorate before June 2019")
 	}


### PR DESCRIPTION
/assign @stevekuznetsov @ixdy @cjwagner 

Also:
* Update sidecar.Validate() to validate all entries, not just the deprecated one
* Do not create a deprecated sidecar entry unless its defined by the env

Fixes https://github.com/kubernetes/test-infra/issues/10833