### PR TITLE
Push new version of logexporter.

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = k8s-testimages
 IMG = gcr.io/$(PROJECT)/logexporter
-TAG = v0.1.3
+TAG = v0.1.4
 
 .PHONY: build push
 

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v0.1.3
+        image: gcr.io/k8s-testimages/logexporter:v0.1.4
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/k8s-testimages/logexporter:v0.1.3
+    image: gcr.io/k8s-testimages/logexporter:v0.1.4
     env:
     - name: NODE_NAME
       valueFrom:


### PR DESCRIPTION
This is to include changes from https://github.com/kubernetes/test-infra/pull/11121

The v0.1.4 image has been already pushed to GCR - https://pantheon.corp.google.com/gcr/images/k8s-testimages/GLOBAL/logexporter?project=k8s-testimages&folder&organizationId=433637338589&gcrImageListsize=30