### PR TITLE
Revert "Add override plugin to kubernetes/utils"

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -441,9 +441,6 @@ plugins:
   - trigger
   - welcome
 
-  kubernetes/utils:
-  - override
-
   kubernetes/website:
   - owners-label
 


### PR DESCRIPTION
`/override` for the CLAbot does not work as there are 2 bots and the
status is just flipped back depending on who wins.

This reverts commit fb4485ef8258fc4e7e7bfa556d50bec073b5a10d.