### PR TITLE
Add --kubeconfig flag to all components, create Kubernetes clientset

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	defer gitClient.Clean()
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, defaultContext, kubernetesClients, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
 	}
@@ -142,10 +142,11 @@ func main() {
 	}
 
 	clientAgent := &plugins.ClientAgent{
-		GitHubClient: githubClient,
-		KubeClient:   kubeClient,
-		GitClient:    gitClient,
-		SlackClient:  slackClient,
+		GitHubClient:     githubClient,
+		KubeClient:       kubeClient,
+		KubernetesClient: kubernetesClients[defaultContext],
+		GitClient:        gitClient,
+		SlackClient:      slackClient,
 	}
 
 	pluginAgent := &plugins.ConfigAgent{}

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -142,7 +142,7 @@ func main() {
 	}
 	cfg := configAgent.Config
 
-	kubeClient, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -115,7 +115,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -107,7 +107,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	defer gitClient.Clean()
 
-	kubeClient, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
 	}

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//prow/slack:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/commentpruner"
@@ -131,10 +132,11 @@ func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help H
 
 // Agent may be used concurrently, so each entry must be thread-safe.
 type Agent struct {
-	GitHubClient *github.Client
-	KubeClient   *kube.Client
-	GitClient    *git.Client
-	SlackClient  *slack.Client
+	GitHubClient     *github.Client
+	KubeClient       *kube.Client
+	KubernetesClient kubernetes.Interface
+	GitClient        *git.Client
+	SlackClient      *slack.Client
 
 	OwnersClient *repoowners.Client
 
@@ -190,10 +192,11 @@ func (a *Agent) CommentPruner() (*commentpruner.EventClient, error) {
 
 // ClientAgent contains the various clients that are attached to the Agent.
 type ClientAgent struct {
-	GitHubClient *github.Client
-	KubeClient   *kube.Client
-	GitClient    *git.Client
-	SlackClient  *slack.Client
+	GitHubClient     *github.Client
+	KubeClient       *kube.Client
+	KubernetesClient kubernetes.Interface
+	GitClient        *git.Client
+	SlackClient      *slack.Client
 }
 
 // ConfigAgent contains the agent mutex and the Agent configuration.


### PR DESCRIPTION
Prior to using the flag (and exposing it through ANNOUNCEMENTS.md), the
plumbing to use the new clients is added to the structure.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
Not useful by itself but is useful as the base on which all the other PRs will build