### PR TITLE
Temporarily suspend branchprotector cronjob.

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   schedule: "54 * * * *"  # Every hour at 54 minutes past the hour
   concurrencyPolicy: Forbid
+  suspend: true  # TODO(Katharine): remove this once we're up to date.
   jobTemplate:
     metadata:
       labels:


### PR DESCRIPTION
Deploy automation overwrites the manually-deployed branchprotector. Just make it stop doing things for now until we're in a reasonable state again.