### PR TITLE
Note that ingress path is not portable

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -392,7 +392,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /
+      - path: /* # Correct for GKE, need / on many other distros
         backend:
           serviceName: deck
           servicePort: 80

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -464,6 +464,11 @@ func applySecret(ctx, name, key, path string) error {
 }
 
 func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bool) error {
+	if !strings.HasPrefix(ctx, "gke_") {
+		// TODO(fejta): maybe do this for us
+		fmt.Printf("Warning: if %s is not on GKE, you may need to change\n", ctx)
+		fmt.Println("the Ingress path to deck from /* to /")
+	}
 	if choice == "" {
 		fmt.Print("Apply starter.yaml from [github upstream]: ")
 		fmt.Scanln(&choice)


### PR DESCRIPTION
/assign @Katharine @BenTheElder 

Obnoxiously the network ingress paths are not portable between distros. GKE does the correct thing according to the spec, and the tool has other dependencies on GCP, so let's default to that but give a warning that other distros may require something else