### PR TITLE
kubeadm: use 'gce' when dumping logs

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -268,7 +268,7 @@ func (k *kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
 	}
 
 	// the e2e framework in k/k does not support the "kubernetes-anywhere" provider,
-	// while the same provider is required by the k/k "./cluster/log-dump/log-dump.sh" script
+	// while a valid provider is required by the k/k "./cluster/log-dump/log-dump.sh" script
 	// for dumping the logs of the GCE cluster that kubernetes-anywhere creates:
 	//   https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh
 	// this fix is quite messy, but an acceptable workaround until "anywhere.go" is removed completely.
@@ -277,7 +277,7 @@ func (k *kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
 	// not use log-dump.sh.
 	providerKey := "KUBERNETES_PROVIDER"
 	oldValue := os.Getenv(providerKey)
-	if err := os.Setenv(providerKey, "kubernetes-anywhere"); err != nil {
+	if err := os.Setenv(providerKey, "gce"); err != nil {
 		return err
 	}
 	err := defaultDumpClusterLogs(localPath, gcsPath)


### PR DESCRIPTION
o_O

failures:
https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1798

```
I0204 22:19:38.408] E0204 22:19:38.408486    1865 test_context.go:430] Unknown provider "kubernetes-anywhere". The following providers are known: aws azure gce gke kubemark local skeleton
```

> seems to me like the log dump is coupled with e2e and that's why it fails.
> my last bet is to modify this line to be "gce" instead of "kubernetes-anywhere"
https://github.com/kubernetes/test-infra/blob/master/kubetest/anywhere.go#L280
> as per:
https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh#L40-L42

caused by:
https://github.com/kubernetes/kubernetes/pull/73402

/shrug
/assign @krzyzacy @BenTheElder 
