### PR TITLE
Initialize KubernetesClient in NewAgent for plugins

### DIFF
--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -157,10 +157,11 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
 	return Agent{
-		GitHubClient:  clientAgent.GitHubClient,
-		ProwJobClient: clientAgent.ProwJobClient,
-		GitClient:     clientAgent.GitClient,
-		SlackClient:   clientAgent.SlackClient,
+		GitHubClient:     clientAgent.GitHubClient,
+		KubernetesClient: clientAgent.KubernetesClient,
+		ProwJobClient:    clientAgent.ProwJobClient,
+		GitClient:        clientAgent.GitClient,
+		SlackClient:      clientAgent.SlackClient,
 		OwnersClient: repoowners.NewClient(
 			clientAgent.GitClient, clientAgent.GitHubClient,
 			prowConfig, pluginConfig.MDYAMLEnabled,


### PR DESCRIPTION
Fixes a SEGV we are seeing in config-updater. Previously, NewAgent did
not populate the `KubernetesClient` member, leading to a crash when
plugins attempted to use it.