### PR TITLE
Correct types in const declarations

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -35,11 +35,11 @@ const (
 	// PresubmitJob means it runs on unmerged PRs.
 	PresubmitJob ProwJobType = "presubmit"
 	// PostsubmitJob means it runs on each new commit.
-	PostsubmitJob = "postsubmit"
+	PostsubmitJob ProwJobType = "postsubmit"
 	// Periodic job means it runs on a time-basis, unrelated to git changes.
-	PeriodicJob = "periodic"
+	PeriodicJob ProwJobType = "periodic"
 	// BatchJob tests multiple unmerged PRs at the same time.
-	BatchJob = "batch"
+	BatchJob ProwJobType = "batch"
 )
 
 // ProwJobState specifies whether the job is running
@@ -50,15 +50,15 @@ const (
 	// TriggeredState means the job has been created but not yet scheduled.
 	TriggeredState ProwJobState = "triggered"
 	// PendingState means the job is scheduled but not yet running.
-	PendingState = "pending"
+	PendingState ProwJobState = "pending"
 	// SuccessState means the job completed without error (exit 0)
-	SuccessState = "success"
+	SuccessState ProwJobState = "success"
 	// FailureState means the job completed with errors (exit non-zero)
-	FailureState = "failure"
+	FailureState ProwJobState = "failure"
 	// AbortedState means prow killed the job early (new commit pushed, perhaps).
-	AbortedState = "aborted"
+	AbortedState ProwJobState = "aborted"
 	// ErrorState means the job could not schedule (bad config, perhaps).
-	ErrorState = "error"
+	ErrorState ProwJobState = "error"
 )
 
 // ProwJobAgent specifies the controller (such as plank or jenkins-agent) that runs the job.
@@ -68,9 +68,9 @@ const (
 	// KubernetesAgent means prow will create a pod to run this job.
 	KubernetesAgent ProwJobAgent = "kubernetes"
 	// JenkinsAgent means prow will schedule the job on jenkins.
-	JenkinsAgent = "jenkins"
+	JenkinsAgent ProwJobAgent = "jenkins"
 	// KnativeBuildAgent means prow will schedule the job via a build-crd resource.
-	KnativeBuildAgent = "knative-build"
+	KnativeBuildAgent ProwJobAgent = "knative-build"
 )
 
 const (

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/crier",
     visibility = ["//visibility:private"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/informers/externalversions:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobinformer "k8s.io/test-infra/prow/client/informers/externalversions"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
@@ -196,7 +197,7 @@ func main() {
 			logrus.WithError(err).Fatal("Error getting GitHub client.")
 		}
 
-		githubReporter := githubreporter.NewReporter(githubClient, cfg, o.reportAgent)
+		githubReporter := githubreporter.NewReporter(githubClient, cfg, v1.ProwJobAgent(o.reportAgent))
 		controllers = append(
 			controllers,
 			crier.NewController(

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -33,11 +33,11 @@ const (
 type Client struct {
 	gc          report.GithubClient
 	config      config.Getter
-	reportAgent string
+	reportAgent v1.ProwJobAgent
 }
 
 // NewReporter returns a reporter client
-func NewReporter(gc report.GithubClient, cfg config.Getter, reportAgent string) *Client {
+func NewReporter(gc report.GithubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
 	return &Client{
 		gc:          gc,
 		config:      cfg,
@@ -63,7 +63,7 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 		return false
 	}
 
-	if c.reportAgent != "" && string(pj.Spec.Agent) != c.reportAgent {
+	if c.reportAgent != "" && pj.Spec.Agent != c.reportAgent {
 		// Only report for specified agent
 		return false
 	}

--- a/prow/github/reporter/reporter_test.go
+++ b/prow/github/reporter/reporter_test.go
@@ -27,7 +27,7 @@ func TestShouldReport(t *testing.T) {
 		name        string
 		pj          *v1.ProwJob
 		report      bool
-		reportAgent string
+		reportAgent v1.ProwJobAgent
 	}{
 		{
 			name: "should not report skip report job",


### PR DESCRIPTION
> https://golang.org/ref/spec#Constant_declarations
>
> If the expression values are untyped constants, the declared constants
> remain untyped and the constant identifiers denote the constant values.