### PR TITLE
Fix regex in local-e2e-containerized

### DIFF
--- a/config/jobs/kubernetes/sig-node/local-e2e-containerized.yaml
+++ b/config/jobs/kubernetes/sig-node/local-e2e-containerized.yaml
@@ -63,7 +63,7 @@ periodics:
       - --extract-source
       - --ginkgo-parallel
       - --provider=local
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[Containerized\] --ginkgo.skip=\[Disruptive\]|\[sig\-apps\]\sDaemon\sset\s\[Serial\]\sshould\srollback\swithout\sunnecessary\srestarts\s\[Conformance\]|\[sig\-apps\]\sDaemon\sset\s[Serial]\sshould\srun\sand\sstop\scomplex\sdaemon\s\[Conformance\]
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[Containerized\] --ginkgo.skip=\[Disruptive\]|\[sig\-apps\]\sDaemon\sset\s\[Serial\]\sshould\srollback\swithout\sunnecessary\srestarts\s\[Conformance\]|\[sig\-apps\]\sDaemon\sset\s\[Serial\]\sshould\srun\sand\sstop\scomplex\sdaemon\s\[Conformance\]
       - --timeout=120m
       env:
       - name: DOCKERIZE_KUBELET


### PR DESCRIPTION
This test was disabled, but the regex needs escapes around the [Serial] to work.

Ref: https://github.com/kubernetes/test-infra/pull/11143
Ref: https://github.com/kubernetes/kubernetes/pull/73703