### PR TITLE
kubetest/anywhere: add workaround for skeleton providers

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -266,7 +266,25 @@ func (k *kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
 		log.Printf("Cluster log dumping disabled for Kubernetes Anywhere.")
 		return nil
 	}
-	return defaultDumpClusterLogs(localPath, gcsPath)
+
+	// the e2e framework in k/k does not support the "kubernetes-anywhere" provider,
+	// while the same provider is required by the k/k "./cluster/log-dump/log-dump.sh" script
+	// for dumping the logs of the GCE cluster that kubernetes-anywhere creates:
+	//   https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh
+	// this fix is quite messy, but an acceptable workaround until "anywhere.go" is removed completely.
+	//
+	// TODO(neolit123): this workaround can be removed if defaultDumpClusterLogs() is refactored to
+	// not use log-dump.sh.
+	providerKey := "KUBERNETES_PROVIDER"
+	oldValue := os.Getenv(providerKey)
+	if err := os.Setenv(providerKey, "kubernetes-anywhere"); err != nil {
+		return err
+	}
+	err := defaultDumpClusterLogs(localPath, gcsPath)
+	if err := os.Setenv(providerKey, oldValue); err != nil {
+		return err
+	}
+	return err
 }
 
 func (k *kubernetesAnywhere) TestSetup() error {


### PR DESCRIPTION
the comment in the diff explains the change:
// the e2e framework in k/k does not support the "kubernetes-anywhere" provider,
// while the same provider is required by the k/k "./cluster/log-dump/log-dump.sh" script
// for dumping the logs of the GCE cluster that kubernetes-anywhere creates:
//   https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh
// this fix is quite messy, but an acceptable workaround until "anywhere.go" is removed completely.

The "fix" is to temporary set the "KUBERNETES_PROVIDER" environment variable
to "kubernetes-anywhere", dump the logs and then set it back to the old value (presumably "skeleton").

/assign @BenTheElder @krzyzacy 
/priority critical-urgent
/sig cluster-lifecycle
/area kubetest
/kind bug
/this-is-fine
