### PR TITLE
rename second preset-aws-credential to fix config loading

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
     cluster: security
     context: pull-security-kubernetes-e2e-aws-eks-1-11-correctness
     labels:
-      preset-aws-credential: aws-oss-testing
+      preset-aws-credential-aws-oss-testing: "true"
       preset-kubernetes-e2e-aws-eks-1-11: "true"
       preset-service-account: "true"
     name: pull-security-kubernetes-e2e-aws-eks-1-11-correctness

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-correctness
   labels:
     preset-service-account: "true"
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -29,7 +29,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-conformance
   labels:
     preset-service-account: "true"
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -54,7 +54,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-11-scalability
   labels:
     preset-service-account: "true"
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
@@ -78,7 +78,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-10-correctness
   labels:
     preset-service-account: "true"
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
     preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:
@@ -103,7 +103,7 @@ periodics:
   name: ci-kubernetes-e2e-aws-eks-1-10-conformance
   labels:
     preset-service-account: "true"
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
     preset-kubernetes-e2e-aws-eks-1-10: "true"
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/k8s-aws-eks-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     optional: true
     labels:
       preset-service-account: "true"
-      preset-aws-credential: "aws-oss-testing"
+      preset-aws-credential-aws-oss-testing: "true"
       preset-kubernetes-e2e-aws-eks-1-11: "true"
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-aws/sig-aws-credentials.yaml
+++ b/config/jobs/kubernetes/sig-aws/sig-aws-credentials.yaml
@@ -16,7 +16,7 @@ presets:
 
 # Credentials for using AWS test account 607362164682. Used for kops/eks tests.
 - labels:
-    preset-aws-credential: "aws-oss-testing"
+    preset-aws-credential-aws-oss-testing: "true"
   env:
   - name: AWS_SHARED_CREDENTIALS_FILE
     value: /etc/aws-cred/credentials


### PR DESCRIPTION
the config agent as deployed cannot load this correctly, renamed to something similar but with a non overlapping key