### PR TITLE
Revert "Use Update() instead of UpdateStatus()"

### DIFF
--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -27,6 +27,12 @@ rules:
       - create
       - list
       - update
+    - apiGroups:
+        - prow.k8s.io
+      resources:
+        - prowjobs/status
+      verbs:
+        - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -10,6 +10,8 @@ spec:
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -38,6 +38,8 @@ spec:
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -42,7 +42,7 @@ const (
 type prowJobClient interface {
 	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
 	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
-	Update(*prowapi.ProwJob) (*prowapi.ProwJob, error)
+	UpdateStatus(*prowapi.ProwJob) (*prowapi.ProwJob, error)
 }
 
 type jenkinsClient interface {
@@ -298,7 +298,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, jbs map[string]Build)
 		c.log.WithFields(pjutil.ProwJobFields(&toCancel)).
 			WithField("from", prevState).
 			WithField("to", toCancel.Status.State).Info("Transitioning states.")
-		npj, err := c.prowJobClient.Update(&toCancel)
+		npj, err := c.prowJobClient.UpdateStatus(&toCancel)
 		if err != nil {
 			return err
 		}
@@ -395,7 +395,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, reports chan<- prowapi.P
 			WithField("from", prevState).
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
-	_, err := c.prowJobClient.Update(&pj)
+	_, err := c.prowJobClient.UpdateStatus(&pj)
 	return err
 }
 
@@ -437,7 +437,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 			WithField("from", prevState).
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
-	_, err := c.prowJobClient.Update(&pj)
+	_, err := c.prowJobClient.UpdateStatus(&pj)
 	return err
 }
 

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -45,7 +45,7 @@ const (
 
 type prowJobClient interface {
 	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
-	Update(*prowapi.ProwJob) (*prowapi.ProwJob, error)
+	UpdateStatus(*prowapi.ProwJob) (*prowapi.ProwJob, error)
 	Get(name string, options metav1.GetOptions) (*prowapi.ProwJob, error)
 	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
 }
@@ -160,7 +160,7 @@ func (c *Controller) setPreviousReportState(pj prowapi.ProwJob) error {
 		latestPJ.Status.PrevReportStates = map[string]prowapi.ProwJobState{}
 	}
 	latestPJ.Status.PrevReportStates[reporter.GithubReporterName] = latestPJ.Status.State
-	_, err = c.prowJobClient.Update(latestPJ)
+	_, err = c.prowJobClient.UpdateStatus(latestPJ)
 	return err
 }
 
@@ -294,7 +294,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]coreapi
 		c.log.WithFields(pjutil.ProwJobFields(&toCancel)).
 			WithField("from", prevState).
 			WithField("to", toCancel.Status.State).Info("Transitioning states.")
-		npj, err := c.prowJobClient.Update(&toCancel)
+		npj, err := c.prowJobClient.UpdateStatus(&toCancel)
 		if err != nil {
 			return err
 		}
@@ -429,7 +429,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			WithField("from", prevState).
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
-	_, err := c.prowJobClient.Update(&pj)
+	_, err := c.prowJobClient.UpdateStatus(&pj)
 	return err
 }
 
@@ -479,7 +479,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]coreapi.
 			WithField("from", prevState).
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
-	_, err := c.prowJobClient.Update(&pj)
+	_, err := c.prowJobClient.UpdateStatus(&pj)
 	return err
 }
 


### PR DESCRIPTION
This reverts commit 6ec5070f9679feb243ef7516d35f2cd94abeb285.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/kubernetes/test-infra/issues/11093

/assign @cjwagner @fejta @munnerz 
/cc @BenTheElder @krzyzacy 