### PR TITLE
Add experiment/logviewer directory

### DIFF
--- a/experiment/logviewer/OWNERS
+++ b/experiment/logviewer/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- mborsz

--- a/experiment/logviewer/README.md
+++ b/experiment/logviewer/README.md
@@ -1,0 +1,5 @@
+# LogViewer
+
+LogViewer is a browser tool to view, search and analyse logs from test builds.
+
+TODO(mborsz): Add more info here.


### PR DESCRIPTION
Create a logviewer directory for a newly developed log viewer tool.

This will be a browser build-oriented tool to view (grep/jump to time) logs from a single prow build.

/assign @BenTheElder 
/assign @wojtek-t 