### PR TITLE
Summarise the spyglass metadata table

### DIFF
--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -49,3 +49,7 @@ body {
 a:visited {
   color: #798bef;
 }
+
+.mdl-card.lens-card {
+  min-height: 0;
+}

--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
     srcs = ["metadata.ts"],
     deps = [
         "//prow/spyglass/lenses:lens_api",
+        "@npm//moment",
     ],
 )
 
@@ -27,6 +28,7 @@ rollup_bundle(
     entry_point = "prow/spyglass/lenses/metadata/metadata",
     deps = [
         ":script",
+        "@npm//moment",
     ],
 )
 

--- a/prow/spyglass/lenses/metadata/metadata.ts
+++ b/prow/spyglass/lenses/metadata/metadata.ts
@@ -1,22 +1,23 @@
-function toggleExpansion(dataId: string, textId: string, iconId: string): void {
-  const body = document.getElementById(dataId)!;
-  body.classList.toggle('hidden');
-  const icon = document.getElementById(iconId)!;
-  const textElem = document.getElementById(textId)!;
-  if (body.classList.contains('hidden')) {
-    icon.innerHTML = 'expand_more';
-    textElem.innerText = 'Show more';
+import moment from "moment";
+
+function handleClick(e: MouseEvent): void {
+  e.preventDefault();
+  const button = document.getElementById('show-table-link')!;
+  const table = document.getElementById('data-table')!;
+  table.classList.toggle('hidden');
+  if (table.classList.contains('hidden')) {
+    button.innerText = 'more info';
   } else {
-    icon.innerHTML = 'expand_less';
-    textElem.innerText = 'Show less';
+    button.innerText = 'less info';
   }
   spyglass.contentUpdated();
 }
 
 function getLocalStartTime(): void {
-  const elem = document.getElementById("start_time")!;
-  elem.innerText = (new Date(elem.innerText)).toString();
+  document.getElementById('show-table-link')!.onclick = handleClick;
+  const elem = document.getElementById("summary-start-time")!;
+  elem.innerText = moment(elem.innerText).calendar().replace(/Last|Yesterday|Today|Tomorrow/,
+      (m) => m.charAt(0).toLowerCase() + m.substr(1));
 }
 
-(window as any).toggleExpansion = toggleExpansion;
 window.onload = getLocalStartTime;

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -3,6 +3,27 @@
     font-size: 1.1em;
 }
 
+.test-summary {
+    color: #e8e8e8;
+    padding-left: 17px;
+}
+
+body {
+    min-height: 40px !important;
+}
+
+.failed {
+    color: #ff4040;
+}
+
+.passed {
+    color: #61ff61;
+}
+
+.passed, .failed {
+    font-weight: bold;
+}
+
 .mdl-data-table .metadata-header th {
     font-size: 1.2em;
     color: black;

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -7,38 +7,34 @@
 {{$len := len .Metadata}}
 {{$passed := eq .Status "SUCCESS"}}
 {{$failed := eq .Status "FAILURE" "FAILED"}}
-<table class="mdl-data-table mdl-js-data-table metadata-table">
+<p class="test-summary">Test started <abbr id="summary-start-time" title="{{.StartTime}}">{{.StartTime}}</abbr> {{if $passed -}}
+  <span class="passed">passed</span>
+{{- else if $failed -}}
+  <span class="failed">failed</span>
+{{- else -}}
+  is still running
+{{- end}} after {{.Elapsed}}. (<a href="#" id="show-table-link">more info</a>)</p>
+<table class="mdl-data-table mdl-js-data-table metadata-table hidden" id="data-table">
   <tbody>
   <tr class="test-row">
     <td class="mdl-data-table__cell--non-numeric">Status</td>
     <td class="mdl-data-table__cell--non-numeric" style="color: {{if $passed}}#00FF00{{else if $failed}}#ff4040{{end}}">{{.Status}}</td>
   </tr>
+  <tr>
+    <td class="mdl-data-table__cell--non-numeric">Started</td>
+    <td class="mdl-data-table__cell--non-numeric" id="start_time">{{.StartTime}}</td>
+  </tr>
+  <tr>
+    <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
+    <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
+  </tr>
+  {{range $key, $value := .Metadata}}
+  {{if $value}}
     <tr>
-      <td class="mdl-data-table__cell--non-numeric">Started</td>
-      <td class="mdl-data-table__cell--non-numeric" id="start_time">{{.StartTime}}</td>
+      <td class="mdl-data-table__cell--non-numeric">{{$key}}</td>
+      <td class="mdl-data-table__cell--non-numeric">{{$value}}</td>
     </tr>
-    <tr>
-      <td class="mdl-data-table__cell--non-numeric">Elapsed</td>
-      <td class="mdl-data-table__cell--non-numeric">{{.Elapsed}}</td>
-    </tr>
-    <tbody id="supplementary_data" class="{{if gt $len 1}}hidden{{end}}">
-    {{range $key, $value := .Metadata}}
-    {{if $value}}
-      <tr>
-        <td class="mdl-data-table__cell--non-numeric">{{$key}}</td>
-        <td class="mdl-data-table__cell--non-numeric">{{$value}}</td>
-      </tr>
-    {{end}}
-    {{end}}
-    </tbody>
-    {{if gt $len 1}}
-    <tr class="expander" onclick="toggleExpansion('supplementary_data', 'expand_text', 'expand_icon')">
-      <td colspan="2" class="mdl-data-table__cell--non-numeric expander">
-        <span id="expand_text">Show more</span>
-        <i id="expand_icon" class="icon-button material-icons arrow-icon">expand_more</i>
-      </td>
-    </tr>
-    {{end}}
-  </tbody>
+  {{end}}
+  {{end}}
 </table>
 {{end}}


### PR DESCRIPTION
Summarise the spyglass metadata table into a sentence.

![image](https://user-images.githubusercontent.com/110792/52451808-4dac4380-2af5-11e9-8a33-e43621533842.png)

Hovering the time gives you an absolute datetime string. Clicking "more info" shows the entire table as seen before.

/cc @BenTheElder @stevekuznetsov 