### PR TITLE
Allow kubeadm presubmit to run a bazel build

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -352,6 +352,294 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kops-aws,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-e2e-kubeadm-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-security-kubernetes-e2e-kubeadm-gce
+    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
+    skip_branches:
+    - release-1.13
+    - release-1.12
+    - release-1.11
+    - release-1.10
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=55m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kubeadm-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        env:
+        - name: SKIP_RELEASE_VALIDATION
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.13
+    cluster: security
+    context: pull-security-kubernetes-e2e-kubeadm-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-security-kubernetes-e2e-kubeadm-gce
+    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=55m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kubeadm-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        env:
+        - name: SKIP_RELEASE_VALIDATION
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.12
+    cluster: security
+    context: pull-security-kubernetes-e2e-kubeadm-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-security-kubernetes-e2e-kubeadm-gce
+    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=55m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kubeadm-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        env:
+        - name: SKIP_RELEASE_VALIDATION
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.11
+    cluster: security
+    context: pull-security-kubernetes-e2e-kubeadm-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-security-kubernetes-e2e-kubeadm-gce
+    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=55m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kubeadm-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        env:
+        - name: SKIP_RELEASE_VALIDATION
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.10
+    cluster: security
+    context: pull-security-kubernetes-e2e-kubeadm-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-security-kubernetes-e2e-kubeadm-gce
+    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
+    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=75
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=55m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kubeadm-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        env:
+        - name: SKIP_RELEASE_VALIDATION
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
@@ -2186,61 +2474,6 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-build,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    cluster: security
-    context: pull-security-kubernetes-e2e-kubeadm-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    max_concurrency: 8
-    name: pull-security-kubernetes-e2e-kubeadm-gce
-    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
-    skip_branches:
-    - release-1.13
-    - release-1.12
-    - release-1.11
-    - release-1.10
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
-          --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        - --gcp-project=k8s-jkns-pr-gce-etcd3
-        env:
-        - name: SKIP_RELEASE_VALIDATION
-          value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
-        name: ""
-        resources: {}
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - release-1.13
@@ -2282,58 +2515,6 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-build,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - release-1.13
-    cluster: security
-    context: pull-security-kubernetes-e2e-kubeadm-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    max_concurrency: 8
-    name: pull-security-kubernetes-e2e-kubeadm-gce
-    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
-          --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        - --gcp-project=k8s-jkns-pr-gce-etcd3
-        env:
-        - name: SKIP_RELEASE_VALIDATION
-          value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
-        name: ""
-        resources: {}
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -2377,58 +2558,6 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-build,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - release-1.12
-    cluster: security
-    context: pull-security-kubernetes-e2e-kubeadm-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    max_concurrency: 8
-    name: pull-security-kubernetes-e2e-kubeadm-gce
-    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
-          --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        - --gcp-project=k8s-jkns-pr-gce-etcd3
-        env:
-        - name: SKIP_RELEASE_VALIDATION
-          value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
-        name: ""
-        resources: {}
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - release-1.11
@@ -2471,58 +2600,6 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-build,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - release-1.11
-    cluster: security
-    context: pull-security-kubernetes-e2e-kubeadm-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    max_concurrency: 8
-    name: pull-security-kubernetes-e2e-kubeadm-gce
-    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
-          --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        - --gcp-project=k8s-jkns-pr-gce-etcd3
-        env:
-        - name: SKIP_RELEASE_VALIDATION
-          value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
-        name: ""
-        resources: {}
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - release-1.10
@@ -2564,58 +2641,6 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-build,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - release-1.10
-    cluster: security
-    context: pull-security-kubernetes-e2e-kubeadm-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    max_concurrency: 8
-    name: pull-security-kubernetes-e2e-kubeadm-gce
-    rerun_command: /test pull-security-kubernetes-e2e-kubeadm-gce
-    run_if_changed: ^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/kubernetes-anywhere=kubeadm-e2e
-        - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
-          --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        - --gcs-shared=gs://kubernetes-security-prow/bazel
-        - --gcp-project=k8s-jkns-pr-gce-etcd3
-        env:
-        - name: SKIP_RELEASE_VALIDATION
-          value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
-        name: ""
-        resources: {}
-        volumeMounts:
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kubeadm-gce,?($|\s.*)
   - agent: kubernetes
     always_run: true
     cluster: security

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -1,4 +1,174 @@
 # kubeadm release and master tests
+presubmits:
+#manual-release-bump-required
+- name: pull-kubernetes-e2e-kubeadm-gce
+  max_concurrency: 8
+  skip_report: true
+  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+  skip_branches:
+  - release-1.13 # per-release job
+  - release-1.12 # per-release job
+  - release-1.11 # per-release job
+  - release-1.10 # per-release job
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
+      args:
+      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+      - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--timeout=75"
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --kubeadm=pull
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=skeleton
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=55m
+      - --use-shared-build=bazel
+      env:
+      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+        value: "true"
+
+- name: pull-kubernetes-e2e-kubeadm-gce
+  max_concurrency: 8
+  skip_report: true
+  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+  branches:
+  - release-1.13
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
+      args:
+      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+      - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--timeout=75"
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --kubeadm=pull
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=skeleton
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=55m
+      - --use-shared-build=bazel
+      env:
+      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+        value: "true"
+
+- name: pull-kubernetes-e2e-kubeadm-gce
+  max_concurrency: 8
+  skip_report: true
+  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+  branches:
+  - release-1.12
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
+      args:
+      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+      - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--timeout=75"
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --kubeadm=pull
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=skeleton
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=55m
+      - --use-shared-build=bazel
+      env:
+      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+        value: "true"
+
+- name: pull-kubernetes-e2e-kubeadm-gce
+  max_concurrency: 8
+  skip_report: true
+  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+  branches:
+  - release-1.11
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
+      args:
+      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+      - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--timeout=75"
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --kubeadm=pull
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=skeleton
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=55m
+      - --use-shared-build=bazel
+      env:
+      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+        value: "true"
+
+- name: pull-kubernetes-e2e-kubeadm-gce
+  max_concurrency: 8
+  skip_report: true
+  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+  branches:
+  - release-1.10
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
+      args:
+      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+      - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--timeout=75"
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=
+      - --deployment=kubernetes-anywhere
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --kubeadm=pull
+      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+      - --provider=skeleton
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=55m
+      - --use-shared-build=bazel
+      env:
+      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+        value: "true"
+
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11
   interval: 12h

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -1,173 +1,204 @@
 # kubeadm release and master tests
 presubmits:
-#manual-release-bump-required
-- name: pull-kubernetes-e2e-kubeadm-gce
-  max_concurrency: 8
-  skip_report: true
-  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-  skip_branches:
-  - release-1.13 # per-release job
-  - release-1.12 # per-release job
-  - release-1.11 # per-release job
-  - release-1.10 # per-release job
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
-      args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-      - "--upload=gs://kubernetes-jenkins/pr-logs"
-      - "--timeout=75"
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --kubeadm=pull
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=skeleton
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=55m
-      - --use-shared-build=bazel
-      env:
-      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-        value: "true"
+  kubernetes/kubernetes:
+  #manual-release-bump-required
+  - name: pull-kubernetes-e2e-kubeadm-gce
+    max_concurrency: 8
+    skip_report: true
+    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+    skip_branches:
+    - release-1.13 # per-release job
+    - release-1.12 # per-release job
+    - release-1.11 # per-release job
+    - release-1.10 # per-release job
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=55m
+        env:
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: "true"
 
-- name: pull-kubernetes-e2e-kubeadm-gce
-  max_concurrency: 8
-  skip_report: true
-  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-  branches:
-  - release-1.13
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
-      args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-      - "--upload=gs://kubernetes-jenkins/pr-logs"
-      - "--timeout=75"
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --kubeadm=pull
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=skeleton
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=55m
-      - --use-shared-build=bazel
-      env:
-      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-        value: "true"
+  - name: pull-kubernetes-e2e-kubeadm-gce
+    max_concurrency: 8
+    skip_report: true
+    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+    branches:
+    - release-1.13
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=55m
+        env:
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: "true"
 
-- name: pull-kubernetes-e2e-kubeadm-gce
-  max_concurrency: 8
-  skip_report: true
-  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-  branches:
-  - release-1.12
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
-      args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-      - "--upload=gs://kubernetes-jenkins/pr-logs"
-      - "--timeout=75"
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --kubeadm=pull
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=skeleton
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=55m
-      - --use-shared-build=bazel
-      env:
-      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-        value: "true"
+  - name: pull-kubernetes-e2e-kubeadm-gce
+    max_concurrency: 8
+    skip_report: true
+    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+    branches:
+    - release-1.12
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=55m
+        env:
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: "true"
 
-- name: pull-kubernetes-e2e-kubeadm-gce
-  max_concurrency: 8
-  skip_report: true
-  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-  branches:
-  - release-1.11
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
-      args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-      - "--upload=gs://kubernetes-jenkins/pr-logs"
-      - "--timeout=75"
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --kubeadm=pull
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=skeleton
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=55m
-      - --use-shared-build=bazel
-      env:
-      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-        value: "true"
+  - name: pull-kubernetes-e2e-kubeadm-gce
+    max_concurrency: 8
+    skip_report: true
+    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+    branches:
+    - release-1.11
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=55m
+        env:
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: "true"
 
-- name: pull-kubernetes-e2e-kubeadm-gce
-  max_concurrency: 8
-  skip_report: true
-  run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-  branches:
-  - release-1.10
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
-      args:
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-      - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-      - "--upload=gs://kubernetes-jenkins/pr-logs"
-      - "--timeout=75"
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=
-      - --deployment=kubernetes-anywhere
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --kubeadm=pull
-      - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-      - --provider=skeleton
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-      - --timeout=55m
-      - --use-shared-build=bazel
-      env:
-      - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-        value: "true"
+  - name: pull-kubernetes-e2e-kubeadm-gce
+    max_concurrency: 8
+    skip_report: true
+    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
+    branches:
+    - release-1.10
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --deployment=kubernetes-anywhere
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --kubeadm=pull
+        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
+        - --provider=skeleton
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kubeadm-gce
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=55m
+        env:
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: "true"
 
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -31,42 +31,6 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-    
-  - name: pull-kubernetes-e2e-kubeadm-gce
-    max_concurrency: 8
-    skip_report: true
-    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-    skip_branches:
-    - release-1.13 # per-release job
-    - release-1.12 # per-release job
-    - release-1.11 # per-release job
-    - release-1.10 # per-release job
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-master
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        env:
-        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-          value: "true"
   
   - name: pull-kubernetes-bazel-build
     always_run: true
@@ -96,39 +60,6 @@ presubmits:
           requests:
             memory: "6Gi"
 
-  - name: pull-kubernetes-e2e-kubeadm-gce
-    max_concurrency: 8
-    skip_report: true
-    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-    branches:
-    - release-1.13
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.13
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        env:
-        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-          value: "true"
-
   - name: pull-kubernetes-bazel-build
     always_run: true
     branches:
@@ -156,39 +87,6 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-
-  - name: pull-kubernetes-e2e-kubeadm-gce
-    max_concurrency: 8
-    skip_report: true
-    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-    branches:
-    - release-1.12
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.12
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        env:
-        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-          value: "true"
 
   - name: pull-kubernetes-bazel-build
     always_run: true
@@ -218,39 +116,6 @@ presubmits:
           requests:
             memory: "6Gi"
 
-  - name: pull-kubernetes-e2e-kubeadm-gce
-    max_concurrency: 8
-    skip_report: true
-    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-    branches:
-    - release-1.11
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.11
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        env:
-        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-          value: "true"
-
   - name: pull-kubernetes-bazel-build
     always_run: true
     branches:
@@ -278,39 +143,6 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
-
-  - name: pull-kubernetes-e2e-kubeadm-gce
-    max_concurrency: 8
-    skip_report: true
-    run_if_changed: '^(cmd/kubeadm|build/debs|pkg/kubelet/certificate|cmd/kubelet/app).*$'
-    branches:
-    - release-1.10
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190125-3d9554697e-1.10
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes-anywhere=kubeadm-e2e"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
-        - --scenario=kubernetes_e2e
-        - --
-        - --cluster=
-        - --deployment=kubernetes-anywhere
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --kubeadm=pull
-        - --kubernetes-anywhere-kubernetes-version=ci-cross/latest
-        - --provider=skeleton
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
-        - --timeout=55m
-        - --use-shared-build=bazel
-        env:
-        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
-          value: "true"
 
   #manual-release-bump-required
   - name: pull-kubernetes-bazel-test


### PR DESCRIPTION
Instead of relying on the shared build stuff.

Also the first commit moves the job from sig-testing into sig-cluster-lifecycle/kubeadm.yaml which should make future management easier.

/assign @neolit123 @BenTheElder 
cc @stevekuznetsov 