### PR TITLE
Prow: add links to Refs and pass Refs to client

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -427,26 +427,37 @@ func (j *ProwJob) ClusterAlias() string {
 
 // Pull describes a pull request at a particular point in time.
 type Pull struct {
-	Number int    `json:"number,omitempty"`
-	Author string `json:"author,omitempty"`
-	SHA    string `json:"sha,omitempty"`
+	Number int    `json:"number"`
+	Author string `json:"author"`
+	SHA    string `json:"sha"`
+	Title  string `json:"title,omitempty"`
 
 	// Ref is git ref can be checked out for a change
 	// for example,
 	// github: pull/123/head
 	// gerrit: refs/changes/00/123/1
 	Ref string `json:"ref,omitempty"`
+	// Link links to the pull request itself.
+	Link string `json:"link,omitempty"`
+	// CommitLink links to the commit identified by the SHA.
+	CommitLink string `json:"commit_link,omitempty"`
+	// AuthorLink links to the author of the pull request.
+	AuthorLink string `json:"author_link,omitempty"`
 }
 
 // Refs describes how the repo was constructed.
 type Refs struct {
 	// Org is something like kubernetes or k8s.io
-	Org string `json:"org,omitempty"`
+	Org string `json:"org"`
 	// Repo is something like test-infra
-	Repo string `json:"repo,omitempty"`
+	Repo string `json:"repo"`
+	// RepoLink links to the source for Repo.
+	RepoLink string `json:"repo_link,omitempty"`
 
 	BaseRef string `json:"base_ref,omitempty"`
 	BaseSHA string `json:"base_sha,omitempty"`
+	// BaseLink is a link to the commit identified by BaseSHA.
+	BaseLink string `json:"base_link,omitempty"`
 
 	Pulls []Pull `json:"pulls,omitempty"`
 

--- a/prow/cmd/deck/static/api/prow.ts
+++ b/prow/cmd/deck/static/api/prow.ts
@@ -1,15 +1,38 @@
 export type JobType = "presubmit" | "postsubmit" | "batch" | "periodic";
 export type JobState = "triggered" | "pending" | "success" | "failure" | "aborted" | "error" | "unknown" | "";
 
-export interface Job {
-  type: JobType;
-  repo: string;
-  refs: string;
-  base_ref: string;
-  base_sha: string;
-  pull_sha: string;
+// Pull describes a pull request at a particular point in time.
+// Pull mirrors the Pull struct defined in types.go.
+export interface Pull {
   number: number;
   author: string;
+  sha: string;
+  title?: string;
+  ref?: string;
+  link?: string;
+  commit_link?: string;
+  author_link?: string;
+}
+
+// Refs describes how the repo was constructed.
+// Refs mirrors the Refs struct defined in types.go.
+export interface Refs {
+  org: string;
+  repo: string;
+  repo_link?: string;
+  base_ref?: string;
+  base_sha?: string;
+  base_link?: string;
+  pulls?: Pull[];
+  path_alias?: string;
+  clone_uri?: string;
+  skip_submodules?: boolean;
+}
+
+export interface Job {
+  type: JobType;
+  refs: Refs;
+  refs_key: string;
   job: string;
   build_id: string;
   context: string;

--- a/prow/cmd/deck/static/api/tide-history.ts
+++ b/prow/cmd/deck/static/api/tide-history.ts
@@ -1,3 +1,4 @@
+import {Pull} from "../api/prow";
 
 export interface HistoryData {
     History: {[key: string]: Record[]};
@@ -7,13 +8,6 @@ export interface Record {
 	time:    string;
 	action:  string;
 	baseSHA?: string;
-	target?:  PRMeta[];
+	target?:  Pull[];
 	err?:     string;
-}
-
-export interface PRMeta {
-	num:    number;
-	author: string;
-	title:  string;
-	SHA:    string;
 }

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -406,10 +406,12 @@ function loadPrStatus(prData: UserData): void {
         let builds: Job[] = [];
         for (let build of allBuilds) {
             if (build.type === 'presubmit' &&
-                build.repo === pr.Repository.NameWithOwner &&
-                build.base_ref === pr.BaseRef.Name &&
-                build.number === pr.Number &&
-                build.pull_sha === pr.HeadRefOID) {
+                build.refs.repo === pr.Repository.NameWithOwner &&
+                build.refs.base_ref === pr.BaseRef.Name &&
+                build.refs.pulls &&
+                build.refs.pulls.length > 0 &&
+                build.refs.pulls[0].number === pr.Number &&
+                build.refs.pulls[0].sha === pr.HeadRefOID) {
                 if (!seenJobs[build.job]) {  // First (latest) build for job.
                     seenJobs[build.job] = true;
                     builds.push(build);

--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -1,6 +1,6 @@
 import {cell} from "../common/common";
 import {JobState} from "../api/prow";
-import {HistoryData, Record, PRMeta} from "../api/tide-history";
+import {HistoryData, Record} from "../api/tide-history";
 import moment from "moment";
 
 declare const tideHistory: HistoryData;
@@ -59,7 +59,7 @@ function optionsForRepoBranch(repo: string, branch: string): Options {
           opts.states[errorState(rec.err)] = true;
           for (const pr of rec.target || []) {
             opts.authors[pr.author] = true;
-            opts.pulls[pr.num] = true;
+            opts.pulls[pr.number] = true;
           }
         }
       }
@@ -209,7 +209,7 @@ function redraw(): void {
 
       let anyTargetMatches = false;
       for (const pr of rec.target || []) {
-        if (!equalSelected(pullSel, pr.num.toString())) {
+        if (!equalSelected(pullSel, pr.number.toString())) {
           continue;
         }
         if (!equalSelected(authorSel, pr.author)) {
@@ -288,13 +288,13 @@ function targetCell(rec: FilteredRecord): HTMLTableDataCellElement {
       return cell.text("");
     case 1:
       let pr = target[0];
-      return cell.prRevision(rec.repo, pr.num, pr.author, pr.title, pr.SHA);
+      return cell.prRevision(rec.repo, pr);
     default:
       // Multiple PRs in 'target'. Add them all to the cell, but on separate lines.
       let td = document.createElement("td");
       td.style.whiteSpace = "pre";
       for (const pr of target) {
-        cell.addPRRevision(td, rec.repo, pr.num, pr.author, pr.title, pr.SHA);
+        cell.addPRRevision(td, rec.repo, pr);
         td.appendChild(document.createTextNode("\n"));
       }
       return td;

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -48,13 +48,8 @@ var (
 // TODO(#5216): Remove this, and all associated machinery.
 type Job struct {
 	Type        string               `json:"type"`
-	Repo        string               `json:"repo"`
-	Refs        string               `json:"refs"`
-	BaseRef     string               `json:"base_ref"`
-	BaseSHA     string               `json:"base_sha"`
-	PullSHA     string               `json:"pull_sha"`
-	Number      int                  `json:"number"`
-	Author      string               `json:"author"`
+	Refs        prowapi.Refs         `json:"refs"`
+	RefsKey     string               `json:"refs_key"`
 	Job         string               `json:"job"`
 	BuildID     string               `json:"build_id"`
 	Context     string               `json:"context"`
@@ -236,15 +231,8 @@ func (ja *JobAgent) update() error {
 			nj.Duration = duration.String()
 		}
 		if j.Spec.Refs != nil {
-			nj.Repo = fmt.Sprintf("%s/%s", j.Spec.Refs.Org, j.Spec.Refs.Repo)
-			nj.Refs = j.Spec.Refs.String()
-			nj.BaseRef = j.Spec.Refs.BaseRef
-			nj.BaseSHA = j.Spec.Refs.BaseSHA
-			if len(j.Spec.Refs.Pulls) == 1 {
-				nj.Number = j.Spec.Refs.Pulls[0].Number
-				nj.Author = j.Spec.Refs.Pulls[0].Author
-				nj.PullSHA = j.Spec.Refs.Pulls[0].SHA
-			}
+			nj.Refs = *j.Spec.Refs
+			nj.RefsKey = j.Spec.Refs.String()
 		}
 		njs = append(njs, nj)
 		if nj.PodName != "" {

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -23,6 +23,9 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//vendor/github.com/andygrunwald/go-gerrit:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -196,13 +197,42 @@ func listChangedFiles(changeInfo client.ChangeInfo) config.ChangedFilesProvider 
 	}
 }
 
-// ProcessChange creates new presubmit prowjobs base off the gerrit changes
-func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) error {
+func createRefs(reviewHost string, change client.ChangeInfo, cloneURI *url.URL, baseSHA string) (prowapi.Refs, error) {
 	rev, ok := change.Revisions[change.CurrentRevision]
 	if !ok {
-		return fmt.Errorf("cannot find current revision for change %v", change.ID)
+		return prowapi.Refs{}, fmt.Errorf("cannot find current revision for change %v", change.ID)
 	}
+	var codeHost string // Something like https://android.googlesource.com
+	parts := strings.SplitN(reviewHost, ".", 2)
+	codeHost = strings.TrimSuffix(parts[0], "-review")
+	if len(parts) > 1 {
+		codeHost += "." + parts[1]
+	}
+	refs := prowapi.Refs{
+		Org:      cloneURI.Host,  // Something like android-review.googlesource.com
+		Repo:     change.Project, // Something like platform/build
+		BaseRef:  change.Branch,
+		BaseSHA:  baseSHA,
+		CloneURI: cloneURI.String(), // Something like https://android-review.googlesource.com/platform/build
+		RepoLink: fmt.Sprintf("%s/%s", codeHost, change.Project),
+		BaseLink: fmt.Sprintf("%s/%s/+/%s", codeHost, change.Project, baseSHA),
+		Pulls: []prowapi.Pull{
+			{
+				Number:     change.Number,
+				Author:     rev.Commit.Author.Name,
+				SHA:        change.CurrentRevision,
+				Ref:        rev.Ref,
+				Link:       fmt.Sprintf("%s/c/%s/+/%d", reviewHost, change.Project, change.Number),
+				CommitLink: fmt.Sprintf("%s/%s/+/%s", codeHost, change.Project, change.CurrentRevision),
+				AuthorLink: fmt.Sprintf("%s/q/%s", reviewHost, rev.Commit.Author.Email),
+			},
+		},
+	}
+	return refs, nil
+}
 
+// ProcessChange creates new presubmit prowjobs base off the gerrit changes
+func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) error {
 	logger := logrus.WithField("gerrit change", change.Number)
 
 	cloneURI, err := makeCloneURI(instance, change.Project)
@@ -217,20 +247,9 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 
 	triggeredJobs := []string{}
 
-	kr := prowapi.Refs{
-		Org:      cloneURI.Host,  // Something like android.googlesource.com
-		Repo:     change.Project, // Something like platform/build
-		BaseRef:  change.Branch,
-		BaseSHA:  baseSHA,
-		CloneURI: cloneURI.String(), // Something like https://android.googlesource.com/platform/build
-		Pulls: []prowapi.Pull{
-			{
-				Number: change.Number,
-				Author: rev.Commit.Author.Name,
-				SHA:    change.CurrentRevision,
-				Ref:    rev.Ref,
-			},
-		},
+	refs, err := createRefs(instance, change, cloneURI, baseSHA)
+	if err != nil {
+		return fmt.Errorf("failed to get refs: %v", err)
 	}
 
 	type jobSpec struct {
@@ -251,7 +270,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 				return fmt.Errorf("failed to determine if postsubmit %q should run: %v", postsubmit.Name, err)
 			} else if shouldRun {
 				jobSpecs = append(jobSpecs, jobSpec{
-					spec:   pjutil.PostsubmitSpec(postsubmit, kr),
+					spec:   pjutil.PostsubmitSpec(postsubmit, refs),
 					labels: postsubmit.Labels,
 				})
 			}
@@ -264,7 +283,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 				return fmt.Errorf("failed to determine if presubmit %q should run: %v", presubmit.Name, err)
 			} else if shouldRun {
 				jobSpecs = append(jobSpecs, jobSpec{
-					spec:   pjutil.PresubmitSpec(presubmit, kr),
+					spec:   pjutil.PresubmitSpec(presubmit, refs),
 					labels: presubmit.Labels,
 				})
 			}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -146,10 +146,11 @@ type CombinedStatus struct {
 
 // User is a GitHub user account.
 type User struct {
-	Login string `json:"login"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
-	ID    int    `json:"id"`
+	Login   string `json:"login"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	ID      int    `json:"id"`
+	HTMLURL string `json:"html_url"`
 }
 
 // NormLogin normalizes GitHub login strings

--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -29,6 +29,7 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -649,5 +650,50 @@ func TestJobURL(t *testing.T) {
 				t.Errorf("%s: expected URL to be %q but got %q", testCase.name, expected, actual)
 			}
 		})
+	}
+}
+
+func TestCreateRefs(t *testing.T) {
+	pr := github.PullRequest{
+		Number:  42,
+		HTMLURL: "https://github.example.com/kubernetes/Hello-World/pull/42",
+		Head: github.PullRequestBranch{
+			SHA: "123456",
+		},
+		Base: github.PullRequestBranch{
+			Ref: "master",
+			Repo: github.Repo{
+				Name:    "Hello-World",
+				HTMLURL: "https://github.example.com/kubernetes/Hello-World",
+				Owner: github.User{
+					Login: "kubernetes",
+				},
+			},
+		},
+		User: github.User{
+			Login:   "ibzib",
+			HTMLURL: "https://github.example.com/ibzib",
+		},
+	}
+	expected := prowapi.Refs{
+		Org:      "kubernetes",
+		Repo:     "Hello-World",
+		RepoLink: "https://github.example.com/kubernetes/Hello-World",
+		BaseRef:  "master",
+		BaseSHA:  "abcdef",
+		BaseLink: "https://github.example.com/kubernetes/Hello-World/commit/abcdef",
+		Pulls: []prowapi.Pull{
+			{
+				Number:     42,
+				Author:     "ibzib",
+				SHA:        "123456",
+				Link:       "https://github.example.com/kubernetes/Hello-World/pull/42",
+				AuthorLink: "https://github.example.com/ibzib",
+				CommitLink: "https://github.example.com/kubernetes/Hello-World/pull/42/commits/123456",
+			},
+		},
+	}
+	if actual := createRefs(pr, "abcdef"); !reflect.DeepEqual(expected, actual) {
+		t.Errorf("diff between expected and actual refs:%s", diff.ObjectReflectDiff(expected, actual))
 	}
 }

--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -24,6 +24,8 @@ go_test(
         "//prow/plugins:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
     ],

--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -45,6 +45,16 @@ func listPushEventChanges(pe github.PushEvent) config.ChangedFilesProvider {
 	}
 }
 
+func createRefs(pe github.PushEvent) prowapi.Refs {
+	return prowapi.Refs{
+		Org:      pe.Repo.Owner.Name,
+		Repo:     pe.Repo.Name,
+		BaseRef:  pe.Branch(),
+		BaseSHA:  pe.After,
+		BaseLink: pe.Compare,
+	}
+}
+
 func handlePE(c Client, pe github.PushEvent) error {
 	if pe.Deleted {
 		// we should not trigger jobs for a branch deletion
@@ -56,18 +66,13 @@ func handlePE(c Client, pe github.PushEvent) error {
 		} else if !shouldRun {
 			continue
 		}
-		kr := prowapi.Refs{
-			Org:     pe.Repo.Owner.Name,
-			Repo:    pe.Repo.Name,
-			BaseRef: pe.Branch(),
-			BaseSHA: pe.After,
-		}
+		refs := createRefs(pe)
 		labels := make(map[string]string)
 		for k, v := range j.Labels {
 			labels[k] = v
 		}
 		labels[github.EventGUID] = pe.GUID
-		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, kr), labels)
+		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels)
 		c.Logger.WithFields(pjutil.ProwJobFields(&pj)).Info("Creating a new prowjob.")
 		if _, err := c.ProwJobClient.Create(&pj); err != nil {
 			return err

--- a/prow/tide/history/BUILD.bazel
+++ b/prow/tide/history/BUILD.bazel
@@ -5,13 +5,17 @@ go_library(
     srcs = ["history.go"],
     importpath = "k8s.io/test-infra/prow/tide/history",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["history_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/apis/prowjobs/v1:go_default_library"],
 )
 
 filegroup(

--- a/prow/tide/history/history_test.go
+++ b/prow/tide/history/history_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 func TestHistory(t *testing.T) {
@@ -36,9 +38,9 @@ func TestHistory(t *testing.T) {
 		return nowTime
 	}
 
-	testMeta := func(num int, author string) PRMeta {
-		return PRMeta{
-			Num:    num,
+	testMeta := func(num int, author string) prowapi.Pull {
+		return prowapi.Pull{
+			Number: num,
 			Title:  fmt.Sprintf("PR #%d", num),
 			SHA:    fmt.Sprintf("SHA for %d", num),
 			Author: author,
@@ -47,17 +49,17 @@ func TestHistory(t *testing.T) {
 
 	hist := New(logSizeLimit)
 	time1 := nextTime()
-	hist.Record("pool A", "TRIGGER", "sha A", "", []PRMeta{testMeta(1, "bob")})
+	hist.Record("pool A", "TRIGGER", "sha A", "", []prowapi.Pull{testMeta(1, "bob")})
 	nextTime()
-	hist.Record("pool B", "MERGE", "sha B1", "", []PRMeta{testMeta(2, "joe")})
+	hist.Record("pool B", "MERGE", "sha B1", "", []prowapi.Pull{testMeta(2, "joe")})
 	time3 := nextTime()
-	hist.Record("pool B", "MERGE", "sha B2", "", []PRMeta{testMeta(3, "jeff")})
+	hist.Record("pool B", "MERGE", "sha B2", "", []prowapi.Pull{testMeta(3, "jeff")})
 	time4 := nextTime()
-	hist.Record("pool B", "MERGE_BATCH", "sha B3", "", []PRMeta{testMeta(4, "joe"), testMeta(5, "jim")})
+	hist.Record("pool B", "MERGE_BATCH", "sha B3", "", []prowapi.Pull{testMeta(4, "joe"), testMeta(5, "jim")})
 	time5 := nextTime()
-	hist.Record("pool C", "TRIGGER_BATCH", "sha C1", "", []PRMeta{testMeta(6, "joe"), testMeta(8, "me")})
+	hist.Record("pool C", "TRIGGER_BATCH", "sha C1", "", []prowapi.Pull{testMeta(6, "joe"), testMeta(8, "me")})
 	time6 := nextTime()
-	hist.Record("pool B", "TRIGGER", "sha B4", "", []PRMeta{testMeta(7, "abe")})
+	hist.Record("pool B", "TRIGGER", "sha B4", "", []prowapi.Pull{testMeta(7, "abe")})
 
 	expected := map[string][]*Record{
 		"pool A": {
@@ -65,7 +67,7 @@ func TestHistory(t *testing.T) {
 				Time:    time1,
 				BaseSHA: "sha A",
 				Action:  "TRIGGER",
-				Target: []PRMeta{
+				Target: []prowapi.Pull{
 					testMeta(1, "bob"),
 				},
 			},
@@ -75,7 +77,7 @@ func TestHistory(t *testing.T) {
 				Time:    time6,
 				BaseSHA: "sha B4",
 				Action:  "TRIGGER",
-				Target: []PRMeta{
+				Target: []prowapi.Pull{
 					testMeta(7, "abe"),
 				},
 			},
@@ -83,7 +85,7 @@ func TestHistory(t *testing.T) {
 				Time:    time4,
 				BaseSHA: "sha B3",
 				Action:  "MERGE_BATCH",
-				Target: []PRMeta{
+				Target: []prowapi.Pull{
 					testMeta(4, "joe"),
 					testMeta(5, "jim"),
 				},
@@ -92,7 +94,7 @@ func TestHistory(t *testing.T) {
 				Time:    time3,
 				BaseSHA: "sha B2",
 				Action:  "MERGE",
-				Target: []PRMeta{
+				Target: []prowapi.Pull{
 					testMeta(3, "jeff"),
 				},
 			},
@@ -102,7 +104,7 @@ func TestHistory(t *testing.T) {
 				Time:    time5,
 				BaseSHA: "sha C1",
 				Action:  "TRIGGER_BATCH",
-				Target: []PRMeta{
+				Target: []prowapi.Pull{
 					testMeta(6, "joe"),
 					testMeta(8, "me"),
 				},

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1127,11 +1127,11 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 		err
 }
 
-func prMeta(prs ...PullRequest) []history.PRMeta {
-	var res []history.PRMeta
+func prMeta(prs ...PullRequest) []prowapi.Pull {
+	var res []prowapi.Pull
 	for _, pr := range prs {
-		res = append(res, history.PRMeta{
-			Num:    int(pr.Number),
+		res = append(res, prowapi.Pull{
+			Number: int(pr.Number),
 			Author: string(pr.Author.Login),
 			Title:  string(pr.Title),
 			SHA:    string(pr.HeadRefOID),


### PR DESCRIPTION
This is the third and hopefully final fix for making Deck links more flexible than just `"github.com" + org + repo + derp`. This is basically a lot of shuffling code around to accomplish just a few things:

- Add links to the `Refs` struct, and populate them when jobs are created.
- Replaced Tide's `PRMeta` struct with the `kube.Pull` struct (which is a superset of the former). This simplifies sharing code in `common.ts`.
- Currently, there's an extra parsing of `Refs` in `deck/jobs`, which does not spark joy (#5216). We'll instead just pass `Refs` directly to the client, and do whatever remaining processing necessary on the front end.

Other notes:
- Wherever possible, I took links from the Github API rather than generating them ourselves. There were a few places that wasn't possible because the Github API didn't directly provide the links I wanted.
- I didn't add links in `mkpj` and Tide. I left the existing frontend code to make links for these and any other spots I missed.
- One annoying nit is that the link text for Gerrit changes is very similar to, but not the same as the actual link. I'm keeping this the way it is for now so as not to mess up Gubernator links.

If you don't like this, compare/contrast with #10644, which would accomplish the same thing in a much less thorough way.

/cc @stevekuznetsov @krzyzacy @cjwagner 
/pony link