### PR TITLE
Allow plank controller to update ProwJob status

### DIFF
--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -27,6 +27,12 @@ rules:
       - create
       - list
       - update
+    - apiGroups:
+        - prow.k8s.io
+      resources:
+        - prowjobs/status
+      verbs:
+        - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @BenTheElder @fejta @krzyzacy 