### PR TITLE
kubeadm-kind: use 'build' instead of 'latest' for the kind binary.

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -8,7 +8,8 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190205-d83780367-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -28,7 +29,7 @@ periodics:
       - "--build=bazel"
       - "--provider=skeleton"
       - "--deployment=kind"
-      - "--kind-binary-version=latest"
+      - "--kind-binary-version=build"
       - "--kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml"
       - "--test-cmd=./../../k8s.io/kubeadm/tests/e2e/kind/test-cmd-basic.sh"
       - "--timeout=30m"

--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -202,6 +202,8 @@ func (d *Deployer) prepareKindBinary() error {
 		if err := downloadFromURL(url, f); err != nil {
 			return err
 		}
+	default:
+		return fmt.Errorf("uknown kind binary version value: %s", d.kindBinaryVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
soon™

The reason 'build' was used in the deployer is due to the fact that
'latest' can be incorrect if the deployer builds from an old tag
from the kind repo.

Also error out on unknown values in the deployer.

/kind bug
/assign @BenTheElder
