### PR TITLE
check-pr.sh: cd to git root dir before running

### DIFF
--- a/hack/check-pr.sh
+++ b/hack/check-pr.sh
@@ -21,6 +21,8 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+cd $(git rev-parse --show-toplevel)
+
 dirs=()
 tests=()
 ref="${1:-HEAD}"


### PR DESCRIPTION
`check-pr.sh` seems to assume it's being run from the root dir of the project. Since I usually have `prow/` set as my working directory, I'd like to be able to run the script without `cd`ing myself.

(PR'd this a while ago and overcomplicated it. Less is more.)

/assign @fejta 