### PR TITLE
disable gce minikube test for now

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -235,12 +235,12 @@ presubmits:
         - sample_test
         - --timeout
         - "3600"
-      - name: kubeflow-pipeline-e2e-test-gce-minikube
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190205-d83780367-1.10
-        command:
-        - ./test/presubmit-tests-gce-minikube.sh
-        args:
-        - --workflow_file
-        - e2e_test_gke.yaml
-        - --test_result_folder
-        - e2e_test_gke
+#       - name: kubeflow-pipeline-e2e-test-gce-minikube
+#         image: gcr.io/k8s-testimages/kubekins-e2e:v20190205-d83780367-1.10
+#         command:
+#         - ./test/presubmit-tests-gce-minikube.sh
+#         args:
+#         - --workflow_file
+#         - e2e_test_gke.yaml
+#         - --test_result_folder
+#         - e2e_test_gke


### PR DESCRIPTION
the test is still under development and not yet ready.
The gce minikube test is part of the presubmit test now which would block all PRs. 
Disable it for now to unblock PRs.