### PR TITLE
Do not change ProwJob spec while decorating Build spec

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -664,7 +664,7 @@ func makeBuild(pj prowjobv1.ProwJob, buildID string) (*buildv1alpha1.Build, erro
 	}
 	b := buildv1alpha1.Build{
 		ObjectMeta: buildMeta(pj),
-		Spec:       *pj.Spec.BuildSpec,
+		Spec:       *pj.Spec.BuildSpec.DeepCopy(),
 	}
 	rawEnv, err := buildEnv(pj, buildID)
 	if err != nil {

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -997,7 +997,7 @@ func TestMakeBuild(t *testing.T) {
 				pj = tc.job(pj)
 			}
 			const randomBuildID = "so-many-builds"
-			originalSpec := pj.Spec.BuildSpec.DeepCopy()
+			originalSpec := pj.Spec.DeepCopy()
 			actual, err := makeBuild(pj, randomBuildID)
 			if err != nil {
 				if !tc.err {
@@ -1007,9 +1007,13 @@ func TestMakeBuild(t *testing.T) {
 			} else if tc.err {
 				t.Error("failed to receive expected error")
 			}
+			if !equality.Semantic.DeepEqual(pj.Spec, *originalSpec) {
+				t.Errorf("makeBuild changed the ProwJob spec:\n:%s", diff.ObjectReflectDiff(*originalSpec, pj.Spec))
+			}
+
 			expected := buildv1alpha1.Build{
 				ObjectMeta: buildMeta(pj),
-				Spec:       *originalSpec,
+				Spec:       *originalSpec.BuildSpec.DeepCopy(),
 			}
 			env, err := buildEnv(pj, randomBuildID)
 			if err != nil {


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov 

Otherwise clicking the rerun button shows decorated build steps, which we do not want: https://prow.k8s.io/rerun?prowjob=a6305cfa-1b65-11e9-988d-0a580a6c0240 

```yaml
spec:
  agent: knative-build
  build_spec:
    steps:
    - command:
      - /entrypoint-tools/entrypoint
      env:
      - name: BUILD_ID
        value: "322"
      - name: JOB_NAME
        value: post-test-infra-build-smoke
      - name: JOB_SPEC
        value: '{"type":"postsubmit","job":"post-test-infra-build-smoke","buildid":"322","prowjobid":"a6305cfa-1b65-11e9-988d-0a580a6c0240","refs":{"org":"kubernetes","repo":"test-infra","base_ref":"master","base_sha":"7f3a68d5492b49df0bc782c91cfc189d8b60f3dc"}}'
      - name: JOB_TYPE
        value: postsubmit
      - name: PROW_JOB_ID
        value: a6305cfa-1b65-11e9-988d-0a580a6c0240
      - name: PULL_BASE_REF
        value: master
      - name: PULL_BASE_SHA
        value: 7f3a68d5492b49df0bc782c91cfc189d8b60f3dc
      - name: PULL_REFS
        value: master:7f3a68d5492b49df0bc782c91cfc189d8b60f3dc
      - name: REPO_NAME
        value: test-infra
      - name: REPO_OWNER
        value: kubernetes
      - name: ENTRYPOINT_OPTIONS
        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/var/prow-build-log/artifacts","always_zero":true,"args":["echo","hello"],"process_log":"/var/prow-build-log/first-log.txt","marker_file":"/var/prow-build-log/first-marker.txt","metadata_file":"/var/prow-build-log/artifacts/first-metadata.json"}'
      image: busybox
      name: first
      resources: {}
      volumeMounts:
      - mountPath: /var/prow-build-log
        name: home
      - mountPath: /entrypoint-tools
        name: entrypoint-tools
      workingDir: /workspace/src/github.com/kubernetes/test-infra
```