### PR TITLE
enable override for kubernetes/kubernetes

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -408,6 +408,7 @@ plugins:
   - cherry-pick-unapproved
   - milestone
   - milestonestatus
+  - override
   - owners-label
   - release-note
   - require-matching-label


### PR DESCRIPTION
/hold
/assign @cblecker @spiffxp 

This will be enabled for repo admins only.

EDIT: while this should generally be avoided, it is reasonable in situations like https://github.com/kubernetes/kubernetes/pull/73042 and preferable to clicking merge (which races the merge robot, and potentially enters into a fully bad state WRT the tests)