### PR TITLE
Enable dump-systemd-journal in node-killer tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -17,6 +17,8 @@ periodics:
       - --timeout=140
       - --scenario=kubernetes_e2e
       - --
+      # TODO(mm4tt): Set it everywhere once it's confirmed to be working.
+      - --env=LOG_DUMP_SYSTEMD_JOURNAL=true
       - --check-leaked-resources
       - --cluster=e2e-big
       - --extract=ci/latest
@@ -26,8 +28,6 @@ periodics:
       - --gcp-zone=us-east1-b
       - --provider=gce
       - --test=false
-      # TODO(mm4tt): Set it everywhere once it's confirmed to be working.
-      - --test_args=--dump-systemd-journal=true
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--nodes=100


### PR DESCRIPTION
Previous attempt to do that was wrong, we need to do it via the env variable
instead of setting the dump-systemd-journal flag.