### PR TITLE
Resolve Kubernetes clients only once

### DIFF
--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -120,6 +120,7 @@ func (o *KubernetesOptions) resolve(dryRun bool) (err error) {
 
 	o.prowJobClientset = pjClient
 	o.kubernetesClientsByContext = clients
+	o.resolved = true
 
 	return nil
 }


### PR DESCRIPTION
When one set of options is used to gather more than one type of client
we only need to resolve the clients once.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta
/cc @krzyzacy @BenTheElder