### PR TITLE
Shuffle jobs into sig-release-master-informing, group it

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4515,33 +4515,6 @@ dashboards:
   - name: windows-prototype
     test_group_name: ci-kubernetes-e2e-windows-gce-poc
 
-- name: sig-release-master-kubectl-skew
-  dashboard_tab:
-  - name: skew-cluster1.10-kubectlmaster-gce
-    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
-    description: 1.10 e2e tests run against a 1.10 gce cluster using a master kubectl binary
-  - name: skew-cluster1.10-kubectlmaster-gke
-    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
-    description: 1.10 e2e tests run against a 1.10 gke cluster using a master kubectl binary
-  - name: skew-clustermaster-kubectl1.10-gce
-    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
-    description: 1.10 e2e tests run against a master gce cluster using a 1.10 kubectl binary
-  - name: skew-cluster1.10-kubectl1.10-gke
-    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
-    description: 1.10 e2e tests run against a master gke cluster using a 1.10 kubectl binary
-  - name: skew-cluster1.10-kubectlmaster-gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
-    description: 1.10 serial tests run against a 1.10 gke cluster using a master kubectl binary
-  - name: skew-cluster1.10-kubectlmaster-gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
-    description: 1.10 serial tests run against a 1.10 gce cluster using a master kubectl binary
-  - name: skew-clustermaster-kubectl1.10-gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
-    description: 1.10 serial tests run against a master gce cluster using a 1.10 kubectl binary
-  - name: skew-clustermaster-kubectl1.10-gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
-    description: 1.10 serial tests run against a master gke cluster using a 1.10 kubectl binary
-
 - name: sig-release-master-upgrade-optional
   dashboard_tab:
   - name: gke-gci-stable-gci-master-upgrade-master
@@ -4661,6 +4634,34 @@ dashboards:
   - name: gce-master-scale-performance
     description: 5000-node performance test, runs once a day on weekdays
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
+  # TODO(spiffxp): these are all formerly from sig-release-master-kubectl-skew
+  #                and may not even merit being on a sig-release dashboard, but
+  #                for the purposes of reducing the number of dashboards, I'm
+  #                putting them here
+  - name: skew-cluster1.10-kubectlmaster-gce
+    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
+    description: 1.10 e2e tests run against a 1.10 gce cluster using a master kubectl binary
+  - name: skew-cluster1.10-kubectlmaster-gke
+    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
+    description: 1.10 e2e tests run against a 1.10 gke cluster using a master kubectl binary
+  - name: skew-clustermaster-kubectl1.10-gce
+    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
+    description: 1.10 e2e tests run against a master gce cluster using a 1.10 kubectl binary
+  - name: skew-cluster1.10-kubectl1.10-gke
+    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
+    description: 1.10 e2e tests run against a master gke cluster using a 1.10 kubectl binary
+  - name: skew-cluster1.10-kubectlmaster-gce-serial
+    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
+    description: 1.10 serial tests run against a 1.10 gke cluster using a master kubectl binary
+  - name: skew-cluster1.10-kubectlmaster-gke-serial
+    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
+    description: 1.10 serial tests run against a 1.10 gce cluster using a master kubectl binary
+  - name: skew-clustermaster-kubectl1.10-gce-serial
+    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
+    description: 1.10 serial tests run against a master gce cluster using a 1.10 kubectl binary
+  - name: skew-clustermaster-kubectl1.10-gke-serial
+    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
+    description: 1.10 serial tests run against a master gke cluster using a 1.10 kubectl binary
 
 - name: sig-release-1.13-all
   dashboard_tab:
@@ -7654,7 +7655,7 @@ dashboard_groups:
 - name: sig-release
   dashboard_names:
   - sig-release-master-blocking
-  - sig-release-master-kubectl-skew
+  - sig-release-master-informing
   - sig-release-master-upgrade
   - sig-release-master-upgrade-optional
   - sig-release-1.13-all


### PR DESCRIPTION
sig-release-master-informing is showing as a toplevel board instead
of grouped under sig-release, this will correct that

While I was here, I dropped sig-release-master-kubectl-skew
and moved all of its tests into -informing (to be triaged later)

/sig release
/area release-team