### PR TITLE
Remove comment parsing for PR trust

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -214,32 +214,7 @@ func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 			return l, false, err
 		}
 	}
-	if github.HasLabel(labels.OkToTest, l) {
-		return l, true, nil
-	}
-	botName, err := ghc.BotName()
-	if err != nil {
-		return l, false, fmt.Errorf("error finding bot name: %v", err)
-	}
-	// Next look for "/ok-to-test" comments on the PR.
-	comments, err := ghc.ListIssueComments(org, repo, num)
-	if err != nil {
-		return l, false, err
-	}
-	for _, comment := range comments {
-		commentAuthor := comment.User.Login
-		// Skip comments: by the PR author, or by bot, or not matching "/ok-to-test".
-		if commentAuthor == author || commentAuthor == botName || !okToTestRe.MatchString(comment.Body) {
-			continue
-		}
-		// Ensure that the commenter is in the org.
-		if commentAuthorMember, err := TrustedUser(ghc, trigger, commentAuthor, org, repo); err != nil {
-			return l, false, fmt.Errorf("error checking %s for trust: %v", commentAuthor, err)
-		} else if commentAuthorMember {
-			return l, true, nil
-		}
-	}
-	return l, false, nil
+	return l, github.HasLabel(labels.OkToTest, l), nil
 }
 
 func buildAll(c Client, pr *github.PullRequest, eventGUID string) error {


### PR DESCRIPTION
Now that we have moved to checking label `ok-to-test` for PR trust, it doesn't make sense to parse old comments to check it.
The code was left several weeks, giving a chance to older PR to get the label by that same plugin.
Prow will work as before, worse case scenario: if a PR from a non-member is missing the label, it will require an `/ok-to-test` again to allow tests to run again.