### PR TITLE
Remove the serial-tests job for nodelocal cache.

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -365,31 +365,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20181105-66d3bcb98-master
 
 - interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=520
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=NODE_LOCAL_SSDS_EXT=1,scsi,fs
-      - --env=CLUSTER_DNS_CORE_DNS=false
-      - --env=KUBE_ENABLE_NODELOCAL_DNS=true
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20181129-33929460d-master
-
-- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
This will be added back after fixing the test to update the right
configmap. NodeLocal cache does not look at kube-dns configmap in
the current implementation. The test currently modifies kube-dns config map.
https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/dns_configmap.go