### PR TITLE
New version of blocking/informing shuffle, which splits tests in sig-…

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4608,6 +4608,29 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce
   - name: kops-aws-master
     test_group_name: ci-kubernetes-e2e-kops-aws
+  - name: gce-device-plugin-gpu-master
+    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
+  - name: gce-cos-master-slow
+    test_group_name: ci-kubernetes-e2e-gci-gce-slow
+  - name: gce-cos-master-serial
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial
+  - name: gce-cos-master-alpha-features
+    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
+  - name: gce-cos-master-scalability-100
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability
+  - name: gce-cos-master-ingress
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
+  - name: gce-cos-master-reboot
+    test_group_name: ci-kubernetes-e2e-gci-gce-reboot
+  - name: kubeadm-gce-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
+  - name: kubeadm-gce-stable-on-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+  - name: packages-pushed-master
+    test_group_name: periodic-kubernetes-e2e-packages-pushed
+
+- name: sig-release-master-informing
+  dashboard_tab:
   - name: Conformance - GCE
     description: Runs conformance tests using kubetest against latest kubernetes master CI build on GCE
     test_group_name: ci-kubernetes-gce-conformance
@@ -4620,30 +4643,12 @@ dashboards:
   - name: Conformance - vSphere
     description: Runs conformance tests using e2e.test against latest kubernetes master with in-tree vSphere
     test_group_name: ci-periodic-vsphere-test-e2e-conformance
-  - name: gce-device-plugin-gpu-master
-    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
-  - name: gce-cos-master-slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
-  - name: gce-cos-master-serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-  - name: gce-cos-master-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-  - name: gce-cos-master-scalability-100
-    test_group_name: ci-kubernetes-e2e-gci-gce-scalability
   - name: gce-master-scale-correctness
+    description: Runs 1000-node performance test once a week and checks that operational results are still all correct at that scale
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
   - name: gce-master-scale-performance
+    description: 5000-node performance test, runs once a day on weekdays
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
-  - name: gce-cos-master-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-  - name: gce-cos-master-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-  - name: kubeadm-gce-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
-  - name: kubeadm-gce-stable-on-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
-  - name: packages-pushed-master
-    test_group_name: periodic-kubernetes-e2e-packages-pushed
 
 - name: sig-release-1.13-all
   dashboard_tab:


### PR DESCRIPTION
…release-master-blocking into blocking vs. informing, based on whether or not the test meets the accepted criteria for blocking tests.  Omits any changes to release-misc or builds, instead just breaking up master-blocking.  

Rather than do more git surgery on #10505, this is a replacement PR which limits its changes to only dividing up the tests currently in sig-release-master-blocking into -blocking and -informing based on the blocking criteria.

See the earlier PR for discussion and comments.  

@spiffxp, @mariantalla please review/approve, thanks!


