### PR TITLE
Add GOPATH/bin to PATH for enhancements verify job

### DIFF
--- a/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
+++ b/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
@@ -7,4 +7,5 @@ presubmits:
       containers:
       - image: golang:1.11
         command:
+        - export PATH=$PATH:$GOPATH/bin
         - ./hack/verify.sh


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/pull/11126#issuecomment-460832335

This occurs due to https://github.com/kubernetes/test-infra/issues/9469.

@BenTheElder is this the right way to mitigate the $GOPATH/bin error?

/cc @justaugustus 
/assign @BenTheElder 
/kind bug

