### PR TITLE
Spyglass junit revamp

### DIFF
--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -21,7 +21,7 @@
   <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{.Title}}</h3></div>
   <div id="{{.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
     <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{.Name}}-loading"></div>
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{.Name}}" sandbox="allow-scripts allow-top-navigation" data-lens="{{.Name}}"></iframe>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{.Name}}"></iframe>
     </div>
   </div>
   {{end}}

--- a/prow/spyglass/lenses/junit/junit.css
+++ b/prow/spyglass/lenses/junit/junit.css
@@ -3,8 +3,8 @@
   display: none;
 }
 
-.test-name {
-  font-family: monospace;
+.hidden {
+  display: none;
 }
 
 .noselect {
@@ -19,11 +19,6 @@
   text-align: right;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 td.failed {
   color: #ff4040;
 }
@@ -34,4 +29,47 @@ td.passed {
 
 td.skipped {
   color: #ffe62d;
+}
+
+.failed-layout {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.failed-layout td {
+  border: 0;
+  padding: 0;
+}
+
+.failure-name {
+  cursor: pointer;
+}
+
+td {
+  white-space: normal !important;
+}
+
+/* We are engaged in a never-ending war of cascade escalation against MDL */
+#failed-tbody > tr:hover {
+  background-color: unset !important;
+}
+
+table.failed-layout tbody tr.failure-text:hover {
+  background-color: unset !important;
+}
+
+.failure-text div {
+  padding-left: 20px;
+  padding-right: 20px;
+  white-space: pre-wrap;
+  font-family: monospace;
+  padding-bottom: 10px;
+}
+
+.failure-text td {
+  padding-bottom: 15px;
+}
+
+.arrow-icon {
+  vertical-align: middle;
 }

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -82,7 +82,7 @@ type JunitResult struct {
 }
 
 func (jr JunitResult) Duration() time.Duration {
-	return time.Duration(jr.Time * float64(time.Second))
+	return time.Duration(jr.Time * float64(time.Second)).Round(time.Second)
 }
 
 // TestResult holds data about a test extracted from junit output

--- a/prow/spyglass/lenses/junit/lens.ts
+++ b/prow/spyglass/lenses/junit/lens.ts
@@ -1,12 +1,59 @@
-function toggleExpansion(bodyId: string, expanderId: string): void {
-  const body = document.getElementById(bodyId)!;
-  body.classList.toggle('hidden-tests');
-  if (body.classList.contains('hidden-tests')) {
-    document.getElementById(expanderId)!.innerHTML = 'expand_more';
-  } else {
-    document.getElementById(expanderId)!.innerHTML = 'expand_less';
+function addSectionExpanders(): void {
+  const expanders = document.querySelectorAll<HTMLTableRowElement>('tr.section-expander');
+  for (const expander of Array.from(expanders)) {
+    expander.onclick = () => {
+      const tbody = expander.parentElement!.nextElementSibling!;
+      const icon = expander.querySelector('i')!;
+      if (tbody.classList.contains('hidden-tests')) {
+        tbody.classList.remove('hidden-tests');
+        icon.innerText = 'expand_less';
+      } else {
+        tbody.classList.add('hidden-tests');
+        icon.innerText = 'expand_more';
+      }
+      spyglass.contentUpdated();
+    };
   }
-  spyglass.contentUpdated();
 }
 
-(window as any).toggleExpansion = toggleExpansion;
+function addTestExpanders(): void {
+  const rows = document.querySelectorAll<HTMLTableRowElement>('.failure-name');
+  for (const row of Array.from(rows)) {
+    row.onclick = () => {
+      const sibling = row.nextElementSibling!;
+      const icon = row.querySelector('i')!;
+      if (sibling.classList.contains('hidden')) {
+        sibling.classList.remove('hidden');
+        icon.innerText = 'expand_less';
+      } else {
+        sibling.classList.add('hidden');
+        icon.innerText = 'expand_more';
+      }
+      spyglass.contentUpdated();
+    };
+  }
+}
+
+function addStdoutOpeners(): void {
+  const links = document.querySelectorAll<HTMLAnchorElement>('a.open-stdout');
+  for (const link of Array.from(links)) {
+    link.onclick = (e) => {
+      e.preventDefault();
+      const text = (link.nextElementSibling! as HTMLElement).innerHTML;
+      const blob = new Blob([`
+      <head>
+        <title>Logs</title>
+      </head>
+      <body style="background-color: #303030; color: white; font-family: monospace; white-space: pre-wrap;">${text}</body>`], {type: 'text/html'});
+      window.open(URL.createObjectURL(blob));
+    };
+  }
+}
+
+function loaded(): void {
+  addTestExpanders();
+  addStdoutOpeners();
+  addSectionExpanders();
+}
+
+window.addEventListener('DOMContentLoaded', loaded);

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -10,12 +10,10 @@
 <div id="junit-container">
   <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="white-space: pre-wrap;">
   {{if gt $numF 0}}
-    <thead id="failed-theader" onclick="toggleExpansion('failed-tbody', 'failed-expander')">
-    <tr>
+    <tr id="failed-theader" class="header" onclick="toggleExpansion('failed-tbody', 'failed-expander')">
       <td class="mdl-data-table__cell--non-numeric expander failed" colspan="3"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
-    </thead>
     <tbody id="failed-tbody">
     {{range $ix, $test := .Failed}}
     <tr class="dark" onclick="toggleExpansion('failed-test-body-{{$ix}}', 'failed-test-expander-{{$ix}}')">
@@ -28,12 +26,10 @@
     </tbody>
   {{end}}
   {{if gt $numP 0}}
-    <thead id="passed-theader" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
-    <tr>
+    <tr id="passed-theader" class="header" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
       <td class="mdl-data-table__cell--non-numeric expander passed" colspan="3"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="passed-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
-    </thead>
     <tbody id="passed-tbody" class="hidden-tests">
     {{range .Passed}}
     <tr>
@@ -46,12 +42,10 @@
     </tbody>
   {{end}}
   {{if gt $numS 0}}
-    <thead id="skipped-theader" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
-    <tr>
+    <tr id="skipped-theader" class="header" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
       <td class="mdl-data-table__cell--non-numeric expander skipped" colspan="3"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="skipped-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
-    </thead>
     <tbody id="skipped-tbody" class="hidden-tests">
     {{range .Skipped}}
     <tr>

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -8,51 +8,60 @@
 {{$numP := len .Passed}}
 {{$numS := len .Skipped}}
 <div id="junit-container">
-  <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="white-space: pre-wrap;">
+  <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
   {{if gt $numF 0}}
-    <tr id="failed-theader" class="header" onclick="toggleExpansion('failed-tbody', 'failed-expander')">
-      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="3"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
+    <tr id="failed-theader" class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     <tbody id="failed-tbody">
     {{range $ix, $test := .Failed}}
-    <tr class="dark" onclick="toggleExpansion('failed-test-body-{{$ix}}', 'failed-test-expander-{{$ix}}')">
-      <td class="mdl-data-table__cell--non-numeric test-name"><a href="{{$test.Link}}">{{$test.Junit.Name}}</a></td>
-      <td class="mdl-data-table__cell--non-numeric failed">Failed</td>
-      <td class="mdl-data-table__cell--non-numeric">{{$test.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
+    <tr>
+      <td colspan="2" style="padding: 0;">
+        <table class="failed-layout">
+          <tr class="failure-name">
+            <td class="mdl-data-table__cell--non-numeric test-name">{{$test.Junit.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+            <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$test.Junit.Duration}}</td>
+          </tr>
+          <tr class="hidden failure-text">
+            <td colspan="2" class="mdl-data-table__cell--non-numeric">
+              <div>{{$test.Junit.Failure}}</div>
+              {{if $test.Junit.Output}}
+              <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+              <pre style="display: none;">{{$test.Junit.Output}}</pre>
+              {{end}}
+            </td>
+          </tr>
+        </table>
+      </td>
     </tr>
     {{end}}
     </tbody>
   {{end}}
   {{if gt $numP 0}}
-    <tr id="passed-theader" class="header" onclick="toggleExpansion('passed-tbody', 'passed-expander')">
-      <td class="mdl-data-table__cell--non-numeric expander passed" colspan="3"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
+    <tr id="passed-theader" class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander passed" colspan="1"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="passed-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     <tbody id="passed-tbody" class="hidden-tests">
     {{range .Passed}}
     <tr>
-      <td class="mdl-data-table__cell--non-numeric test-name"><a href="{{.Link}}">{{.Junit.Name}}</a></td>
-      <td class="mdl-data-table__cell--non-numeric passed">Passed</td>
+      <td class="mdl-data-table__cell--non-numeric test-name">{{.Junit.Name}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}
     </tbody>
   {{end}}
   {{if gt $numS 0}}
-    <tr id="skipped-theader" class="header" onclick="toggleExpansion('skipped-tbody', 'skipped-expander')">
-      <td class="mdl-data-table__cell--non-numeric expander skipped" colspan="3"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
+    <tr id="skipped-theader" class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander skipped" colspan="1"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="skipped-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     <tbody id="skipped-tbody" class="hidden-tests">
     {{range .Skipped}}
     <tr>
-      <td class="mdl-data-table__cell--non-numeric test-name"><a href="{{.Link}}">{{.Junit.Name}}</a></td>
-      <td class="mdl-data-table__cell--non-numeric skipped">Skipped</td>
+      <td class="mdl-data-table__cell--non-numeric test-name">{.Junit.Name}}</td>
       <td class="mdl-data-table__cell--non-numeric">{{.Junit.Duration}}</td>
-      <td class="mdl-data-table__cell--non-numeric"></td>
     </tr>
     {{end}}
     </tbody>


### PR DESCRIPTION
This PR revamps the spyglass junit view to provide more details on test failures. By default, it looks like this:

![image](https://user-images.githubusercontent.com/110792/52513338-11ddb080-2bbf-11e9-9d50-5d72f1e28e73.png)

If you click on a test to expand it, you get this:

![image](https://user-images.githubusercontent.com/110792/52513605-bd3b3500-2bc0-11e9-8b92-fe9a9192fb5b.png)

Clicking 'open stdout' opens a new tab/window with the associated standard output. We don't attempt to parse ANSI codes because they are stored corrupted in the JUnit files.

Dunno who wants to review this excitement any more, so...
/cc @BenTheElder 