### PR TITLE
Don't use v3 for scheduler logs in scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -104,9 +104,6 @@ presets:
   # Reduce logs verbosity.
   - name: TEST_CLUSTER_LOG_LEVEL
     value: --v=2
-  # Use verbosity 3 for the scheduler logs, as otherwise the logs are meaningless.
-  - name: SCHEDULER_TEST_LOG_LEVEL
-    value: --v=3
   # Increase resync period to simulate production.
   - name: TEST_CLUSTER_RESYNC_PERIOD
     value: --min-resync-period=12h


### PR DESCRIPTION
We tried that and realized it wasn't a good idea.
Scheduler log grew by few orders of magnitude and was clogged with totally useless stuff, e.g. it logged "Node gce-scale-cluster-minion-group-XXX is a potential node for preemption." over **250 000 000** times.