### PR TITLE
Adding 1 node redundancy for kubemark 500 and more nodes tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -318,7 +318,7 @@ periodics:
       - --gcp-master-size=n1-standard-2
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-4
-      - --gcp-nodes=3
+      - --gcp-nodes=4
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --kubemark
@@ -365,7 +365,7 @@ periodics:
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8
-      - --gcp-nodes=7
+      - --gcp-nodes=8
       - --gcp-project=k8s-jenkins-blocking-kubemark
       - --gcp-zone=us-central1-f
       - --kubemark
@@ -412,7 +412,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8
-      - --gcp-nodes=82
+      - --gcp-nodes=83
       - --gcp-project=kubemark-scalability-testing
       - --gcp-zone=us-east1-b
       - --kubemark
@@ -462,7 +462,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8
-      - --gcp-nodes=8
+      - --gcp-nodes=9
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --kubemark

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -37,6 +37,9 @@ presets:
   # See https://github.com/kubernetes/kubernetes/issues/67120 for context.
   - name: KUBE_FEATURE_GATES
     value: "TaintBasedEvictions=true"
+  # Allow one node to not be ready after cluster creation.
+  - name: ALLOWED_NOTREADY_NODES
+    value: 1
 ### kubemark-gce-big
 - labels:
     preset-e2e-kubemark-gce-big: "true"


### PR DESCRIPTION
Allowing one node to not be ready in all scalability kubemark tests:

Reducing flaky runs.
