### PR TITLE
Add kubo Windows test results

### DIFF
--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -42,3 +42,6 @@ gs://k8s-conformance-openstack/:
 gs://k8s-conformance-gardener:
   contact: "OlegLoewen"
   prefix: "gardener:"
+gs://pivotal-e2e-results:
+  contact: "benmoss"
+  prefix: "pivotal:"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3290,6 +3290,10 @@ test_groups:
 - name: ci-kubernetes-e2e-windows-gce-poc
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce-poc
 
+# Pivotal Windows test groups
+- name: ci-kubernetes-e2e-windows-cfcr
+  gcs_prefix: pivotal-e2e-results/kubo-windows-2019
+
 # bazelbuild/rules_k8s tests
 - name: pull-rules-k8s-e2e
   gcs_prefix: kubernetes-jenkins/logs/pull-rules-k8s-e2e
@@ -7511,6 +7515,9 @@ dashboards:
   - name: gce-windows-master
     description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
     test_group_name: ci-kubernetes-e2e-windows-gce
+  - name: cfcr-vsphere-windows-master
+    description: Runs Windows verification tests on a master-branch Kubernetes cluster provided by CFCR (https://github.com/cloudfoundry-incubator/kubo-release) on vSphere"
+    test_group_name: ci-kubernetes-e2e-windows-cfcr
 
 # sig-azure dashboard
 - name: sig-azure-master


### PR DESCRIPTION
I wasn't entirely sure what the `prefix` field in bucket.yaml matters for. I looked at some of the other buckets and couldn't see that string in their test files, and it's not obviously in the job names either (the jobs from luxas' bucket are called `periodic-multi-platform-kubeadm-gce-amd64`, not `luxas-periodic-multi-platform-kubeadm-gce-amd64` or something). Lemme know if I'm just misunderstanding something!