### PR TITLE
Fix bad test args for ci-kubernetes-e2e-node-canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -266,7 +266,7 @@ periodics:
       - --node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=8 --focus=\"\[NodeConformance\]\" --skip=\"\[Flaky\]|\[Serial\]\"
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
       - --timeout=90m
       env:
       - name: GOPATH


### PR DESCRIPTION
Failure looks like below. We have extra `\` which do not help

```
Start Test Suite on Host tmp-node-e2e-69d631d1-cos-stable-60-9592-76-0
sh: [Serial]": command not found
Found no test suites
For usage instructions:
	ginkgo help
```
from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-node-canary/12159/build-log.txt

Change-Id: Iad5d8e9442addc653de174f44705edce99b7412b