### PR TITLE
GCE: add a windows test job

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
@@ -37,7 +37,7 @@ periodics:
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
       - --test-cmd-args=--ginkgo.focus=\[Conformance\] --minStartupPods=8
-      - --timeout=720m
+      - --timeout=120m
       env:
       - name: USE_RELEASE_NODE_BINARIES
         value: "true"
@@ -47,3 +47,38 @@ periodics:
       resources:
         requests:
           memory: "8Gi"
+
+- name: ci-kubernetes-e2e-windows-gce
+  decorate: true
+  extra_refs:
+  - org: yujuhong
+    repo: gce-k8s-windows-testing
+    base_ref: master
+    path_alias: k8s.io/gce-k8s-windows-testing
+  interval: 2h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\] --minStartupPods=8
+      - --timeout=120m
+      env:
+      - name: KUBE_GCE_ENABLE_IP_ALIASES
+        value: "true"
+      - name: NUM_WINDOWS_NODES
+        value: "3"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3284,6 +3284,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-kubedns-performance-nodecache
 
 # GCE windows test groups.
+- name: ci-kubernetes-e2e-windows-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce
 - name: ci-kubernetes-e2e-windows-gce-poc
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce-poc
 
@@ -4579,6 +4581,8 @@ dashboards:
   dashboard_tab:
   - name: windows-prototype
     test_group_name: ci-kubernetes-e2e-windows-gce-poc
+  - name: windows-gce
+    test_group_name: ci-kubernetes-e2e-windows-gce
 
 - name: sig-release-master-upgrade
   dashboard_tab:
@@ -7560,6 +7564,9 @@ dashboards:
   - name: "Conformance acs-engine on Azure"
     description: Runs conformance tests on a Kubernetes cluster provided by acs-engine (https://github.com/Azure/acs-engine) on Azure cloud"
     test_group_name: ci-kubernetes-e2e-win-1-13
+  - name: "gce-windows-master"
+    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
+    test_group_name: ci-kubernetes-e2e-windows-gce
 
 # sig-azure dashboard
 - name: sig-azure-master


### PR DESCRIPTION
This test job runs against the k8s.io/kubernetes master branch.  It consumes the build artifacts from the hourly(?) post-submit build job.
The test script is hosted in a separate repository, and taints/untaints nodes to facilitating testing on only the Windows nodes.