### PR TITLE
Fix bump_e2e_image.sh tree finding.

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -36,7 +36,7 @@ if [[ -n "${dirty}" ]]; then
   exit 1
 fi
 
-TREE="$(dirname "${BASH_SOURCE[0]}")/.."
+TREE="$(git rev-parse --show-toplevel)"
 
 DATE="$(date +v%Y%m%d)"
 TAG="${DATE}-$(git describe --tags --always --dirty)"


### PR DESCRIPTION
`bump_e2e_image.sh` can produce a relative path for `TREE` (e.g. when invoked as `./bump_e2e_image.sh`), which is then wrong when the bazel invocation causes the current working directory to change.

Use instead the root of the git repo, which is a) what we want, and also b) an absolute path.

/kind bug