### PR TITLE
Add area/contributor-summit label

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -164,6 +164,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/contributor-guide" href="#area/contributor-guide">`area/contributor-guide`</a> | Issues or PRs related to the contributor guide| label | |
+| <a id="area/contributor-summit" href="#area/contributor-summit">`area/contributor-summit`</a> | Issues or PRs related to contributor summit events| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/developer-guide" href="#area/developer-guide">`area/developer-guide`</a> | Issues or PRs related to the developer guide| label | |
 | <a id="area/devstats" href="#area/devstats">`area/devstats`</a> | Issues or PRs related to the devstats subproject| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -661,6 +661,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to contributor summit events
+        name: area/contributor-summit
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to deflaking kubernetes tests
         name: area/deflake
         target: both

--- a/prow/cmd/deck/static/labels.css
+++ b/prow/cmd/deck/static/labels.css
@@ -33,6 +33,11 @@
     color: #ffffff;
 }
 
+.areax00002fcontributorx00002dsummit {
+    background-color: #0052cc;
+    color: #ffffff;
+}
+
 .areax00002fdeflake {
     background-color: #0052cc;
     color: #ffffff;


### PR DESCRIPTION
Per contributor summit call yesterday. Tasks related to upcoming contributor summits are now going to be tracked in the community repo. This PR adds a label for that purpose.

/cc @parispittman @castrojo 