### PR TITLE
kubetest/anywhere.go: don't set  KUBERNETES_CONFORMANCE_PROVIDER

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -193,12 +193,6 @@ func newKubernetesAnywhere(project, zone string) (deployer, error) {
 		return nil, err
 	}
 
-	// Set KUBERNETES_CONFORMANCE_PROVIDER since KUBERNETES_CONFORMANCE_TEST is set
-	// to ensure the right provider is passed onto the test.
-	if err := os.Setenv("KUBERNETES_CONFORMANCE_PROVIDER", "kubernetes-anywhere"); err != nil {
-		return nil, err
-	}
-
 	if err := k.writeConfig(kubernetesAnywhereConfigTemplate); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If set to "kubernetes-anywhere", this ENV variable is read
by ginkgo-e2e.sh and the ENV variable KUBERNETES_PROVIDER
is set to this value:
https://github.com/kubernetes/kubernetes/blob/master/hack/ginkgo-e2e.sh#L62

This value then reaches test_context.go in the e2e framework
and errors out because the provider is unknown after the recent changes:
```
E0210 00:04:51.715669    1867 test_context.go:430] Unknown provider "kubernetes-anywhere". The following providers are known: aws azure gce gke kubemark local skeleton
```

/kind bug
/assign @krzyzacy @BenTheElder 

As side note the master node "serial-1" log isn't available anymore by using the new log dump:
http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1861/artifacts/
