### PR TITLE
kubetest: extend the kind deployer with optional build and download

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -246,7 +246,7 @@ func getDeployer(o *options) (deployer, error) {
 	case "eks":
 		return newEKS(timeout, verbose)
 	case "kind":
-		return kind.NewKind(control)
+		return kind.NewKind(control, string(o.build))
 	case "kops":
 		return newKops(o.provider, o.gcpProject, o.cluster)
 	case "kubeadm-dind":


### PR DESCRIPTION
The build functionality already existed and was the default option
for both the node image and kind binary.

Enable support for:
- optional build types for the node image (e.g. bazel).
- pulling node image instead of always building one.
- downloading a kind release binary from GitHub instead
of building from souce.

Added some TODOs related to multi-platform and multi-arch.

ref https://github.com/kubernetes-sigs/kind/issues/161

/area kubetest
/kind feature
/priority important-soon
/assign @BenTheElder @krzyzacy 
