### PR TITLE
deck: perform initial tide update asynchronously

### DIFF
--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -57,16 +57,11 @@ type tideAgent struct {
 }
 
 func (ta *tideAgent) start() {
-	startTimePool := time.Now()
-	if err := ta.updatePools(); err != nil {
-		ta.log.WithError(err).Error("Updating pools the first time.")
-	}
-	startTimeHistory := time.Now()
-	if err := ta.updateHistory(); err != nil {
-		ta.log.WithError(err).Error("Updating history the first time.")
-	}
-
 	go func() {
+		startTimePool := time.Now()
+		if err := ta.updatePools(); err != nil {
+			ta.log.WithError(err).Error("Updating pools the first time.")
+		}
 		for {
 			time.Sleep(time.Until(startTimePool.Add(ta.updatePeriod())))
 			startTimePool = time.Now()
@@ -76,6 +71,10 @@ func (ta *tideAgent) start() {
 		}
 	}()
 	go func() {
+		startTimeHistory := time.Now()
+		if err := ta.updateHistory(); err != nil {
+			ta.log.WithError(err).Error("Updating history the first time.")
+		}
 		for {
 			time.Sleep(time.Until(startTimeHistory.Add(ta.updatePeriod())))
 			startTimeHistory = time.Now()


### PR DESCRIPTION
If tide is unavailable at deck startup (as it tends to be during a prow upgrade), deck gets stuck waiting for it for potentially several minutes, which is not a desirable user experience, and can be conerning for the person actually performing the upgrade.

As far as I know, there is no particular reason that the tide status must be known at startup (and if they fail it blindly starts up anyway), so this PR moves the initial update to happen asynchronously. That said, I assume this was done this way for a reason, so I am very willing to believe I'm wrong.

Fixes #10351 (or, rather, the real bug that lead to that issue being filed).

/assign @cjwagner 