### PR TITLE
Removing resource constraints from gce stable2 and stable3

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -227,7 +227,7 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
+      #TODO: Add resource constraints when stable2 >= 1.12
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
@@ -270,7 +270,7 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
+      #TODO: Add resource constraints when stable3 >= 1.12
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter


### PR DESCRIPTION
The resource constraints don't apply to old kubernetes releases (version < 1.12).