### PR TITLE
Remove TODOs related to https://github.com/kubernetes/kubernetes/issues/72976

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -62,8 +62,6 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      # TODO(https://github.com/kubernetes/kubernetes/issues/72976): Remove line below, change get-master-root-disk-size function if needed.
-      - --env=MASTER_ROOT_DISK_SIZE=1000GB
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -52,8 +52,6 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      # TODO(https://github.com/kubernetes/kubernetes/issues/72976): Remove line below, change get-master-root-disk-size function if needed.
-      - --env=MASTER_ROOT_DISK_SIZE=1000GB
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale


### PR DESCRIPTION
Removing temporary todos created when working on https://github.com/kubernetes/kubernetes/issues/72976.
We should wait with merging this PR until https://github.com/kubernetes/kubernetes/pull/73460 gets merged.