### PR TITLE
Handle nil data map in existing ConfigMap

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/mattn/go-zglob"
+	zglob "github.com/mattn/go-zglob"
 	"github.com/sirupsen/logrus"
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -101,8 +101,10 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 				Name:      name,
 				Namespace: namespace,
 			},
-			Data: map[string]string{},
 		}
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
 	}
 
 	for key, filename := range updates {


### PR DESCRIPTION
When the client returns a ConfigMap with a nil `Data` field we need to
intialize it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes:

```
panic: assignment to entry in nil map

goroutine 1 [running]:
k8s.io/test-infra/prow/plugins/updateconfig.Update(0x16756e0, 0xc0049dd3f0, 0x169e2c0, 0xc00411b5a0, 0xc0004e46c0, 0x19, 0xc000af9b56, 0x6, 0xc002853f20, 0xc0027071a0, ...)
	prow/plugins/updateconfig/updateconfig.go:120 +0x5f0
main.main()
	prow/cmd/config-bootstrapper/main.go:127 +0x74a
```

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 