### PR TITLE
Remove the title from the metadata lens

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -654,11 +654,12 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 	ls := sg.Lenses(viewerCache)
 	lensNames := []string{}
 	for _, l := range ls {
-		lensNames = append(lensNames, l.Name())
+		lensNames = append(lensNames, l.Config().Name)
 	}
 
 	jobHistLink := ""
 	jobPath, err := sg.JobPath(src)
+
 	if err == nil {
 		jobHistLink = path.Join("/job-history", jobPath)
 	}
@@ -722,7 +723,8 @@ func handleArtifactView(o options, sg *spyglass.Spyglass, cfg config.Getter) htt
 			return
 		}
 
-		lensResourcesDir := lenses.ResourceDirForLens(o.spyglassFilesLocation, lens.Name())
+		lensConfig := lens.Config()
+		lensResourcesDir := lenses.ResourceDirForLens(o.spyglassFilesLocation, lensConfig.Name)
 
 		reqString := r.URL.Query().Get("req")
 		var request spyglass.LensRequest
@@ -753,7 +755,7 @@ func handleArtifactView(o options, sg *spyglass.Spyglass, cfg config.Getter) htt
 				Head    template.HTML
 				Body    template.HTML
 			}{
-				lens.Title(),
+				lensConfig.Title,
 				"/spyglass/static/" + lensName + "/",
 				template.HTML(lens.Header(artifacts, lensResourcesDir)),
 				template.HTML(lens.Body(artifacts, lensResourcesDir, "")),

--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -32,6 +32,10 @@ body {
   padding-bottom: 0;
 }
 
+.mdl-card.hidden-title .lens-title {
+  display: none;
+}
+
 #lens-container .lens-view-content {
   width: 100%;
   padding: 0;

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -48,6 +48,9 @@ window.addEventListener('message', async (e) => {
       case "contentUpdated":
         frame.style.height = `${message.height}px`;
         frame.style.visibility = 'visible';
+        if (frame.dataset.hideTitle) {
+          frame.parentElement!.parentElement!.classList.add('hidden-title');
+        }
         document.querySelector<HTMLElement>(`#${lens}-loading`)!.style.display = 'none';
         respond('');
         break;

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -12,16 +12,14 @@
 
 {{define "content"}}
 {{$source:=.Source}}
-{{if .JobHistLink}}
-<h4>&nbsp;<a href="{{.JobHistLink}}">Job History</a></h4>
-{{end}}
 <div id="lens-container">
   {{range .Lenses}}
+  {{$config:=.Config}}
   <div class="mdl-card mdl-shadow--2dp lens-card">
-  <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{.Title}}</h3></div>
-  <div id="{{.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
-    <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{.Name}}-loading"></div>
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{.Name}}"></iframe>
+  <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
+  <div id="{{.Config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
+    <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{$config.Name}}-loading"></div>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$config.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{$config.Name}}"></iframe>
     </div>
   </div>
   {{end}}

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -12,14 +12,17 @@
 
 {{define "content"}}
 {{$source:=.Source}}
+{{if .JobHistLink}}
+<h4>&nbsp;<a href="{{.JobHistLink}}">Job History</a></h4>
+{{end}}
 <div id="lens-container">
   {{range .Lenses}}
   {{$config:=.Config}}
   <div class="mdl-card mdl-shadow--2dp lens-card">
-  <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
-  <div id="{{.Config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
-    <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{$config.Name}}-loading"></div>
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$config.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{$config.Name}}"></iframe>
+    <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
+    <div id="{{.Config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
+      <div class="mdl-spinner mdl-js-spinner is-active lens-card-loading" id="{{$config.Name}}-loading"></div>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$config.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
     </div>
   </div>
   {{end}}

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -42,19 +42,13 @@ const (
 // Lens implements the build lens.
 type Lens struct{}
 
-// Name returns the name.
-func (lens Lens) Name() string {
-	return name
-}
-
-// Title returns the title.
-func (lens Lens) Title() string {
-	return title
-}
-
-// Priority returns the priority.
-func (lens Lens) Priority() int {
-	return priority
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:     name,
+		Title:    title,
+		Priority: priority,
+	}
 }
 
 // Header executes the "header" section of the template.

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -44,19 +44,13 @@ func init() {
 // Lens is the implementation of a JUnit-rendering Spyglass lens.
 type Lens struct{}
 
-// Name returns the name.
-func (lens Lens) Name() string {
-	return name
-}
-
-// Title returns the title.
-func (lens Lens) Title() string {
-	return title
-}
-
-// Priority returns the priority.
-func (lens Lens) Priority() int {
-	return priority
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:     name,
+		Title:    title,
+		Priority: priority,
+	}
 }
 
 // Header renders the content of <head> from template.html.

--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -51,6 +51,8 @@ type LensConfig struct {
 	Title string
 	// Priority is used to determine where to position the lens. Higher is better.
 	Priority uint
+	// HideTitle will hide the lens title after loading if set to true.
+	HideTitle bool
 }
 
 // Lens defines the interface that lenses are required to implement in order to be used by Spyglass.

--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -44,14 +44,19 @@ var (
 	ErrContextUnsupported = errors.New("artifact does not support context operations")
 )
 
+type LensConfig struct {
+	// Name is the name of the lens. It must match the package name.
+	Name string
+	// Title is a human-readable title for the lens.
+	Title string
+	// Priority is used to determine where to position the lens. Higher is better.
+	Priority uint
+}
+
 // Lens defines the interface that lenses are required to implement in order to be used by Spyglass.
 type Lens interface {
-	// Name returns the name of the lens. It must match the package name.
-	Name() string
-	// Title returns a human-readable title for the lens.
-	Title() string
-	// Priority returns a number used to sort viewers. Lower is more important.
-	Priority() int
+	// Config returns a LensConfig that describes the lens.
+	Config() LensConfig
 	// Header returns a a string that is injected into the rendered lens's <head>
 	Header(artifacts []Artifact, resourceDir string) string
 	// Body returns a string that is initially injected into the rendered lens's <body>.
@@ -87,19 +92,20 @@ func ResourceDirForLens(baseDir, name string) string {
 
 // RegisterLens registers new viewers
 func RegisterLens(lens Lens) error {
-	_, ok := lensReg[lens.Name()]
+	config := lens.Config()
+	_, ok := lensReg[config.Name]
 	if ok {
-		return fmt.Errorf("viewer already registered with name %s", lens.Name())
+		return fmt.Errorf("viewer already registered with name %s", config.Name)
 	}
 
-	if lens.Title() == "" {
+	if config.Title == "" {
 		return errors.New("empty title field in view metadata")
 	}
-	if lens.Priority() < 0 {
+	if config.Priority < 0 {
 		return errors.New("priority must be >=0")
 	}
-	lensReg[lens.Name()] = lens
-	logrus.Infof("Spyglass registered viewer %s with title %s.", lens.Name(), lens.Title())
+	lensReg[config.Name] = lens
+	logrus.Infof("Spyglass registered viewer %s with title %s.", config.Name, config.Title)
 	return nil
 }
 

--- a/prow/spyglass/lenses/lenses_test.go
+++ b/prow/spyglass/lenses/lenses_test.go
@@ -82,16 +82,11 @@ func (fa *FakeArtifact) ReadAtMost(n int64) ([]byte, error) {
 
 type dumpLens struct{}
 
-func (dumpLens) Name() string {
-	return "dump"
-}
-
-func (dumpLens) Title() string {
-	return "Dump View"
-}
-
-func (dumpLens) Priority() int {
-	return 1
+func (dumpLens) Config() LensConfig {
+	return LensConfig{
+		Name:  "dump",
+		Title: "Dump Lens",
+	}
 }
 
 func (dumpLens) Header(artifacts []Artifact, resourceDir string) string {

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -44,19 +44,13 @@ func init() {
 	lenses.RegisterLens(Lens{})
 }
 
-// Title returns the title.
-func (lens Lens) Title() string {
-	return title
-}
-
-// Name returns the name.
-func (lens Lens) Name() string {
-	return name
-}
-
-// Priority returns the priority.
-func (lens Lens) Priority() int {
-	return priority
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Title:    title,
+		Name:     name,
+		Priority: priority,
+	}
 }
 
 // Header renders the <head> from template.html.

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -47,9 +47,10 @@ func init() {
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Title:    title,
-		Name:     name,
-		Priority: priority,
+		Title:     title,
+		Name:      name,
+		Priority:  priority,
+		HideTitle: true,
 	}
 }
 

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -6,10 +6,12 @@
 .test-summary {
     color: #e8e8e8;
     padding-left: 17px;
+    padding-bottom: 15px;
+    margin: 0;
 }
 
 body {
-    min-height: 40px !important;
+    padding-top: 15px;
 }
 
 .failed {

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -86,10 +86,12 @@ func (s *Spyglass) Lenses(matchCache map[string][]string) []lenses.Lens {
 	}
 	// Make sure lenses are rendered in order by ascending priority
 	sort.Slice(ls, func(i, j int) bool {
-		iname := ls[i].Name()
-		jname := ls[j].Name()
-		pi := ls[i].Priority()
-		pj := ls[j].Priority()
+		iconf := ls[i].Config()
+		jconf := ls[j].Config()
+		iname := iconf.Name
+		jname := jconf.Name
+		pi := iconf.Priority
+		pj := jconf.Priority
 		if pi == pj {
 			return iname < jname
 		}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -163,16 +163,11 @@ test/e2e/e2e.go:137 BeforeSuite on Node 1 failed test/e2e/e2e.go:137
 
 type dumpLens struct{}
 
-func (dumpLens) Name() string {
-	return "dump"
-}
-
-func (dumpLens) Title() string {
-	return "Dump View"
-}
-
-func (dumpLens) Priority() int {
-	return 1
+func (dumpLens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:  "dump",
+		Title: "Dump View",
+	}
 }
 
 func (dumpLens) Header(artifacts []lenses.Artifact, resourceDir string) string {
@@ -232,18 +227,18 @@ func TestViews(t *testing.T) {
 			for _, l := range lenses {
 				var found bool
 				for _, title := range tc.expectedLensTitles {
-					if title == l.Title() {
+					if title == l.Config().Title {
 						found = true
 					}
 				}
 				if !found {
-					t.Errorf("lens title %s not found in expected titles.", l.Title())
+					t.Errorf("lens title %s not found in expected titles.", l.Config().Title)
 				}
 			}
 			for _, title := range tc.expectedLensTitles {
 				var found bool
 				for _, l := range lenses {
-					if title == l.Title() {
+					if title == l.Config().Title {
 						found = true
 					}
 				}


### PR DESCRIPTION
This PR removes the title from the Metadata lens. This also involves a minor refactoring of lenses:

- Lenses now register a `Config()` that returns a `LensConfig` struct, instead of individual `Name()`, `Title()` and `Priority()` methods. This enables adding new lens properties without needing to go back and update every lens to comply.
- I added a `HideTitle` switch to lenses. If set to `true`, they will hide their title when they finish loading. I chose to make this lens-level rather than config-level in order to avoid lenses making incorrect assumptions when not configured in the way they imagined. If `false` (the default), the title remains visible.

The end result looks like this:

![image](https://user-images.githubusercontent.com/110792/52605266-dfcc8880-2e22-11e9-8c4f-a9768049253b.png)

/cc @BenTheElder 