### PR TITLE
Trigger correct set of jobs on PR events

### DIFF
--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -1118,3 +1118,207 @@ func TestPresubmitFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandFilter(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		body       string
+		presubmits []config.Presubmit
+		expected   [][]bool
+	}{
+		{
+			name: "command filter matches jobs whose triggers match the body",
+			body: "/test trigger",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "trigger",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "other-trigger",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
+					RerunCommand: "/test other-trigger",
+				},
+			},
+			expected: [][]bool{{true, true, true}, {false, false, true}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if len(testCase.presubmits) != len(testCase.expected) {
+				t.Fatalf("%s: have %d presubmits but only %d expected filter outputs", testCase.name, len(testCase.presubmits), len(testCase.expected))
+			}
+			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
+				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
+			}
+			filter := commandFilter(testCase.body)
+			for i, presubmit := range testCase.presubmits {
+				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
+				if actualFiltered != expectedFiltered {
+					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)
+				}
+				if actualForced != expectedForced {
+					t.Errorf("%s: filter did not determine forced correctly, expected %v but got %v for %v", testCase.name, expectedForced, actualForced, presubmit.Name)
+				}
+				if actualDefault != expectedDefault {
+					t.Errorf("%s: filter did not determine default correctly, expected %v but got %v for %v", testCase.name, expectedDefault, actualDefault, presubmit.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestRetestFilter(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		failedContexts sets.String
+		allContexts    sets.String
+		presubmits     []config.Presubmit
+		expected       [][]bool
+	}{
+		{
+			name:           "retest filter matches jobs that produce contexts which have failed",
+			failedContexts: sets.NewString("failed"),
+			allContexts:    sets.NewString("failed", "succeeded"),
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "failed",
+					},
+					Context: "failed",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "succeeded",
+					},
+					Context: "succeeded",
+				},
+			},
+			expected: [][]bool{{true, false, true}, {false, false, true}},
+		},
+		{
+			name:           "retest filter matches jobs that would run automatically and haven't yet ",
+			failedContexts: sets.NewString(),
+			allContexts:    sets.NewString("finished"),
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "finished",
+					},
+					Context: "finished",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "not-yet-run",
+					},
+					AlwaysRun: true,
+					Context:   "not-yet-run",
+				},
+			},
+			expected: [][]bool{{false, false, true}, {true, false, true}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if len(testCase.presubmits) != len(testCase.expected) {
+				t.Fatalf("%s: have %d presubmits but only %d expected filter outputs", testCase.name, len(testCase.presubmits), len(testCase.expected))
+			}
+			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
+				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
+			}
+			filter := retestFilter(testCase.failedContexts, testCase.allContexts)
+			for i, presubmit := range testCase.presubmits {
+				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
+				if actualFiltered != expectedFiltered {
+					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)
+				}
+				if actualForced != expectedForced {
+					t.Errorf("%s: filter did not determine forced correctly, expected %v but got %v for %v", testCase.name, expectedForced, actualForced, presubmit.Name)
+				}
+				if actualDefault != expectedDefault {
+					t.Errorf("%s: filter did not determine default correctly, expected %v but got %v for %v", testCase.name, expectedDefault, actualDefault, presubmit.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestTestAllFilter(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		presubmits []config.Presubmit
+		expected   [][]bool
+	}{
+		{
+			name: "test all filter matches jobs which do not require human triggering",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "always-runs",
+					},
+					AlwaysRun: true,
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					AlwaysRun: false,
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-triggered",
+					},
+					Context:      "runs-if-triggered",
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "literal-test-all-trigger",
+					},
+					Context:      "runs-if-triggered",
+					Trigger:      `(?m)^/test (?:.*? )?all(?: .*?)?$`,
+					RerunCommand: "/test all",
+				},
+			},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {false, false, false}, {false, false, false}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if len(testCase.presubmits) != len(testCase.expected) {
+				t.Fatalf("%s: have %d presubmits but only %d expected filter outputs", testCase.name, len(testCase.presubmits), len(testCase.expected))
+			}
+			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
+				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
+			}
+			filter := testAllFilter()
+			for i, presubmit := range testCase.presubmits {
+				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
+				if actualFiltered != expectedFiltered {
+					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)
+				}
+				if actualForced != expectedForced {
+					t.Errorf("%s: filter did not determine forced correctly, expected %v but got %v for %v", testCase.name, expectedForced, actualForced, presubmit.Name)
+				}
+				if actualDefault != expectedDefault {
+					t.Errorf("%s: filter did not determine default correctly, expected %v but got %v for %v", testCase.name, expectedDefault, actualDefault, presubmit.Name)
+				}
+			}
+		})
+	}
+}

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -216,11 +216,9 @@ func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 	return l, github.HasLabel(labels.OkToTest, l), nil
 }
 
-// buildAll acts as if a `/test all` comment has been placed on the PR
+// buildAll ensures that all builds that should run and will be required are built
 func buildAll(c Client, pr *github.PullRequest, eventGUID string) error {
-	// we pass a literal `/test all` here as it's the most direct way to achieve
-	// that functionality from the logic that parses out comment triggers
-	toTest, err := FilterPresubmits(false, c.GitHubClient, `/test all`, pr, c.Config.Presubmits[pr.Base.Repo.FullName])
+	toTest, err := filterPresubmits(testAllFilter(), c.GitHubClient, pr, c.Config.Presubmits[pr.Base.Repo.FullName])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When a PR is opened or updated, the set of jobs that would automatically
run should be triggered. The previous implementation attempted to reuse
the comment-command triggering code to determine which jobs to trigger
by passing `/test all` as a synthetic comment. This was incorrect as the
comment command `/test all` not only triggers jobs automatically but
will also trigger jobs that have a trigger regex that matches the
command. This resulted in jobs that had a configuration like the
following being triggered on PR creation:

    always_run: false
    run_if_changed: nil
    trigger: ((?m)^/test( all| job-name),?(\s+|$))

These sorts of jobs should be triggered only manually with a comment
command from a user.

This change refactors the filtering mechanisms in order to allow us to
explicitly request the correct behavior instead of trying to achieve it
by reusing a comment command parsing mechanism.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta @cjwagner
/cc @bentheelder @krzyzacy @Katharine 