### PR TITLE
Fix node-test-args for ci-kubernetes-e2e-node-canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -263,7 +263,7 @@ periodics:
       - --deployment=node
       - --gcp-zone=us-central1-f
       - --node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud
-      - --node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"
+      - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"


### PR DESCRIPTION
We have extra '\' which throws off the the following error:
```
[1] unknown flag: --cgroup-root
```

See https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-node-canary/12169/build-log.txt

Change-Id: Ib948d83bad7e555d408c64e163d7f106feeff6f8