### PR TITLE
Set max_concurrency on peribolos runs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - name: post-org-peribolos
     cluster: test-infra-trusted
     decorate: true
+    max_concurrency: 1
     spec:
       containers:
       - image: launcher.gcr.io/google/bazel
@@ -73,6 +74,7 @@ periodics:
   name: ci-org-peribolos
   cluster: test-infra-trusted
   decorate: true
+  max_concurrency: 1
   extra_refs:
   - org: kubernetes
     repo: org


### PR DESCRIPTION
We never want concurrent runs of peribolos as they will race each other and potentially revert each others changes.

/cc @fejta 