### PR TITLE
Add verify job for enhancements repo

### DIFF
--- a/config/jobs/kubernetes/enhancements/OWNERS
+++ b/config/jobs/kubernetes/enhancements/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - calebamiles # SIG PM Lead
+  - idvoretskyi # SIG PM Lead
+  - apsinha # SIG PM Lead
+  - jdumars # Program Mgmt Chair
+  - justaugustus # Product Mgmt Chair
+labels:
+  - sig/pm

--- a/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
+++ b/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
@@ -1,0 +1,10 @@
+presubmits:
+  kubernetes/enhancements:
+  - name: pull-enhancements-verify
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - image: golang:1.11
+        command:
+        - ./hack/verify.sh

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -397,6 +397,7 @@ plugins:
   - milestone
   - require-sig
   - stage
+  - trigger
 
   kubernetes/examples:
   - trigger


### PR DESCRIPTION
Since we are adding a prowjob, this PR also enables the trigger plugin for the repo.

/hold
depends on https://github.com/kubernetes/enhancements/pull/816 (adds spelling verification scripts to the repo)

/assign @cblecker @justaugustus 