### PR TITLE
Add files that show up in invocation and target logs

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/google.golang.org/genproto/googleapis/devtools/resultstore/v2:go_default_library",
+        "//vendor/google.golang.org/genproto/protobuf/field_mask:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/google.golang.org/grpc/credentials:go_default_library",
         "//vendor/google.golang.org/grpc/credentials/oauth:go_default_library",


### PR DESCRIPTION
Example: https://source.cloud.google.com/results/invocations/ef3e45bd-96ef-47c9-8a2e-0691b3a1589a/targets (still working on creating publicly invocations)