### PR TITLE
Add an issue template for kind/cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/cleanup.md
+++ b/.github/ISSUE_TEMPLATE/cleanup.md
@@ -1,0 +1,13 @@
+---
+name: Cleanup 
+about: Pay down technical debt, reduce friction, etc.
+labels: kind/cleanup
+
+---
+
+<!-- Please use this template while filing an issue to highlight technical debt to be paid down, or friction to be reduced -->
+
+**What should be cleaned up or changed**:
+
+**Provide any links for context**:
+


### PR DESCRIPTION
I most often find when I want to make a new issue for test-infra, it's something to do with cleaning up something, or following up on something else.

When we used templates that put the label in the description, I could just edit the description.  Now that we're using labels natively, I need to make a new issue template for kind/cleanup

Part of me wonders if we shouldn't just have a "misc" template that doesn't use any of the native labels.  But this will meet my need for now