### PR TITLE
Fix panic in giving welcome message

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -155,7 +155,7 @@ func welcomeMsg(ghc githubClient, trigger *plugins.Trigger, pr github.PullReques
 	}
 
 	var comment string
-	if trigger.IgnoreOkToTest {
+	if trigger != nil && trigger.IgnoreOkToTest {
 		comment = fmt.Sprintf(`Hi @%s. Thanks for your PR.
 
 PRs from untrusted users cannot be marked as trusted with `+"`/ok-to-test`"+` in this repo meaning untrusted PR authors can never trigger tests themselves. Collaborators can still trigger tests on the PR using `+"`/test all`"+`.


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @krzyzacy @BenTheElder @Katharine 

Fixes
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x121788d]

goroutine 6789 [running]:
k8s.io/test-infra/prow/plugins/trigger.welcomeMsg(0x1724de0, 0xc000174000, 0x0, 0x36, 0xc00016f360, 0x41, 0xc002a9bfa8, 0x7, 0x0, 0x0, ...)
	prow/plugins/trigger/pull-request.go:158 +0x21d
k8s.io/test-infra/prow/plugins/trigger.handlePR(0x1724de0, 0xc000174000, 0x7f75b93a5978, 0xc00014db40, 0xc002908380, 0xc001e81860, 0x0, 0xc002a9bf88, 0x6, 0x36, ...)
	prow/plugins/trigger/pull-request.go:48 +0x37b
k8s.io/test-infra/prow/plugins/trigger.handlePullRequest(0xc000174000, 0x171dc20, 0xc00014db40, 0x1735960, 0xc000777d00, 0xc00084d480, 0xc00014dba0, 0xc0027fc3c0, 0xc002908380, 0xc000798d80, ...)
	prow/plugins/trigger/trigger.go:133 +0x255
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1(0xc00290a310, 0xc0014e46f8, 0xc0040a3400, 0xc002a9a854, 0x7, 0x15e2248)
	prow/hook/events.go:174 +0x1e8
created by k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent
	prow/hook/events.go:166 +0x620
```