### PR TITLE
Upgrade heapster machine type in scale tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -61,7 +61,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=gce-scale-cluster
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
       # TODO(https://github.com/kubernetes/kubernetes/issues/72976): Remove line below, change get-master-root-disk-size function if needed.
       - --env=MASTER_ROOT_DISK_SIZE=1000GB
       - --extract=ci/latest
@@ -223,7 +223,7 @@ periodics:
       - --ginkgo-parallel=30
       - --gke-create-command=container clusters create --quiet --enable-ip-alias --create-subnetwork name=ip-alias-subnet --cluster-ipv4-cidr=/11 --services-ipv4-cidr=/18 --timeout=2700
       - --gke-environment=staging
-      - '--gke-shape={"default":{"Nodes":4999,"MachineType":"g1-small"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-16"}}'
+      - '--gke-shape={"default":{"Nodes":4999,"MachineType":"g1-small"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-32"}}'
       - --provider=gke
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8
       - --timeout=210m
@@ -259,7 +259,7 @@ periodics:
       - --gcp-zone=us-east1-a
       - --gke-create-command=container clusters create --quiet --enable-ip-alias --create-subnetwork name=ip-alias-subnet --cluster-ipv4-cidr=/11 --services-ipv4-cidr=/18 --timeout=2700
       - --gke-environment=staging
-      - '--gke-shape={"default":{"Nodes":4999,"MachineType":"n1-standard-1"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-16"}}'
+      - '--gke-shape={"default":{"Nodes":4999,"MachineType":"n1-standard-1"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-32"}}'
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Performance\]
       - --timeout=1030m

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -14,7 +14,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=gce-scale-cluster
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
@@ -51,7 +51,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=gce-scale-cluster
-      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-16
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
       # TODO(https://github.com/kubernetes/kubernetes/issues/72976): Remove line below, change get-master-root-disk-size function if needed.
       - --env=MASTER_ROOT_DISK_SIZE=1000GB
       - --extract=ci/latest


### PR DESCRIPTION
The 16 core one can run out of memory when heapster / metric server pods are scaled up during cluster creation.

The resources for heapster / metric server pod depend on number of nodes in the cluster. During cluster creation these pods are scaled-up multiple times (via pod-nanny).
While the n1-standard-16 machine has enough memory to run fully scaled-up heapster / metric server pods, due to the way the scaling-up works it's possible that the node will run out of available memory during cluster creation. \
E.g. consider situation where fully scaled heapster / metric server needs 60% of available memory and during cluster creation pod-nanny created version that uses 45% of memory. Cluster eventually reaches 5K nodes and pod nanny wants to create new version using 60% of memory, but there are no resources available to do that in a safe way (e.g. first add new pod then remove old).

It's currently happening in the 5K node scalability test clusters (see https://github.com/kubernetes/kubernetes/issues/73176) and that's why we need this change.
