### PR TITLE
Print team name in peribolos log

### DIFF
--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1294,8 +1294,12 @@ func TestConfigureTeamMembers(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		if tc.id == 0 {
-			tc.id = teamID
+		gt := github.Team{
+			ID:   teamID,
+			Name: "whatev",
+		}
+		if tc.id != 0 {
+			gt.ID = tc.id
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			fc := &fakeClient{
@@ -1306,7 +1310,7 @@ func TestConfigureTeamMembers(t *testing.T) {
 				newAdmins:  sets.String{},
 				newMembers: sets.String{},
 			}
-			err := configureTeamMembers(fc, tc.id, tc.team)
+			err := configureTeamMembers(fc, gt, tc.team)
 			switch {
 			case err != nil:
 				if !tc.err {


### PR DESCRIPTION
Right now we get logs like
```
{"component":"peribolos","level":"info","msg":"Set spiffxp as a maintainer of 2241179","time":"2019-01-19T03:18:58Z"}
```

Which means you need to look up the team ID via the API to get the team name. Modified the code to pass down and print the team name out in the log output.

We will then get something like:
```
{"component":"peribolos","level":"info","msg":"Set spiffxp as a maintainer of 2241179(kubernetes-release-managers)","time":"2019-01-19T03:18:58Z"}
```

/assign @fejta 