### PR TITLE
Make k/utils manual merges notify sig-architecture

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -182,6 +182,12 @@ slack:
     whitelist:
     - k8s-ci-robot
   - repos:
+    - kubernetes/utils
+    channels:
+    - sig-architecture
+    whitelist:
+    - k8s-ci-robot
+  - repos:
     - kubernetes/kubernetes
     channels:
     - kubernetes-dev


### PR DESCRIPTION
Since we tried and were unable to use /override as a workaround for
CLAbot failures when extracting kubernetes/kubernetes code into 
kubernetes/utils, we're going to say manual merges are OK.

But, to raise visiblity on this I'd like to suggest we have manual
merges notify #sig-archticture in slack

ref: https://groups.google.com/d/msg/kubernetes-sig-architecture/lohdOInzcuQ/9NrKCUiKGgAJ

/sig architecture