### PR TITLE
Flip Report to Skip_Report for postsubmit jobs

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -2,7 +2,7 @@
 
 New features added to each component:
  - *February 6, 2019* prow (both plank and crier) will set status on the commit
-   for postsubmit jobs on github. You can add `Skip_Report: true` to opt-out of
+   for postsubmit jobs on github. You can add `skip_report: true` to opt-out of
    reporting.
  - *January 15, 2019* `approve` now considers self-approval and github review
    state by default. Configure with `require_self_approval` and

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,7 +1,9 @@
 # Announcements
 
 New features added to each component:
-
+ - *February 6, 2019* prow (both plank and crier) will set status on the commit
+   for postsubmit jobs on github. You can add `Skip_Report: true` to opt-out of
+   reporting.
  - *January 15, 2019* `approve` now considers self-approval and github review
    state by default. Configure with `require_self_approval` and
    `ignore_review_state`. Temporarily revert to old defaults with `use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019` and `use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019`.

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,9 +1,19 @@
 # Announcements
 
 New features added to each component:
- - *February 6, 2019* prow (both plank and crier) will set status on the commit
-   for postsubmit jobs on github. You can add `skip_report: true` to opt-out of
-   reporting.
+ - *February 13, 2019* prow (both plank and crier) can set status on the commit
+   for postsubmit jobs on github now! 
+   Type of jobs can be reported to github is gated by a config field like
+   ```yaml
+   github_reporter: 
+     job_types_to_report:
+     - presubmit
+     - postsubmit
+   ```
+   now and default to report for presubmit only.
+   *** The default will change in April to include postsubmit jobs as well ***
+   You can also add `skip_report: true` to your post-submit jobs to skip reporting
+    if you enable postsubmit reporting on.
  - *January 15, 2019* `approve` now considers self-approval and github review
    state by default. Configure with `require_self_approval` and
    `ignore_review_state`. Temporarily revert to old defaults with `use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019` and `use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019`.

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -303,36 +303,46 @@ func TestBranchRequirements(t *testing.T) {
 			name: "basic",
 			config: []Presubmit{
 				{
-					Context:    "always-run",
-					AlwaysRun:  true,
-					SkipReport: false,
+					AlwaysRun: true,
+					Reporter: Reporter{
+						Context:    "always-run",
+						SkipReport: false,
+					},
 				},
 				{
-					Context: "run-if-changed",
 					RegexpChangeMatcher: RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
-					AlwaysRun:  false,
-					SkipReport: false,
+					AlwaysRun: false,
+					Reporter: Reporter{
+						Context:    "run-if-changed",
+						SkipReport: false,
+					},
 				},
 				{
-					Context:    "not-always",
-					AlwaysRun:  false,
-					SkipReport: false,
+					AlwaysRun: false,
+					Reporter: Reporter{
+						Context:    "not-always",
+						SkipReport: false,
+					},
 				},
 				{
-					Context:    "skip-report",
-					AlwaysRun:  true,
-					SkipReport: true,
+					AlwaysRun: true,
+					Reporter: Reporter{
+						Context:    "skip-report",
+						SkipReport: true,
+					},
 					Brancher: Brancher{
 						SkipBranches: []string{"master"},
 					},
 				},
 				{
-					Context:    "optional",
-					AlwaysRun:  true,
-					SkipReport: false,
-					Optional:   true,
+					AlwaysRun: true,
+					Reporter: Reporter{
+						Context:    "optional",
+						SkipReport: false,
+					},
+					Optional: true,
 				},
 			},
 			masterExpected:  []string{"always-run"},
@@ -606,7 +616,9 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 								JobBase: JobBase{
 									Name: "required presubmit",
 								},
-								Context:   "required presubmit",
+								Reporter: Reporter{
+									Context: "required presubmit",
+								},
 								AlwaysRun: true,
 							},
 						},
@@ -638,7 +650,9 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 								JobBase: JobBase{
 									Name: "required presubmit",
 								},
-								Context:   "required presubmit",
+								Reporter: Reporter{
+									Context: "required presubmit",
+								},
 								AlwaysRun: true,
 							},
 						},
@@ -672,7 +686,9 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 								JobBase: JobBase{
 									Name: "required presubmit",
 								},
-								Context:   "required presubmit",
+								Reporter: Reporter{
+									Context: "required presubmit",
+								},
 								AlwaysRun: true,
 							},
 						},
@@ -699,7 +715,9 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 								JobBase: JobBase{
 									Name: "optional presubmit",
 								},
-								Context:   "optional presubmit",
+								Reporter: Reporter{
+									Context: "optional presubmit",
+								},
 								AlwaysRun: true,
 								Optional:  true,
 							},
@@ -730,7 +748,9 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 								JobBase: JobBase{
 									Name: "optional presubmit",
 								},
-								Context:   "optional presubmit",
+								Reporter: Reporter{
+									Context: "optional presubmit",
+								},
 								AlwaysRun: true,
 								Optional:  true,
 							},

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -115,18 +115,15 @@ type Presubmit struct {
 	// AlwaysRun automatically for every PR, or only when a comment triggers it.
 	AlwaysRun bool `json:"always_run"`
 
-	// Context is the name of the GitHub status context for the job.
-	Context string `json:"context"`
 	// Optional indicates that the job's status context should not be required for merge.
 	Optional bool `json:"optional,omitempty"`
-	// SkipReport skips commenting and setting status on GitHub.
-	SkipReport bool `json:"skip_report,omitempty"`
 
 	// Trigger is the regular expression to trigger the job.
 	// e.g. `@k8s-bot e2e test this`
 	// RerunCommand must also be specified if this field is specified.
 	// (Default: `(?m)^/test (?:.*? )?<job name>(?: .*?)?$`)
 	Trigger string `json:"trigger"`
+
 	// The RerunCommand to give users. Must match Trigger.
 	// Trigger must also be specified if this field is specified.
 	// (Default: `/test <job name>`)
@@ -135,6 +132,8 @@ type Presubmit struct {
 	Brancher
 
 	RegexpChangeMatcher
+
+	Reporter
 
 	// We'll set these when we load it.
 	re *regexp.Regexp // from Trigger.
@@ -148,12 +147,8 @@ type Postsubmit struct {
 
 	Brancher
 
-	// Context is the name of the GitHub status context for the job.
-	Context string `json:"context"`
-
-	// TODO(krzyzacy): opt-in for now - Consider make it default true like presubmits
-	// Report will comment and set status on GitHub.
-	Report bool `json:"report,omitempty"`
+	// TODO(krzyzacy): Move existing `Report` into `Skip_Report` once this is deployed
+	Reporter
 }
 
 // Periodic runs on a timer.
@@ -199,6 +194,13 @@ type RegexpChangeMatcher struct {
 	// If any file in the changeset matches this regex, the job will be triggered
 	RunIfChanged string         `json:"run_if_changed,omitempty"`
 	reChanges    *regexp.Regexp // from RunIfChanged
+}
+
+type Reporter struct {
+	// Context is the name of the GitHub status context for the job.
+	Context string `json:"context"`
+	// SkipReport skips commenting and setting status on GitHub.
+	SkipReport bool `json:"skip_report,omitempty"`
 }
 
 // RunsAgainstAllBranch returns true if there are both branches and skip_branches are unset

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -131,7 +131,7 @@ func TestPostsubmits(t *testing.T) {
 				t.Errorf("Job %v needs a name.", job)
 				continue
 			}
-			if job.Report && job.Context == "" {
+			if !job.SkipReport && job.Context == "" {
 				t.Errorf("Job %s needs a context.", job.Name)
 			}
 
@@ -196,25 +196,35 @@ func TestRetestPresubmits(t *testing.T) {
 			Presubmits: map[string][]Presubmit{
 				"org/repo": {
 					{
-						Context:   "gce",
+						Reporter: Reporter{
+							Context: "gce",
+						},
 						AlwaysRun: true,
 					},
 					{
-						Context:   "unit",
+						Reporter: Reporter{
+							Context: "unit",
+						},
 						AlwaysRun: true,
 					},
 					{
-						Context:   "gke",
+						Reporter: Reporter{
+							Context: "gke",
+						},
 						AlwaysRun: false,
 					},
 					{
-						Context:   "federation",
+						Reporter: Reporter{
+							Context: "federation",
+						},
 						AlwaysRun: false,
 					},
 				},
 				"org/repo2": {
 					{
-						Context:   "shouldneverrun",
+						Reporter: Reporter{
+							Context: "shouldneverrun",
+						},
 						AlwaysRun: true,
 					},
 				},

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -311,11 +311,15 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 					Presubmits: map[string][]Presubmit{
 						"org/repo": {
 							Presubmit{
-								Context:   "pr1",
+								Reporter: Reporter{
+									Context: "pr1",
+								},
 								AlwaysRun: true,
 							},
 							Presubmit{
-								Context:   "po1",
+								Reporter: Reporter{
+									Context: "po1",
+								},
 								AlwaysRun: true,
 								Optional:  true,
 							},

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -168,6 +168,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 	jenkinsConfig := s.configAgent.Config().JenkinsOperators
 	kubeReport := s.configAgent.Config().Plank.ReportTemplate
+	reportTypes := s.configAgent.Config().GithubReporter.JobTypesToReport
 	for _, pj := range pjutil.GetLatestProwJobs(presubmits, prowapi.PresubmitJob) {
 		var reportTemplate *template.Template
 		switch pj.Spec.Agent {
@@ -181,7 +182,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 
 		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		if err := report.Report(s.ghc, reportTemplate, pj); err != nil {
+		if err := report.Report(s.ghc, reportTemplate, pj, reportTypes); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
 		}
 	}

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -74,5 +74,5 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 // Report will report via reportlib
 func (c *Client) Report(pj *v1.ProwJob) error {
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	return report.Report(c.gc, c.config().Plank.ReportTemplate, *pj)
+	return report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GithubReporter.JobTypesToReport)
 }

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -219,8 +219,9 @@ func (c *Controller) Sync() error {
 
 	var reportErrs []error
 	reportTemplate := c.config().ReportTemplate
+	reportTypes := c.cfg().GithubReporter.JobTypesToReport
 	for report := range reportCh {
-		if err := reportlib.Report(c.ghc, reportTemplate, report); err != nil {
+		if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 			reportErrs = append(reportErrs, err)
 			c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 		}

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -588,7 +588,9 @@ func TestBatch(t *testing.T) {
 			Name:  "pr-some-job",
 			Agent: "jenkins",
 		},
-		Context: "Some Job Context",
+		Reporter: config.Reporter{
+			Context: "Some Job Context",
+		},
 	}
 	pj := pjutil.NewProwJob(pjutil.BatchSpec(pre, prowapi.Refs{
 		Org:     "o",

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -121,7 +121,7 @@ func PostsubmitSpec(p config.Postsubmit, refs prowapi.Refs) prowapi.ProwJobSpec 
 	pjs := specFromJobBase(p.JobBase)
 	pjs.Type = prowapi.PostsubmitJob
 	pjs.Context = p.Context
-	pjs.Report = p.Report
+	pjs.Report = !p.SkipReport
 	pjs.Refs = completePrimaryRefs(refs, p.JobBase)
 
 	return pjs

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -56,6 +56,7 @@ func TestPostsubmitSpec(t *testing.T) {
 					PathAlias: "foo",
 					CloneURI:  "bar",
 				},
+				Report: true,
 			},
 		},
 		{
@@ -70,6 +71,7 @@ func TestPostsubmitSpec(t *testing.T) {
 					PathAlias: "fancy",
 					CloneURI:  "cats",
 				},
+				Report: true,
 			},
 		},
 		{
@@ -92,6 +94,7 @@ func TestPostsubmitSpec(t *testing.T) {
 					PathAlias: "foo",
 					CloneURI:  "bar",
 				},
+				Report: true,
 			},
 		},
 	}

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -229,8 +229,9 @@ func (c *Controller) Sync() error {
 	var reportErrs []error
 	if !c.skipReport {
 		reportTemplate := c.config().Plank.ReportTemplate
+		reportTypes := c.config().GithubReporter.JobTypesToReport
 		for report := range reportCh {
-			if err := reportlib.Report(c.ghc, reportTemplate, report); err != nil {
+			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 			}

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -412,7 +412,9 @@ func TestHandle(t *testing.T) {
 			},
 			presubmits: map[string]config.Presubmit{
 				"prow-job": {
-					Context: "prow-job",
+					Reporter: config.Reporter{
+						Context: "prow-job",
+					},
 				},
 			},
 			jobs: sets.NewString("prow-job"),

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -44,13 +44,19 @@ func TestSkipStatus(t *testing.T) {
 
 			presubmits: []config.Presubmit{
 				{
-					Context: "passing-tests",
+					Reporter: config.Reporter{
+						Context: "passing-tests",
+					},
 				},
 				{
-					Context: "failed-tests",
+					Reporter: config.Reporter{
+						Context: "failed-tests",
+					},
 				},
 				{
-					Context: "pending-tests",
+					Reporter: config.Reporter{
+						Context: "pending-tests",
+					},
 				},
 			},
 			sha: "shalala",
@@ -98,11 +104,15 @@ func TestSkipStatus(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Optional: true,
-					Context:  "failed-tests",
+					Reporter: config.Reporter{
+						Context: "failed-tests",
+					},
 				},
 				{
 					Optional: true,
-					Context:  "pending-tests",
+					Reporter: config.Reporter{
+						Context: "pending-tests",
+					},
 				},
 			},
 			sha: "shalala",
@@ -144,7 +154,9 @@ func TestSkipStatus(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Optional: true,
-					Context:  "untriggered-tests",
+					Reporter: config.Reporter{
+						Context: "untriggered-tests",
+					},
 				},
 			},
 			sha: "shalala",
@@ -166,7 +178,9 @@ func TestSkipStatus(t *testing.T) {
 			presubmits: []config.Presubmit{
 				{
 					Optional: true,
-					Context:  "succeeded-tests",
+					Reporter: config.Reporter{
+						Context: "succeeded-tests",
+					},
 				},
 			},
 			sha: "shalala",
@@ -200,7 +214,9 @@ func TestSkipStatus(t *testing.T) {
 					Optional:     true,
 					Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
 					RerunCommand: "/test job",
-					Context:      "failed-tests",
+					Reporter: config.Reporter{
+						Context: "failed-tests",
+					},
 				},
 			},
 			sha: "shalala",

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -240,8 +240,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						Brancher:     config.Brancher{Branches: []string{"master"}},
-						Context:      "pull-jab",
+						Brancher: config.Brancher{Branches: []string{"master"}},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      "Nice weather outside, right?",
 						RerunCommand: "Nice weather outside, right?",
 					},
@@ -264,8 +266,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "job",
 						},
-						AlwaysRun:    false,
-						Context:      "pull-job",
+						AlwaysRun: false,
+						Reporter: config.Reporter{
+							Context: "pull-job",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
 						RerunCommand: `/test job`,
 					},
@@ -273,8 +277,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						AlwaysRun:    false,
-						Context:      "pull-jib",
+						AlwaysRun: false,
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
 						RerunCommand: `/test jib`,
 					},
@@ -297,9 +303,11 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "job",
 						},
-						AlwaysRun:    true,
-						SkipReport:   true,
-						Context:      "pull-job",
+						AlwaysRun: true,
+						Reporter: config.Reporter{
+							SkipReport: true,
+							Context:    "pull-job",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
 						RerunCommand: `/test job`,
 						Brancher:     config.Brancher{Branches: []string{"master"}},
@@ -322,8 +330,10 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
-						SkipReport:   true,
-						Context:      "pull-jab",
+						Reporter: config.Reporter{
+							SkipReport: true,
+							Context:    "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -347,7 +357,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
-						Context:      "pull-jib",
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
 						RerunCommand: `/test jib`,
 					},
@@ -371,7 +383,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
-						Context:      "pull-jub",
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
 						RerunCommand: `/test jub`,
 					},
@@ -395,7 +409,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
-						Context:      "pull-jib",
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
 						RerunCommand: `/test jib`,
 					},
@@ -418,7 +434,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
-						Context:      "pull-jab",
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -442,8 +460,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						Brancher:     config.Brancher{Branches: []string{"master"}},
-						Context:      "pull-jab",
+						Brancher: config.Brancher{Branches: []string{"master"}},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -451,8 +471,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						Brancher:     config.Brancher{Branches: []string{"release"}},
-						Context:      "pull-jab",
+						Brancher: config.Brancher{Branches: []string{"release"}},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -474,8 +496,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						Brancher:     config.Brancher{Branches: []string{"master"}},
-						Context:      "pull-jab",
+						Brancher: config.Brancher{Branches: []string{"master"}},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -483,8 +507,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jab",
 						},
-						Brancher:     config.Brancher{Branches: []string{"release"}},
-						Context:      "pull-jab",
+						Brancher: config.Brancher{Branches: []string{"release"}},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
 						RerunCommand: `/test jab`,
 					},
@@ -508,7 +534,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
-						Context:      "pull-jeb",
+						Reporter: config.Reporter{
+							Context: "pull-jeb",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jeb(?: .*?)?$`,
 						RerunCommand: `/test jeb`,
 					},
@@ -532,7 +560,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
-						Context:      "pull-jeb",
+						Reporter: config.Reporter{
+							Context: "pull-jeb",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jeb(?: .*?)?$`,
 						RerunCommand: `/test jeb`,
 					},
@@ -555,7 +585,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
 						},
-						Context:      "pull-jub",
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
 						RerunCommand: `/test jub`,
 					},
@@ -579,7 +611,9 @@ func TestHandleGenericComment(t *testing.T) {
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
 						},
-						Context:      "pull-jub",
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
 						RerunCommand: `/test jub`,
 					},
@@ -659,8 +693,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "job",
 						},
-						AlwaysRun:    true,
-						Context:      "pull-job",
+						AlwaysRun: true,
+						Reporter: config.Reporter{
+							Context: "pull-job",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
 						RerunCommand: `/test job`,
 						Brancher:     config.Brancher{Branches: []string{"master"}},
@@ -669,8 +705,10 @@ func TestHandleGenericComment(t *testing.T) {
 						JobBase: config.JobBase{
 							Name: "jib",
 						},
-						AlwaysRun:    false,
-						Context:      "pull-jib",
+						AlwaysRun: false,
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
 						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
 						RerunCommand: `/test jib`,
 					},
@@ -805,13 +843,17 @@ func TestPresubmitFilter(t *testing.T) {
 						Name: "always-runs",
 					},
 					AlwaysRun: true,
-					Context:   "always-runs",
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "runs-if-changed",
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -820,7 +862,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -840,13 +884,17 @@ func TestPresubmitFilter(t *testing.T) {
 						Name: "always-runs",
 					},
 					AlwaysRun: true,
-					Context:   "always-runs",
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "runs-if-changed",
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -855,7 +903,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -875,13 +925,17 @@ func TestPresubmitFilter(t *testing.T) {
 						Name: "always-runs",
 					},
 					AlwaysRun: true,
-					Context:   "always-runs",
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "runs-if-changed",
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -890,7 +944,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -930,32 +986,42 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "successful-job",
 					},
-					Context: "existing-successful",
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "pending-job",
 					},
-					Context: "existing-pending",
+					Reporter: config.Reporter{
+						Context: "existing-pending",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "failure-job",
 					},
-					Context: "existing-failure",
+					Reporter: config.Reporter{
+						Context: "existing-failure",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "error-job",
 					},
-					Context: "existing-error",
+					Reporter: config.Reporter{
+						Context: "existing-error",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "missing-always-runs",
 					},
+					Reporter: config.Reporter{
+						Context: "missing-always-runs",
+					},
 					AlwaysRun: true,
-					Context:   "missing-always-runs",
 				},
 			},
 			expected: [][]bool{{false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, true}},
@@ -971,8 +1037,10 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "always-runs",
 					},
-					AlwaysRun:    true,
-					Context:      "always-runs",
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -980,7 +1048,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "runs-if-changed",
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -991,7 +1061,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -999,8 +1071,10 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "always-runs",
 					},
-					AlwaysRun:    true,
-					Context:      "always-runs",
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "always-runs",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
 					RerunCommand: "/test other-trigger",
 				},
@@ -1008,7 +1082,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "runs-if-changed",
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -1019,7 +1095,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
 					RerunCommand: "/test other-trigger",
 				},
@@ -1039,8 +1117,10 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "always-runs",
 					},
-					AlwaysRun:    true,
-					Context:      "existing-successful",
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
 					RerunCommand: "/test other-trigger",
 				},
@@ -1048,7 +1128,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-changed",
 					},
-					Context: "existing-successful",
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
 					},
@@ -1059,7 +1141,9 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -1067,32 +1151,42 @@ func TestPresubmitFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "successful-job",
 					},
-					Context: "existing-successful",
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "pending-job",
 					},
-					Context: "existing-pending",
+					Reporter: config.Reporter{
+						Context: "existing-pending",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "failure-job",
 					},
-					Context: "existing-failure",
+					Reporter: config.Reporter{
+						Context: "existing-failure",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "error-job",
 					},
-					Context: "existing-error",
+					Reporter: config.Reporter{
+						Context: "existing-error",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "missing-always-runs",
 					},
 					AlwaysRun: true,
-					Context:   "missing-always-runs",
+					Reporter: config.Reporter{
+						Context: "missing-always-runs",
+					},
 				},
 			},
 			expected: [][]bool{{true, false, false}, {true, false, false}, {true, true, true}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, true}},
@@ -1214,13 +1308,17 @@ func TestRetestFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "failed",
 					},
-					Context: "failed",
+					Reporter: config.Reporter{
+						Context: "failed",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "succeeded",
 					},
-					Context: "succeeded",
+					Reporter: config.Reporter{
+						Context: "succeeded",
+					},
 				},
 			},
 			expected: [][]bool{{true, false, true}, {false, false, true}},
@@ -1234,14 +1332,18 @@ func TestRetestFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "finished",
 					},
-					Context: "finished",
+					Reporter: config.Reporter{
+						Context: "finished",
+					},
 				},
 				{
 					JobBase: config.JobBase{
 						Name: "not-yet-run",
 					},
 					AlwaysRun: true,
-					Context:   "not-yet-run",
+					Reporter: config.Reporter{
+						Context: "not-yet-run",
+					},
 				},
 			},
 			expected: [][]bool{{false, false, true}, {true, false, true}},
@@ -1302,7 +1404,9 @@ func TestTestAllFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
 					RerunCommand: "/test trigger",
 				},
@@ -1310,7 +1414,9 @@ func TestTestAllFilter(t *testing.T) {
 					JobBase: config.JobBase{
 						Name: "literal-test-all-trigger",
 					},
-					Context:      "runs-if-triggered",
+					Reporter: config.Reporter{
+						Context: "runs-if-triggered",
+					},
 					Trigger:      `(?m)^/test (?:.*? )?all(?: .*?)?$`,
 					RerunCommand: "/test all",
 				},

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -89,10 +89,12 @@ func TestAddedBlockingPresubmits(t *testing.T) {
   context: new-context`,
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
-					JobBase:    config.JobBase{Name: "new-job"},
-					Context:    "new-context",
-					Optional:   false,
-					SkipReport: false,
+					JobBase: config.JobBase{Name: "new-job"},
+					Reporter: config.Reporter{
+						Context:    "new-context",
+						SkipReport: false,
+					},
+					Optional: false,
 				}},
 			},
 		},
@@ -120,8 +122,8 @@ func TestAddedBlockingPresubmits(t *testing.T) {
   context: old-context`,
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
-					JobBase: config.JobBase{Name: "old-job"},
-					Context: "old-context",
+					JobBase:  config.JobBase{Name: "old-job"},
+					Reporter: config.Reporter{Context: "old-context"},
 				}},
 			},
 		},
@@ -138,7 +140,7 @@ func TestAddedBlockingPresubmits(t *testing.T) {
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
 					JobBase:             config.JobBase{Name: "old-job"},
-					Context:             "old-context",
+					Reporter:            config.Reporter{Context: "old-context"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{RunIfChanged: "new-changes"},
 				}},
 			},
@@ -172,7 +174,7 @@ func TestAddedBlockingPresubmits(t *testing.T) {
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
 					JobBase:             config.JobBase{Name: "old-job"},
-					Context:             "old-context",
+					Reporter:            config.Reporter{Context: "old-context"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{RunIfChanged: "changes"},
 				}},
 			},
@@ -255,8 +257,8 @@ func TestRemovedBlockingPresubmits(t *testing.T) {
 			new: `"org/repo": []`,
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
-					JobBase: config.JobBase{Name: "old-job"},
-					Context: "old-context",
+					JobBase:  config.JobBase{Name: "old-job"},
+					Reporter: config.Reporter{Context: "old-context"},
 				}},
 			},
 		},
@@ -294,8 +296,8 @@ func TestRemovedBlockingPresubmits(t *testing.T) {
 			new: `{}`,
 			expected: map[string][]config.Presubmit{
 				"org/repo": {{
-					JobBase: config.JobBase{Name: "old-job"},
-					Context: "old-context",
+					JobBase:  config.JobBase{Name: "old-job"},
+					Reporter: config.Reporter{Context: "old-context"},
 				}},
 			},
 		},
@@ -454,12 +456,12 @@ func TestMigratedBlockingPresubmits(t *testing.T) {
 			expected: map[string][]presubmitMigration{
 				"org/repo": {{
 					from: config.Presubmit{
-						JobBase: config.JobBase{Name: "old-job"},
-						Context: "old-context",
+						JobBase:  config.JobBase{Name: "old-job"},
+						Reporter: config.Reporter{Context: "old-context"},
 					},
 					to: config.Presubmit{
-						JobBase: config.JobBase{Name: "old-job"},
-						Context: "new-context",
+						JobBase:  config.JobBase{Name: "old-job"},
+						Reporter: config.Reporter{Context: "new-context"},
 					},
 				}},
 			},

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -60,7 +60,17 @@ func testPullsMatchList(t *testing.T, test string, actual []PullRequest, expecte
 }
 
 func TestAccumulateBatch(t *testing.T) {
-	jobSet := []config.Presubmit{{Context: "foo"}, {Context: "bar"}, {Context: "baz"}}
+	jobSet := []config.Presubmit{
+		{
+			Reporter: config.Reporter{Context: "foo"},
+		},
+		{
+			Reporter: config.Reporter{Context: "bar"},
+		},
+		{
+			Reporter: config.Reporter{Context: "baz"},
+		},
+	}
 	type pull struct {
 		number int
 		sha    string
@@ -83,11 +93,14 @@ func TestAccumulateBatch(t *testing.T) {
 			name: "no batches running",
 		},
 		{
-			name:       "batch pending",
-			presubmits: map[int][]config.Presubmit{1: {{Context: "foo"}}, 2: {{Context: "foo"}}},
-			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs:   []prowjob{{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}}},
-			pending:    true,
+			name: "batch pending",
+			presubmits: map[int][]config.Presubmit{
+				1: {{Reporter: config.Reporter{Context: "foo"}}},
+				2: {{Reporter: config.Reporter{Context: "foo"}}},
+			},
+			pulls:    []pull{{1, "a"}, {2, "b"}},
+			prowJobs: []prowjob{{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}}},
+			pending:  true,
 		},
 		{
 			name:       "pending batch missing presubmits is ignored",
@@ -159,7 +172,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "missing job required by one PR",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Context: "boo"})},
+			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -169,7 +182,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "successful run with PR that requires additional job",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Context: "boo"})},
+			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -235,7 +248,18 @@ func TestAccumulateBatch(t *testing.T) {
 }
 
 func TestAccumulate(t *testing.T) {
-	jobSet := []config.Presubmit{{Context: "job1"}, {Context: "job2"}}
+	jobSet := []config.Presubmit{
+		{
+			Reporter: config.Reporter{
+				Context: "job1",
+			},
+		},
+		{
+			Reporter: config.Reporter{
+				Context: "job2",
+			},
+		},
+	}
 	type prowjob struct {
 		prNumber int
 		job      string
@@ -284,7 +308,14 @@ func TestAccumulate(t *testing.T) {
 		},
 		{
 			pullRequests: map[int]string{7: ""},
-			presubmits:   map[int][]config.Presubmit{7: {{Context: "job1"}, {Context: "job2"}, {Context: "job3"}, {Context: "job4"}}},
+			presubmits: map[int][]config.Presubmit{
+				7: {
+					{Reporter: config.Reporter{Context: "job1"}},
+					{Reporter: config.Reporter{Context: "job2"}},
+					{Reporter: config.Reporter{Context: "job3"}},
+					{Reporter: config.Reporter{Context: "job4"}},
+				},
+			},
 			prowJobs: []prowjob{
 				{7, "job1", prowapi.SuccessState, ""},
 				{7, "job2", prowapi.FailureState, ""},
@@ -303,7 +334,14 @@ func TestAccumulate(t *testing.T) {
 		},
 		{
 			pullRequests: map[int]string{7: ""},
-			presubmits:   map[int][]config.Presubmit{7: {{Context: "job1"}, {Context: "job2"}, {Context: "job3"}, {Context: "job4"}}},
+			presubmits: map[int][]config.Presubmit{
+				7: {
+					{Reporter: config.Reporter{Context: "job1"}},
+					{Reporter: config.Reporter{Context: "job2"}},
+					{Reporter: config.Reporter{Context: "job3"}},
+					{Reporter: config.Reporter{Context: "job4"}},
+				},
+			},
 			prowJobs: []prowjob{
 				{7, "job1", prowapi.FailureState, ""},
 				{7, "job2", prowapi.FailureState, ""},
@@ -322,7 +360,14 @@ func TestAccumulate(t *testing.T) {
 		},
 		{
 			pullRequests: map[int]string{7: ""},
-			presubmits:   map[int][]config.Presubmit{7: {{Context: "job1"}, {Context: "job2"}, {Context: "job3"}, {Context: "job4"}}},
+			presubmits: map[int][]config.Presubmit{
+				7: {
+					{Reporter: config.Reporter{Context: "job1"}},
+					{Reporter: config.Reporter{Context: "job2"}},
+					{Reporter: config.Reporter{Context: "job3"}},
+					{Reporter: config.Reporter{Context: "job4"}},
+				},
+			},
 			prowJobs: []prowjob{
 				{7, "job1", prowapi.SuccessState, ""},
 				{7, "job2", prowapi.FailureState, ""},
@@ -342,7 +387,14 @@ func TestAccumulate(t *testing.T) {
 		},
 		{
 			pullRequests: map[int]string{7: ""},
-			presubmits:   map[int][]config.Presubmit{7: {{Context: "job1"}, {Context: "job2"}, {Context: "job3"}, {Context: "job4"}}},
+			presubmits: map[int][]config.Presubmit{
+				7: {
+					{Reporter: config.Reporter{Context: "job1"}},
+					{Reporter: config.Reporter{Context: "job2"}},
+					{Reporter: config.Reporter{Context: "job3"}},
+					{Reporter: config.Reporter{Context: "job4"}},
+				},
+			},
 			prowJobs: []prowjob{
 				{7, "job1", prowapi.SuccessState, ""},
 				{7, "job2", prowapi.FailureState, ""},
@@ -361,7 +413,11 @@ func TestAccumulate(t *testing.T) {
 			none:      []int{},
 		},
 		{
-			presubmits:   map[int][]config.Presubmit{7: {{Context: "job1"}}},
+			presubmits: map[int][]config.Presubmit{
+				7: {
+					{Reporter: config.Reporter{Context: "job1"}},
+				},
+			},
 			pullRequests: map[int]string{7: "new", 8: "new"},
 			prowJobs: []prowjob{
 				{7, "job1", prowapi.SuccessState, "old"},
@@ -787,8 +843,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 0,
 			action:    Wait,
@@ -801,8 +861,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{1},
 			nones:        []int{0, 2},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 0,
 			action:    Wait,
@@ -815,8 +879,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{0, 2},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 0,
 			action:    Wait,
@@ -829,8 +897,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{0, 1, 2},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 1,
 			action:    Trigger,
@@ -843,8 +915,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{0},
 			nones:        []int{1, 2, 3},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:           0,
 			triggered:        1,
 			triggeredBatches: 1,
@@ -858,8 +934,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{0},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 1,
 			action:    Trigger,
@@ -872,8 +952,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{1, 2, 3},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    1,
 			triggered: 0,
 			action:    Merge,
@@ -886,8 +970,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{2, 3},
 			nones:        []int{4, 5},
 			batchMerges:  []int{6, 7, 8},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    3,
 			triggered: 0,
 			action:    MergeBatch,
@@ -900,8 +988,12 @@ func TestTakeAction(t *testing.T) {
 			pendings:     []int{},
 			nones:        []int{100},
 			batchMerges:  []int{},
-			presubmits:   map[int][]config.Presubmit{100: {{Context: "foo"}, {Context: "if-changed"}}},
-
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
 			merged:    0,
 			triggered: 2,
 			action:    Trigger,
@@ -941,13 +1033,13 @@ func TestTakeAction(t *testing.T) {
 			map[string][]config.Presubmit{
 				"o/r": {
 					{
-						Context:      "foo",
+						Reporter:     config.Reporter{Context: "foo"},
 						Trigger:      "/test all",
 						RerunCommand: "/test all",
 						AlwaysRun:    true,
 					},
 					{
-						Context:      "if-changed",
+						Reporter:     config.Reporter{Context: "if-changed"},
 						Trigger:      "/test if-changed",
 						RerunCommand: "/test if-changed",
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
@@ -962,7 +1054,7 @@ func TestTakeAction(t *testing.T) {
 		ca.Set(cfg)
 		if len(tc.presubmits) > 0 {
 			for i := 0; i <= 8; i++ {
-				tc.presubmits[i] = []config.Presubmit{{Context: "foo"}}
+				tc.presubmits[i] = []config.Presubmit{{Reporter: config.Reporter{Context: "foo"}}}
 			}
 		}
 		lg, gc, err := localgit.New()
@@ -1338,8 +1430,8 @@ func TestSync(t *testing.T) {
 
 func TestFilterSubpool(t *testing.T) {
 	presubmits := map[int][]config.Presubmit{
-		1: {{Context: "pj-a"}},
-		2: {{Context: "pj-a"}, {Context: "pj-b"}},
+		1: {{Reporter: config.Reporter{Context: "pj-a"}}},
+		2: {{Reporter: config.Reporter{Context: "pj-a"}}, {Reporter: config.Reporter{Context: "pj-b"}}},
 	}
 
 	trueVar := true
@@ -1799,13 +1891,13 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "no matching presubmits",
 			presubmits: []config.Presubmit{
 				{
-					Context: "always",
+					Reporter: config.Reporter{Context: "always"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"CHANGED"}},
@@ -1820,7 +1912,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "no matching presubmits (check cache eviction)",
 			presubmits: []config.Presubmit{
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			initialChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
@@ -1830,13 +1922,13 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "no matching presubmits (check cache retention)",
 			presubmits: []config.Presubmit{
 				{
-					Context: "always",
+					Reporter: config.Reporter{Context: "always"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "foo",
 					},
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			initialChangeCache:  map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
@@ -1847,15 +1939,15 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "always_run",
 			presubmits: []config.Presubmit{
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context:   "always",
+				Reporter:  config.Reporter{Context: "always"},
 				AlwaysRun: true,
 			}}},
 		},
@@ -1863,18 +1955,18 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "runs against branch",
 			presubmits: []config.Presubmit{
 				{
-					Context:   "presubmit",
+					Reporter:  config.Reporter{Context: "presubmit"},
 					AlwaysRun: true,
 					Brancher: config.Brancher{
 						Branches: []string{"master", "dev"},
 					},
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context:   "presubmit",
+				Reporter:  config.Reporter{Context: "presubmit"},
 				AlwaysRun: true,
 				Brancher: config.Brancher{
 					Branches: []string{"master", "dev"},
@@ -1885,22 +1977,22 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "doesn't run against branch",
 			presubmits: []config.Presubmit{
 				{
-					Context:   "presubmit",
+					Reporter:  config.Reporter{Context: "presubmit"},
 					AlwaysRun: true,
 					Brancher: config.Brancher{
 						Branches: []string{"release", "dev"},
 					},
 				},
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context:   "always",
+				Reporter:  config.Reporter{Context: "always"},
 				AlwaysRun: true,
 			}}},
 		},
@@ -1908,26 +2000,26 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (uncached)",
 			presubmits: []config.Presubmit{
 				{
-					Context: "presubmit",
+					Reporter: config.Reporter{Context: "presubmit"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^CHANGE.$",
 					},
 				},
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context: "presubmit",
+				Reporter: config.Reporter{Context: "presubmit"},
 				RegexpChangeMatcher: config.RegexpChangeMatcher{
 					RunIfChanged: "^CHANGE.$",
 				},
 			}, {
-				Context:   "always",
+				Reporter:  config.Reporter{Context: "always"},
 				AlwaysRun: true,
 			}}},
 			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"CHANGED"}},
@@ -1936,28 +2028,28 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (cached)",
 			presubmits: []config.Presubmit{
 				{
-					Context: "presubmit",
+					Reporter: config.Reporter{Context: "presubmit"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^FIL.$",
 					},
 				},
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			initialChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context: "presubmit",
+				Reporter: config.Reporter{Context: "presubmit"},
 				RegexpChangeMatcher: config.RegexpChangeMatcher{
 					RunIfChanged: "^FIL.$",
 				},
 			},
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				}}},
 			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
@@ -1966,22 +2058,22 @@ func TestPresubmitsByPull(t *testing.T) {
 			name: "run_if_changed (cached) (skippable)",
 			presubmits: []config.Presubmit{
 				{
-					Context: "presubmit",
+					Reporter: config.Reporter{Context: "presubmit"},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "^CHANGE.$",
 					},
 				},
 				{
-					Context:   "always",
+					Reporter:  config.Reporter{Context: "always"},
 					AlwaysRun: true,
 				},
 				{
-					Context: "never",
+					Reporter: config.Reporter{Context: "never"},
 				},
 			},
 			initialChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 			expectedPresubmits: map[int][]config.Presubmit{100: {{
-				Context:   "always",
+				Reporter:  config.Reporter{Context: "always"},
 				AlwaysRun: true,
 			}}},
 			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
@@ -2001,7 +2093,7 @@ func TestPresubmitsByPull(t *testing.T) {
 		cfg := &config.Config{}
 		cfg.SetPresubmits(map[string][]config.Presubmit{
 			"/":       tc.presubmits,
-			"foo/bar": {{Context: "wrong-repo", AlwaysRun: true}},
+			"foo/bar": {{Reporter: config.Reporter{Context: "wrong-repo"}, AlwaysRun: true}},
 		})
 		cfgAgent := &config.Agent{}
 		cfgAgent.Set(cfg)


### PR DESCRIPTION
Works for https://github.com/kubernetes/test-infra/commits/master (click the green check-mark from each merge commits, you can see the context and detail link etc)

Also dry'd out SkipReport and Context && Added an announcement.

(We only have ~10s of postsubmits, should not have negative impacts on our token usage)

/assign @cjwagner @fejta @stevekuznetsov 