### PR TITLE
Github GraphQL Support For On-Prem Github

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -55,8 +55,8 @@ func flagOptions() options {
 	flag.StringVar(&o.jenkinsTokenFile, "jenkins-token-file", "", "Path to the file containing the Jenkins API token.")
 	flag.StringVar(&o.jenkinsUserName, "jenkins-user-name", "", "Jenkins username.")
 
-	flag.StringVar(&o.githubEndpoint, "github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
-	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API endpoint.")
+	flag.StringVar(&o.githubEndpoint, "github-endpoint", github.DefaultAPIEndpoint, "GitHub's API endpoint.")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub's GraphQL API endpoint.")
 	flag.StringVar(&o.githubTokenFile, "github-token-file", "", "Path to file containing GitHub OAuth token.")
 
 	flag.StringVar(&o.jobName, "job-name", "", "Name of Jenkins job")

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -35,6 +35,7 @@ import (
 
 type options struct {
 	githubEndpoint         string
+	graphqlEndpoint        string
 	githubTokenFile        string
 	jenkinsBearerTokenFile string
 	jenkinsURL             string
@@ -55,6 +56,7 @@ func flagOptions() options {
 	flag.StringVar(&o.jenkinsUserName, "jenkins-user-name", "", "Jenkins username.")
 
 	flag.StringVar(&o.githubEndpoint, "github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API endpoint.")
 	flag.StringVar(&o.githubTokenFile, "github-token-file", "", "Path to file containing GitHub OAuth token.")
 
 	flag.StringVar(&o.jobName, "job-name", "", "Name of Jenkins job")
@@ -91,6 +93,12 @@ func sanityCheckFlags(o options) error {
 		return fmt.Errorf("empty --github-endpoint")
 	} else if _, err := url.Parse(o.githubEndpoint); err != nil {
 		return fmt.Errorf("bad --github-endpoint provided: %v", err)
+	}
+
+	if o.graphqlEndpoint == "" {
+		return fmt.Errorf("empty --graphql-endpoint")
+	} else if _, err := url.Parse(o.graphqlEndpoint); err != nil {
+		return fmt.Errorf("bad --graphql-endpoint provided: %v", err)
 	}
 
 	if o.jenkinsURL == "" {
@@ -145,7 +153,7 @@ func main() {
 		log.Fatalf("cannot setup Jenkins client: %v", err)
 	}
 
-	gc := github.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.githubEndpoint)
+	gc := github.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.graphqlEndpoint, o.githubEndpoint)
 
 	pr, err := gc.GetPullRequest(o.org, o.repo, o.num)
 	if err != nil {

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -117,21 +117,22 @@ const (
 
 // TODO(fejta): rewrite this to use an option struct which we can unit test, like everything else.
 var (
-	debug        = flag.Bool("debug", false, "Turn on debug to be more verbose")
-	confirm      = flag.Bool("confirm", false, "Make mutating API calls to GitHub.")
-	endpoint     = flagutil.NewStrings("https://api.github.com")
-	labelsPath   = flag.String("config", "", "Path to labels.yaml")
-	onlyRepos    = flag.String("only", "", "Only look at the following comma separated org/repos")
-	orgs         = flag.String("orgs", "", "Comma separated list of orgs to sync")
-	skipRepos    = flag.String("skip", "", "Comma separated list of org/repos to skip syncing")
-	token        = flag.String("token", "", "Path to github oauth secret")
-	action       = flag.String("action", "sync", "One of: sync, docs")
-	cssTemplate  = flag.String("css-template", "", "Path to template file for label css")
-	cssOutput    = flag.String("css-output", "", "Path to output file for css")
-	docsTemplate = flag.String("docs-template", "", "Path to template file for label docs")
-	docsOutput   = flag.String("docs-output", "", "Path to output file for docs")
-	tokens       = flag.Int("tokens", defaultTokens, "Throttle hourly token consumption (0 to disable)")
-	tokenBurst   = flag.Int("token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst")
+	debug           = flag.Bool("debug", false, "Turn on debug to be more verbose")
+	confirm         = flag.Bool("confirm", false, "Make mutating API calls to GitHub.")
+	endpoint        = flagutil.NewStrings("https://api.github.com")
+	graphqlEndpoint = flag.String("graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API endpoint")
+	labelsPath      = flag.String("config", "", "Path to labels.yaml")
+	onlyRepos       = flag.String("only", "", "Only look at the following comma separated org/repos")
+	orgs            = flag.String("orgs", "", "Comma separated list of orgs to sync")
+	skipRepos       = flag.String("skip", "", "Comma separated list of org/repos to skip syncing")
+	token           = flag.String("token", "", "Path to github oauth secret")
+	action          = flag.String("action", "sync", "One of: sync, docs")
+	cssTemplate     = flag.String("css-template", "", "Path to template file for label css")
+	cssOutput       = flag.String("css-output", "", "Path to output file for css")
+	docsTemplate    = flag.String("docs-template", "", "Path to template file for label docs")
+	docsOutput      = flag.String("docs-output", "", "Path to output file for docs")
+	tokens          = flag.Int("tokens", defaultTokens, "Throttle hourly token consumption (0 to disable)")
+	tokenBurst      = flag.Int("token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst")
 )
 
 func init() {
@@ -642,7 +643,7 @@ type client interface {
 	GetRepoLabels(string, string) ([]github.Label, error)
 }
 
-func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, hosts ...string) (client, error) {
+func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEndpoint string, hosts ...string) (client, error) {
 	if tokenPath == "" {
 		return nil, errors.New("--token unset")
 	}
@@ -653,9 +654,9 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, hosts ...s
 	}
 
 	if dryRun {
-		return github.NewDryRunClient(secretAgent.GetTokenGenerator(tokenPath), hosts...), nil
+		return github.NewDryRunClient(secretAgent.GetTokenGenerator(tokenPath), graphqlEndpoint, hosts...), nil
 	}
-	c := github.NewClient(secretAgent.GetTokenGenerator(tokenPath), hosts...)
+	c := github.NewClient(secretAgent.GetTokenGenerator(tokenPath), graphqlEndpoint, hosts...)
 	if tokens > 0 && tokenBurst >= tokens {
 		return nil, fmt.Errorf("--tokens=%d must exceed --token-burst=%d", tokens, tokenBurst)
 	}
@@ -706,7 +707,7 @@ func main() {
 			logrus.WithError(err).Fatalf("failed to write css file using css-template %s to css-output %s", *cssTemplate, *cssOutput)
 		}
 	case *action == "sync":
-		githubClient, err := newClient(*token, *tokens, *tokenBurst, !*confirm, endpoint.Strings()...)
+		githubClient, err := newClient(*token, *tokens, *tokenBurst, !*confirm, *graphqlEndpoint, endpoint.Strings()...)
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to create client")
 		}

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -119,8 +119,8 @@ const (
 var (
 	debug           = flag.Bool("debug", false, "Turn on debug to be more verbose")
 	confirm         = flag.Bool("confirm", false, "Make mutating API calls to GitHub.")
-	endpoint        = flagutil.NewStrings("https://api.github.com")
-	graphqlEndpoint = flag.String("graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API endpoint")
+	endpoint        = flagutil.NewStrings(github.DefaultAPIEndpoint)
+	graphqlEndpoint = flag.String("graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub's GraphQL API endpoint")
 	labelsPath      = flag.String("config", "", "Path to labels.yaml")
 	onlyRepos       = flag.String("only", "", "Only look at the following comma separated org/repos")
 	orgs            = flag.String("orgs", "", "Comma separated list of orgs to sync")

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -454,9 +454,9 @@ func githubClient(tokenPath string, dry bool) (*github.Client, error) {
 
 	gen := secretAgent.GetTokenGenerator(tokenPath)
 	if dry {
-		return github.NewDryRunClient(gen, "https://api.github.com"), nil
+		return github.NewDryRunClient(gen, "https://api.github.com/graphql", "https://api.github.com"), nil
 	}
-	return github.NewClient(gen, "https://api.github.com"), nil
+	return github.NewClient(gen, "https://api.github.com/graphql", "https://api.github.com"), nil
 }
 
 func applySecret(ctx, ns, name, key, path string) error {

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -454,9 +454,9 @@ func githubClient(tokenPath string, dry bool) (*github.Client, error) {
 
 	gen := secretAgent.GetTokenGenerator(tokenPath)
 	if dry {
-		return github.NewDryRunClient(gen, "https://api.github.com/graphql", "https://api.github.com"), nil
+		return github.NewDryRunClient(gen, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
 	}
-	return github.NewClient(gen, "https://api.github.com/graphql", "https://api.github.com"), nil
+	return github.NewClient(gen, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
 }
 
 func applySecret(ctx, ns, name, key, path string) error {

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -68,7 +68,7 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 		}
 	}
 
-	if _, err := url.ParseRequestURI(o.graphqlEndpoint); err != nil {
+	if _, err := url.Parse(o.graphqlEndpoint); err != nil {
 		return fmt.Errorf("invalid -github-graphql-endpoint URI: %q", o.graphqlEndpoint)
 	}
 

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -63,12 +63,16 @@ func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagS
 // Validate validates GitHub options.
 func (o *GitHubOptions) Validate(dryRun bool) error {
 	for _, uri := range o.endpoint.Strings() {
-		if _, err := url.ParseRequestURI(uri); err != nil {
+		if uri == "" {
+			uri = github.DefaultAPIEndpoint
+		} else if _, err := url.ParseRequestURI(uri); err != nil {
 			return fmt.Errorf("invalid -github-endpoint URI: %q", uri)
 		}
 	}
 
-	if _, err := url.Parse(o.graphqlEndpoint); err != nil {
+	if o.graphqlEndpoint == "" {
+		o.graphqlEndpoint = github.DefaultGraphQLEndpoint
+	} else if _, err := url.Parse(o.graphqlEndpoint); err != nil {
 		return fmt.Errorf("invalid -github-graphql-endpoint URI: %q", o.graphqlEndpoint)
 	}
 

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -49,9 +49,9 @@ func (o *GitHubOptions) AddFlagsWithoutDefaultGitHubTokenPath(fs *flag.FlagSet) 
 }
 
 func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagSet) {
-	o.endpoint = NewStrings("https://api.github.com")
+	o.endpoint = NewStrings(github.DefaultAPIEndpoint)
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
-	fs.StringVar(&o.graphqlEndpoint, "github-graphql-endpoint", "https://api.github.com/graphql", "GitHub GraphQL API endpoint (may differ for enterprise).")
+	fs.StringVar(&o.graphqlEndpoint, "github-graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub GraphQL API endpoint (may differ for enterprise).")
 	defaultGitHubTokenPath := ""
 	if wantDefaultGitHubTokenPath {
 		defaultGitHubTokenPath = "/etc/github/oauth"

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -231,14 +231,16 @@ func (c *Client) Throttle(hourlyTokens, burst int) {
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewClientWithFields(fields logrus.Fields, getToken func() []byte, bases ...string) *Client {
+func NewClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
 	return &Client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		time:   &standardTime{},
-		gqlc: githubql.NewClient(&http.Client{
-			Timeout:   maxRequestTime,
-			Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
-		}),
+		gqlc: githubql.NewEnterpriseClient(
+			graphqlEndpoint,
+			&http.Client{
+				Timeout:   maxRequestTime,
+				Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
+			}),
 		client:   &http.Client{Timeout: maxRequestTime},
 		bases:    bases,
 		getToken: getToken,
@@ -247,8 +249,8 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, bases ...
 }
 
 // NewClient creates a new fully operational GitHub client.
-func NewClient(getToken func() []byte, bases ...string) *Client {
-	return NewClientWithFields(logrus.Fields{}, getToken, bases...)
+func NewClient(getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
+	return NewClientWithFields(logrus.Fields{}, getToken, graphqlEndpoint, bases...)
 }
 
 // NewDryRunClientWithFields creates a new client that will not perform mutating actions
@@ -259,14 +261,16 @@ func NewClient(getToken func() []byte, bases ...string) *Client {
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, bases ...string) *Client {
+func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
 	return &Client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		time:   &standardTime{},
-		gqlc: githubql.NewClient(&http.Client{
-			Timeout:   maxRequestTime,
-			Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
-		}),
+		gqlc: githubql.NewEnterpriseClient(
+			graphqlEndpoint,
+			&http.Client{
+				Timeout:   maxRequestTime,
+				Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
+			}),
 		client:   &http.Client{Timeout: maxRequestTime},
 		bases:    bases,
 		getToken: getToken,
@@ -282,8 +286,8 @@ func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, bas
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClient(getToken func() []byte, bases ...string) *Client {
-	return NewDryRunClientWithFields(logrus.Fields{}, getToken, bases...)
+func NewDryRunClient(getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
+	return NewDryRunClientWithFields(logrus.Fields{}, getToken, graphqlEndpoint, bases...)
 }
 
 // NewFakeClient creates a new client that will not perform any actions at all.

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -42,6 +42,12 @@ const (
 	// SearchTimeFormat is a time.Time format string for ISO8601 which is the
 	// format that GitHub requires for times specified as part of a search query.
 	SearchTimeFormat = "2006-01-02T15:04:05Z"
+
+	// DefaultAPIEndpoint is the default GitHub API endpoint.
+	DefaultAPIEndpoint = "https://api.github.com"
+
+	// DefaultGraphQLEndpoint is the default GitHub GraphQL API endpoint.
+	DefaultGraphQLEndpoint = "https://api.github.com/graphql"
 )
 
 var (

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -35,12 +35,10 @@ import (
 )
 
 const (
-	loginSession    = "github_login"
-	githubEndpoint  = "https://api.github.com"
-	graphqlEndpoint = "https://api.github.com/graphql"
-	tokenSession    = "access-token-session"
-	tokenKey        = "access-token"
-	loginKey        = "login"
+	loginSession = "github_login"
+	tokenSession = "access-token-session"
+	tokenKey     = "access-token"
+	loginKey     = "login"
 )
 
 type githubClient interface {
@@ -202,7 +200,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 		var user *github.User
 		var botName string
 		if ok && token.Valid() {
-			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, graphqlEndpoint, githubEndpoint)
+			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 			var err error
 			botName, err = githubClient.BotName()
 			user = &github.User{Login: botName}
@@ -239,7 +237,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 
 			// Construct query
-			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, graphqlEndpoint, githubEndpoint)
+			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -35,11 +35,12 @@ import (
 )
 
 const (
-	loginSession   = "github_login"
-	githubEndpoint = "https://api.github.com"
-	tokenSession   = "access-token-session"
-	tokenKey       = "access-token"
-	loginKey       = "login"
+	loginSession    = "github_login"
+	githubEndpoint  = "https://api.github.com"
+	graphqlEndpoint = "https://api.github.com/graphql"
+	tokenSession    = "access-token-session"
+	tokenKey        = "access-token"
+	loginKey        = "login"
 )
 
 type githubClient interface {
@@ -201,7 +202,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 		var user *github.User
 		var botName string
 		if ok && token.Valid() {
-			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, githubEndpoint)
+			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, graphqlEndpoint, githubEndpoint)
 			var err error
 			botName, err = githubClient.BotName()
 			user = &github.User{Login: botName}
@@ -238,7 +239,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 
 			// Construct query
-			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, githubEndpoint)
+			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, graphqlEndpoint, githubEndpoint)
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -68,6 +68,7 @@ func flagOptions() options {
 	flag.BoolVar(&o.useTemplate, "template", false, templateHelp)
 	flag.IntVar(&o.ceiling, "ceiling", 3, "Maximum number of issues to modify, 0 for infinite")
 	flag.Var(&o.endpoint, "endpoint", "GitHub's API endpoint")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API Endpoint")
 	flag.StringVar(&o.token, "token", "", "Path to github token")
 	flag.BoolVar(&o.random, "random", false, "Choose random issues to comment on from the query")
 	flag.Parse()
@@ -82,18 +83,19 @@ type meta struct {
 }
 
 type options struct {
-	asc           bool
-	ceiling       int
-	comment       string
-	includeClosed bool
-	useTemplate   bool
-	query         string
-	sort          string
-	endpoint      flagutil.Strings
-	token         string
-	updated       time.Duration
-	confirm       bool
-	random        bool
+	asc             bool
+	ceiling         int
+	comment         string
+	includeClosed   bool
+	useTemplate     bool
+	query           string
+	sort            string
+	endpoint        flagutil.Strings
+	graphqlEndpoint string
+	token           string
+	updated         time.Duration
+	confirm         bool
+	random          bool
 }
 
 func parseHTMLURL(url string) (string, string, int, error) {
@@ -161,9 +163,9 @@ func main() {
 
 	var c client
 	if o.confirm {
-		c = github.NewClient(secretAgent.GetTokenGenerator(o.token), o.endpoint.Strings()...)
+		c = github.NewClient(secretAgent.GetTokenGenerator(o.token), o.graphqlEndpoint, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.token), o.endpoint.Strings()...)
+		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.token), o.graphqlEndpoint, o.endpoint.Strings()...)
 	}
 
 	query, err := makeQuery(o.query, o.includeClosed, o.updated)

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -58,7 +58,7 @@ const (
 
 func flagOptions() options {
 	o := options{
-		endpoint: flagutil.NewStrings("https://api.github.com"),
+		endpoint: flagutil.NewStrings(github.DefaultAPIEndpoint),
 	}
 	flag.StringVar(&o.query, "query", "", "See https://help.github.com/articles/searching-issues-and-pull-requests/")
 	flag.DurationVar(&o.updated, "updated", 2*time.Hour, "Filter to issues unmodified for at least this long if set")
@@ -68,7 +68,7 @@ func flagOptions() options {
 	flag.BoolVar(&o.useTemplate, "template", false, templateHelp)
 	flag.IntVar(&o.ceiling, "ceiling", 3, "Maximum number of issues to modify, 0 for infinite")
 	flag.Var(&o.endpoint, "endpoint", "GitHub's API endpoint")
-	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", "https://api.github.com/graphql", "GitHub's GraphQL API Endpoint")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub's GraphQL API Endpoint")
 	flag.StringVar(&o.token, "token", "", "Path to github token")
 	flag.BoolVar(&o.random, "random", false, "Choose random issues to comment on from the query")
 	flag.Parse()

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -56,9 +56,9 @@ type options struct {
 
 func flagOptions() options {
 	o := options{
-		endpoint: flagutil.NewStrings("https://api.github.com"),
+		endpoint: flagutil.NewStrings(github.DefaultAPIEndpoint),
 	}
-	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", "https://api.github.com/graphql", "github graphql endpoint")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "github graphql endpoint")
 	flag.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
 	flag.StringVar(&o.org, "org", "", "github org")
 	flag.StringVar(&o.repo, "repo", "", "github repo")


### PR DESCRIPTION
This change adds a `github-graphql-endpoint` flag for passing to github graphql client. This mostly fixes 
 github enterprise for tide.

Enhancement on https://github.com/kubernetes/test-infra/pull/11075

components: hook, tide, label_sync, tackle, and prstatus

I am not sure whom to include for approval on this, please make testing and change suggestions.