### PR TITLE
Don't run in dry-run mode for horologium and sinker

### DIFF
--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -35,6 +35,7 @@ spec:
         image: gcr.io/k8s-prow/horologium:v20190206-75d4a95
         args:
         - --job-config-path=/etc/job-config
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,6 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
+        - --dry-run=false
         image: gcr.io/k8s-prow/sinker:v20190206-75d4a95
         volumeMounts:
         - mountPath: /etc/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -239,6 +239,8 @@ spec:
       containers:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20190206-75d4a95
+        args:
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -321,6 +321,8 @@ spec:
       containers:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20190206-75d4a95
+        args:
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
This is a new flag used in the rest of the k8s client implementations,
so we need to set it now.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @krzyzacy  @BenTheElder 