### PR TITLE
Git Client Support On-Prem Github

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -42,7 +42,10 @@ func TestOptions_Validate(t *testing.T) {
 			name: "all ok",
 			opt: options{
 				config: "dummy",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "fake",
+				},
 			},
 			expectedErr: false,
 		},
@@ -50,7 +53,10 @@ func TestOptions_Validate(t *testing.T) {
 			name: "no config",
 			opt: options{
 				config: "",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "fake",
+				},
 			},
 			expectedErr: true,
 		},
@@ -58,6 +64,9 @@ func TestOptions_Validate(t *testing.T) {
 			name: "no token, allow",
 			opt: options{
 				config: "dummy",
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+				},
 			},
 			expectedErr: false,
 		},

--- a/prow/cmd/jenkins-operator/main_test.go
+++ b/prow/cmd/jenkins-operator/main_test.go
@@ -33,7 +33,10 @@ func TestOptions_Validate(t *testing.T) {
 			input: options{
 				jenkinsURL:       "https://example.com",
 				jenkinsTokenFile: "secret",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -42,7 +45,10 @@ func TestOptions_Validate(t *testing.T) {
 			input: options{
 				jenkinsURL:             "https://example.com",
 				jenkinsBearerTokenFile: "secret",
-				github:                 flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -52,7 +58,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsURL:             "https://example.com",
 				jenkinsTokenFile:       "secret",
 				jenkinsBearerTokenFile: "other",
-				github:                 flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -64,7 +73,10 @@ func TestOptions_Validate(t *testing.T) {
 				certFile:         "cert",
 				keyFile:          "key",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -75,7 +87,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				certFile:         "cert",
 				keyFile:          "key",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -86,7 +101,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				keyFile:          "key",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -97,7 +115,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				certFile:         "cert",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -42,6 +42,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "github_test.go",
         "kubernetes_cluster_clients_test.go",
         "kubernetes_test.go",
     ],

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -108,7 +108,9 @@ func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (cl
 
 // GitClient returns a Git client.
 func (o *GitHubOptions) GitClient(secretAgent *secret.Agent, dryRun bool) (client *git.Client, err error) {
-	client, err = git.NewClient(o.GitEndpoint)
+	// We already validated this during flag validation
+	gitURL, _ := url.Parse(o.GitEndpoint)
+	client, err = git.NewClient(gitURL)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -31,6 +31,7 @@ import (
 // GitHubOptions holds options for interacting with GitHub.
 type GitHubOptions struct {
 	endpoint            Strings
+	GitEndpoint         string
 	TokenPath           string
 	deprecatedTokenFile string
 }
@@ -50,6 +51,7 @@ func (o *GitHubOptions) AddFlagsWithoutDefaultGithubTokenPath(fs *flag.FlagSet) 
 func (o *GitHubOptions) addFlags(wantDefaultGithubTokenPath bool, fs *flag.FlagSet) {
 	o.endpoint = NewStrings("https://api.github.com")
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
+	fs.StringVar(&o.GitEndpoint, "git-endpoint", "https://github.com", "GitHub endpoint (may differ for enterprise).")
 	defaultGithubTokenPath := ""
 	if wantDefaultGithubTokenPath {
 		defaultGithubTokenPath = "/etc/github/oauth"
@@ -64,6 +66,10 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 		if _, err := url.ParseRequestURI(uri); err != nil {
 			return fmt.Errorf("invalid -github-endpoint URI: %q", uri)
 		}
+	}
+
+	if _, err := url.ParseRequestURI(o.GitEndpoint); err != nil {
+		return fmt.Errorf("invalid -git-endpoint URI: %q", o.GitEndpoint)
 	}
 
 	if o.deprecatedTokenFile != "" {
@@ -102,7 +108,7 @@ func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (cl
 
 // GitClient returns a Git client.
 func (o *GitHubOptions) GitClient(secretAgent *secret.Agent, dryRun bool) (client *git.Client, err error) {
-	client, err = git.NewClient()
+	client, err = git.NewClient(o.GitEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/flagutil/github_test.go
+++ b/prow/flagutil/github_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+)
+
+func TestGithubOptions(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		endpoints   Strings
+		gitEndpoint string
+		tokenPath   string
+		expectedErr bool
+	}{
+		{
+			name:        "No token provided, we expect no errors",
+			endpoints:   NewStrings("https://github.mycorp.com/apis/v3"),
+			gitEndpoint: "https://github.mycorp.com",
+			tokenPath:   "",
+			expectedErr: false,
+		},
+		{
+			name:        "Good github options provided, we expect no errors",
+			endpoints:   NewStrings("http://ghproxy", "https://api.github.com"),
+			gitEndpoint: "https://github.com",
+			tokenPath:   "token",
+			expectedErr: false,
+		},
+		{
+			name:        "Invalid git url provided, we expect an error",
+			endpoints:   NewStrings("http://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitEndpoint: "://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid github endpoint provided, we expect an error",
+			endpoints:   NewStrings("://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitEndpoint: "http://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			o := GitHubOptions{
+				endpoint:    testCase.endpoints,
+				GitEndpoint: testCase.gitEndpoint,
+				TokenPath:   testCase.tokenPath,
+			}
+			err := o.Validate(false)
+			if testCase.expectedErr && err == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+		})
+	}
+}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -51,7 +51,7 @@ type Client struct {
 	git string
 	// base is the base path for git clone calls. For users it will be set to
 	// GitHub, but for tests set it to a directory with git repos.
-	base string
+	base *url.URL
 
 	// The mutex protects repoLocks which protect individual repos. This is
 	// necessary because Clone calls for the same repo are racy. Rather than
@@ -68,7 +68,7 @@ func (c *Client) Clean() error {
 
 // NewClient returns a client that talks to GitHub. It will fail if git is not
 // in the PATH.
-func NewClient(base string) (*Client, error) {
+func NewClient(base *url.URL) (*Client, error) {
 	g, err := exec.LookPath("git")
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func NewClient(base string) (*Client, error) {
 // SetRemote sets the remote for the client. This is not thread-safe, and is
 // useful for testing. The client will clone from remote/org/repo, and Repo
 // objects spun out of the client will also hit that path.
-func (c *Client) SetRemote(remote string) {
+func (c *Client) SetRemote(remote *url.URL) {
 	c.base = remote
 }
 
@@ -108,8 +108,8 @@ func (c *Client) getCredentials() (string, string) {
 	return c.user, string(c.tokenGenerator())
 }
 
-// GetBase returns Client.base as a string
-func (c *Client) GetBase() string {
+// GetBase returns Client.base as a *url.URL
+func (c *Client) GetBase() *url.URL {
 	return c.base
 }
 
@@ -146,7 +146,7 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 		if err != nil {
 			return nil, err
 		}
-		base = gitURL.String()
+		base = gitURL
 	}
 	cache := filepath.Join(c.dir, repo) + ".git"
 	if _, err := os.Stat(cache); os.IsNotExist(err) {
@@ -155,7 +155,7 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 		if err := os.MkdirAll(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
-		remote := fmt.Sprintf("%s/%s", base, repo)
+		remote := fmt.Sprintf("%s/%s", base.Path, repo)
 		if b, err := retryCmd(c.logger, "", c.git, "clone", "--mirror", remote, cache); err != nil {
 			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
 		}
@@ -195,7 +195,7 @@ type Repo struct {
 	// git is the path to the git binary.
 	git string
 	// base is the base path for remote git fetch calls.
-	base string
+	base *url.URL
 	// repo is the full repo name: "org/repo".
 	repo string
 	// user is used for pushing to the remote repo.
@@ -302,11 +302,6 @@ func (r *Repo) Push(repo, branch string) error {
 		return fmt.Errorf("Remote error: %v", err)
 	}
 
-	// We can't push without user and repo in remote path
-	if !strings.Contains(remote.String(), strings.Join([]string{r.user, repo}, "/")) {
-		return errors.New("git remote must contain :user and :repo to push")
-	}
-
 	co := r.gitCommand("push", remote.String(), branch)
 	_, err = co.CombinedOutput()
 	return err
@@ -315,7 +310,8 @@ func (r *Repo) Push(repo, branch string) error {
 // CheckoutPullRequest does exactly that.
 func (r *Repo) CheckoutPullRequest(number int) error {
 	r.logger.Infof("Fetching and checking out %s#%d.", r.repo, number)
-	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
+	//r.base.Path = strings.Join([]string{r.base.Path, r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)}, "/")
+	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base.String()+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
 		return fmt.Errorf("git fetch failed for PR %d: %v. output: %s", number, err, string(b))
 	}
 	co := r.gitCommand("checkout", fmt.Sprintf("pull%d", number))
@@ -335,14 +331,10 @@ func (r *Repo) Config(key, value string) error {
 }
 
 // Remote builds a remote url from user, pasword, and a slice of path items
-func Remote(base string, user string, pass string, pathItems ...string) (*url.URL, error) {
-	newURL, err := url.Parse(base)
-	if err != nil {
-		return nil, fmt.Errorf("Error while parsing base: %v", err)
-	}
-	newURL.User = url.UserPassword(user, pass)
-	newURL.Path = strings.Join(pathItems, "/")
-	return newURL, nil
+func Remote(base *url.URL, user string, pass string, pathItems ...string) (*url.URL, error) {
+	base.User = url.UserPassword(user, pass)
+	base.Path = strings.Join(pathItems, "/")
+	return base, nil
 }
 
 // retryCmd will retry the command a few times with backoff. Use this for any

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -310,7 +310,6 @@ func (r *Repo) Push(repo, branch string) error {
 // CheckoutPullRequest does exactly that.
 func (r *Repo) CheckoutPullRequest(number int) error {
 	r.logger.Infof("Fetching and checking out %s#%d.", r.repo, number)
-	//r.base.Path = strings.Join([]string{r.base.Path, r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)}, "/")
 	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base.String()+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
 		return fmt.Errorf("git fetch failed for PR %d: %v. output: %s", number, err, string(b))
 	}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -18,6 +18,7 @@ package git_test
 
 import (
 	"bytes"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -136,7 +137,7 @@ func TestCheckoutPR(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	gitURL := "https://github.mycorp.com"
+	gitURL, _ := url.Parse("https://github.mycorp.com")
 	t.Logf("Verifying client is created with correct base endpoint.")
 	a, err := git.NewClient(gitURL)
 	if err != nil {
@@ -150,7 +151,7 @@ func TestNewClient(t *testing.T) {
 func TestRemote(t *testing.T) {
 	tests := []struct {
 		name      string
-		base      string
+		base      *url.URL
 		user      string
 		pass      string
 		pathItems string
@@ -159,7 +160,7 @@ func TestRemote(t *testing.T) {
 	}{
 		{
 			name:      "A valid remote url, with user, and password, no path",
-			base:      "https://github.com",
+			base:      &url.URL{Scheme: "https", Host: "github.com"},
 			user:      "user",
 			pass:      "pass",
 			pathItems: "",
@@ -167,7 +168,7 @@ func TestRemote(t *testing.T) {
 		},
 		{
 			name:      "A valid remote url, with user, password, organization, and repository",
-			base:      "https://github.com",
+			base:      &url.URL{Scheme: "https", Host: "github.com"},
 			user:      "user",
 			pass:      "pass",
 			pathItems: "user/repo",
@@ -181,7 +182,7 @@ func TestRemote(t *testing.T) {
 			t.Fatalf("Error creating git remote: %+v", err)
 		}
 		if test.expected != testURL.String() {
-			t.Errorf("git remote did not match expected remote: %v", err)
+			t.Errorf(`git remote did not match expected remote: expected: "%v" actual: "%v"`, test.expected, testURL)
 		}
 	}
 }

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -48,7 +48,7 @@ func New() (*LocalGit, *git.Client, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	c, err := git.NewClient()
+	c, err := git.NewClient("https://github.com")
 	if err != nil {
 		os.RemoveAll(t)
 		return nil, nil, err

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -21,6 +21,7 @@ package localgit
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,7 +49,7 @@ func New() (*LocalGit, *git.Client, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	c, err := git.NewClient("https://github.com")
+	c, err := git.NewClient(&url.URL{Host: "https://github.com"})
 	if err != nil {
 		os.RemoveAll(t)
 		return nil, nil, err
@@ -60,7 +61,11 @@ func New() (*LocalGit, *git.Client, error) {
 
 	c.SetCredentials("", getSecret)
 
-	c.SetRemote(t)
+	c.SetRemote(&url.URL{
+		Scheme: "file",
+		Host:   "",
+		Path:   t,
+	})
 	return &LocalGit{
 		Dir: t,
 		Git: g,


### PR DESCRIPTION
This change adds a `git-endpoint` flag for passing to git client. This is an alternative implementation of 
PR https://github.com/kubernetes/test-infra/pull/10129

components: hook, tide and the cherrypicker external plugin.

Fixes #10068, #11014

/assign @fejta @stevekuznetsov

I welcome testing suggestions :smile: 