### PR TITLE
Revert "Bump prow from v20190125-2aca69d to v20190205-2820e5e"

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -430,10 +430,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 4200000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190205-2820e5e
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190205-2820e5e
-        initupload: gcr.io/k8s-prow/initupload:v20190205-2820e5e
-        sidecar: gcr.io/k8s-prow/sidecar:v20190205-2820e5e
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -513,10 +513,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 4200000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190205-2820e5e
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190205-2820e5e
-        initupload: gcr.io/k8s-prow/initupload:v20190205-2820e5e
-        sidecar: gcr.io/k8s-prow/sidecar:v20190205-2820e5e
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -590,10 +590,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 4200000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190205-2820e5e
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190205-2820e5e
-        initupload: gcr.io/k8s-prow/initupload:v20190205-2820e5e
-        sidecar: gcr.io/k8s-prow/sidecar:v20190205-2820e5e
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -667,10 +667,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 4200000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190205-2820e5e
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190205-2820e5e
-        initupload: gcr.io/k8s-prow/initupload:v20190205-2820e5e
-        sidecar: gcr.io/k8s-prow/sidecar:v20190205-2820e5e
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -744,10 +744,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 4200000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190205-2820e5e
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190205-2820e5e
-        initupload: gcr.io/k8s-prow/initupload:v20190205-2820e5e
-        sidecar: gcr.io/k8s-prow/sidecar:v20190205-2820e5e
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
     extra_refs:
     - base_ref: master
       org: kubernetes

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190205-2820e5e
+            image: gcr.io/k8s-prow/branchprotector:v20190125-2aca69d
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20190205-2820e5e
+        image: gcr.io/k8s-prow/build:v20190125-2aca69d
         args:
         - --all-contexts
         - --tot-url=http://tot

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190205-2820e5e
+        image: gcr.io/k8s-prow/crier:v20190125-2aca69d
         args:
         - --github-workers=1
         - --report-agent=knative-build

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190205-2820e5e
+        image: gcr.io/k8s-prow/deck:v20190125-2aca69d
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190205-2820e5e
+        image: gcr.io/k8s-prow/grandmatriarch:v20190125-2aca69d
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190205-2820e5e
+        image: gcr.io/k8s-prow/hook:v20190125-2aca69d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190205-2820e5e
+        image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190205-2820e5e
+        image: gcr.io/k8s-prow/needs-rebase:v20190125-2aca69d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190205-2820e5e
+        image: gcr.io/k8s-prow/plank:v20190125-2aca69d
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20190205-2820e5e
+        image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -138,7 +138,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190205-2820e5e
+        image: gcr.io/k8s-prow/hook:v20190125-2aca69d
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -203,7 +203,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190205-2820e5e
+        image: gcr.io/k8s-prow/plank:v20190125-2aca69d
         args:
         - --dry-run=false
         volumeMounts:
@@ -238,7 +238,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190205-2820e5e
+        image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -271,7 +271,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190205-2820e5e
+        image: gcr.io/k8s-prow/deck:v20190125-2aca69d
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
@@ -320,7 +320,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190205-2820e5e
+        image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -349,7 +349,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190205-2820e5e
+        image: gcr.io/k8s-prow/tide:v20190125-2aca69d
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20190205-2820e5e
+        image: gcr.io/k8s-prow/status-reconciler:v20190125-2aca69d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190205-2820e5e
+        image: gcr.io/k8s-prow/tide:v20190125-2aca69d
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190205-2820e5e
+        image: gcr.io/k8s-prow/tot:v20190125-2aca69d
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,10 +7,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190205-2820e5e"
-      initupload: "gcr.io/k8s-prow/initupload:v20190205-2820e5e"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190205-2820e5e"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190205-2820e5e"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190125-2aca69d"
+      initupload: "gcr.io/k8s-prow/initupload:v20190125-2aca69d"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190125-2aca69d"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190125-2aca69d"
     gcs_configuration:
       bucket: "kubernetes-jenkins"
       path_strategy: "legacy"


### PR DESCRIPTION
This reverts commit 2a5cf15d827a308cc9ff7862d074acdc766254e0.

The updated branchprotector run did not behave as expected; PRs are getting wedged with missing statuses.