### PR TITLE
Fix kompose -> komposer typo in Tide config.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -373,7 +373,7 @@ tide:
     - kubernetes/ingress-nginx
     - kubernetes/k8s.io
     - kubernetes/klog
-    - kubernetes/komposer
+    - kubernetes/kompose
     - kubernetes/kops
     - kubernetes/kube-deploy
     - kubernetes/kube-openapi


### PR DESCRIPTION
This fix will enable Tide on the `kubernetes/kompose` repo. It should have already been enabled, but was not due to a typo.

/assign @spiffxp @cblecker 