### PR TITLE
Be more precise in identifying irrelevant comments

### DIFF
--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -30,7 +30,6 @@ import (
 var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 var testAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
 var retestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
-var genericTestRe = regexp.MustCompile(`(?m)^/test (?:.*? )?.+(?: .*?)?$`)
 
 func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericCommentEvent) error {
 	org := gc.Repo.Owner.Login
@@ -44,8 +43,17 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericC
 		return nil
 	}
 	// Skip comments not germane to this plugin
-	if !retestRe.MatchString(gc.Body) && !okToTestRe.MatchString(gc.Body) && !testAllRe.MatchString(gc.Body) && !genericTestRe.MatchString(gc.Body) {
-		return nil
+	if !retestRe.MatchString(gc.Body) && !okToTestRe.MatchString(gc.Body) && !testAllRe.MatchString(gc.Body) {
+		matched := false
+		for _, presubmit := range c.Config.Presubmits[gc.Repo.FullName] {
+			matched = matched || presubmit.TriggerMatches(gc.Body)
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return nil
+		}
 	}
 
 	// Skip bot comments.

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -229,6 +229,28 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jib",
 		},
 		{
+			name:   "test of silly regex job",
+			Author: "trusted-member",
+			Body:   "Nice weather outside, right?",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						Brancher:     config.Brancher{Branches: []string{"master"}},
+						Context:      "pull-jab",
+						Trigger:      "Nice weather outside, right?",
+						RerunCommand: "Nice weather outside, right?",
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+		},
+		{
 			name: "needs-ok-to-test label is removed when no presubmit runs by default",
 
 			Author:      "trusted-member",


### PR DESCRIPTION
Test triggers are unbounded in their input space so the only way to tell
that we have a comment not germane to the trigger plugin is to check
that the comment does not match any trigger on a job that could possibly
run for the pull request at hand.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com

/assign @cjwagner @fejta
/cc @BenTheElder @krzyzacy

addresses https://github.com/kubernetes/test-infra/pull/11160#discussion_r255321163
alternative to https://github.com/kubernetes/test-infra/pull/11218

This is the other solution and would be more work intensive but should be reasonable as long as the number of presubmits for the org/repo is not too large. Technically would not be a regression in response time to before the refactor, anyway.