### PR TITLE
Check for ExtraRefs presence correctly

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -236,7 +236,7 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 
 	var filtered []prowapi.ProwJob
 	for _, item := range prowJobList.Items {
-		if item.Spec.Refs == nil && item.Spec.ExtraRefs == nil {
+		if item.Spec.Refs == nil && len(item.Spec.ExtraRefs) == 0 {
 			// periodic jobs with no refs cannot be filtered
 			filtered = append(filtered, item)
 		}


### PR DESCRIPTION
A zero-length slice is not nil but still cannot be used for filtering.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @krzyzacy @BenTheElder 