### PR TITLE
Send JobURL a pj with a valid BuildID

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -302,6 +302,7 @@ func (c *controller) buildID(pj prowjobv1.ProwJob) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	pj.Status.BuildID = id
 	url := pjutil.JobURL(c.config().Plank, pj, logrus.NewEntry(logrus.StandardLogger()))
 	return id, url, nil
 }


### PR DESCRIPTION
🤦‍♂️ 
contexts now have links, but they don't include the build id

ref https://github.com/kubernetes/test-infra/pull/10832
ref https://github.com/kubernetes/test-infra/issues/10888