### PR TITLE
kind: remove workaround for kube::util::find-binary-for-platform() bug

### DIFF
--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -74,13 +74,6 @@ build() {
     #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"
     bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
 
-    # e2e.test does not show up in a path with platform in it and will not be found
-    # by kube::util::find-binary, so we will copy it to an acceptable location
-    # until this is fixed upstream
-    # https://github.com/kubernetes/kubernetes/issues/68306
-    mkdir -p "_output/bin/"
-    cp "bazel-bin/test/e2e/e2e.test" "_output/bin/"
-
     # try to make sure the kubectl we built is in PATH
     local maybe_kubectl
     maybe_kubectl="$(find "${PWD}/bazel-bin/" -name "kubectl" -type f)"

--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -269,17 +269,6 @@ func (d *Deployer) Build() error {
 		if err := d.control.FinishRunning(cmd); err != nil {
 			return err
 		}
-		/*
-			e2e.test does not show up in a path with platform in it and will
-			not be found by kube::util::find-binary, so we will copy it to an
-			acceptable location until this is fixed upstream
-			https://github.com/kubernetes/kubernetes/issues/68306
-		*/
-		cmd = exec.Command("cp", "-r", "bazel-bin/test/e2e/e2e.test", "./_output/bin/")
-		cmd.Dir = d.importPathK8s
-		if err := d.control.FinishRunning(cmd); err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-master/76/build-log.txt

```
W0210 19:35:35.186] 2019/02/10 19:35:35 process.go:153: Running: cp -r bazel-bin/test/e2e/e2e.test ./_output/bin/
W0210 19:35:35.187] cp: cannot create regular file './_output/bin/': Not a directory
```

/kind bug
/assign @BenTheElder 
