### PR TITLE
images: cleanup after package installs in all images

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     zip \
     zlib1g-dev \
-    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && python -m pip install --upgrade pip setuptools wheel
 
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \

--- a/images/bigquery/Dockerfile
+++ b/images/bigquery/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     python \
     python-yaml \
     python-pip && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install influxdb google-cloud-bigquery==0.24.0
 

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     zip \
     zlib1g-dev \
-    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && python -m pip install --upgrade pip setuptools wheel
 
 # Install gcloud
@@ -82,7 +82,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg2 \
     software-properties-common \
-    lsb-release
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the Docker apt-repository
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
@@ -101,6 +102,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce=18.06.0* && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 

--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     python \
     rsync \
     wget && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 # Install gcloud
 

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash-completion \
     git \
     wget && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 ENV TERRAFORM_VERSION=0.9.4 \
     KUBERNETES_PROVIDER=kubernetes-anywhere \

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -38,7 +38,8 @@ RUN mkdir -p /go/src/k8s.io/kubernetes \
 # - rpm for building RPMs with Bazel
 RUN apt-get install -y bc \
     graphviz \
-    rpm
+    rpm && \
+    rm -rf /var/lib/apt/lists/*
 # preinstall this for kops tests xref kubetest prepareAws(...)
 # TODO(bentheelder,krzyzacy,justisb,chrislovecnm): remove this
 RUN pip install awscli
@@ -73,6 +74,7 @@ RUN bash /install-bazel.sh
 ARG UPGRADE_DOCKER_ARG=false
 RUN [ "${UPGRADE_DOCKER_ARG}" = "true" ] && \
     apt-get install -y --no-install-recommends docker-ce && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker || true
 
 # add env we can debug with the image name:tag

--- a/images/kubekins-test/Dockerfile-1.11
+++ b/images/kubekins-test/Dockerfile-1.11
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg2 \
     software-properties-common \
-    lsb-release
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the Docker apt-repository
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
@@ -73,6 +74,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 

--- a/images/kubekins-test/Dockerfile-1.12
+++ b/images/kubekins-test/Dockerfile-1.12
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg2 \
     software-properties-common \
-    lsb-release
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the Docker apt-repository
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
@@ -73,6 +74,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 

--- a/images/kubekins-test/Dockerfile-1.13
+++ b/images/kubekins-test/Dockerfile-1.13
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg2 \
     software-properties-common \
-    lsb-release
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the Docker apt-repository
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
@@ -73,6 +74,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 

--- a/images/kubemci/Dockerfile
+++ b/images/kubemci/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer "nikhiljindal@google.com"
 
 RUN apt-get update && apt-get install -y \
     git && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 # Build latest kubemci from HEAD.
 RUN cd /${GOPATH}/src && \

--- a/images/pull-test-infra-gubernator/Dockerfile
+++ b/images/pull-test-infra-gubernator/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     python \
     python-pip \
     mocha && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 ENV GCLOUD_VERSION 138.0.0
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -14,7 +14,14 @@
 
 FROM ubuntu
 
-RUN apt-get update && apt-get install -y tzdata curl pv time sqlite3 python-pip && apt-get clean
+RUN apt-get update && apt-get install -y \
+    tzdata \
+    curl \
+    pv \
+    time \
+    sqlite3 \
+    python-pip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2 | tar xj -C opt
 RUN ln -s /opt/pypy*/bin/pypy /usr/bin

--- a/maintenance/aws-janitor/Dockerfile
+++ b/maintenance/aws-janitor/Dockerfile
@@ -15,7 +15,8 @@
 FROM gcr.io/k8s-testimages/gcloud-in-go:0.4
 LABEL maintainer="zml@google.com"
 
-RUN apt-get install ca-certificates && update-ca-certificates
+RUN apt-get install ca-certificates && update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY aws-janitor /aws-janitor
 ENTRYPOINT ["/bin/bash", "/runner"]

--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     wget \
     zip \
-    zlib1g-dev \
-    && apt-get clean && \
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/* \
     python -m pip install --upgrade pip setuptools wheel && \
     pip install pylint pyyaml
 


### PR DESCRIPTION
- clean up the apt cache by removing `/var/lib/apt/lists`
- remove explicit `apt-get clean` which is not required

ref: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

fixes https://github.com/kubernetes/test-infra/issues/7520

/assign @BenTheElder @dims 

(oh I should say `/cc` instead)