### PR TITLE
Resume branchprotector runs

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   schedule: "54 * * * *"  # Every hour at 54 minutes past the hour
   concurrencyPolicy: Forbid
-  suspend: true  # TODO(Katharine): remove this once we're up to date.
   jobTemplate:
     metadata:
       labels:


### PR DESCRIPTION
I disabled branchprotector runs in order to ensure we wouldn't have unwanted rollbacks while performing our strictly ordered prow update. Now that we've successfully made it to the new world, it should start running again.

/cc @krzyzacy 