### PR TITLE
planter: fix a missing `&&` in Dockerfile

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     zip \
     zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/* && \
     python -m pip install --upgrade pip setuptools wheel && \
     pip install pylint pyyaml
 


### PR DESCRIPTION
address https://github.com/kubernetes/test-infra/pull/10849#discussion_r252432357

/cc @ixdy