### PR TITLE
use latest tag for kubeadm presubmit

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -483,7 +483,8 @@ presubmits:
         env:
         - name: SKIP_RELEASE_VALIDATION
           value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190201-234c5ddcf-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
         name: ""
         resources: {}
         volumeMounts:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm.yaml
@@ -31,7 +31,9 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190201-234c5ddcf-master
+      # TODO(krzyzacy): use stable tag after debugging
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py


### PR DESCRIPTION
easier for me so I can just push ad-hoc images and don't have to bump endlessly

/assign @neolit123 @BenTheElder 