### PR TITLE
Add defaulting for mkpj

### DIFF
--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -13,6 +13,9 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/mkpj",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/config/secret:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
@@ -37,6 +40,12 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//prow/kube:go_default_library",
+    ],
 )
 
 go_binary(

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -27,6 +27,9 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/secret"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 )
@@ -41,6 +44,86 @@ type options struct {
 	pullNumber int
 	pullSha    string
 	pullAuthor string
+	org        string
+	repo       string
+
+	github       prowflagutil.GitHubOptions
+	githubClient githubClient
+	pullRequest  *github.PullRequest
+}
+
+func (o *options) getPullRequest() (*github.PullRequest, error) {
+	if o.pullRequest != nil {
+		return o.pullRequest, nil
+	}
+	pr, err := o.githubClient.GetPullRequest(o.org, o.repo, o.pullNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch PullRequest from Github: %v", err)
+	}
+	o.pullRequest = pr
+	return pr, nil
+}
+
+func (o *options) defaultPR(pjs *kube.ProwJobSpec) error {
+	if pjs.Refs.Pulls[0].Number == 0 {
+		fmt.Fprint(os.Stderr, "PR Number: ")
+		var pullNumber int
+		fmt.Scanln(&pullNumber)
+		pjs.Refs.Pulls[0].Number = pullNumber
+		o.pullNumber = pullNumber
+	}
+	if pjs.Refs.Pulls[0].Author == "" {
+		pr, err := o.getPullRequest()
+		if err != nil {
+			return err
+		}
+		pjs.Refs.Pulls[0].Author = pr.User.Login
+	}
+	if pjs.Refs.Pulls[0].SHA == "" {
+		pr, err := o.getPullRequest()
+		if err != nil {
+			return err
+		}
+		pjs.Refs.Pulls[0].SHA = pr.Head.SHA
+	}
+	return nil
+}
+
+func (o *options) defaultBaseRef(pjs *kube.ProwJobSpec) error {
+	if pjs.Refs.BaseRef == "" {
+		if o.pullNumber != 0 {
+			pr, err := o.getPullRequest()
+			if err != nil {
+				return err
+			}
+			pjs.Refs.BaseRef = pr.Base.Ref
+		} else {
+			fmt.Fprint(os.Stderr, "Base ref (e.g. master): ")
+			fmt.Scanln(&pjs.Refs.BaseRef)
+		}
+	}
+	if pjs.Refs.BaseSHA == "" {
+		if o.pullNumber != 0 {
+			pr, err := o.getPullRequest()
+			if err != nil {
+				return err
+			}
+			pjs.Refs.BaseSHA = pr.Base.SHA
+		} else {
+			baseSHA, err := o.githubClient.GetRef(o.org, o.repo, fmt.Sprintf("heads/%s", pjs.Refs.BaseRef))
+			if err != nil {
+				logrus.Fatalf("failed to get base sha: %v", err)
+				return err
+			}
+			pjs.Refs.BaseSHA = baseSHA
+		}
+	}
+	return nil
+}
+
+type githubClient interface {
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	GetRef(org, repo, ref string) (string, error)
 }
 
 func (o *options) Validate() error {
@@ -57,15 +140,17 @@ func (o *options) Validate() error {
 
 func gatherOptions() options {
 	o := options{}
-	flag.StringVar(&o.jobName, "job", "", "Job to run.")
-	flag.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
-	flag.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
-	flag.StringVar(&o.baseRef, "base-ref", "", "Git base ref under test")
-	flag.StringVar(&o.baseSha, "base-sha", "", "Git base SHA under test")
-	flag.IntVar(&o.pullNumber, "pull-number", 0, "Git pull number under test")
-	flag.StringVar(&o.pullSha, "pull-sha", "", "Git pull SHA under test")
-	flag.StringVar(&o.pullAuthor, "pull-author", "", "Git pull author under test")
-	flag.Parse()
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.jobName, "job", "", "Job to run.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
+	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+	fs.StringVar(&o.baseRef, "base-ref", "", "Git base ref under test")
+	fs.StringVar(&o.baseSha, "base-sha", "", "Git base SHA under test")
+	fs.IntVar(&o.pullNumber, "pull-number", 0, "Git pull number under test")
+	fs.StringVar(&o.pullSha, "pull-sha", "", "Git pull SHA under test")
+	fs.StringVar(&o.pullAuthor, "pull-author", "", "Git pull author under test")
+	o.github.AddFlagsWithoutDefaultGithubTokenPath(fs)
+	fs.Parse(os.Args[1:])
 	return o
 }
 
@@ -78,6 +163,18 @@ func main() {
 	conf, err := config.Load(o.configPath, o.jobConfigPath)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error loading config.")
+	}
+
+	var secretAgent *secret.Agent
+	if o.github.TokenPath != "" {
+		secretAgent = &secret.Agent{}
+		if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+			logrus.Fatalf("Failed to start secret agent: %v", err)
+		}
+	}
+	o.githubClient, err = o.github.GitHubClient(secretAgent, false)
+	if err != nil {
+		logrus.Fatalf("failed to get Github client: %v", err)
 	}
 
 	var pjs kube.ProwJobSpec
@@ -108,6 +205,8 @@ func main() {
 				found = true
 				needsBaseRef = true
 				needsPR = true
+				o.org = org
+				o.repo = repo
 			}
 		}
 	}
@@ -128,6 +227,8 @@ func main() {
 				labels = p.Labels
 				found = true
 				needsBaseRef = true
+				o.org = org
+				o.repo = repo
 			}
 		}
 	}
@@ -141,28 +242,14 @@ func main() {
 	if !found {
 		logrus.Fatalf("Job %s not found.", o.jobName)
 	}
-	if needsBaseRef {
-		if pjs.Refs.BaseRef == "" {
-			fmt.Fprint(os.Stderr, "Base ref (e.g. master): ")
-			fmt.Scanln(&pjs.Refs.BaseRef)
-		}
-		if pjs.Refs.BaseSHA == "" {
-			fmt.Fprint(os.Stderr, "Base SHA (e.g. 72bcb5d80): ")
-			fmt.Scanln(&pjs.Refs.BaseSHA)
+	if needsPR {
+		if err := o.defaultPR(&pjs); err != nil {
+			logrus.Fatalf("failed to default PR: %v", err)
 		}
 	}
-	if needsPR {
-		if pjs.Refs.Pulls[0].Number == 0 {
-			fmt.Fprint(os.Stderr, "PR Number: ")
-			fmt.Scanln(&pjs.Refs.Pulls[0].Number)
-		}
-		if pjs.Refs.Pulls[0].Author == "" {
-			fmt.Fprint(os.Stderr, "PR author: ")
-			fmt.Scanln(&pjs.Refs.Pulls[0].Author)
-		}
-		if pjs.Refs.Pulls[0].SHA == "" {
-			fmt.Fprint(os.Stderr, "PR SHA (e.g. 72bcb5d80): ")
-			fmt.Scanln(&pjs.Refs.Pulls[0].SHA)
+	if needsBaseRef {
+		if err := o.defaultBaseRef(&pjs); err != nil {
+			logrus.Fatalf("failed to default base ref: %v", err)
 		}
 	}
 	pj := pjutil.NewProwJob(pjs, labels)

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -37,9 +37,24 @@ type GitHubOptions struct {
 
 // AddFlags injects GitHub options into the given FlagSet.
 func (o *GitHubOptions) AddFlags(fs *flag.FlagSet) {
+	o.addFlags(true, fs)
+}
+
+// AddFlagsWithoutDefaultGithubTokenPath injects GitHub options into the given
+// Flagset without setting a default for for the githubTokenPath, allowing to
+// use an anonymous Github client
+func (o *GitHubOptions) AddFlagsWithoutDefaultGithubTokenPath(fs *flag.FlagSet) {
+	o.addFlags(false, fs)
+}
+
+func (o *GitHubOptions) addFlags(wantDefaultGithubTokenPath bool, fs *flag.FlagSet) {
 	o.endpoint = NewStrings("https://api.github.com")
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
-	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	defaultGithubTokenPath := ""
+	if wantDefaultGithubTokenPath {
+		defaultGithubTokenPath = "/etc/github/oauth"
+	}
+	fs.StringVar(&o.TokenPath, "github-token-path", defaultGithubTokenPath, "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.deprecatedTokenFile, "github-token-file", "", "DEPRECATED: use -github-token-path instead.  -github-token-file may be removed anytime after 2019-01-01.")
 }
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -442,7 +442,9 @@ func (c *Client) doRequest(method, path, accept string, body interface{}) (*http
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Token "+string(c.getToken()))
+	if token := c.getToken(); len(token) > 0 {
+		req.Header.Set("Authorization", "Token "+string(token))
+	}
 	if accept == acceptNone {
 		req.Header.Add("Accept", "application/vnd.github.v3+json")
 	} else {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -26,8 +26,12 @@ import (
 
 const botName = "k8s-ci-robot"
 
-// Bot is the exported botName
-const Bot = botName
+const (
+	// Bot is the exported botName
+	Bot = botName
+	// TestRef is the ref returned when calling GetRef
+	TestRef = "abcde"
+)
 
 // FakeClient is like client, but fake.
 type FakeClient struct {
@@ -192,7 +196,7 @@ func (f *FakeClient) GetPullRequestChanges(org, repo string, number int) ([]gith
 
 // GetRef returns the hash of a ref.
 func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
-	return "abcde", nil
+	return TestRef, nil
 }
 
 // DeleteRef returns an error indicating if deletion of the given ref was successful

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -186,7 +186,11 @@ func (f *FakeClient) DeleteStaleComments(org, repo string, number int, comments 
 
 // GetPullRequest returns details about the PR.
 func (f *FakeClient) GetPullRequest(owner, repo string, number int) (*github.PullRequest, error) {
-	return f.PullRequests[number], nil
+	val, exists := f.PullRequests[number]
+	if !exists {
+		return nil, fmt.Errorf("Pull request number %d does not exit", number)
+	}
+	return val, nil
 }
 
 // GetPullRequestChanges returns the file modifications in a PR.


### PR DESCRIPTION

This PR adds defaulting for mkpj using the Github api. Unless a token file is passed in, it will just do unauthenticated requests, which required a small change in the Github client.

After this change, the only args required for `mkpj` are:

* Presubmit: Configfiles, Job name, Pull number
* Postsubmit: Configfiles, Job name, Base name


/assign @stevekuznetsov 

cc @nikhita 