### PR TITLE
kubeadm-kind: fix wrong argument for kind config path

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -29,7 +29,7 @@ periodics:
       - "--provider=skeleton"
       - "--deployment=kind"
       - "--kind-binary-version=latest"
-      - "--kind-config=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml"
+      - "--kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml"
       - "--test-cmd=./../../k8s.io/kubeadm/tests/e2e/kind/test-cmd-basic.sh"
       - "--timeout=30m"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
this time for real?

might be a good indication that i should have named the flag `kind-config` instead of `kind-config-path` in the deployer.

/kind cleanup
/assign @krzyzacy @BenTheElder 
