### PR TITLE
Use the DRY kubernetes client flags in sinker

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -40,6 +40,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *February 1, 2019* `horologium` and `sinker` now support the `--dry-run` flag,
+   so you must pass `--dry-run=false` to keep the previous behavior.
  - *January 31, 2019* `sub` no longer supports the `--masterurl` flag for connecting
    to the infrastructure cluster. Use `--kubeconfig` with `--context` for this.
  - *January 31, 2019* `crier` no longer supports the `--masterurl` flag for connecting

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -41,15 +41,15 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
     ],
 )


### PR DESCRIPTION
This doesn't change the flag names, just refactors how they're set.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 