### PR TITLE
Optionally persist Tide action history to GCS.

### DIFF
--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -20,7 +20,10 @@ go_library(
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/tide:go_default_library",
+        "//testgrid/util/gcs:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -57,11 +57,14 @@ type options struct {
 	github     prowflagutil.GitHubOptions
 
 	maxRecordsPerPool int
-
 	// The following are used for persisting action history in GCS.
 	gcsCredentialsFile string
-	historyURI         gcs.Path
-	historyGCSObj      *storage.ObjectHandle // Generated using the above two values.
+	// historyURI is the GCS object URI where Tide should store its action
+	// history. The object should not be publicly readable if any repos handled
+	// by the Tide instance are sensitive, but otherwise can be any object path
+	// that the credentials can write to.
+	historyURI    gcs.Path
+	historyGCSObj *storage.ObjectHandle // Generated using the above two values.
 }
 
 func (o *options) Validate() error {
@@ -107,8 +110,8 @@ func gatherOptions() options {
 	fs.IntVar(&o.statusThrottle, "status-hourly-tokens", 400, "The maximum number of tokens per hour to be used by the status controller.")
 
 	fs.IntVar(&o.maxRecordsPerPool, "max-records-per-pool", 1000, "The maximum number of history records stored for an individual Tide pool.")
-	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "File where Google Cloud authentication credentials are stored.")
-	fs.Var(&o.historyURI, "history-uri", "The URI at which Tide action history should be stored. Currently this must be a GCS URI like 'gs://bucket/path/to/object'.")
+	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "File where Google Cloud authentication credentials are stored. Required with --history-uri.")
+	fs.Var(&o.historyURI, "history-uri", "The URI at which Tide action history should be stored. It should not be publicly readable if any repos are sensitive. Must be a GCS URI like 'gs://bucket/path/to/object'.")
 
 	fs.Parse(os.Args[1:])
 	return o

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -26,7 +28,9 @@ import (
 	"syscall"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -35,6 +39,7 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/tide"
+	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
 type options struct {
@@ -50,6 +55,13 @@ type options struct {
 	runOnce    bool
 	kubernetes prowflagutil.KubernetesOptions
 	github     prowflagutil.GitHubOptions
+
+	maxRecordsPerPool int
+
+	// The following are used for persisting action history in GCS.
+	gcsCredentialsFile string
+	historyURI         gcs.Path
+	historyGCSObj      *storage.ObjectHandle // Generated using the above two values.
 }
 
 func (o *options) Validate() error {
@@ -57,6 +69,24 @@ func (o *options) Validate() error {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err
 		}
+	}
+
+	if (o.gcsCredentialsFile == "") != (o.historyURI.String() == "") {
+		return errors.New("these flags must be specified together or not at all: --gcs-credentials-file, --history-uri")
+	}
+	if o.historyURI.String() != "" {
+		if o.historyURI.Bucket() == "" || o.historyURI.Object() == "" {
+			return fmt.Errorf("history URI %q does not specify a bucket and object path in the form %q.",
+				o.historyURI.String(),
+				"gs://bucket/path/to/object",
+			)
+		}
+		// Try to generate o.historyGCSObj
+		client, err := storage.NewClient(context.Background(), option.WithCredentialsFile(o.gcsCredentialsFile))
+		if err != nil {
+			return fmt.Errorf("error creating GCS client: %v", err)
+		}
+		o.historyGCSObj = client.Bucket(o.historyURI.Bucket()).Object(o.historyURI.Object())
 	}
 
 	return nil
@@ -76,19 +106,23 @@ func gatherOptions() options {
 	fs.IntVar(&o.syncThrottle, "sync-hourly-tokens", 800, "The maximum number of tokens per hour to be used by the sync controller.")
 	fs.IntVar(&o.statusThrottle, "status-hourly-tokens", 400, "The maximum number of tokens per hour to be used by the status controller.")
 
+	fs.IntVar(&o.maxRecordsPerPool, "max-records-per-pool", 1000, "The maximum number of history records stored for an individual Tide pool.")
+	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "File where Google Cloud authentication credentials are stored.")
+	fs.Var(&o.historyURI, "history-uri", "The URI at which Tide action history should be stored. Currently this must be a GCS URI like 'gs://bucket/path/to/object'.")
+
 	fs.Parse(os.Args[1:])
 	return o
 }
 
 func main() {
+	logrus.SetFormatter(
+		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tide"}),
+	)
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tide"}),
-	)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
@@ -131,7 +165,10 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
 	}
 
-	c := tide.NewController(githubSync, githubStatus, kubeClient, cfg, gitClient, nil)
+	c, err := tide.NewController(githubSync, githubStatus, kubeClient, cfg, gitClient, o.maxRecordsPerPool, o.historyGCSObj, nil)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating Tide controller.")
+	}
 	defer c.Shutdown()
 	http.Handle("/", c)
 	http.Handle("/history", c.History)

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/tide/history/BUILD.bazel
+++ b/prow/tide/history/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
@@ -15,7 +16,11 @@ go_test(
     name = "go_default_test",
     srcs = ["history_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/apis/prowjobs/v1:go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -194,11 +194,11 @@ func init() {
 }
 
 // NewController makes a Controller out of the given clients.
-func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, gcsObj *storage.ObjectHandle, logger *logrus.Entry) (*Controller, error) {
+func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, historyHandle *storage.ObjectHandle, logger *logrus.Entry) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}
-	hist, err := history.New(maxRecordsPerPool, gcsObj)
+	hist, err := history.New(maxRecordsPerPool, historyHandle)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing history client: %v", err)
 	}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/storage"
+
 	"github.com/prometheus/client_golang/prometheus"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
@@ -192,9 +194,13 @@ func init() {
 }
 
 // NewController makes a Controller out of the given clients.
-func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, cfg config.Getter, gc *git.Client, logger *logrus.Entry) *Controller {
+func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, gcsObj *storage.ObjectHandle, logger *logrus.Entry) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
+	}
+	hist, err := history.New(maxRecordsPerPool, gcsObj)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing history client: %v", err)
 	}
 	sc := &statusController{
 		logger:         logger.WithField("controller", "status-update"),
@@ -218,14 +224,15 @@ func NewController(ghcSync, ghcStatus *github.Client, kc *kube.Client, cfg confi
 			ghc:             ghcSync,
 			nextChangeCache: make(map[changeCacheKey][]string),
 		},
-		History: history.New(1000),
-	}
+		History: hist,
+	}, nil
 }
 
 // Shutdown signals the statusController to stop working and waits for it to
 // finish its last update loop before terminating.
 // Controller.Sync() should not be used after this function is called.
 func (c *Controller) Shutdown() {
+	c.History.Flush()
 	c.sc.shutdown()
 }
 
@@ -350,8 +357,10 @@ func (c *Controller) Sync() error {
 	}
 	sortPools(pools)
 	c.m.Lock()
-	defer c.m.Unlock()
 	c.pools = pools
+	c.m.Unlock()
+
+	c.History.Flush()
 	return nil
 }
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1163,6 +1163,10 @@ func TestServeHTTP(t *testing.T) {
 		Context:     githubql.String("coverage/coveralls"),
 		Description: githubql.String("Coverage increased (+0.1%) to 27.599%"),
 	}}
+	hist, err := history.New(100, nil)
+	if err != nil {
+		t.Fatalf("Failed to create history client: %v", err)
+	}
 	c := &Controller{
 		pools: []Pool{
 			{
@@ -1170,7 +1174,7 @@ func TestServeHTTP(t *testing.T) {
 				Action:     Merge,
 			},
 		},
-		History: history.New(100),
+		History: hist,
 	}
 	s := httptest.NewServer(c)
 	defer s.Close()
@@ -1385,6 +1389,10 @@ func TestSync(t *testing.T) {
 				},
 			},
 		})
+		hist, err := history.New(100, nil)
+		if err != nil {
+			t.Fatalf("Failed to create history client: %v", err)
+		}
 		sc := &statusController{
 			logger:         logrus.WithField("controller", "status-update"),
 			ghc:            fgc,
@@ -1404,7 +1412,7 @@ func TestSync(t *testing.T) {
 				ghc:             fgc,
 				nextChangeCache: make(map[changeCacheKey][]string),
 			},
-			History: history.New(100),
+			History: hist,
 		}
 
 		if err := c.Sync(); err != nil {

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/test-infra/testgrid/util/gcs",
     visibility = [
         "//experiment/resultstore:__subpackages__",
+        "//prow/cmd/tide:__subpackages__",
         "//prow/gcsupload:__subpackages__",
         "//prow/spyglass:__subpackages__",
         "//testgrid:__subpackages__",


### PR DESCRIPTION
Not sure how to unit test this without mocking out the bucket, object iterator, readers, and writers. Any recommendations on testing this cleanly? 

/assign @stevekuznetsov 
/cc @fejta @krzyzacy 