### PR TITLE
disable kubernetes kops presubmit

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -51,7 +51,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-aws-eks-1-11-correctness,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     cluster: security
     context: pull-security-kubernetes-e2e-kops-aws
     labels:
@@ -114,7 +114,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kops-aws,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - release-1.13
     cluster: security
@@ -174,7 +174,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kops-aws,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - release-1.12
     cluster: security
@@ -233,7 +233,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kops-aws,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - release-1.11
     cluster: security
@@ -292,7 +292,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kops-aws,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - release-1.10
     cluster: security

--- a/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-1.11  # per-release image
     - release-1.10  # per-release image
     max_concurrency: 12
-    always_run: true
+    always_run: false
     optional: true
     labels:
       preset-service-account: "true"
@@ -54,7 +54,7 @@ presubmits:
     branches:
     - release-1.13  # per-release image
     max_concurrency: 12
-    always_run: true
+    always_run: false
     optional: true
     labels:
       preset-service-account: "true"
@@ -100,7 +100,7 @@ presubmits:
     branches:
     - release-1.12  # per-release image
     max_concurrency: 12
-    always_run: true
+    always_run: false
     labels:
       preset-service-account: "true"
       preset-aws-ssh: "true"
@@ -145,7 +145,7 @@ presubmits:
     branches:
     - release-1.11  # per-release image
     max_concurrency: 12
-    always_run: true
+    always_run: false
     labels:
       preset-service-account: "true"
       preset-aws-ssh: "true"
@@ -190,7 +190,7 @@ presubmits:
     branches:
     - release-1.10  # per-release image
     max_concurrency: 12
-    always_run: true
+    always_run: false
     optional: true
     labels:
       preset-service-account: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -7087,11 +7087,6 @@ dashboards:
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: michelle.192837+alerts@gmail.com, lusensjtu+alerts@gmail.com
-  - name: pull-kubernetes-e2e-kops-aws
-    test_group_name: pull-kubernetes-e2e-kops-aws
-    base_options: width=10
-    alert_options:
-      alert_mail_to_addresses: michelle.192837+alerts@gmail.com, lusensjtu+alerts@gmail.com
   - name: pull-kubernetes-kubemark-e2e-gce-big
     test_group_name: pull-kubernetes-kubemark-e2e-gce-big
     base_options: width=10
@@ -7145,6 +7140,11 @@ dashboards:
   - name: pull-kubernetes-node-e2e-alpha
     test_group_name: pull-kubernetes-node-e2e-alpha
     base_options: width=10
+  - name: pull-kubernetes-e2e-kops-aws
+    test_group_name: pull-kubernetes-e2e-kops-aws
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: michelle.192837+alerts@gmail.com, lusensjtu+alerts@gmail.com
 
 - name: presubmits-cloud-provider-vsphere-blocking
   dashboard_tab:


### PR DESCRIPTION
This kubernetes/kubernetes presubmit was already made "optional" but is spamming PRs with failures and long known to be "blocking" (for merge), this disables running it unless requested with `/test pull-kubernetes-e2e-kops-aws`.

Currently this job cannot and will not pass, it's pointless to continue to run this against PRs filling them up with endless unrelated failures. https://testgrid.k8s.io/presubmits-kops#e2e

Additionally, I've updated testgrid to correctly show this.

cc @justinsb
/sig aws