### PR TITLE
Update to rules_go 0.17.0, rules_nodejs 0.16.6, and rules_docker 0.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "5235045774d2f40f37331636378f21fe11f69906c0386a790c5987a09211c3c4",
-    strip_prefix = "rules_docker-8010a50ef03d1e13f1bebabfc625478da075fa60",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/8010a50ef03d1e13f1bebabfc625478da075fa60.tar.gz"],
+    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.7.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
 
 load(
@@ -52,10 +52,7 @@ _go_repositories()
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
-    container_repositories = "repositories",
 )
-
-container_repositories()
 
 container_pull(
     name = "distroless-base",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,8 +15,8 @@ versions.check(minimum_bazel_version = "0.18.0")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ade51a315fa17347e5c31201fdc55aa5ffb913377aa315dceb56ee9725e620ee",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.6/rules_go-0.16.6.tar.gz"],
+    sha256 = "492c3ac68ed9dcf527a07e6a1b2dcbf199c6bf8b35517951467ac32e421c06c1",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.17.0/rules_go-0.17.0.tar.gz"],
 )
 
 http_archive(
@@ -25,7 +25,7 @@ http_archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -117,12 +117,8 @@ git_repository(
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.16.5",
+    tag = "0.16.6",
 )
-
-load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
-
-rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
 

--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -12,7 +12,6 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/ghproxy:latest": ":image",
         "{STABLE_DOCKER_REPO}/ghproxy:latest-{BUILD_USER}": ":image",
     },
-    stamp = True,
 )
 
 docker_push(

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -23,7 +23,6 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/label_sync:latest": ":label_sync-image",
         "{STABLE_DOCKER_REPO}/label_sync:latest-{BUILD_USER}": ":label_sync-image",
     },
-    stamp = True,
 )
 
 docker_push(

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -40,7 +40,6 @@ container_bundle(
     }) + image_tags(**{
         prefix("refresh"): "//prow/external-plugins/refresh:image",
     }),
-    stamp = True,
 )
 
 docker_push(

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -11,7 +11,6 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/commenter:latest": ":commenter-image",
         "{STABLE_DOCKER_REPO}/commenter:latest-{BUILD_USER}": ":commenter-image",
     },
-    stamp = True,
 )
 
 docker_push(

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -10,7 +10,6 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/issue-creator:latest": ":issue-creator-image",
         "{STABLE_DOCKER_REPO}/issue-creator:latest-{BUILD_USER}": ":issue-creator-image",
     },
-    stamp = True,
 )
 
 docker_push(

--- a/robots/pr-labeler/BUILD.bazel
+++ b/robots/pr-labeler/BUILD.bazel
@@ -11,7 +11,6 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/pr-labeler:latest": ":pr-labeler-image",
         "{STABLE_DOCKER_REPO}/pr-labeler:latest-{BUILD_USER}": ":pr-labeler-image",
     },
-    stamp = True,
 )
 
 docker_push(

--- a/testgrid/images/BUILD.bazel
+++ b/testgrid/images/BUILD.bazel
@@ -26,7 +26,6 @@ container_bundle(
         "gcr.io/fejta-prod/testgrid/updater": ":updater",
         "gcr.io/fejta-prod/testgrid/configurator": ":configurator",
     }),
-    stamp = True,
 )
 
 docker_push(


### PR DESCRIPTION
From the release notes, it sounds like the new `rules_go` release will adequately support bazel 0.23.0, which might be making some incompatible API changes.

The main benefit of the `rules_nodejs` update is to suppress spammy output from `yarn_install` and `npm_install`.

/assign @fejta @BenTheElder @Katharine 