### PR TITLE
Restrict triggering regexes to require `/test` prefix

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -40,6 +40,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *February 10, 2019* Re-test commands and trigger regexes must match expressions
+   prefixed with `/test`. If using default triggers and re-test commands, this is
+   already true.
  - *February 1, 2019* Now that `hook` and `tide` will no longer post "Skipped" statuses
    for jobs that do not need to run, it is not possible to require those statuses with
    branch protection. Therefore, it is necessary to run the `branchprotector` from at

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1153,6 +1153,8 @@ func (c *ProwConfig) defaultPeriodicFields(js []Periodic) {
 	}
 }
 
+var genericTestRe = regexp.MustCompile(`(?m)^/test (?:.*? )?.+(?: .*?)?$`)
+
 // SetPresubmitRegexes compiles and validates all the regular expressions for
 // the provided presubmits.
 func SetPresubmitRegexes(js []Presubmit) error {
@@ -1164,6 +1166,9 @@ func SetPresubmitRegexes(js []Presubmit) error {
 		}
 		if !js[i].re.MatchString(j.RerunCommand) {
 			return fmt.Errorf("for job %s, rerun command \"%s\" does not match trigger \"%s\"", j.Name, j.RerunCommand, j.Trigger)
+		}
+		if !genericTestRe.MatchString(j.RerunCommand) {
+			return fmt.Errorf("for job %s, rerun command \"%s\" does not match generic trigger \"%s\"", j.Name, j.RerunCommand, genericTestRe)
 		}
 		b, err := setBrancherRegexes(j.Brancher)
 		if err != nil {


### PR DESCRIPTION
Without a bounding set of valid regexes it is not possible to determine
whether or not a comment required the expensive (in time and API tokens)
work of detecting whether tests should run.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 

addresses https://github.com/kubernetes/test-infra/pull/11160#discussion_r255321163

This is the naive and simple solution, we *could* take this route if we wanted. Discussion welcome.