### PR TITLE
Remove duplicated flag in plank controller

### DIFF
--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -59,7 +59,6 @@ func gatherOptions() options {
 
 	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
-	fs.StringVar(&o.buildCluster, "build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	fs.StringVar(&o.selector, "label-selector", labels.Everything().String(), "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 	fs.BoolVar(&o.skipReport, "skip-report", false, "Whether or not to ignore report with githubClient")
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes:

```
/app/prow/cmd/plank/app.binary flag redefined: build-cluster
panic: /app/prow/cmd/plank/app.binary flag redefined: build-cluster

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc0000385a0, 0x1606540, 0xc00041e158, 0x148083a, 0xd, 0x14dfe54, 0x90)
	GOROOT/src/flag/flag.go:805 +0x529
flag.(*FlagSet).StringVar(0xc0000385a0, 0xc00041e158, 0x148083a, 0xd, 0x0, 0x0, 0x14dfe54, 0x90)
	GOROOT/src/flag/flag.go:708 +0x8a
k8s.io/test-infra/prow/flagutil.(*KubernetesOptions).AddFlags(0xc00041e158, 0xc0000385a0)
	prow/flagutil/kubernetes_cluster_clients.go:53 +0x6d
main.gatherOptions(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	prow/cmd/plank/main.go:68 +0x3b5
main.main()
	prow/cmd/plank/main.go:90 +0x54
```

/assign @fejta @BenTheElder @cjwagner @krzyzacy 