### PR TITLE
Drop sudo from local-e2e DumpClusterLogs

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -204,7 +204,7 @@ func (n localCluster) IsUp() error {
 }
 
 func (n localCluster) DumpClusterLogs(localPath, gcsPath string) error {
-	cmd := exec.Command("sudo", "cp", "-r", n.tempDir, localPath)
+	cmd := exec.Command("cp", "-r", n.tempDir, localPath)
 	return control.FinishRunning(cmd)
 }
 


### PR DESCRIPTION
`sudo` was dropped from the bootstrap image, so update code to match
what is available in the kubekins image.

Change-Id: Ib0d2a04084bea5490329484295b0bc1e216d7ac0