### PR TITLE
Horologium Improvements

### DIFF
--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/cron/BUILD.bazel
+++ b/prow/cron/BUILD.bazel
@@ -7,8 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/gopkg.in/robfig/cron.v2:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Expose errors in removing cached cronjob entries

The original use of the defer statement in a loop here was to get
around the concurrent use of the jobs map, but it did not bubble up the
error returned from the removal function. By computing the full list of
jobs to remove from the cache first we can remove the jobs without using
defer and ensure we bubble up the errors.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Use a set for checking if a job is a cron job

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Log decisions to trigger new periodic jobs

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @fejta @cjwagner 
/cc @Katharine @krzyzacy @BenTheElder 

Should help understand https://github.com/kubernetes/test-infra/issues/11146