### PR TITLE
Print line number in the logs

### DIFF
--- a/experiment/resultstore/main.go
+++ b/experiment/resultstore/main.go
@@ -101,7 +101,8 @@ func parseOptions() options {
 }
 
 func main() {
-	logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "storeship"})
+	logrusutil.ComponentInit("storeship")
+
 	opt := parseOptions()
 	for {
 		err := run(opt)

--- a/experiment/tracer/main.go
+++ b/experiment/tracer/main.go
@@ -73,11 +73,12 @@ func gatherOptions() options {
 }
 
 func main() {
+	logrusutil.ComponentInit("tracer")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tracer"}))
 
 	client, err := o.kubernetes.InfrastructureClusterClient(o.dryRun)
 	if err != nil {

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -117,9 +117,7 @@ func flagOptions() *options {
 }
 
 func main() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "ghproxy"}),
-	)
+	logrusutil.ComponentInit("ghproxy")
 
 	o := flagOptions()
 	flag.Parse()

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -64,9 +64,8 @@ var diskCheckInterval = flag.Duration("disk-check-interval", time.Second*10,
 var promMetrics *prometheusMetrics
 
 func init() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "greenhouse"}),
-	)
+	logrusutil.ComponentInit("greenhouse")
+
 	logrus.SetOutput(os.Stdout)
 	promMetrics = initMetrics()
 }

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -675,9 +675,7 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEnd
 // It took about 10 minutes to process all my 8 repos with all wanted "kubernetes" labels (70+)
 // Next run takes about 22 seconds to check if all labels are correct on all repos
 func main() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "label_sync"}),
-	)
+	logrusutil.ComponentInit("label_sync")
 
 	flag.Parse()
 	if *debug {

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -107,14 +107,12 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("migratestatus")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "migratestatus"}),
-	)
 
 	secretAgent := &secret.Agent{}
 	if o.github.TokenPath != "" {

--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -55,8 +55,9 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
+	logrusutil.ComponentInit("admission")
+
 	o := parseOptions()
-	logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "admission"})
 
 	pjutil.ServePProf()
 	health := pjutil.NewHealth()

--- a/prow/cmd/artifact-uploader/main.go
+++ b/prow/cmd/artifact-uploader/main.go
@@ -151,6 +151,8 @@ func (o *Options) Run() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("artifact-uploader")
+
 	o := newOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -159,10 +161,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "artifact-uploader"}),
-	)
 
 	if err := o.Run(); err != nil {
 		logrus.WithError(err).Fatal("Failed to run the GCS uploader controller")

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -85,9 +85,7 @@ func (e *Errors) add(err error) {
 }
 
 func main() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "branchprotector"}),
-	)
+	logrusutil.ComponentInit("branchprotector")
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/build/main.go
+++ b/prow/cmd/build/main.go
@@ -129,8 +129,9 @@ func newBuildConfig(cfg rest.Config, stop chan struct{}) (*buildConfig, error) {
 }
 
 func main() {
+	logrusutil.ComponentInit("build")
+
 	o := parseOptions()
-	logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "build"})
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -137,6 +137,8 @@ func gatherOptions() options {
 }
 
 func main() {
+	logrusutil.ComponentInit("checkconfig")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
@@ -146,10 +148,6 @@ func main() {
 	if len(o.warnings.Strings()) == 0 {
 		o.warnings = flagutil.NewStrings(allWarnings...)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(&logrus.TextFormatter{}, logrus.Fields{"component": "checkconfig"}),
-	)
 
 	configAgent := config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -25,6 +25,8 @@ import (
 )
 
 func main() {
+	logrusutil.ComponentInit("clonerefs")
+
 	o := &clonerefs.Options{}
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -33,10 +35,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "clonerefs"}),
-	)
 
 	if err := o.Run(); err != nil {
 		logrus.WithError(err).Fatal("Failed to clone refs")

--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -75,14 +75,12 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("config-bootstrapper")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "config-bootstrapper"}),
-	)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -150,11 +150,9 @@ func parseOptions() options {
 }
 
 func main() {
-	o := parseOptions()
+	logrusutil.ComponentInit("crier")
 
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "crier"}),
-	)
+	o := parseOptions()
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -229,14 +229,12 @@ func getPathPrefix(path string) string {
 }
 
 func main() {
+	logrusutil.ComponentInit("deck")
+
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "deck"}),
-	)
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -26,6 +26,8 @@ import (
 )
 
 func main() {
+	logrusutil.ComponentInit("entrypoint")
+
 	o := entrypoint.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -34,10 +36,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "entrypoint"}),
-	)
 
 	os.Exit(o.Run())
 }

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -29,6 +29,8 @@ import (
 )
 
 func main() {
+	logrusutil.ComponentInit("gcsupload")
+
 	o := gcsupload.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -37,10 +39,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "gcsupload"}),
-	)
 
 	spec, err := downwardapi.ResolveSpecFromEnv()
 	if err != nil {

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -77,7 +77,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "gerrit"}))
+	logrusutil.ComponentInit("gerrit")
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -93,11 +93,12 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
+	logrusutil.ComponentInit("hook")
+
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "hook"}))
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -71,14 +71,12 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("horologium")
+
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "horologium"}),
-	)
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -30,6 +30,8 @@ import (
 )
 
 func main() {
+	logrusutil.ComponentInit("initupload")
+
 	o := initupload.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -38,10 +40,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "initupload"}),
-	)
 
 	if err := o.Run(); err != nil {
 		logrus.WithError(err).Fatal("Failed to initialize job")

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -123,13 +123,12 @@ func gatherOptions() options {
 }
 
 func main() {
+	logrusutil.ComponentInit("jenkins-operator")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "jenkins-operator"}),
-	)
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -147,9 +147,8 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "peribolos"}),
-	)
+	logrusutil.ComponentInit("peribolos")
+
 	o := parseOptions()
 
 	secretAgent := &secret.Agent{}

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -125,8 +125,9 @@ func newPipelineConfig(cfg rest.Config, stop chan struct{}) (*pipelineConfig, er
 }
 
 func main() {
+	logrusutil.ComponentInit("pipeline")
+
 	o := parseOptions()
-	logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "pipeline"})
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -87,14 +87,12 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("plank")
+
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "plank"}),
-	)
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -27,6 +27,8 @@ import (
 )
 
 func main() {
+	logrusutil.ComponentInit("sidecar")
+
 	o := sidecar.NewOptions()
 	if err := options.Load(o); err != nil {
 		logrus.Fatalf("Could not resolve options: %v", err)
@@ -35,10 +37,6 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "sidecar"}),
-	)
 
 	failures, err := o.Run(context.Background())
 	if err != nil {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -84,16 +84,14 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("sinker")
+
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 
 	pjutil.ServePProf()
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "sinker"}),
-	)
 
 	if !o.dryRun.Explicit {
 		logrus.Warning("Sinker requires --dry-run=false to function correctly in production.")

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -88,14 +88,12 @@ func (o *options) Validate() error {
 }
 
 func main() {
+	logrusutil.ComponentInit("status-reconciler")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
-
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "status-reconciler"}),
-	)
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -89,8 +89,7 @@ func init() {
 }
 
 func main() {
-
-	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "pubsub-subscriber"}))
+	logrusutil.ComponentInit("pubsub-subscriber")
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(flagOptions.configPath, flagOptions.jobConfigPath); err != nil {

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -105,9 +105,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tide"}),
-	)
+	logrusutil.ComponentInit("tide")
 
 	pjutil.ServePProf()
 

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -269,13 +269,12 @@ func (f fallbackHandler) getURL(jobName string) string {
 }
 
 func main() {
+	logrusutil.ComponentInit("tot")
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
-	logrus.SetFormatter(
-		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tot"}),
-	)
 
 	pjutil.ServePProf()
 	health := pjutil.NewHealth()


### PR DESCRIPTION
This eases debugging by adding an option to print caller line number to the logs, something like this:
```
{"component":"deck","error":"stat /etc/config/config.yaml: no such file or directory","file":"/Users/mostafa/dev/test-infra/prow/cmd/deck/main.go:157","func":"main.main","level":"fatal","msg":"Error starting config agent.","time":"2019-02-05T03:56:34+03:00"}
```

It will be disabled by default for cleaner logs. However, it can be enabled faster than compiling then pushing a new image.

What do you guys think 🤔? I'll add it to the other components if approved.