### PR TITLE
bazel-build-test.yaml: use 'skeleton' for kubeadm jobs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1698,7 +1698,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -1798,7 +1798,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -1893,7 +1893,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -1988,7 +1988,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m
@@ -2083,7 +2083,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
             --minStartupPods=8
           - --timeout=55m

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -60,7 +60,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -120,7 +120,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -180,7 +180,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -240,7 +240,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel
@@ -300,7 +300,7 @@ presubmits:
           - --ginkgo-parallel=30
           - --kubeadm=pull
           - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-          - --provider=kubernetes-anywhere
+          - --provider=skeleton
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
           - --timeout=55m
           - --use-shared-build=bazel


### PR DESCRIPTION
recently did change these under kubernetes/sig-cluster-lifecycle but missed the pre-submits.

xref: https://github.com/kubernetes/kubernetes/pull/73402

/assign @krzyzacy @BenTheElder 
/priority important-soon
/kind cleanup
/area config
