### PR TITLE
Notify #sig-pm if kubernetes/enhancements are merged manually

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -166,6 +166,12 @@ slack:
     whitelist:
     - k8s-ci-robot
   - repos:
+    - kubernetes/enhancements
+    channels:
+    - sig-pm
+    whitelist:
+    - k8s-ci-robot
+  - repos:
     - kubernetes/utils
     channels:
     - sig-architecture


### PR DESCRIPTION
We're likely going to have to do this to override CLA check at some points
so let's be really brightly visible about this practice