### PR TITLE
Make plank set PrevReportState after report a job

### DIFF
--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/test-infra/prow/report"
 )
 
+const (
+	// GithubReporterName is the name for github reporter
+	GithubReporterName = "github-reporter"
+)
+
 // Client is a github reporter client
 type Client struct {
 	gc          report.GithubClient
@@ -42,7 +47,7 @@ func NewReporter(gc report.GithubClient, cfg config.Getter, reportAgent string) 
 
 // GetName returns the name of the reporter
 func (c *Client) GetName() string {
-	return "github-reporter"
+	return GithubReporterName
 }
 
 // ShouldReport returns if this prowjob should be reported by the github reporter

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/github/reporter:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
@@ -28,6 +29,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/github/reporter:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/pull/10973
ref https://github.com/kubernetes/test-infra/issues/7741

Technically we can ask user to run crier in dry-run mode for n days (n > ttl for pj), but that's not an ideal migrate pattern. It might be better let plank populate the field, so next time we can make the switch seamlessly.

(Is there a k8s api token limit? since I saw other k8s client calls are within sub go routines. Let me know if this logic need to move to other places)

/assign @cjwagner @fejta @stevekuznetsov 
cc @amwat 