### PR TITLE
Add AWS EBS CSI Driver e2e test to prow job

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -48,7 +48,41 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190122-6eca4133a-master
         command:
-          - runner.sh
+        - runner.sh
         args:
-          - make
-          - test-integration
+        - make
+        - test-integration
+  - name: pull-aws-ebs-csi-driver-e2e-single-az
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-ebs-csi-driver-common: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190122-6eca4133a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-single-az
+        securityContext:
+          privileged: true
+  - name: pull-aws-ebs-csi-driver-e2e-multi-az
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-ebs-csi-driver-common: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190122-6eca4133a-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-multi-az
+        securityContext:
+          privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3318,6 +3318,12 @@ test_groups:
 - name: pull-aws-ebs-csi-driver-integration
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-ebs-csi-driver-integration
   num_columns_recent: 30
+- name: pull-aws-ebs-csi-driver-e2e-single-az
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-ebs-csi-driver-e2e-single-az
+  num_columns_recent: 30
+- name: pull-aws-ebs-csi-driver-e2e-multi-az
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-ebs-csi-driver-e2e-multi-az
+  num_columns_recent: 30
 
 # OpenShift
 - name: release-openshift-origin-installer-e2e-aws-4.0
@@ -5659,6 +5665,13 @@ dashboards:
   - name: integration-test
     test_group_name: pull-aws-ebs-csi-driver-integration
     description: aws ebs csi driver integration test
+  - name: e2e-test-single-az
+    test_group_name: pull-aws-ebs-csi-driver-e2e-single-az
+    description: aws ebs csi driver e2e test on single az
+  - name: e2e-test-multi-az
+    test_group_name: pull-aws-ebs-csi-driver-e2e-multi-az
+    description: aws ebs csi driver e2e test on mutiple AZs
+
 
 - name: sig-aws-eks-presubmits
   dashboard_tab:


### PR DESCRIPTION
This PR is to enable prow job for running e2e test for aws ebs csi driver. dind is enabled since the e2e test relies on docker to build container image.

Fixes: kubernetes-sigs/aws-ebs-csi-driver#141

/assign @krzyzacy 
/cc @gyuho @bertinatto 