### PR TITLE
Move sig-aws-eks-presubmits into sig-aws dashboard gorup

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -7610,6 +7610,7 @@ dashboard_groups:
   - sig-aws-cloud-provider-aws
   - sig-aws-ebs-csi-driver
   - sig-aws-eks-periodics
+  - sig-aws-eks-presubmits
 
 - name: sig-cli
   dashboard_names:


### PR DESCRIPTION
Shouldn't be a top-level testgrid dashboard

/sig aws