### PR TITLE
Changing kubemark-500 zone to us-central1-f

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -387,7 +387,7 @@ periodics:
       - --gcp-node-size=n1-standard-8
       - --gcp-nodes=7
       - --gcp-project=k8s-jenkins-blocking-kubemark
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-f
       - --kubemark
       - --kubemark-nodes=500
       - --provider=gce


### PR DESCRIPTION
Project `k8s-jenkins-blocking-kubemark` has additional quota in zone `us-central1-f`, that is required to run `ci-kubernetes-kubemark-500-gce`.
Reverting change introduced by #11002.