### PR TITLE
Refactor components to use upstream ConfigMap client

### DIFF
--- a/prow/cmd/config-bootstrapper/BUILD.bazel
+++ b/prow/cmd/config-bootstrapper/BUILD.bazel
@@ -11,17 +11,11 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
-        "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/updateconfig:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	defer gitClient.Clean()
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, defaultContext, kubernetesClients, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
 	}
@@ -142,10 +142,11 @@ func main() {
 	}
 
 	clientAgent := &plugins.ClientAgent{
-		GitHubClient: githubClient,
-		KubeClient:   kubeClient,
-		GitClient:    gitClient,
-		SlackClient:  slackClient,
+		GitHubClient:     githubClient,
+		KubeClient:       kubeClient,
+		KubernetesClient: kubernetesClients[defaultContext],
+		GitClient:        gitClient,
+		SlackClient:      slackClient,
 	}
 
 	pluginAgent := &plugins.ConfigAgent{}

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -142,7 +142,7 @@ func main() {
 	}
 	cfg := configAgent.Config
 
-	kubeClient, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -115,7 +115,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -107,7 +107,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	kubeClient, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(configAgent.Config().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -126,7 +126,7 @@ func main() {
 	}
 	defer gitClient.Clean()
 
-	kubeClient, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
+	kubeClient, _, _, err := o.kubernetes.Client(cfg().ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
 	}

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//prow/slack:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/commentpruner"
@@ -131,10 +132,11 @@ func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help H
 
 // Agent may be used concurrently, so each entry must be thread-safe.
 type Agent struct {
-	GitHubClient *github.Client
-	KubeClient   *kube.Client
-	GitClient    *git.Client
-	SlackClient  *slack.Client
+	GitHubClient     *github.Client
+	KubeClient       *kube.Client
+	KubernetesClient kubernetes.Interface
+	GitClient        *git.Client
+	SlackClient      *slack.Client
 
 	OwnersClient *repoowners.Client
 
@@ -190,10 +192,11 @@ func (a *Agent) CommentPruner() (*commentpruner.EventClient, error) {
 
 // ClientAgent contains the various clients that are attached to the Agent.
 type ClientAgent struct {
-	GitHubClient *github.Client
-	KubeClient   *kube.Client
-	GitClient    *git.Client
-	SlackClient  *slack.Client
+	GitHubClient     *github.Client
+	KubeClient       *kube.Client
+	KubernetesClient kubernetes.Interface
+	GitClient        *git.Client
+	SlackClient      *slack.Client
 }
 
 // ConfigAgent contains the agent mutex and the Agent configuration.

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -13,11 +13,18 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
-        "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )
 
@@ -27,11 +34,14 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
     deps = [
         "//prow/github:go_default_library",
-        "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/mattn/go-zglob:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
     ],
 )
 

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -22,9 +22,12 @@ import (
 
 	"github.com/mattn/go-zglob"
 	"github.com/sirupsen/logrus"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -62,15 +65,8 @@ type githubClient interface {
 	GetFile(org, repo, filepath, commit string) ([]byte, error)
 }
 
-// KubeClient knows how to interact with ConfigMaps on a cluster
-type KubeClient interface {
-	GetConfigMap(name, namespace string) (kube.ConfigMap, error)
-	ReplaceConfigMap(name string, config kube.ConfigMap) (kube.ConfigMap, error)
-	CreateConfigMap(content kube.ConfigMap) (kube.ConfigMap, error)
-}
-
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
-	return handle(pc.GitHubClient, pc.KubeClient, pc.Logger, pre, maps(pc))
+	return handle(pc.GitHubClient, pc.KubernetesClient.CoreV1(), pc.Config.ProwJobNamespace, pc.Logger, pre, maps(pc))
 }
 
 func maps(pc plugins.Agent) map[string]plugins.ConfigMapSpec {
@@ -92,22 +88,27 @@ func (g *gitHubFileGetter) GetFile(filename string) ([]byte, error) {
 }
 
 // Update updates the configmap with the data from the identified files
-func Update(fg FileGetter, kc KubeClient, name, namespace string, updates map[string]string, logger *logrus.Entry) error {
-	currentContent, getErr := kc.GetConfigMap(name, namespace)
-	_, isNotFound := getErr.(kube.NotFoundError)
+func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string, updates map[string]string, logger *logrus.Entry) error {
+	cm, getErr := kc.Get(name, metav1.GetOptions{})
+	isNotFound := errors.IsNotFound(getErr)
 	if getErr != nil && !isNotFound {
 		return fmt.Errorf("failed to fetch current state of configmap: %v", getErr)
 	}
 
-	data := map[string]string{}
-	if currentContent.Data != nil {
-		data = currentContent.Data
+	if cm == nil {
+		cm = &coreapi.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Data: map[string]string{},
+		}
 	}
 
 	for key, filename := range updates {
 		if filename == "" {
 			logger.WithField("key", key).Debug("Deleting key.")
-			delete(data, key)
+			delete(cm.Data, key)
 			continue
 		}
 
@@ -116,25 +117,20 @@ func Update(fg FileGetter, kc KubeClient, name, namespace string, updates map[st
 			return fmt.Errorf("get file err: %v", err)
 		}
 		logger.WithFields(logrus.Fields{"key": key, "filename": filename}).Debug("Populating key.")
-		data[key] = string(content)
-	}
-
-	cm := kube.ConfigMap{
-		ObjectMeta: kube.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data: data,
+		cm.Data[key] = string(content)
 	}
 
 	var updateErr error
+	var verb string
 	if getErr != nil && isNotFound {
-		_, updateErr = kc.CreateConfigMap(cm)
+		verb = "create"
+		_, updateErr = kc.Create(cm)
 	} else {
-		_, updateErr = kc.ReplaceConfigMap(name, cm)
+		verb = "update"
+		_, updateErr = kc.Update(cm)
 	}
 	if updateErr != nil {
-		return fmt.Errorf("replace config map err: %v", updateErr)
+		return fmt.Errorf("%s config map err: %v", verb, updateErr)
 	}
 	return nil
 }
@@ -196,7 +192,7 @@ func FilterChanges(configMaps map[string]plugins.ConfigMapSpec, changes []github
 	return toUpdate
 }
 
-func handle(gc githubClient, kc KubeClient, log *logrus.Entry, pre github.PullRequestEvent, configMaps map[string]plugins.ConfigMapSpec) error {
+func handle(gc githubClient, kc corev1.ConfigMapsGetter, defaultNamespace string, log *logrus.Entry, pre github.PullRequestEvent, configMaps map[string]plugins.ConfigMapSpec) error {
 	// Only consider newly merged PRs
 	if pre.Action != github.PullRequestActionClosed {
 		return nil
@@ -242,8 +238,11 @@ func handle(gc githubClient, kc KubeClient, log *logrus.Entry, pre github.PullRe
 		indent = "   " // three spaces for sub bullets
 	}
 	for cm, data := range toUpdate {
+		if cm.Namespace == "" {
+			cm.Namespace = defaultNamespace
+		}
 		logger := log.WithFields(logrus.Fields{"configmap": map[string]string{"name": cm.Name, "namespace": cm.Namespace}})
-		if err := Update(&gitHubFileGetter{org: org, repo: repo, commit: *pr.MergeSHA, client: gc}, kc, cm.Name, cm.Namespace, data, logger); err != nil {
+		if err := Update(&gitHubFileGetter{org: org, repo: repo, commit: *pr.MergeSHA, client: gc}, kc.ConfigMaps(cm.Namespace), cm.Name, cm.Namespace, data, logger); err != nil {
 			return err
 		}
 		updated = append(updated, message(cm.Name, cm.Namespace, data, indent))


### PR DESCRIPTION
The `updateconfig` plugin and the command-line developer
`config-bootstrapper` tool now use the upstream `ConfigMap` client.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
/cc @cjwagner 
depends on #10985 