### PR TITLE
Try to speed up ci-kubernetes-e2e-gce-min-node-permissions

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
@@ -40,6 +40,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-project=k8s-min-node-permissions
       - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m


### PR DESCRIPTION
velodrome says that this job has failed for 495 days:
http://velodrome.kubernetes.io/dashboard/db/bigquery-metrics?orgId=1

Looking at build log:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-min-node-permissions/509/build-log.txt

It seems to be running a bunch of tests but timing out after 8+ shours.
Let's try to run the tests in parallel to see if we can speed this job
up.

Change-Id: I66adb472c4cdb8ff1510e7e0b0cbe5ee1b390fa8