### PR TITLE
Make AWS credentials configurable easily

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -9,8 +9,8 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-aws-eks-1-11-correctness
     labels:
+      preset-aws-credential: aws-oss-testing
       preset-kubernetes-e2e-aws-eks-1-11: "true"
-      preset-kubernetes-e2e-aws-eks-common: "true"
       preset-service-account: "true"
     name: pull-security-kubernetes-e2e-aws-eks-1-11-correctness
     optional: true

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-correctness
   labels:
     preset-service-account: "true"
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -29,7 +29,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-conformance
   labels:
     preset-service-account: "true"
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -54,7 +54,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-scalability
   labels:
     preset-service-account: "true"
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -78,7 +78,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-10-correctness
   labels:
     preset-service-account: "true"
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
     preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
@@ -103,7 +103,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-10-conformance
   labels:
     preset-service-account: "true"
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
     preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presets.yaml
@@ -1,23 +1,16 @@
 presets:
 - env:
-  # URL to download 'kubectl', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
-  # TODO: use upstream 'kubectl'
-  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl
-  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
-  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
-    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator
-  # AWS test account credential mounted path, required for AWS API call
+  # Credentials for using AWS test account 607362164682.
   - name: AWS_SHARED_CREDENTIALS_FILE
-    value: /etc/eks-aws-credentials/eks-aws-credentials
+    value: /etc/aws-cred/credentials
   labels:
-    preset-kubernetes-e2e-aws-eks-common: "true"
+    preset-aws-credential: "aws-oss-testing"
   volumeMounts:
-  - mountPath: /etc/eks-aws-credentials
-    name: eks-aws-credentials
+  - mountPath: /etc/aws-cred
+    name: aws-cred
     readOnly: true
   volumes:
-  - name: eks-aws-credentials
+  - name: aws-cred
     secret:
       secretName: eks-aws-credentials
 
@@ -28,6 +21,12 @@ presets:
   # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
   - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
     value: ami-0a2abab4107669c1b
+  # URL to download 'kubectl', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl
+  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator
   labels:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
 
@@ -38,5 +37,11 @@ presets:
   # Amazon EKS-optimized AMI (non-GPU, https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
   - name: AWS_K8S_TESTER_EKS_WORKER_NODE_AMI
     value: ami-09e1df3bad220af0b
+  # URL to download 'kubectl', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_KUBECTL_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.11/2018-12-06/bin/linux/amd64/kubectl
+  # URL to download 'aws-iam-authenticator', required for 'kubectl' calls to EKS (https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+  - name: AWS_K8S_TESTER_EKS_AWS_IAM_AUTHENTICATOR_DOWNLOAD_URL
+    value: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.11/2018-12-06/bin/linux/amd64/aws-iam-authenticator
   labels:
     preset-kubernetes-e2e-aws-eks-1-10: "true"

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     optional: true
     labels:
       preset-service-account: "true"
-      preset-kubernetes-e2e-aws-eks-common: "true"
+      preset-aws-credential: "aws-oss-testing"
       preset-kubernetes-e2e-aws-eks-1-11: "true"
     spec:
       containers:

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -469,14 +469,15 @@ func (c *Config) mergeJobConfig(jc JobConfig) error {
 	// *** Presets ***
 	c.Presets = append(c.Presets, jc.Presets...)
 
-	// validate no duplicated presets
-	validLabels := map[string]string{}
+	// validate no duplicated preset key-value pairs
+	validLabels := map[string]bool{}
 	for _, preset := range c.Presets {
 		for label, val := range preset.Labels {
-			if _, ok := validLabels[label]; ok {
-				return fmt.Errorf("duplicated preset label : %s", label)
+			pair := label + ":" + val
+			if _, ok := validLabels[pair]; ok {
+				return fmt.Errorf("duplicated preset 'label:value' pair : %s", pair)
 			}
-			validLabels[label] = val
+			validLabels[pair] = true
 		}
 	}
 


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/test-infra/pull/10866
This change standardizes way we pass credentials to kops/eks jobs - allowing to do testing in newer accounts.

/cc @gyuho