### PR TITLE
Adding overrides to gke 2000

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -162,6 +162,7 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/density/2000_nodes/override.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter
@@ -209,6 +210,7 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/density/2000_nodes/override.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter


### PR DESCRIPTION
Adding overrides to gke-2000 and gke-2000-regional to reduce number of resource usage observers (from every node to master + dns nodes).