### PR TITLE
prow: sinker/horologium: revert flag changes for starter.yaml

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -239,8 +239,6 @@ spec:
       containers:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
-        args:
-        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -323,8 +321,6 @@ spec:
       containers:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
-        args:
-        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
This should have been done as part of
5de290cec3b7162be40639f3bafb74306dcbd11a. Without this, both sinker and
horologium go into CrashLoopBackOff because the flag is unrecognized.