### PR TITLE
move kops out of release-blocking

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4639,8 +4639,9 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet
   - name: gce-cos-master-default
     test_group_name: ci-kubernetes-e2e-gci-gce
-  - name: kops-aws-master
-    test_group_name: ci-kubernetes-e2e-kops-aws
+  # https://github.com/kubernetes/kubernetes/issues/73444
+  #- name: kops-aws-master
+  #  test_group_name: ci-kubernetes-e2e-kops-aws
   - name: gce-device-plugin-gpu-master
     test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
   - name: gce-cos-master-slow
@@ -4842,8 +4843,9 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures
   - name: gce-device-plugin-gpu-1.13
     test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
-  - name: kops-aws-1.13
-    test_group_name: ci-kubernetes-e2e-kops-aws-beta
+  # https://github.com/kubernetes/kubernetes/issues/73444
+  #- name: kops-aws-1.13
+  #  test_group_name: ci-kubernetes-e2e-kops-aws-beta
   - name: node-kubelet-1.13
     test_group_name: ci-kubernetes-node-kubelet-beta
   - name: gci-gce-scalability-1.13
@@ -4996,8 +4998,9 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-ingress
   - name: gce-cos-1.12-reboot
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-reboot
-  - name: kops-aws-1.12
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable1
+  # https://github.com/kubernetes/kubernetes/issues/73444
+  #- name: kops-aws-1.12
+  #  test_group_name: ci-kubernetes-e2e-kops-aws-stable1
   - name: node-kubelet-1.12
     test_group_name: ci-kubernetes-node-kubelet-stable1
   - name: gce-device-plugin-gpu-1.12
@@ -5243,8 +5246,9 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-serial
   - name: gce-cos-1.10-slow
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-slow
-  - name: kops-aws-1.10
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable3
+  # https://github.com/kubernetes/kubernetes/issues/73444
+  #- name: kops-aws-1.10
+  #  test_group_name: ci-kubernetes-e2e-kops-aws-stable3
   - name: gci-gce-scalability-1.10
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-stable3
 


### PR DESCRIPTION
it doesn't look like it was in 1.11 blocking, but it was in the rest of the branches
see https://github.com/kubernetes/kubernetes/issues/73444

brought up by @feiskyer (thank you!)

/hold
/cc @spiffxp 