### PR TITLE
fix dashboard tide config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -108,7 +108,7 @@ branch-protection:
         dashboard:
           required_status_checks:
             contexts:
-            - continuous-integration/travis-ci
+            - continuous-integration/travis-ci/pr
           required_pull_request_reviews:
             required_approving_review_count: 1
         dns:


### PR DESCRIPTION
I think this should fix #10921 -- they have this enabled:
```yaml
    orgs:
     kubernetes:
      repos:
        dashboard:
          skip-unknown-contexts: true
          from-branch-protection: true
```
but while the status on github is `continuous-integration/travis-ci/pr`, the branch protection is for `continuous-integration/travis-ci` which is marked Required on GitHub -- I'm not sure how GitHub matches these (looked for docs, found some but no mention of any non-literal matching...) but tide seems to be unhappy with this `Pending — Not mergeable. Job continuous-integration/travis-ci has no ...`

in the logs:
```yaml
{
  base-sha:  "01c2a3548e17e99a4232c154831d32b03a96d74e"   
  branch:  "master"   
  component:  "tide"   
  controller:  "sync"   
  level:  "debug"   
  msg:  "from 5 total contexts ([tide cla/linuxfoundation codecov/patch codecov/project continuous-integration/travis-ci/pr]) found 1 failing contexts: [continuous-integration/travis-ci]"   
  org:  "kubernetes"   
  pr:  3529   
  repo:  "dashboard"   
  sha:  "eb6f4f9df887cd82ca6ea0c4aa3e4654bf56b7f3"   
 }
```