### PR TITLE
Add output connection throttling to ghproxy

### DIFF
--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//vendor/github.com/peterbourgon/diskv:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/golang.org/x/sync/semaphore:go_default_library",
     ],
 )
 

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -73,6 +73,8 @@ type options struct {
 	upstream       string
 	upstreamParsed *url.URL
 
+	maxConcurrency int
+
 	// pushGateway fields are used to configure pushing prometheus metrics.
 	pushGateway         string
 	pushGatewayInterval time.Duration
@@ -96,6 +98,7 @@ func flagOptions() *options {
 	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB if using a disk cache.")
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")
+	flag.IntVar(&o.maxConcurrency, "concurrency", 25, "Maximum number of concurrent in-flight requests to GitHub.")
 	flag.StringVar(&o.pushGateway, "push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
 	flag.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics are pushed.")
 	return o
@@ -114,9 +117,9 @@ func main() {
 
 	var cache http.RoundTripper
 	if o.dir == "" {
-		cache = ghcache.NewMemCache(http.DefaultTransport)
+		cache = ghcache.NewMemCache(http.DefaultTransport, o.maxConcurrency)
 	} else {
-		cache = ghcache.NewDiskCache(http.DefaultTransport, o.dir, o.sizeGB)
+		cache = ghcache.NewDiskCache(http.DefaultTransport, o.dir, o.sizeGB, o.maxConcurrency)
 	}
 
 	if o.pushGateway != "" {


### PR DESCRIPTION
In order not to hit the abuse detection rate limits on concurrent
requests against the GitHub API, we should throttle the maximum amount
of outbound connection to the GitHub servers from ghproxy. This is not
implemented with a throttle and burst potential as any concurrency above
the limit would trigger abuse detection errors.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @krzyzacy @BenTheElder @nickvanw