### PR TITLE
Do not delete BUILD files in update-bazel.sh

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -19,7 +19,6 @@ set -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 mkdir -p ./vendor
-find vendor -name BUILD -o -name BUILD.bazel -exec rm '{}' +
 touch ./vendor/BUILD.bazel
 bazel run //:gazelle
 bazel run //:kazel


### PR DESCRIPTION
We only need to delete the bazel files when we run `update-dep.sh` (aka `go mod vendor`), and this will already clean out those files:

https://github.com/kubernetes/test-infra/blob/d9d41813e2d378a1c22d58ee953e1db110969027/hack/update-deps.sh#L32-L45

/assign @stevekuznetsov @ixdy 