### PR TITLE
label_sync: add area/developer-guide label

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -163,7 +163,9 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/contributor-guide" href="#area/contributor-guide">`area/contributor-guide`</a> | Issues or PRs related to the contributor guide| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
+| <a id="area/developer-guide" href="#area/developer-guide">`area/developer-guide`</a> | Issues or PRs related to the developer guide| label | |
 | <a id="area/devstats" href="#area/devstats">`area/devstats`</a> | Issues or PRs related to the devstats subproject| label | |
 | <a id="area/release-team" href="#area/release-team">`area/release-team`</a> | Issues or PRs related to the release-team subproject| label | |
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -656,8 +656,18 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to the contributor guide
+        name: area/contributor-guide
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to deflaking kubernetes tests
         name: area/deflake
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the developer guide
+        name: area/developer-guide
         target: both
         addedBy: label
       - color: 0052cc

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -28,7 +28,17 @@
     color: #ffffff;
 }
 
+.areax00002fcontributorx00002dguide {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fdeflake {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
+.areax00002fdeveloperx00002dguide {
     background-color: #0052cc;
     color: #ffffff;
 }


### PR DESCRIPTION
This PR adds the `area/developer-guide` label to k/community so that it can be automatically applied for PRs targeting https://github.com/kubernetes/community/tree/master/contributors/devel. This will help in triaging @eduartua's work in that area as well.

/cc @cblecker @parispittman  
/sig contributor-experience