### PR TITLE
Migrate a result in GCS to ResultStore

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "k8s.io/test-infra/experiment/resultstore",
     visibility = ["//visibility:private"],
     deps = [
+        "//testgrid/resultstore:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/google.golang.org/genproto/googleapis/devtools/resultstore/v2:go_default_library",
@@ -15,6 +15,7 @@ go_library(
         "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/google.golang.org/grpc/credentials:go_default_library",
         "//vendor/google.golang.org/grpc/credentials/oauth:go_default_library",
+        "//vendor/google.golang.org/grpc/metadata:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -2,20 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "convert.go",
+        "download.go",
+        "main.go",
+    ],
     importpath = "k8s.io/test-infra/experiment/resultstore",
     visibility = ["//visibility:private"],
     deps = [
         "//testgrid/resultstore:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
-        "//vendor/github.com/google/uuid:go_default_library",
-        "//vendor/google.golang.org/genproto/googleapis/devtools/resultstore/v2:go_default_library",
-        "//vendor/google.golang.org/genproto/protobuf/field_mask:go_default_library",
-        "//vendor/google.golang.org/grpc:go_default_library",
-        "//vendor/google.golang.org/grpc/credentials:go_default_library",
-        "//vendor/google.golang.org/grpc/credentials/oauth:go_default_library",
-        "//vendor/google.golang.org/grpc/metadata:go_default_library",
+        "//testgrid/util/gcs:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/experiment/resultstore/convert.go
+++ b/experiment/resultstore/convert.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"k8s.io/test-infra/testgrid/resultstore"
+	"k8s.io/test-infra/testgrid/util/gcs"
+)
+
+func dur(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}
+
+// convertSuiteMeta converts a junit result in gcs to a ResultStore Suite.
+func convertSuiteMeta(suiteMeta gcs.SuitesMeta) resultstore.Suite {
+	out := resultstore.Suite{
+		Name: path.Base(suiteMeta.Path),
+		Files: []resultstore.File{
+			{
+				ContentType: "text/xml",
+				ID:          resultstore.UUID(),
+				URL:         suiteMeta.Path, // ensure the junit.xml file appears in artifacts list
+			},
+		},
+	}
+	for _, suite := range suiteMeta.Suites.Suites {
+		child := resultstore.Suite{
+			Name:     suite.Name,
+			Duration: dur(suite.Time),
+		}
+		switch {
+		case suite.Failures > 0 && suite.Tests >= suite.Failures:
+			child.Failures = append(child.Failures, resultstore.Failure{
+				Message: fmt.Sprintf("%d out of %d tests failed (%.1f%% passing)", suite.Failures, suite.Tests, float64(suite.Tests-suite.Failures)*100.0/float64(suite.Tests)),
+			})
+		case suite.Failures > 0:
+			child.Failures = append(child.Failures, resultstore.Failure{
+				Message: fmt.Sprintf("%d tests failed", suite.Failures),
+			})
+		}
+		for _, result := range suite.Results {
+			name, tags := stripTags(result.Name)
+			class := result.ClassName
+			if class == "" {
+				class = strings.Join(tags, " ")
+			} else {
+				class += " " + strings.Join(tags, " ")
+			}
+			c := resultstore.Case{
+				Name:     name,
+				Class:    class,
+				Duration: dur(result.Time),
+				Result:   resultstore.Completed,
+			}
+			msg := result.Message()
+			switch {
+			case result.Failure != nil:
+				// failing tests have a completed result with an error
+				if msg == "" {
+					msg = "unknown failure"
+				}
+				c.Failures = append(c.Failures, resultstore.Failure{
+					Message: msg,
+				})
+			case result.Skipped != nil:
+				c.Result = resultstore.Skipped
+				if msg != "" { // skipped results do not require an error, but may.
+					c.Errors = append(c.Errors, resultstore.Error{
+						Message: msg,
+					})
+				}
+			}
+			child.Cases = append(child.Cases, c)
+			if c.Duration > child.Duration {
+				child.Duration = c.Duration
+			}
+		}
+		if child.Duration > out.Duration {
+			// Assume suites run in parallel, so choose max
+			out.Duration = child.Duration
+		}
+		out.Suites = append(out.Suites, child)
+	}
+	return out
+}
+
+// Convert converts build metadata stored in gcp into the corresponding ResultStore Invocation, Target and Test.
+func convert(project, details string, url gcs.Path, result downloadResult) (resultstore.Invocation, resultstore.Target, resultstore.Test) {
+	started := result.started
+	finished := result.finished
+	artifacts := result.artifactURLs
+
+	basePath := trailingSlash(url.String())
+	artifactsPath := basePath + "artifacts/"
+	buildLog := basePath + "build-log.txt"
+	bucket := url.Bucket()
+	inv := resultstore.Invocation{
+		Project: project,
+		Details: details,
+		Files: []resultstore.File{
+			{
+				ID:          resultstore.InvocationLog,
+				ContentType: "text/plain",
+				URL:         buildLog, // ensure build-log.txt appears as the invocation log
+			},
+		},
+	}
+
+	// Files need a unique identifier, trim the common prefix and provide this.
+	uniqPath := func(s string) string { return strings.TrimPrefix(basePath, s) }
+
+	for i, a := range artifacts {
+		artifacts[i] = "gs://" + bucket + "/" + a
+	}
+
+	for _, a := range artifacts { // add started.json, etc to the invocation artifact list.
+		if strings.HasPrefix(a, artifactsPath) {
+			continue // things under artifacts/ are owned by the test
+		}
+		if a == buildLog {
+			continue // Handle this in InvocationLog
+		}
+		inv.Files = append(inv.Files, resultstore.File{
+			ID:          uniqPath(a),
+			ContentType: "text/plain",
+			URL:         a,
+		})
+	}
+	if started.Timestamp > 0 {
+		inv.Start = time.Unix(started.Timestamp, 0)
+		if finished.Timestamp != nil {
+			inv.Duration = time.Duration(*finished.Timestamp-started.Timestamp) * time.Second
+		}
+	}
+
+	const day = 24 * 60 * 60
+	switch {
+	case finished.Timestamp == nil && started.Timestamp < time.Now().Unix()+day:
+		inv.Status = resultstore.Running
+		inv.Description = "In progress..."
+	case finished.Passed != nil && *finished.Passed:
+		inv.Status = resultstore.Passed
+		inv.Description = "Passed"
+	case finished.Timestamp == nil:
+		inv.Status = resultstore.Failed
+		inv.Description = "Timed out"
+	default:
+		inv.Status = resultstore.Failed
+		inv.Description = "Failed"
+	}
+
+	test := resultstore.Test{
+		Action: resultstore.Action{
+			Node: started.Node,
+		},
+		Suite: resultstore.Suite{
+			Name: "test",
+			Files: []resultstore.File{
+				{
+					ID:          resultstore.TargetLog,
+					ContentType: "text/plain",
+					URL:         buildLog, // ensure build-log.txt appears as the target log.
+				},
+			},
+		},
+	}
+
+	for _, suiteMeta := range result.suiteMetas {
+		child := convertSuiteMeta(suiteMeta)
+		test.Suite.Suites = append(test.Suite.Suites, child)
+		test.Suite.Files = append(test.Suite.Files, child.Files...)
+	}
+	for _, a := range artifacts {
+		if !strings.HasPrefix(a, artifactsPath) {
+			continue // Non-artifacts (started.json, etc) are owned by the invocation
+		}
+		if a == buildLog {
+			continue // Already in the list.
+		}
+		// TODO(fejta): use set.Strings instead
+		var found bool
+		for _, sm := range result.suiteMetas {
+			if sm.Path == a {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		test.Suite.Files = append(test.Suite.Files, resultstore.File{
+			ID:          uniqPath(a),
+			ContentType: "text/plain",
+			URL:         a,
+		})
+	}
+
+	test.Suite.Start = inv.Start
+	test.Action.Start = inv.Start
+	test.Suite.Duration = inv.Duration
+	test.Action.Duration = inv.Duration
+	test.Status = inv.Status
+	test.Description = inv.Description
+
+	target := resultstore.Target{
+		Start:       inv.Start,
+		Duration:    inv.Duration,
+		Status:      inv.Status,
+		Description: inv.Description,
+	}
+
+	return inv, target, test
+}

--- a/experiment/resultstore/download.go
+++ b/experiment/resultstore/download.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/test-infra/testgrid/util/gcs"
+)
+
+type downloadResult struct {
+	started      gcs.Started
+	finished     gcs.Finished
+	artifactURLs []string
+	suiteMetas   []gcs.SuitesMeta
+}
+
+func download(ctx context.Context, opt options) (*downloadResult, error) {
+	var creds []string
+	if opt.account != "" {
+		creds = append(creds, opt.account)
+	}
+	client, err := gcs.ClientWithCreds(ctx, creds...)
+	if err != nil {
+		return nil, fmt.Errorf("client: %v", err)
+	}
+
+	build := gcs.Build{
+		Bucket:     client.Bucket(opt.path.Bucket()),
+		Context:    ctx,
+		Prefix:     trailingSlash(opt.path.Object()),
+		BucketPath: opt.path.Bucket(),
+	}
+
+	fmt.Println("Read started...")
+	started, err := build.Started()
+	if err != nil {
+		return nil, fmt.Errorf("started: %v", err)
+	}
+	fmt.Println("Read finished...")
+	finished, err := build.Finished()
+	if err != nil {
+		return nil, fmt.Errorf("finished: %v", err)
+	}
+
+	ec := make(chan error, 2)
+	artifacts := make(chan string)
+	suitesChan := make(chan gcs.SuitesMeta)
+	fmt.Println("List suites...")
+
+	go func() { // err1
+		defer close(artifacts)
+		err := build.Artifacts(artifacts)
+		if err != nil {
+			err = fmt.Errorf("artifacts: %v", err)
+		}
+		ec <- err
+	}()
+
+	var artifactURLs []string
+
+	for a := range artifacts {
+		artifactURLs = append(artifactURLs, a)
+	}
+
+	artifacts = make(chan string)
+	go func() {
+		defer close(artifacts)
+		for _, a := range artifactURLs {
+			select {
+			case artifacts <- a:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	go func() { // err2
+		defer close(suitesChan)
+		err := build.Suites(artifacts, suitesChan)
+		if err != nil {
+			err = fmt.Errorf("suites: %v", err)
+		}
+		ec <- err
+	}()
+
+	var suites []gcs.SuitesMeta
+	for s := range suitesChan {
+		suites = append(suites, s)
+	}
+
+	err1, err2 := <-ec, <-ec
+	if err1 != nil {
+		return nil, err1
+	}
+	if err2 != nil {
+		return nil, err2
+	}
+
+	return &downloadResult{
+		started:      *started,
+		finished:     *finished,
+		artifactURLs: artifactURLs,
+		suiteMetas:   suites,
+	}, nil
+}

--- a/experiment/resultstore/main.go
+++ b/experiment/resultstore/main.go
@@ -14,115 +14,72 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Resultstore converts --build=gs://prefix/JOB/NUMBER from prow's pod-utils to a ResultStore invocation suite, which it optionally will --upload=gcp-project.
 package main
 
 import (
 	"context"
-	"crypto/x509"
+	"flag"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
-	"strconv"
+	"regexp"
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/google/uuid"
-	resultstore "google.golang.org/genproto/googleapis/devtools/resultstore/v2"
-	"google.golang.org/genproto/protobuf/field_mask"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/oauth"
-	"google.golang.org/grpc/metadata"
 	"sigs.k8s.io/yaml"
 
-	tirs "k8s.io/test-infra/testgrid/resultstore"
+	"k8s.io/test-infra/testgrid/resultstore"
+	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
-// See https://godoc.org/google.golang.org/genproto/googleapis/devtools/resultstore/v2
+var re = regexp.MustCompile(`( ?|^)\[[^]]+\]( |$)`)
 
-func main() {
-	var invID, tok string
-	creds := os.Args[1]
-	if len(os.Args) > 2 {
-		tok = os.Args[2]
+// Converts "[k8s.io] hello world [foo]" into "hello world", []string{"k8s.io", "foo"}
+func stripTags(str string) (string, []string) {
+	tags := re.FindAllString(str, -1)
+	for i, w := range tags {
+		w = strings.TrimSpace(w)
+		tags[i] = w[1 : len(w)-1]
 	}
-	if len(os.Args) > 3 {
-		invID = os.Args[3]
+	var reals []string
+	for _, p := range re.Split(str, -1) {
+		if p == "" {
+			continue
+		}
+		reals = append(reals, p)
 	}
-	if err := setup(creds, tok, invID); err != nil {
-		log.Fatal(err)
-	}
+	return strings.Join(reals, " "), tags
 }
 
-func newUUID() string {
-	return uuid.New().String()
+type options struct {
+	path    gcs.Path
+	account string
+	project string
+	secret  string
 }
 
-func prop(key, value string) *resultstore.Property {
-	return &resultstore.Property{
-		Key:   key,
-		Value: value,
-	}
-}
-
-func tdur(seconds int64, nanos int32) time.Duration {
-	return time.Second*time.Duration(seconds) + time.Nanosecond*time.Duration(nanos)
-}
-
-func dur(seconds int64, nanos int32) *duration.Duration {
+func (o *options) parse(flags *flag.FlagSet, args []string) error {
+	flags.Var(&o.path, "build", "The gs://bucket/to/job/build-1234/ url")
+	flags.StringVar(&o.account, "service-account", "", "Authenticate with the service account at specified path")
+	flags.StringVar(&o.project, "upload", "", "Upload results to specified gcp project instead of stdout")
+	flags.StringVar(&o.secret, "secret", "", "Use the specified secret guid instead of randomly generating one.")
+	flags.Parse(args)
 	return nil
 }
 
-func grpcConn(accountPath string) (*grpc.ClientConn, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("system cert pool: %v", err)
+func parseOptions() options {
+	var o options
+	if err := o.parse(flag.CommandLine, os.Args[1:]); err != nil {
+		log.Fatalf("Invalid flags: %v", err)
 	}
-	creds := credentials.NewClientTLSFromCert(pool, "")
-	const scope = "https://www.googleapis.com/auth/cloud-platform"
-	perRPC, err := oauth.NewServiceAccountFromFile(accountPath, scope)
-	if err != nil {
-		return nil, fmt.Errorf("create oauth: %v", err)
-	}
-	conn, err := grpc.Dial(
-		"resultstore.googleapis.com:443",
-		grpc.WithTransportCredentials(creds),
-		grpc.WithPerRPCCredentials(perRPC),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("dial: %v", err)
-	}
-
-	return conn, nil
+	return o
 }
 
-type (
-	uploadClient   = resultstore.ResultStoreUploadClient
-	downloadClient = resultstore.ResultStoreDownloadClient
-)
-
-func clients(conn *grpc.ClientConn) (uploadClient, downloadClient) {
-	up := resultstore.NewResultStoreUploadClient(conn)
-	down := resultstore.NewResultStoreDownloadClient(conn)
-	return up, down
-}
-
-func createInvocation(ctx context.Context, up uploadClient) (*resultstore.Invocation, string, error) {
-	tok := newUUID()
-	fmt.Println("Auth token", tok)
-	inv, err := up.CreateInvocation(ctx, &resultstore.CreateInvocationRequest{
-		Invocation: tirs.Invocation{
-			Project:     "fejta-prod",
-			Description: "hello world",
-			Start:       time.Now(),
-			Duration:    50 * time.Second,
-		}.To(),
-		AuthorizationToken: tok,
-	})
-	return inv, tok, err
+func main() {
+	if err := run(parseOptions()); err != nil {
+		log.Fatalf("Failed: %v", err)
+	}
 }
 
 func str(inv interface{}) string {
@@ -139,495 +96,70 @@ func print(inv ...interface{}) {
 	}
 }
 
-const (
-	finishConfiguredTarget = false
-	finishTarget           = false
-	finishInvocation       = false
-)
-
-func pick(choices ...string) string {
-	return choices[rand.Intn(len(choices))]
+func trailingSlash(s string) string {
+	if strings.HasSuffix(s, "/") {
+		return s
+	}
+	return s + "/"
 }
 
-func caseName() string {
-	return pick(
-		"testFoo",
-		"testBar",
-		"testSanta",
-		"testGeorge",
-		"testAbstractFactoryBuilderBuilderBuilderFactory",
-		"testCRUD [Feature:Demo]",
-	)
-}
-
-func className() string {
-	return pick(
-		"com.google.omg",
-		"com.google.whynot",
-		"io.k8s.java",
-		"k8s.io/golang",
-		"ignore",
-	)
-}
-
-func flip() bool {
-	return rand.Int()%2 == 0
-}
-
-func randomTestCase() tirs.Case {
-	c := tirs.Case{
-		Name:     caseName(),
-		Class:    className(),
-		Start:    time.Now(),
-		Duration: tdur(15, 30),
-		Properties: []tirs.Property{
-			tirs.Prop("whatever", "yo"),
-		},
-		Files: manyFiles,
-	}
-
-	failed, errored := flip(), flip()
-	switch roll := rand.Int() % 5; {
-	case !failed && !errored, roll < 3:
-		c.Result = tirs.Completed
-	case roll == 3:
-		c.Result = tirs.Cancelled
-	default:
-		c.Result = tirs.Skipped
-	}
-
-	if failed {
-		c.Failures = []tirs.Failure{
-			{
-				Message:  "Expected err not to have occurred",
-				Kind:     "NotEverythingIsJavaException",
-				Stack:    "TODO: stacktrace joke",
-				Expected: []string{"foo", "bar"},
-				Actual:   []string{"spam", "eggs"},
-			},
-		}
-	}
-
-	if errored {
-		c.Errors = []tirs.Error{
-			{
-				Message: "true != false",
-				Kind:    "panic",
-				Stack:   "lines",
-			},
-		}
-	}
-
-	return c
-}
-
-const (
-	e2eLog        = "gs://kubernetes-jenkins/logs/ci-kubernetes-local-e2e/3355/build-log.txt"
-	compressedLog = e2eLog
-	pushLog       = "gs://kubernetes-jenkins/logs/post-test-infra-push-prow/1079/build-log.txt"
-	bumpLog       = "gs://kubernetes-jenkins/logs/ci-test-infra-autobump-prow/67/build-log.txt"
-	oldPushLog    = "gs://kubernetes-jenkins/logs/post-test-infra-push-prow/1077/build-log.txt"
-	erickLog      = "gs://kubernetes-jenkins/erick.txt"
-	fejtaLog      = "gs://kubernetes-jenkins/erick-fejta.txt"
-)
-
-var (
-	testLog = tirs.File{
-		ID:  tirs.TestLog,
-		URL: pushLog,
-	}
-	buildLog = tirs.File{
-		ID:  tirs.BuildLog,
-		URL: bumpLog,
-	}
-	stdout = tirs.File{
-		ID:  tirs.Stdout,
-		URL: erickLog,
-	}
-	stderr = tirs.File{
-		ID:  "stderr",
-		URL: fejtaLog,
-	}
-	manyFiles = []tirs.File{ // special ids: build: stdout,stderr,baseline.lcov; test: test.xml,test.log,test.lcov
-		buildLog, testLog, stdout, stderr,
-	}
-)
-
-func mask(ctx context.Context, fields ...string) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, "X-Goog-FieldMask", strings.Join(fields, ","))
-}
-
-func listMask(ctx context.Context, fields ...string) context.Context {
-	out := []string{"next_page_token"}
-	for _, f := range fields {
-		out = append(out, f)
-	}
-	return mask(ctx, out...)
-}
-
-func setup(account, tok, invID string) error {
-	// create connection and clients
-	conn, err := grpcConn(account)
-	if err != nil {
-		return fmt.Errorf("setup: %v", err)
-	}
-	up, down := clients(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func run(opt options) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	// ensure invocation
-
-	var inv *resultstore.Invocation
-	if invID == "" {
-		inv, tok, err = createInvocation(ctx, up)
-		if err != nil {
-			return fmt.Errorf("create invocation: %v", err)
-		}
-		invID = inv.Id.InvocationId
-	}
-	invName := "invocations/" + invID
-	inv, err = down.GetInvocation(mask(ctx, "timing,name"), &resultstore.GetInvocationRequest{
-		Name: invName,
-	})
+	result, err := download(ctx, opt)
 	if err != nil {
-		return fmt.Errorf("get invocation %s: %v", invName, err)
-	}
-	print("gi", tok, inv)
-
-	inv.Files = tirs.Files(manyFiles)
-	inv, err = up.UpdateInvocation(ctx, &resultstore.UpdateInvocationRequest{
-		Invocation: inv,
-		UpdateMask: &field_mask.FieldMask{
-			Paths: []string{"files"},
-		},
-		AuthorizationToken: tok,
-	})
-	if err != nil {
-		return fmt.Errorf("update invocation %s: %v", invName, err)
+		return fmt.Errorf("download %s: %v", opt.path, err)
 	}
 
-	// add a target
+	inv, target, test := convert(
+		opt.project,
+		"hello again",
+		opt.path,
+		*result,
+	)
+	print(inv.To(), test.To())
 
-	t, err := up.CreateTarget(ctx, &resultstore.CreateTargetRequest{
-		Parent:   inv.Name,
-		TargetId: "//erick//fejta:stardate-" + strconv.FormatInt(time.Now().Unix(), 10),
-		Target: &resultstore.Target{ // https://godoc.org/google.golang.org/genproto/googleapis/devtools/resultstore/v2#Target
-			StatusAttributes: &resultstore.StatusAttributes{
-				Status:      resultstore.Status_BUILDING,
-				Description: "fun fun",
-			},
-			Visible: true, // Will not appear in UI otherwise
-			//   Timing
-			//   TargetAttributes
-			//   TestAttributes
-			//   Properties
-			//   Files
-		},
-		AuthorizationToken: tok,
-	})
+	if opt.project == "" {
+		return nil
+	}
+
+	conn, err := resultstore.Connect(ctx, opt.account)
 	if err != nil {
+		return fmt.Errorf("resultstore connection: %v", err)
+	}
+	rsClient := resultstore.NewClient(conn).WithContext(ctx)
+	if opt.secret != "" {
+		rsClient = rsClient.WithSecret(resultstore.Secret(opt.secret))
+	} else {
+		secret := resultstore.NewSecret()
+		fmt.Println("Secret:", secret)
+		rsClient = rsClient.WithSecret(secret)
+	}
+
+	targetID := test.Name
+	const configID = resultstore.Default
+	invName, err := rsClient.Invocations().Create(inv)
+	if err != nil {
+		return fmt.Errorf("create invocation: %v", err)
+	}
+	targetName, err := rsClient.Targets(invName).Create(targetID, target)
+	if err != nil {
+		fmt.Println(resultstore.URL(invName))
 		return fmt.Errorf("create target: %v", err)
 	}
-	print("ct", t)
-
-	tr, err := down.ListTargets(listMask(ctx, "targets.name"), &resultstore.ListTargetsRequest{
-		Parent: inv.Name,
-		// PageSize
-		// PageStart
-	})
+	fmt.Println(resultstore.URL(targetName))
+	_, err = rsClient.Configurations(invName).Create(configID)
 	if err != nil {
-		return fmt.Errorf("list targets: %v", err)
+		return fmt.Errorf("create configuration: %v", err)
 	}
-	print("lt", inv, tr)
-
-	// create a configuration
-	c, err := up.CreateConfiguration(ctx, &resultstore.CreateConfigurationRequest{
-		Parent:             inv.Name,
-		ConfigId:           "default",
-		AuthorizationToken: tok,
-		Configuration: &resultstore.Configuration{
-			// Overall status of this config
-			StatusAttributes: &resultstore.StatusAttributes{
-				Status:      resultstore.Status_BUILDING, // https://godoc.org/google.golang.org/genproto/googleapis/devtools/resultstore/v2#Status
-				Description: "very exciting",
-			},
-			ConfigurationAttributes: &resultstore.ConfigurationAttributes{
-				Cpu: "amd64", // this is the only value, LOL
-			},
-			Properties: []*resultstore.Property{
-				prop("something", fmt.Sprintf("exciting-%d", time.Now().Unix())),
-				prop("more", "excitement"),
-			},
-		},
-	})
-	if err != nil {
-		print("create failed (already exists?", err)
-	}
-	print("cc", c)
-
-	lr, err := down.ListConfigurations(listMask(ctx, "configurations.name", "configurations.id"), &resultstore.ListConfigurationsRequest{
-		Parent: inv.Name,
-		// PageSize, PageStart
-	})
-	if err != nil {
-		return fmt.Errorf("list configurations: %v", err)
-	}
-	print("lc", lr)
-
-	cfgs := lr.Configurations
-
-	// create a configured target
-
-	ct, err := up.CreateConfiguredTarget(ctx, &resultstore.CreateConfiguredTargetRequest{
-		Parent:             t.Name,
-		ConfigId:           cfgs[len(cfgs)-1].Id.ConfigurationId,
-		AuthorizationToken: tok,
-		ConfiguredTarget: &resultstore.ConfiguredTarget{
-			StatusAttributes: &resultstore.StatusAttributes{
-				Status:      resultstore.Status_TESTING,
-				Description: "oh wow",
-			},
-			// Timing: timingEnd(time.Now(), 50, 7),
-			TestAttributes: &resultstore.ConfiguredTestAttributes{
-				TotalRunCount:   1,
-				TotalShardCount: 1,
-				TimeoutDuration: dur(500, 0),
-			},
-			Properties: []*resultstore.Property{
-				prop("fun", fmt.Sprintf("times-%d", time.Now().Unix())),
-			},
-			Files: []*resultstore.File{
-				{
-					Uid: newUUID(),
-					Uri: "gs://erick/fejta/likes/uuids",
-					Length: &wrappers.Int64Value{
-						Value: 19,
-					},
-					ContentType: "orange",
-					ArchiveEntry: &resultstore.ArchiveEntry{
-						Path: "/freedom",
-						Length: &wrappers.Int64Value{
-							Value: 10000,
-						},
-						ContentType: "text/plain",
-					},
-					ContentViewer: "https://prow.k8s.io/tide",
-					Hidden:        false,
-					Description:   "many thanks",
-					Digest:        "yes", // what is hexadecimal-"like"
-					HashType:      resultstore.File_SHA256,
-				},
-			},
-		},
-	})
+	ctName, err := rsClient.ConfiguredTargets(targetName, configID).Create()
 	if err != nil {
 		return fmt.Errorf("create configured target: %v", err)
 	}
-	print("cct", ct)
-
-	lctr, err := down.ListConfiguredTargets(listMask(ctx, "configured_targets.name"), &resultstore.ListConfiguredTargetsRequest{
-		Parent: t.Name,
-		// pagesize/start
-	})
+	_, err = rsClient.Actions(ctName).Create("primary", test)
 	if err != nil {
-		return fmt.Errorf("list %s configured targets: %v", t.Name, err)
+		return fmt.Errorf("create action: %v", err)
 	}
-	print("lct", lctr)
-
-	cts := lctr.ConfiguredTargets
-	ct = cts[len(cts)-1]
-
-	a, err := up.CreateAction(ctx, &resultstore.CreateActionRequest{
-		Parent:             ct.Name,
-		ActionId:           "build",
-		AuthorizationToken: tok,
-		Action: &resultstore.Action{
-			StatusAttributes: &resultstore.StatusAttributes{
-				Status:      resultstore.Status_BUILT,
-				Description: "so built",
-			},
-			// Timing
-			ActionType: &resultstore.Action_BuildAction{
-				BuildAction: &resultstore.BuildAction{
-					Type:              "javac",
-					PrimaryInputPath:  "java/com/google/whatever/foo.java",
-					PrimaryOutputPath: "whatever.o",
-				},
-			},
-			// ActionType: Action_BuildAction / Test
-			ActionAttributes: &resultstore.ActionAttributes{
-				ExecutionStrategy: resultstore.ExecutionStrategy_LOCAL_SEQUENTIAL, // https://godoc.org/google.golang.org/genproto/googleapis/devtools/resultstore/v2#ExecutionStrategy
-				ExitCode:          1,
-				Hostname:          "foo",
-				InputFileInfo: &resultstore.InputFileInfo{
-					Count:             3,
-					DistinctCount:     2,
-					CountLimit:        12,
-					DistinctBytes:     100,
-					DistinctByteLimit: 1000,
-				},
-			},
-			ActionDependencies: []*resultstore.Dependency{
-				{
-					Resource: &resultstore.Dependency_Target{
-						Target: t.Name,
-					},
-					Label: "Root Cause", // exact resource that caused falure
-				},
-			},
-			Properties: nil,
-			Files: []*resultstore.File{ // special ids: build: stdout,stderr,baseline.lcov; test: test.xml,test.log,test.lcov
-				stdout.To(),
-				stderr.To(),
-			},
-			Coverage: nil, // https://godoc.org/google.golang.org/genproto/googleapis/devtools/resultstore/v2#ActionCoverage
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("create build action: %v", err)
-	}
-	print("ca#build", a)
-
-	a, err = up.CreateAction(ctx, &resultstore.CreateActionRequest{
-		Parent:             ct.Name,
-		ActionId:           "test",
-		AuthorizationToken: tok,
-		Action: tirs.Test{
-			Action: tirs.Action{
-				Status:      tirs.Passed,
-				Description: "so healthy",
-				Start:       time.Now(),
-				Duration:    10 * time.Minute,
-				Node:        "foo",
-				ExitCode:    1,
-			},
-			Suite: tirs.Suite{
-				Name: "sweeeeet",
-				Cases: []tirs.Case{
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-					randomTestCase(),
-				},
-				Failures: []tirs.Failure{
-					{
-						Message: "bitter",
-						Kind:    "VegetableException",
-						Expected: []string{
-							"candy",
-							"fruit",
-							"meat",
-						},
-						Actual: []string{
-							"broccoli",
-							"kale",
-							"cucumber",
-						},
-					},
-				},
-				Errors: []tirs.Error{
-					{
-						Message: "salty",
-						Kind:    "wound",
-					},
-				},
-				Start:    time.Now(),
-				Duration: tdur(173, 0),
-				Properties: []tirs.Property{
-					tirs.Prop("sweet", "success"),
-				},
-				Files: manyFiles,
-			},
-			Warnings: []string{"global warning", "a warn oven"},
-		}.To(),
-	})
-	if err != nil {
-		return fmt.Errorf("create test action: %v", err)
-	}
-	print("ca#test", a)
-
-	lar, err := down.ListActions(listMask(ctx, "actions.name", "actions.build_action", "actions.test_action"), &resultstore.ListActionsRequest{
-		Parent: ct.Name,
-		// pagesizestart
-	})
-	print("la", lar, err)
-
-	if finishConfiguredTarget {
-		fct, err := up.FinishConfiguredTarget(ctx, &resultstore.FinishConfiguredTargetRequest{
-			Name:               ct.Name,
-			AuthorizationToken: tok,
-		})
-		if err != nil {
-			return fmt.Errorf("finish %s: %v", ct.Name, err)
-		}
-		print("fct", fct)
-	}
-
-	if finishTarget {
-		ft, err := up.FinishTarget(ctx, &resultstore.FinishTargetRequest{
-			Name:               t.Name,
-			AuthorizationToken: tok,
-		})
-		if err != nil {
-			return fmt.Errorf("finish %s: %v", t.Name, err)
-		}
-		print("ft", ft)
-	}
-
-	if finishInvocation {
-		fi, err := up.FinishInvocation(ctx, &resultstore.FinishInvocationRequest{
-			Name:               inv.Name,
-			AuthorizationToken: tok,
-		})
-		if err != nil {
-			return fmt.Errorf("finish %s: %v", inv.Name, err)
-		}
-		print("fi", fi)
-
-	}
-
-	fmt.Println("Token: " + tok)
-	fmt.Printf("See https://source.cloud.google.com/results/invocations/%s\n", inv.Id.InvocationId)
 	return nil
 }

--- a/testgrid/BUILD.bazel
+++ b/testgrid/BUILD.bazel
@@ -58,6 +58,7 @@ filegroup(
         "//testgrid/cmd/updater:all-srcs",
         "//testgrid/images:all-srcs",
         "//testgrid/metadata:all-srcs",
+        "//testgrid/resultstore:all-srcs",
         "//testgrid/util/gcs:all-srcs",
     ],
     tags = ["automanaged"],

--- a/testgrid/cmd/updater/main.go
+++ b/testgrid/cmd/updater/main.go
@@ -101,28 +101,6 @@ func testGroupPath(g gcs.Path, name string) (*gcs.Path, error) {
 	return np, nil
 }
 
-// Message extracts the message for the junit test case.
-//
-// Will use the first non-empty <failure/>, <skipped/>, <output/> value.
-func message(jr junit.Result) string {
-	const max = 140
-	var msg string
-	switch {
-	case jr.Failure != nil && *jr.Failure != "":
-		msg = *jr.Failure
-	case jr.Skipped != nil && *jr.Skipped != "":
-		msg = *jr.Skipped
-	case jr.Output != nil && *jr.Output != "":
-		msg = *jr.Output
-	}
-	l := len(msg)
-	if max == 0 || l <= max {
-		return msg
-	}
-	h := max / 2
-	return msg[:h] + "..." + msg[l-h-1:]
-}
-
 // Row converts the junit result into a Row result, prepending the suite name.
 func row(jr junit.Result, suite string) (string, Row) {
 	n := jr.Name
@@ -138,7 +116,7 @@ func row(jr junit.Result, suite string) (string, Row) {
 	if jr.Time > 0 {
 		r.Metrics[elapsedKey] = jr.Time
 	}
-	if msg := message(jr); msg != "" {
+	if msg := jr.Message(); msg != "" {
 		r.Message = msg
 	}
 	switch {

--- a/testgrid/metadata/junit/junit.go
+++ b/testgrid/metadata/junit/junit.go
@@ -55,6 +55,30 @@ type Result struct {
 	Skipped   *string `xml:"skipped,omitempty"`
 }
 
+// Message extracts the message for the junit test case.
+//
+// Will use the first non-empty <failure/>, <skipped/>, <system-err/>, <system-out/> value.
+func (jr Result) Message() string {
+	const max = 140
+	var msg string
+	switch {
+	case jr.Failure != nil && *jr.Failure != "":
+		msg = *jr.Failure
+	case jr.Skipped != nil && *jr.Skipped != "":
+		msg = *jr.Skipped
+	case jr.Error != nil && *jr.Error != "":
+		msg = *jr.Error
+	case jr.Output != nil && *jr.Output != "":
+		msg = *jr.Output
+	}
+	l := len(msg)
+	if max == 0 || l <= max {
+		return msg
+	}
+	h := max / 2
+	return msg[:h] + "..." + msg[l-h-1:]
+}
+
 func unmarshalXML(buf []byte, i interface{}) error {
 	reader := bytes.NewReader(buf)
 	dec := xml.NewDecoder(reader)

--- a/testgrid/resultstore/BUILD.bazel
+++ b/testgrid/resultstore/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resultstore.go"],
+    importpath = "k8s.io/test-infra/testgrid/resultstore",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
+        "//vendor/google.golang.org/genproto/googleapis/devtools/resultstore/v2:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/testgrid/resultstore/BUILD.bazel
+++ b/testgrid/resultstore/BUILD.bazel
@@ -2,14 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["resultstore.go"],
+    srcs = [
+        "client.go",
+        "resultstore.go",
+    ],
     importpath = "k8s.io/test-infra/testgrid/resultstore",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/google.golang.org/genproto/googleapis/devtools/resultstore/v2:go_default_library",
+        "//vendor/google.golang.org/genproto/protobuf/field_mask:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/google.golang.org/grpc/credentials:go_default_library",
+        "//vendor/google.golang.org/grpc/credentials/oauth:go_default_library",
+        "//vendor/google.golang.org/grpc/metadata:go_default_library",
     ],
 )
 

--- a/testgrid/resultstore/client.go
+++ b/testgrid/resultstore/client.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resultstore
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	resultstore "google.golang.org/genproto/googleapis/devtools/resultstore/v2"
+	"google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+	"google.golang.org/grpc/metadata"
+)
+
+// Connect returns a secure gRPC connection.
+//
+// Authenticates as the service account if specified otherwise the default user.
+func Connect(ctx context.Context, serviceAccountPath string) (*grpc.ClientConn, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("system cert pool: %v", err)
+	}
+	creds := credentials.NewClientTLSFromCert(pool, "")
+	const scope = "https://www.googleapis.com/auth/cloud-platform"
+	var perRPC credentials.PerRPCCredentials
+	if serviceAccountPath != "" {
+		perRPC, err = oauth.NewServiceAccountFromFile(serviceAccountPath, scope)
+	} else {
+		perRPC, err = oauth.NewApplicationDefault(ctx, scope)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create oauth: %v", err)
+	}
+	conn, err := grpc.Dial(
+		"resultstore.googleapis.com:443",
+		grpc.WithTransportCredentials(creds),
+		grpc.WithPerRPCCredentials(perRPC),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dial: %v", err)
+	}
+
+	return conn, nil
+}
+
+// Secret represents a secret authorization uuid to protect invocations.
+type Secret string
+
+// UUID represents a universally "unique" identifier.
+func UUID() string {
+	return uuid.New().String()
+}
+
+// NewSecret returns a new, unique identifier.
+func NewSecret() Secret {
+	return Secret(UUID())
+}
+
+// Client provides ResultStore CRUD methods.
+type Client struct {
+	up    resultstore.ResultStoreUploadClient
+	down  resultstore.ResultStoreDownloadClient
+	ctx   context.Context
+	token string
+}
+
+// NewClient uses the specified gRPC connection to connect to ResultStore.
+func NewClient(conn *grpc.ClientConn) *Client {
+	return &Client{
+		up:   resultstore.NewResultStoreUploadClient(conn),
+		down: resultstore.NewResultStoreDownloadClient(conn),
+		ctx:  context.Background(),
+	}
+}
+
+// WithContext uses the specified context for all RPCs.
+func (c *Client) WithContext(ctx context.Context) *Client {
+	c.ctx = ctx
+	return c
+}
+
+// WithSecret applies the specified secret to all requests.
+func (c *Client) WithSecret(authorizationToken Secret) *Client {
+	c.token = string(authorizationToken)
+	return c
+}
+
+// Access resources
+
+// Invocations provides Invocation CRUD methods.
+func (c Client) Invocations() Invocations {
+	return Invocations{
+		Client: c,
+	}
+}
+
+// Configurations provides CRUD methods for an invocation's configurations.
+func (c Client) Configurations(invocationName string) Configurations {
+	return Configurations{
+		Client: c,
+		inv:    invocationName,
+	}
+}
+
+// Targets provides CRUD methods for an invocations's targets.
+func (c Client) Targets(invocationName string) Targets {
+	return Targets{
+		Client: c,
+		inv:    invocationName,
+	}
+}
+
+// ConfiguredTargets provides CRUD methods for a target's configured targets.
+func (c Client) ConfiguredTargets(targetName, configID string) ConfiguredTargets {
+	return ConfiguredTargets{
+		Client: c,
+		target: targetName,
+		config: configID,
+	}
+}
+
+// Actions provides CRUD methods for a configured target.
+func (c Client) Actions(configuredTargetName string) Actions {
+	return Actions{
+		Client:           c,
+		configuredTarget: configuredTargetName,
+	}
+}
+
+// Resources
+
+// Invocations client.
+type Invocations struct {
+	Client
+}
+
+// Targets client.
+type Targets struct {
+	Client
+	inv string
+}
+
+// Configurations client.
+type Configurations struct {
+	Client
+	inv string
+}
+
+// ConfiguredTargets client.
+type ConfiguredTargets struct {
+	Client
+	target string
+	config string
+}
+
+// Actions client.
+type Actions struct {
+	Client
+	configuredTarget string
+}
+
+// Mask methods
+
+// fieldMask is required by gRPC for GET methods.
+func fieldMask(ctx context.Context, fields ...string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "X-Goog-FieldMask", strings.Join(fields, ","))
+}
+
+// listMask adds the required next_page_token for list requests, as well as any other methods.
+func listMask(ctx context.Context, fields ...string) context.Context {
+	return fieldMask(ctx, append(fields, "next_page_token")...)
+}
+
+// Target methods
+
+// Create a new target with the specified id (target basename), returing the fully qualified path.
+func (t Targets) Create(id string, target Target) (string, error) {
+	tgt, err := t.up.CreateTarget(t.ctx, &resultstore.CreateTargetRequest{
+		Parent:             t.inv,
+		TargetId:           id,
+		Target:             target.To(),
+		AuthorizationToken: t.token,
+	})
+	if err != nil {
+		return "", err
+	}
+	return tgt.Name, nil
+}
+
+// List requested fields in targets, does not currently handle paging.
+func (t Targets) List(fields ...string) ([]Target, error) {
+	resp, err := t.down.ListTargets(listMask(t.ctx, fields...), &resultstore.ListTargetsRequest{
+		Parent: t.inv,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var targets []Target
+	for _, r := range resp.Targets {
+		targets = append(targets, fromTarget(r))
+	}
+	return targets, nil
+}
+
+// Configuration methods
+
+const (
+	// Default is the expected single-configuration id.
+	Default = "default"
+)
+
+// Create a new configuration using the specified basename, returning the fully qualified path.
+func (c Configurations) Create(id string) (string, error) {
+	config, err := c.up.CreateConfiguration(c.ctx, &resultstore.CreateConfigurationRequest{
+		Parent:             c.inv,
+		ConfigId:           id,
+		AuthorizationToken: c.token,
+		// Configuration is useless
+	})
+	if err != nil {
+		return "", err
+	}
+	return config.Name, nil
+}
+
+// ConfiguredTarget methods
+
+// Create a new configured target, returning the fully qualified path.
+func (ct ConfiguredTargets) Create() (string, error) {
+	resp, err := ct.up.CreateConfiguredTarget(ct.ctx, &resultstore.CreateConfiguredTargetRequest{
+		Parent:             ct.target,
+		ConfigId:           ct.config,
+		AuthorizationToken: ct.token,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// Action methods
+
+// Create a test action under the specified ID, returning the fully-qualified path.
+//
+// Technically there are also build actions, but these do not show up in the ResultStore UI.
+func (a Actions) Create(id string, test Test) (string, error) {
+	resp, err := a.up.CreateAction(a.ctx, &resultstore.CreateActionRequest{
+		Parent:             a.configuredTarget,
+		ActionId:           id,
+		AuthorizationToken: a.token,
+		Action:             test.To(),
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// TestFields represent all fields this client cares about.
+var TestFields = [...]string{
+	"actions.name",
+	"actions.test_action",
+	"actions.description",
+	"actions.timing",
+}
+
+// List tests in this configured target.
+func (a Actions) List(fields ...string) ([]Test, error) {
+	if len(fields) == 0 {
+		fields = TestFields[:]
+	}
+	resp, err := a.down.ListActions(listMask(a.ctx, fields...), &resultstore.ListActionsRequest{
+		Parent: a.configuredTarget,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var ret []Test
+	for _, r := range resp.Actions {
+		ret = append(ret, fromTest(r))
+	}
+	return ret, nil
+}
+
+// Invocation methods
+
+// Create a new invocation (project must be specified).
+func (i Invocations) Create(inv Invocation) (string, error) {
+	resp, err := i.up.CreateInvocation(i.ctx, &resultstore.CreateInvocationRequest{
+		Invocation:         inv.To(),
+		AuthorizationToken: i.token,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// Update a pre-existing invocation at name.
+func (i Invocations) Update(inv Invocation, fields ...string) error {
+	_, err := i.up.UpdateInvocation(i.ctx, &resultstore.UpdateInvocationRequest{
+		Invocation: inv.To(),
+		UpdateMask: &field_mask.FieldMask{
+			Paths: fields,
+		},
+		AuthorizationToken: i.token,
+	})
+	return err
+}
+
+// Finish an invocation, preventing further updates.
+func (i Invocations) Finish(name string) error {
+	_, err := i.up.FinishInvocation(i.ctx, &resultstore.FinishInvocationRequest{
+		Name:               name,
+		AuthorizationToken: i.token,
+	})
+	return err
+}
+
+// Get an existing invocation at name.
+func (i Invocations) Get(name string, fields ...string) (*Invocation, error) {
+	inv, err := i.down.GetInvocation(fieldMask(i.ctx, fields...), &resultstore.GetInvocationRequest{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	resp := fromInvocation(inv)
+	return &resp, nil
+}

--- a/testgrid/resultstore/resultstore.go
+++ b/testgrid/resultstore/resultstore.go
@@ -1,0 +1,690 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resultstore
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	resultstore "google.golang.org/genproto/googleapis/devtools/resultstore/v2"
+)
+
+// Invocation represents a flatted ResultStore invocation
+type Invocation struct {
+	// Name of the invocation, immutable after creation.
+	Name string
+	// Project in GCP that owns this invocation.
+	Project string
+
+	// Details describing the invocation.
+	Details string
+	// Duration of the invocation
+	Duration time.Duration
+	// Start time of the invocation
+	Start time.Time
+
+	// Files for this invocation (InvocationLog in particular)
+	Files []File
+	// Properties of the invocation, currently appears to be useless.
+	Properties []Property
+
+	// Status indicating whether the invocation completed successfully.
+	Status Status
+	// Description of the status.
+	Description string
+}
+
+func URL(resourceName string) string {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "source.cloud.google.com",
+		Path:   "results/" + resourceName,
+	}
+	return u.String()
+}
+
+func fromInvocation(rsi *resultstore.Invocation) Invocation {
+	i := Invocation{
+		Name:       rsi.Name,
+		Files:      fromFiles(rsi.Files),
+		Properties: fromProperties(rsi.Properties),
+	}
+	if ia := rsi.InvocationAttributes; ia != nil {
+		i.Project = ia.ProjectId
+		i.Description = ia.Description
+	}
+	if rsi.Timing != nil {
+		i.Start, i.Duration = fromTiming(rsi.Timing)
+	}
+	i.Status, i.Description = fromStatus(rsi.StatusAttributes)
+	return i
+}
+
+// To converts the invocation into a ResultStore Invoation proto.
+func (i Invocation) To() *resultstore.Invocation {
+	inv := resultstore.Invocation{
+		Name:             i.Name,
+		Timing:           timing(i.Start, i.Duration),
+		StatusAttributes: status(i.Status, i.Description),
+		Files:            Files(i.Files),
+		Properties:       properties(i.Properties),
+	}
+	if i.Project != "" || i.Details != "" {
+		inv.InvocationAttributes = &resultstore.InvocationAttributes{
+			ProjectId:   i.Project,
+			Description: i.Details,
+		}
+	}
+	return &inv
+}
+
+// Timing
+
+func dur(d time.Duration) *duration.Duration {
+	return &duration.Duration{
+		Seconds: int64(d / time.Second),
+		Nanos:   int32(d % time.Second),
+	}
+}
+
+func stamp(when time.Time) *timestamp.Timestamp {
+	return &timestamp.Timestamp{
+		Seconds: when.Unix(),
+		Nanos:   int32(when.UnixNano() % int64(time.Second)),
+	}
+}
+
+func fromTiming(t *resultstore.Timing) (time.Time, time.Duration) {
+	var when time.Time
+	var dur time.Duration
+	if t == nil {
+		return when, dur
+	}
+	if s := t.StartTime; s != nil {
+		when = time.Unix(s.Seconds, int64(s.Nanos))
+	}
+	if d := t.Duration; d != nil {
+		dur = time.Duration(d.Seconds)*time.Second + time.Duration(d.Nanos)*time.Nanosecond
+	}
+	return when, dur
+}
+
+func timing(when time.Time, d time.Duration) *resultstore.Timing {
+	never := when.IsZero()
+	if never && d == 0 {
+		return nil
+	}
+	rst := resultstore.Timing{}
+	if !never {
+		rst.StartTime = stamp(when)
+	}
+	if d > 0 {
+		rst.Duration = dur(d)
+	}
+	return &rst
+}
+
+// TestFailure == Failure
+
+// Failure describes the encountered problem.
+type Failure struct {
+	// Message is the failure message.
+	Message string
+	// Type is the type/type/class of error, currently appears useless.
+	Type string
+	// Stack represents the call stack, separated by new lines.
+	Stack string
+	// Expected represents what we expected, often just one value.
+	Expected []string
+	// Actual represents what we actually got.
+	Actual []string
+}
+
+func fromFailures(tfs []*resultstore.TestFailure) []Failure {
+	var ret []Failure
+	for _, tf := range tfs {
+		ret = append(ret, Failure{
+			Message:  tf.FailureMessage,
+			Type:     tf.ExceptionType,
+			Stack:    tf.StackTrace,
+			Expected: tf.Expected,
+			Actual:   tf.Actual,
+		})
+	}
+	return ret
+}
+
+// To converts the failure into a ResultStore TestFailure proto
+func (f Failure) To() *resultstore.TestFailure {
+	return &resultstore.TestFailure{
+		FailureMessage: f.Message,
+		ExceptionType:  f.Type,
+		StackTrace:     f.Stack,
+		Expected:       f.Expected,
+		Actual:         f.Actual,
+	}
+}
+
+func failures(fs []Failure) []*resultstore.TestFailure {
+	var rstfs []*resultstore.TestFailure
+	for _, f := range fs {
+		rstfs = append(rstfs, f.To())
+	}
+	return rstfs
+}
+
+// TestError == Error
+
+// Error describes what prevented completion.
+type Error struct {
+	// Message of the error
+	Message string
+	// Type of error, currently useless.
+	Type string
+	// Stack trace, separated by new lines.
+	Stack string
+}
+
+// Error returns the corresponding ResultStore TestError message
+func (e Error) To() *resultstore.TestError {
+	return &resultstore.TestError{
+		ErrorMessage:  e.Message,
+		ExceptionType: e.Type,
+		StackTrace:    e.Stack,
+	}
+}
+
+func fromErrors(tes []*resultstore.TestError) []Error {
+	var ret []Error
+	for _, te := range tes {
+		ret = append(ret, Error{
+			Message: te.ErrorMessage,
+			Type:    te.ExceptionType,
+			Stack:   te.StackTrace,
+		})
+	}
+	return ret
+}
+
+func errors(es []Error) []*resultstore.TestError {
+	var rstes []*resultstore.TestError
+	for _, e := range es {
+		rstes = append(rstes, e.To())
+	}
+	return rstes
+}
+
+// Property
+
+// Properties converts key, value pairs into a property list.
+func Properties(pairs ...string) []Property {
+	if len(pairs)%2 == 1 {
+		panic(fmt.Sprintf("unbalanced properties: %v", pairs))
+	}
+	var out []Property
+	for i := 0; i < len(pairs); i += 2 {
+		out = append(out, Property{Key: pairs[i], Value: pairs[i+1]})
+	}
+	return out
+}
+
+// Property represents a key-value pairing.
+type Property = resultstore.Property
+
+func properties(ps []Property) []*Property {
+	var out []*Property
+	for _, p := range ps {
+		p2 := p
+		out = append(out, &p2)
+	}
+	return out
+}
+
+func fromProperties(ps []*Property) []Property {
+	var out []Property
+	for _, p := range ps {
+		out = append(out, *p)
+	}
+	return out
+}
+
+// File
+
+// The following logs cause ResultStore to do additional processing
+const (
+	// BuildLog appears in the invocation log
+	BuildLog = "build.log"
+
+	// Stdout of a build action, which isn't useful right now.
+	Stdout = "stdout"
+	// Stderr of a build action, which also isn't useful.
+	Stderr = "stderr"
+
+	// TestLog appears in the Target Log tab.
+	TestLog = "test.log"
+	// TestXml causes ResultStore to process this junit.xml to add cases automatically (we aren't using).
+	TestXml = "test.xml"
+
+	// TestCov provides line coverage, currently we're not using this.
+	TestCov = "test.lcov"
+	// BaselineCov provides original line coverage, currently we're not using this.
+	BaselineCov = "baseline.lcov"
+)
+
+// ResultStore will display the following logs inline.
+const (
+	// InvocationLog is a more obvious name for the invocation log
+	InvocationLog = BuildLog
+	// TargetLog is a more obvious name for the target log.
+	TargetLog = TestLog
+)
+
+// File represents a file stored in GCS
+type File struct {
+	// Unique name within the set
+	ID string
+
+	// ContentType tells the browser how to render
+	ContentType string
+	// Length if complete and known
+	Length int64
+	// URL to file in Google Cloud Storage, such as gs://bucket/path/foo
+	URL string
+}
+
+func wrap64(v int64) *wrappers.Int64Value {
+	if v == 0 {
+		return nil
+	}
+	return &wrappers.Int64Value{Value: v}
+}
+
+func unwrap64(w *wrappers.Int64Value) int64 {
+	if w == nil {
+		return 0
+	}
+	return w.Value
+}
+
+// To converts the file to the corresponding ResultStore File proto.
+func (f File) To() *resultstore.File {
+	return &resultstore.File{
+		Uid:         f.ID,
+		Uri:         f.URL,
+		Length:      wrap64(f.Length),
+		ContentType: f.ContentType,
+	}
+}
+
+// Files converts a list of files.
+func Files(fs []File) []*resultstore.File {
+	var rsfs []*resultstore.File
+	for _, f := range fs {
+		rsfs = append(rsfs, f.To())
+	}
+	return rsfs
+}
+
+func fromFiles(fs []*resultstore.File) []File {
+	var out []File
+	for _, f := range fs {
+		out = append(out, File{
+			ID:          f.Uid,
+			URL:         f.Uri,
+			Length:      unwrap64(f.Length),
+			ContentType: f.ContentType,
+		})
+	}
+	return out
+}
+
+// Case == TestCase
+
+// Result specifies whether the test passed.
+type Result = resultstore.TestCase_Result
+
+// Common constants.
+const (
+	// Completed cases finished, producing failures if it failed.
+	Completed = resultstore.TestCase_COMPLETED
+	// Cancelled cases did not complete (should have an error).
+	Cancelled = resultstore.TestCase_CANCELLED
+	// Skipped cases did not run.
+	Skipped = resultstore.TestCase_SKIPPED
+)
+
+// Case represents the completion of a test case/method.
+type Case struct {
+	// Name identifies the test within its class.
+	Name string
+
+	// Class is the container holding one or more names.
+	Class string
+	// Result indicates whether it ran and to completion.
+	Result Result
+
+	// Duration of the case.
+	Duration time.Duration
+	// Errors preventing the case from completing.
+	Errors []Error
+	// Failures encountered upon completion.
+	Failures []Failure
+	// Files specific to this case
+	Files []File
+	// Properties of the case
+	Properties []Property
+	// Start time of the case.
+	Start time.Time
+}
+
+func fromCase(tc *resultstore.TestCase) Case {
+	c := Case{
+		Name:       tc.CaseName,
+		Class:      tc.ClassName,
+		Result:     tc.Result,
+		Properties: fromProperties(tc.Properties),
+		Errors:     fromErrors(tc.Errors),
+		Failures:   fromFailures(tc.Failures),
+	}
+	c.Start, c.Duration = fromTiming(tc.Timing)
+	return c
+}
+
+// To converts the case to the corresponding ResultStore TestCase proto.
+func (c Case) To() *resultstore.TestCase {
+	return &resultstore.TestCase{
+		CaseName:   c.Name,
+		ClassName:  c.Class,
+		Errors:     errors(c.Errors),
+		Failures:   failures(c.Failures),
+		Result:     c.Result,
+		Timing:     timing(c.Start, c.Duration),
+		Properties: properties(c.Properties),
+	}
+}
+
+// TestAction == Test
+
+// Status represents the status of the action/target/invocation.
+type Status = resultstore.Status
+
+// Common statuses
+const (
+	// Running means incomplete.
+	Running = resultstore.Status_TESTING
+	// Passed means successful.
+	Passed = resultstore.Status_PASSED
+	// Failed means unsuccessful.
+	Failed = resultstore.Status_FAILED
+)
+
+// Test represents a test action, containing action, suite and warnings.
+type Test struct {
+	// Action holds generic metadata about the test
+	Action
+	// Suite holds a variety of case and sub-suite data.
+	Suite
+	// Warnings, appear to be useless.
+	Warnings []string
+}
+
+// To converts the test into the corresponding ResultStore Action proto
+func (t Test) To() *resultstore.Action {
+	a := t.Action.to()
+	a.ActionType = &resultstore.Action_TestAction{
+		TestAction: &resultstore.TestAction{
+			Warnings:  warnings(t.Warnings),
+			TestSuite: t.Suite.To(),
+		},
+	}
+	a.Files = Files(t.Files)
+	a.Properties = properties(t.Properties)
+	return a
+}
+
+func fromTestAction(ta *resultstore.TestAction) (Suite, []string) {
+	if ta == nil {
+		return Suite{}, nil
+	}
+	return fromSuite(ta.TestSuite), fromWarnings(ta.Warnings)
+}
+
+func fromTest(a *resultstore.Action) Test {
+	t := Test{
+		Action: fromAction(a),
+	}
+	t.Suite, t.Warnings = fromTestAction(a.GetTestAction())
+	return t
+}
+
+// Action rerepresents a step in the target, such as a container or command.
+type Action struct {
+	// StatusAttributes
+	// Description of the status.
+	Description string
+	// Status indicates whether the action completed successfully.
+	Status Status
+
+	// Timing
+	// Start of the action.
+	Start time.Time
+	// Duration of the action.
+	Duration time.Duration
+
+	// Node or machine on which the test ran.
+	Node string
+	// ExitCode of the command
+	ExitCode int
+
+	// TODO(fejta): deps, coverage
+}
+
+func (act Action) to() *resultstore.Action {
+	return &resultstore.Action{
+		StatusAttributes: status(act.Status, act.Description),
+		Timing:           timing(act.Start, act.Duration),
+		ActionAttributes: actionAttributes(act.Node, act.ExitCode),
+	}
+}
+
+func actionAttributes(node string, exit int) *resultstore.ActionAttributes {
+	if node == "" && exit == 0 {
+		return nil
+	}
+	return &resultstore.ActionAttributes{
+		Hostname: node,
+		ExitCode: int32(exit),
+	}
+}
+
+func fromActionAttributes(aa *resultstore.ActionAttributes) (string, int) {
+	if aa == nil {
+		return "", 0
+	}
+	return aa.Hostname, int(aa.ExitCode)
+}
+
+func fromAction(a *resultstore.Action) Action {
+	var ret Action
+	ret.Status, ret.Description = fromStatus(a.StatusAttributes)
+	ret.Start, ret.Duration = fromTiming(a.Timing)
+	ret.Node, ret.ExitCode = fromActionAttributes(a.ActionAttributes)
+	return ret
+}
+
+func status(s Status, d string) *resultstore.StatusAttributes {
+	return &resultstore.StatusAttributes{
+		Status:      s,
+		Description: d,
+	}
+}
+
+func fromStatus(sa *resultstore.StatusAttributes) (Status, string) {
+	if sa == nil {
+		return 0, ""
+	}
+	return sa.Status, sa.Description
+}
+
+func warnings(ws []string) []*resultstore.TestWarning {
+	var rstws []*resultstore.TestWarning
+	for _, w := range ws {
+		rstws = append(rstws, &resultstore.TestWarning{WarningMessage: w})
+	}
+	return rstws
+}
+
+func fromWarnings(ws []*resultstore.TestWarning) []string {
+	var ret []string
+	for _, w := range ws {
+		ret = append(ret, w.WarningMessage)
+	}
+	return ret
+}
+
+// TestSuite == Suite
+
+// Suite represents testing details.
+type Suite struct {
+	// Name of the suite, such as the tested class.
+	Name string
+
+	// Cases holds details about each case in the suite.
+	Cases []Case
+	// Duration of the entire suite.
+	Duration time.Duration
+	// Errors that prevented the suite from completing.
+	Errors []Error
+	// Failures detected during the suite.
+	Failures []Failure
+	// Files outputted by the suite.
+	Files []File
+	// Properties of the suite.
+	Properties []Property
+	// Result determines whether the suite ran and finished.
+	Result Result
+	// Time the suite started
+	Start time.Time
+	// Suites hold details about child suites.
+	Suites []Suite
+}
+
+func (s Suite) tests() []*resultstore.Test {
+	var ts []*resultstore.Test
+	for _, suite := range s.Suites {
+		ts = append(ts, &resultstore.Test{
+			TestType: &resultstore.Test_TestSuite{
+				TestSuite: suite.To(),
+			},
+		})
+	}
+	for _, c := range s.Cases {
+		ts = append(ts, &resultstore.Test{
+			TestType: &resultstore.Test_TestCase{
+				TestCase: c.To(),
+			},
+		})
+	}
+	return ts
+}
+
+func (s *Suite) fromTests(tests []*resultstore.Test) {
+	for _, t := range tests {
+		if tc := t.GetTestCase(); tc != nil {
+			s.Cases = append(s.Cases, fromCase(tc))
+		}
+		if ts := t.GetTestSuite(); ts != nil {
+			s.Suites = append(s.Suites, fromSuite(ts))
+		}
+	}
+}
+
+// To converts a suite into the corresponding ResultStore TestSuite proto.
+func (s Suite) To() *resultstore.TestSuite {
+	return &resultstore.TestSuite{
+		Errors:     errors(s.Errors),
+		Failures:   failures(s.Failures),
+		Properties: properties(s.Properties),
+		SuiteName:  s.Name,
+		Tests:      s.tests(),
+		Timing:     timing(s.Start, s.Duration),
+		Files:      Files(s.Files),
+	}
+}
+
+func fromSuite(ts *resultstore.TestSuite) Suite {
+	s := Suite{
+		Errors:     fromErrors(ts.Errors),
+		Failures:   fromFailures(ts.Failures),
+		Properties: fromProperties(ts.Properties),
+		Name:       ts.SuiteName,
+		Files:      fromFiles(ts.Files),
+	}
+	s.fromTests(ts.Tests)
+	s.Start, s.Duration = fromTiming(ts.Timing)
+	return s
+}
+
+// Target represents a set of commands run inside the same pod.
+type Target struct {
+	// Name of the target, immutable.
+	Name string
+
+	// Start time of the target.
+	Start time.Time
+	// Duration the target ran.
+	Duration time.Duration
+
+	// Status specifying whether the target completed successfully.
+	Status Status
+	// Description of the status
+	Description string
+
+	// Tags are metadata for the target (like github labels).
+	Tags []string
+}
+
+func fromTarget(t *resultstore.Target) Target {
+	tgt := Target{
+		Name: t.Name,
+	}
+	if t.TargetAttributes != nil {
+		copy(tgt.Tags, t.TargetAttributes.Tags)
+	}
+	tgt.Start, tgt.Duration = fromTiming(t.Timing)
+	tgt.Status, tgt.Description = fromStatus(t.StatusAttributes)
+	return tgt
+}
+
+// To converts a target into the corresponding ResultStore Target proto.
+func (t Target) To() *resultstore.Target {
+	tgt := resultstore.Target{
+		Timing:           timing(t.Start, t.Duration),
+		StatusAttributes: status(t.Status, t.Description),
+		Visible:          true,
+	}
+	if t.Tags != nil {
+		tgt.TargetAttributes = &resultstore.TargetAttributes{
+			Tags: t.Tags,
+		}
+	}
+	return &tgt
+}

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/testgrid/util/gcs",
     visibility = [
+        "//experiment/resultstore:__subpackages__",
         "//prow/gcsupload:__subpackages__",
         "//prow/spyglass:__subpackages__",
         "//testgrid:__subpackages__",


### PR DESCRIPTION
* Flatten the raw proto structures into the `testgrid/resultstore` package:
  - Excessive use of pointers and nested methods
  - A bunch of seemingly/currently irrelevant fields
  - [oneof fields](https://github.com/googleapis/googleapis/blob/master/google/devtools/resultstore/v2/action.proto#L75-L81) are [ugly and a pain](https://github.com/google/go-genproto/blob/master/googleapis/devtools/resultstore/v2/action.pb.go#L173-L176) to work with, resulting in [nonsense](https://github.com/google/go-genproto/blob/master/googleapis/devtools/resultstore/v2/action.pb.go#L277-L291).
* Wrap the gRPC client with a cleaner interface
* Migrate testgrid updater's `message(junit.Result)` to `junit.Result.Message()` so it can be reused
* Update experiment/resultstore to:
  - Read a build the same way as the testgrid updater
  - Convert it into a ResultStore Invocation, Target, Test
  - Optionally upload this into ResultStore

/assign @krzyzacy