### PR TITLE
Remove K8s 1.10 / add 1.13 for vSphere cloud provider

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3197,11 +3197,6 @@ test_groups:
   alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
-- name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.10
-  gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.10
-  alert_stale_results_hours: 32
-  num_failures_to_alert: 1
-
 # vsphere e2e conformance tests
 - name: ci-periodic-vsphere-test-e2e-conformance
   gcs_prefix: k8s-conformance-vsphere/head/ci/latest
@@ -3215,11 +3210,6 @@ test_groups:
 
 - name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.11
   gcs_prefix: k8s-conformance-vsphere/head/release/v1.11
-  alert_stale_results_hours: 32
-  num_failures_to_alert: 1
-
-- name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.10
-  gcs_prefix: k8s-conformance-vsphere/head/release/v1.10
   alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
@@ -3437,11 +3427,6 @@ dashboards:
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
-  - name: vSphere-cloud-provider, v1.10 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.10 branch with cloud-provider-vsphere
-    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.10
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: vSphere-cloud-provider, v1.11 (dev)
     description: Runs conformance tests using kubetest against kubernetes from the release-1.11 branch with cloud-provider-vsphere
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.11
@@ -3456,11 +3441,6 @@ dashboards:
   - name: vSphere, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with the in-tree vSphere cloud provider
     test_group_name: ci-periodic-vsphere-test-e2e-conformance
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
-  - name: vSphere, v1.10 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.10 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.10
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: vSphere, v1.11 (dev)
@@ -3590,11 +3570,6 @@ dashboards:
 
 - name: conformance-vsphere
   dashboard_tab:
-  - name: periodic-v1.10
-    description: Runs conformance tests using kubetest against kubernetes v1.10 with in-tree vSphere components
-    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.10
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: periodic-v1.11
     description: Runs conformance tests using kubetest against kubernetes v1.11 with in-tree vSphere components
     test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.11
@@ -3608,11 +3583,6 @@ dashboards:
 
 - name: vmware-conformance
   dashboard_tab:
-  - name: periodic-v1.10
-    description: Runs conformance tests using kubetest against kubernetes v1.10 with in-tree vSphere components
-    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.10
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: periodic-v1.11
     description: Runs conformance tests using kubetest against kubernetes v1.11 with in-tree vSphere components
     test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.11
@@ -3659,11 +3629,6 @@ dashboards:
 
 - name: conformance-cloud-provider-vsphere
   dashboard_tab:
-  - name: periodic-v1.10
-    description: Runs conformance tests using kubetest against kubernetes v1.10 with cloud-provider-vsphere
-    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.10
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: periodic-v1.11
     description: Runs conformance tests using kubetest against kubernetes v1.11 with cloud-provider-vsphere
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.11
@@ -3677,11 +3642,6 @@ dashboards:
 
 - name: vmware-conformance-cloud-provider
   dashboard_tab:
-  - name: periodic-v1.10
-    description: Runs conformance tests using kubetest against kubernetes v1.10 with cloud-provider-vsphere
-    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.10
-    alert_options:
-      alert_mail_to_addresses: cnx+e2e@vmware.com
   - name: periodic-v1.11
     description: Runs conformance tests using kubetest against kubernetes v1.11 with cloud-provider-vsphere
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.11

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3187,6 +3187,11 @@ test_groups:
   alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
+- name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.13
+  gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.13
+  alert_stale_results_hours: 32
+  num_failures_to_alert: 1
+
 - name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
   gcs_prefix: k8s-conformance-cloud-provider-vsphere/head/release/v1.12
   alert_stale_results_hours: 32
@@ -3200,6 +3205,11 @@ test_groups:
 # vsphere e2e conformance tests
 - name: ci-periodic-vsphere-test-e2e-conformance
   gcs_prefix: k8s-conformance-vsphere/head/ci/latest
+  alert_stale_results_hours: 32
+  num_failures_to_alert: 1
+
+- name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.13
+  gcs_prefix: k8s-conformance-vsphere/head/release/v1.13
   alert_stale_results_hours: 32
   num_failures_to_alert: 1
 
@@ -3437,6 +3447,11 @@ dashboards:
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: vSphere-cloud-provider, v1.13 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with cloud-provider-vsphere
+    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.13
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
 
   - name: vSphere, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with the in-tree vSphere cloud provider
@@ -3451,6 +3466,11 @@ dashboards:
   - name: vSphere, v1.12 (dev)
     description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with the in-tree vSphere cloud provider
     test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.12
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: vSphere, v1.13 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with the in-tree vSphere cloud provider
+    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.13
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
 
@@ -3580,6 +3600,11 @@ dashboards:
     test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.12
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
+    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.13
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
 
 - name: vmware-conformance
   dashboard_tab:
@@ -3591,6 +3616,11 @@ dashboards:
   - name: periodic-v1.12
     description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
     test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.12
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
+    test_group_name: ci-periodic-vsphere-test-e2e-conformance-branch-v1.13
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
 
@@ -3639,6 +3669,11 @@ dashboards:
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
+    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.13
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
 
 - name: vmware-conformance-cloud-provider
   dashboard_tab:
@@ -3650,6 +3685,11 @@ dashboards:
   - name: periodic-v1.12
     description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
     test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.12
+    alert_options:
+      alert_mail_to_addresses: cnx+e2e@vmware.com
+  - name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
+    test_group_name: ci-periodic-cloud-provider-vsphere-test-e2e-conformance-branch-v1.13
     alert_options:
       alert_mail_to_addresses: cnx+e2e@vmware.com
 


### PR DESCRIPTION
This PR removes Kubernetes 1.10 from the list of GA releases tested against the vSphere cloud provider. In its place K8s 1.13 has been added. The prevailing CI strategy is to test `ci/latest` and the three, previous GA release trains, which are currently `1.13`, `1.12`, and `1.11`.

cc @figo @frapposelli 