### PR TITLE
kuberentes_e2e.py: skip add_gce_ssh for the 'kind' deployer

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -592,7 +592,7 @@ def main(args):
         set_up_kops_aws(mode.workspace, args, mode, cluster, runner_args)
     elif args.deployment == 'kops' and args.provider == 'gce':
         set_up_kops_gce(mode.workspace, args, mode, cluster, runner_args)
-    elif args.gce_ssh:
+    elif args.deployment != 'kind' and args.gce_ssh:
         mode.add_gce_ssh(args.gce_ssh, args.gce_pub)
 
     # TODO(fejta): delete this?


### PR DESCRIPTION
/assign @krzyzacy @BenTheElder 

testing ci-kubernetes-e2e-kubeadm-kind-master.
i see this happening:
```
W0207 15:30:21.354]   File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
W0207 15:30:21.354]     with open(src, 'rb') as fsrc:
W0207 15:30:21.354] IOError: [Errno 2] No such file or directory: '/root/.ssh/google_compute_engine'
```
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-master/2/build-log.txt

the arg value is set to this default:
`JENKINS_GCE_SSH_PRIVATE_KEY_FILE`
https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_e2e.py#L627-L630

but the file doesn't exists in the case of the kind deployer it seems.

not sure if this PR is the best fix.
