### PR TITLE
Capture output from binary building in Azure

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -400,8 +400,12 @@ func (c *Cluster) buildHyperKube() error {
 	}
 	log.Println("Docker login success.")
 	log.Println("Building hyperkube.")
+
 	pushHyperkube := util.K8s("kubernetes", "hack", "dev-push-hyperkube.sh")
-	if err1 := control.FinishRunning(exec.Command(pushHyperkube)); err1 != nil {
+	cmd = exec.Command(pushHyperkube)
+	// dev-push-hyperkube will produce a lot of output to stdout. We should capture the output here.
+	cmd.Stdout = ioutil.Discard
+	if err1 := control.FinishRunning(cmd); err1 != nil {
 		return err1
 	}
 	c.acsCustomHyperKubeURL = fmt.Sprintf("%s/hyperkube-amd64:%s", os.Getenv("REGISTRY"), os.Getenv("VERSION"))
@@ -501,7 +505,10 @@ func (c *Cluster) buildWinZip() error {
 	if err != nil {
 		return err
 	}
-	if err := control.FinishRunning(exec.Command(buildScriptPath, "-u", zipName, "-z", buildFolder)); err != nil {
+	// the build script for the windows binaries will produce a lot of output. Capture it here.
+	cmd := exec.Command(buildScriptPath, "-u", zipName, "-z", buildFolder)
+	cmd.Stdout = ioutil.Discard
+	if err := control.FinishRunning(cmd); err != nil {
 		return err
 	}
 	log.Printf("Uploading %s", zipPath)


### PR DESCRIPTION
The build commands for the Windows binaries and hyperkube in acs-engine provider
produce a lot of output making the job build logs huge.

This patch captures and discards the output from those commands, preserving only
stderr.