### PR TITLE
Add presubmit and CI jobs for node-problem-detector

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/OWNERS
+++ b/config/jobs/kubernetes/node-problem-detector/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - wangzhen127
+  - Random-Liu
+  - andyxning
+  - dchen1107

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -1,0 +1,134 @@
+periodics:
+- name: ci-npd-build
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      command:
+      - runner.sh
+      args:
+      - ./test/build.sh ci
+
+- name: ci-npd-test
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      command:
+      - runner.sh
+      args:
+      - make
+      - test
+
+- name: ci-npd-e2e-node
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        ./test/build.sh get-ci-env &&
+        source ci.env &&
+        /workspace/scenarios/kubernetes_e2e.py
+        --extract=ci-latest
+        --deployment=node
+        --provider=gce
+        --gcp-zone=us-west1-b
+        --node-tests=true
+        --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+        --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+        --test_args="--nodes=8 --focus=NodeProblemDetector"
+        --timeout=60m
+
+- name: ci-npd-e2e-kubernetes-gce-gci
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        ./test/build.sh get-ci-env &&
+        source ci.env &&
+        /workspace/scenarios/kubernetes_e2e.py
+        --cluster=
+        --extract=ci-latest
+        --provider=gce
+        --gcp-node-image=gci
+        --gcp-zone=us-west1-b
+        --ginkgo-parallel=30
+        --test_args=--ginkgo.focus=NodeProblemDetector
+        --timeout=60m
+
+- name: ci-npd-e2e-kubernetes-gce-ubuntu
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        ./test/build.sh get-ci-env &&
+        source ci.env &&
+        /workspace/scenarios/kubernetes_e2e.py
+        --cluster=
+        --extract=ci-latest
+        --provider=gce
+        --gcp-node-image=ubuntu
+        --gcp-zone=us-west1-b
+        --ginkgo-parallel=30
+        --test_args=--ginkgo.focus=NodeProblemDetector
+        --timeout=60m

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -1,0 +1,121 @@
+presubmits:
+  kubernetes/node-problem-detector:
+  - name: pull-npd-build
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - build
+
+  - name: pull-npd-test
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test
+
+  - name: pull-npd-e2e-node
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          ./test/build.sh pr $(PULL_REFS) &&
+          source pr.env &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --extract=ci-latest
+          --deployment=node
+          --provider=gce
+          --gcp-zone=us-west1-b
+          --node-tests=true
+          --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+          --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+          --test_args="--nodes=8 --focus=NodeProblemDetector"
+          --timeout=60m
+
+  - name: pull-npd-e2e-kubernetes-gce-gci
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          ./test/build.sh pr $(PULL_REFS) &&
+          source pr.env &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --cluster=
+          --extract=ci-latest
+          --provider=gce
+          --gcp-node-image=gci
+          --gcp-zone=us-west1-b
+          --ginkgo-parallel=30
+          --test_args=--ginkgo.focus=NodeProblemDetector
+          --timeout=60m
+
+  - name: pull-npd-e2e-kubernetes-gce-ubuntu
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          ./test/build.sh pr $(PULL_REFS) &&
+          source pr.env &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --cluster=
+          --extract=ci-latest
+          --provider=gce
+          --gcp-node-image=ubuntu
+          --gcp-zone=us-west1-b
+          --ginkgo-parallel=30
+          --test_args=--ginkgo.focus=NodeProblemDetector
+          --timeout=60m

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -341,6 +341,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes/federation",
 		"kubernetes/kops",
 		"kubernetes/kubernetes",
+		"kubernetes/node-problem-detector",
 		"kubernetes/org",
 		"kubernetes/publishing-bot",
 		"kubernetes/test-infra",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3432,6 +3432,49 @@ test_groups:
   - configuration_value: kube_version
   - configuration_value: docker_version
 
+# node-problem-detector
+- name: pull-npd-build
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-build
+  num_columns_recent: 30
+- name: pull-npd-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-test
+  num_columns_recent: 30
+- name: pull-npd-e2e-node
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-node
+  num_columns_recent: 30
+- name: pull-npd-e2e-kubernetes-gce-gci
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-gci
+  num_columns_recent: 30
+- name: pull-npd-e2e-kubernetes-gce-ubuntu
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-ubuntu
+  num_columns_recent: 30
+
+- name: ci-npd-build
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-build
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-test
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-e2e-node
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-node
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-e2e-kubernetes-gce-gci
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-gci
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-e2e-kubernetes-gce-ubuntu
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-ubuntu
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+
 #
 # Start dashboards
 #
@@ -6502,6 +6545,29 @@ dashboards:
     test_group_name: arm64-conformance
     description: Runs conformance test by using kubetest against latest version of kubernetes on arm64
 
+- name: sig-node-node-problem-detector
+  dashboard_tab:
+  - name: ci-npd-build
+    test_group_name: ci-npd-build
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-test
+    test_group_name: ci-npd-test
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-e2e-node
+    test_group_name: ci-npd-e2e-node
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-e2e-kubernetes-gce-gci
+    test_group_name: ci-npd-e2e-kubernetes-gce-gci
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-e2e-kubernetes-gce-ubuntu
+    test_group_name: ci-npd-e2e-kubernetes-gce-ubuntu
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+
 # Move sig-release here
 
 - name: sig-scalability-gce
@@ -7319,6 +7385,19 @@ dashboards:
   - name: e2e
     test_group_name: ci-poseidon-e2e-gce
 
+- name: presubmits-node-problem-detector
+  dashboard_tab:
+  - name: pull-npd-build
+    test_group_name: pull-npd-build
+  - name: pull-npd-test
+    test_group_name: pull-npd-test
+  - name: pull-npd-e2e-node
+    test_group_name: pull-npd-e2e-node
+  - name: pull-npd-e2e-kubernetes-gce-gci
+    test_group_name: pull-npd-e2e-kubernetes-gce-gci
+  - name: pull-npd-e2e-kubernetes-gce-ubuntu
+    test_group_name: pull-npd-e2e-kubernetes-gce-ubuntu
+
 - name: google-rules_k8s
   dashboard_tab:
   - name: pull-rules-k8s-e2e
@@ -7741,6 +7820,7 @@ dashboard_groups:
   - presubmits-kubernetes-scalability
   - presubmits-test-infra
   - presubmits-kops
+  - presubmits-node-problem-detector
   - presubmits-poseidon
   - presubmits-misc
 
@@ -7799,6 +7879,7 @@ dashboard_groups:
   - sig-node-cri-1.12
   - sig-node-arm64
   - sig-node-docker
+  - sig-node-node-problem-detector
 
 - name: sig-release
   dashboard_names:


### PR DESCRIPTION
This PR adds presubmit and CI jobs for node-problem-detector. This is part of https://github.com/kubernetes/node-problem-detector/issues/236.

This PR needs to work with the node-problem-detector side PR https://github.com/kubernetes/node-problem-detector/pull/254.