### PR TITLE
flip github reporting to crier

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -32,7 +32,6 @@ spec:
         image: gcr.io/k8s-prow/crier:v20190122-e707848
         args:
         - --github-workers=1
-        - --report-agent=knative-build
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --job-config-path=/etc/job-config
+        - --skip-report=true
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster


### PR DESCRIPTION
/hold
/assign

How does everyone feel? :-) (It seems to work with dryrun and the knative build job - technically I want to dry it with test-infra only but I don't see an easy way to split the traffic between plank and crier)

cc @fejta @cjwagner @stevekuznetsov @spiffxp @amwat 