### PR TITLE
Change name of binary used to deploy Azure-clusters

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -161,7 +161,7 @@ func newAcsEngine() (*Cluster, error) {
 		credentials:             &Creds{},
 		acsCustomHyperKubeURL:   "",
 		acsCustomWinBinariesURL: "",
-		acsEngineBinaryPath:     "acs-engine", // use the one in path by default
+		acsEngineBinaryPath:     "aks-engine", // use the one in path by default
 	}
 	c.getAzCredentials()
 	err = c.getARMClient(c.ctx)
@@ -302,7 +302,7 @@ func (c *Cluster) generateTemplate() error {
 }
 
 func (c *Cluster) getAcsEngine(retry int) error {
-	downloadPath := path.Join(os.Getenv("HOME"), "acs-engine.tar.gz")
+	downloadPath := path.Join(os.Getenv("HOME"), "aks-engine.tar.gz")
 	f, err := os.Create(downloadPath)
 	if err != nil {
 		return err
@@ -342,7 +342,7 @@ func (c *Cluster) getAcsEngine(retry int) error {
 	if err = control.FinishRunning(exec.Command("tar", "-xzf", f.Name(), "--strip", "1")); err != nil {
 		return err
 	}
-	c.acsEngineBinaryPath = path.Join(cwd, "acs-engine")
+	c.acsEngineBinaryPath = path.Join(cwd, "aks-engine")
 	return nil
 
 }


### PR DESCRIPTION
Acs-engine ( https://github.com/Azure/acs-engine ) has been moved to Aks-engine (https://github.com/Azure/aks-engine)

This patch changes the binary name used to invoke it to aks-engine as it should be.

This is step 1 and the most pressing. Step 2 is to modify all kubetest references to acsengine ( deployer name, param names etc )