### PR TITLE
Bump label_sync to v20190126-6c4304780

### DIFF
--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-testimages/label_sync:v20180921-f7ff24f34
+              image: gcr.io/k8s-testimages/label_sync:v20190126-6c4304780
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-testimages/label_sync:v20180921-f7ff24f34
+        image: gcr.io/k8s-testimages/label_sync:v20190126-6c4304780
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true


### PR DESCRIPTION
To capture https://github.com/kubernetes/test-infra/pull/10580
/cc @cblecker @cjwagner 