### PR TITLE
Fix spyglass cell generation when using spyglass as primary viewer

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -516,7 +516,7 @@ function redraw(fz: FuzzySearch): void {
         if (spyglass) {
             const buildIndex = build.url.indexOf('/build/');
             if (buildIndex !== -1) {
-                let url = window.location.origin + '/view/gcs/' +
+                const url = window.location.origin + '/view/gcs/' +
                     build.url.substring(buildIndex + '/build/'.length);
                 r.appendChild(createSpyglassCell(url));
             } else if (build.url.includes('/view/')) {

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -514,19 +514,15 @@ function redraw(fz: FuzzySearch): void {
             r.appendChild(cell.text(""));
         }
         if (spyglass) {
-            if (build.state == 'pending') {
-                let url = window.location.origin + '/view/prowjob/' + build.job + '/' +
-                    build.build_id;
+            const buildIndex = build.url.indexOf('/build/');
+            if (buildIndex !== -1) {
+                let url = window.location.origin + '/view/gcs/' +
+                    build.url.substring(buildIndex + '/build/'.length);
                 r.appendChild(createSpyglassCell(url));
+            } else if (build.url.includes('/view/')) {
+                r.appendChild(createSpyglassCell(build.url))
             } else {
-                const buildIndex = build.url.indexOf('/build/');
-                if (buildIndex === -1) {
-                    r.appendChild(cell.text(''));
-                } else {
-                    let url = window.location.origin + '/view/gcs/' +
-                        build.url.substring(buildIndex + '/build/'.length);
-                    r.appendChild(createSpyglassCell(url));
-                }
+                r.appendChild(cell.text(''));
             }
         } else {
             r.appendChild(cell.text(''));


### PR DESCRIPTION
Currently, Deck won't show the Spyglass cell when using Spyglass links for the Job url. This pull fixes that.

This is the first time in my life I wrote {Java,Type}Script which is why I didn't add a test. I did deploy it thought and verify that the cell works correctly for both jobs that have a `/view/...` and jobs that have a `/build/...` uri.

This whole weird and hard to understand parsing is only required because Deck doesn't know which bucket to use and there is guaranteed-to-work way to get it from the Job, because only Jobs that use the `PodUtils` have it in their spec.

IMHO it would be the better approach if we either:

* Configured the BucketName on Deck/Spyglass so it can offer a handler that doesn't need to contain that
* Always had the BucketName in a ProwJobs spec

That may be an issue for some use cases thought and will require a more involved analysis so here is the band aid fix.

/shrug

/assign @ixdy @Katharine 