### PR TITLE
Refactor git client to be testable and encapsulated

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -42,7 +42,10 @@ func TestOptions_Validate(t *testing.T) {
 			name: "all ok",
 			opt: options{
 				config: "dummy",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "fake",
+				},
 			},
 			expectedErr: false,
 		},
@@ -50,7 +53,10 @@ func TestOptions_Validate(t *testing.T) {
 			name: "no config",
 			opt: options{
 				config: "",
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "fake",
+				},
 			},
 			expectedErr: true,
 		},
@@ -58,6 +64,9 @@ func TestOptions_Validate(t *testing.T) {
 			name: "no token, allow",
 			opt: options{
 				config: "dummy",
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+				},
 			},
 			expectedErr: false,
 		},

--- a/prow/cmd/jenkins-operator/main_test.go
+++ b/prow/cmd/jenkins-operator/main_test.go
@@ -33,7 +33,10 @@ func TestOptions_Validate(t *testing.T) {
 			input: options{
 				jenkinsURL:       "https://example.com",
 				jenkinsTokenFile: "secret",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -42,7 +45,10 @@ func TestOptions_Validate(t *testing.T) {
 			input: options{
 				jenkinsURL:             "https://example.com",
 				jenkinsBearerTokenFile: "secret",
-				github:                 flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -52,7 +58,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsURL:             "https://example.com",
 				jenkinsTokenFile:       "secret",
 				jenkinsBearerTokenFile: "other",
-				github:                 flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -64,7 +73,10 @@ func TestOptions_Validate(t *testing.T) {
 				certFile:         "cert",
 				keyFile:          "key",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: false,
 		},
@@ -75,7 +87,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				certFile:         "cert",
 				keyFile:          "key",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -86,7 +101,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				keyFile:          "key",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},
@@ -97,7 +115,10 @@ func TestOptions_Validate(t *testing.T) {
 				jenkinsTokenFile: "secret",
 				certFile:         "cert",
 				caCertFile:       "cacert",
-				github:           flagutil.GitHubOptions{TokenPath: "token"},
+				github: flagutil.GitHubOptions{
+					GitEndpoint: "https://github.com",
+					TokenPath:   "token",
+				},
 			},
 			expectedErr: true,
 		},

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -79,7 +79,7 @@ type Server struct {
 
 	gc *git.Client
 	// Used for unit testing
-	push func(repo, newBranch string) error
+	push func(newBranch string) error
 	ghc  githubClient
 	log  *logrus.Entry
 
@@ -382,7 +382,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 		push = s.push
 	}
 	// Push the new branch in the bot's fork.
-	if err := push(repo, newBranch); err != nil {
+	if err := push(newBranch); err != nil {
 		resp := fmt.Sprintf("failed to push cherry-picked changes in Github: %v", err)
 		s.log.WithFields(l.Data).Info(resp)
 		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -214,7 +214,7 @@ func TestCherryPickIC(t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(repo, newBranch string) error { return nil },
+		push:           func(newBranch string) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -336,7 +336,7 @@ func TestCherryPickPR(t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(repo, newBranch string) error { return nil },
+		push:           func(newBranch string) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -43,6 +43,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "github_test.go",
         "kubernetes_cluster_clients_test.go",
         "kubernetes_test.go",
     ],

--- a/prow/flagutil/github_test.go
+++ b/prow/flagutil/github_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+)
+
+func TestGithubOptions(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		endpoints   Strings
+		gitEndpoint string
+		tokenPath   string
+		expectedErr bool
+	}{
+		{
+			name:        "No token provided, we expect no errors",
+			endpoints:   NewStrings("https://github.mycorp.com/apis/v3"),
+			gitEndpoint: "https://github.mycorp.com",
+			tokenPath:   "",
+			expectedErr: false,
+		},
+		{
+			name:        "Good github options provided, we expect no errors",
+			endpoints:   NewStrings("http://ghproxy", "https://api.github.com"),
+			gitEndpoint: "https://github.com",
+			tokenPath:   "token",
+			expectedErr: false,
+		},
+		{
+			name:        "Invalid git url provided, we expect an error",
+			endpoints:   NewStrings("http://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitEndpoint: "://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid github endpoint provided, we expect an error",
+			endpoints:   NewStrings("://github.mycorp.com/apis/v3", "http://apisgateway.mycorp.com/github"),
+			gitEndpoint: "http://github.com",
+			tokenPath:   "token",
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			o := GitHubOptions{
+				endpoint:    testCase.endpoints,
+				GitEndpoint: testCase.gitEndpoint,
+				TokenPath:   testCase.tokenPath,
+			}
+			err := o.Validate(false)
+			if testCase.expectedErr && err == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+		})
+	}
+}

--- a/prow/git/BUILD.bazel
+++ b/prow/git/BUILD.bazel
@@ -1,16 +1,26 @@
-package(default_visibility = ["//visibility:public"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["git.go"],
     importpath = "k8s.io/test-infra/prow/git",
+    visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "client_test.go",
+        "git_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/git/localgit:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )
 
 filegroup(
@@ -27,11 +37,5 @@ filegroup(
         "//prow/git/localgit:all-srcs",
     ],
     tags = ["automanaged"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["git_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//prow/git/localgit:go_default_library"],
+    visibility = ["//visibility:public"],
 )

--- a/prow/git/client_test.go
+++ b/prow/git/client_test.go
@@ -1,0 +1,662 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"net/url"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type runWithRetries struct {
+	retries int
+	args    []string
+}
+
+type pluggableGitExecutor struct {
+	recordedRuns [][]string
+	runHandlers  []func(args ...string) (handled bool, output []byte, err error)
+
+	recordedRetries        []runWithRetries
+	runWithRetriesHandlers []func(retries int, args ...string) (handled bool, output []byte, err error)
+
+	remoteURL string
+}
+
+func (e *pluggableGitExecutor) run(args ...string) ([]byte, error) {
+	e.recordedRuns = append(e.recordedRuns, args)
+	for _, handler := range e.runHandlers {
+		if handled, output, err := handler(args...); handled {
+			return output, err
+		}
+	}
+	return nil, nil
+}
+
+func (e *pluggableGitExecutor) runWithRetries(retries int, args ...string) ([]byte, error) {
+	e.recordedRetries = append(e.recordedRetries, runWithRetries{retries: retries, args: args})
+	for _, handler := range e.runWithRetriesHandlers {
+		if handled, output, err := handler(retries, args...); handled {
+			return output, err
+		}
+	}
+	return nil, nil
+}
+
+func (e *pluggableGitExecutor) remote() string {
+	return e.remoteURL
+}
+
+func TestGitClient(t *testing.T) {
+	var testCases = []struct {
+		name string
+		// returns the gitExecutor mock to use and a func to check output state
+		generator func() (gitExecutor, func(t *testing.T))
+		run       func(underTest Repo, t *testing.T)
+	}{
+		{
+			name: "checkout calls git checkout successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"checkout", "commitlike"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Checkout("commitlike"); err != nil {
+					t.Errorf("expected no error from checkout, got %v", err)
+				}
+			},
+		},
+		{
+			name: "checkout calls git checkout unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"checkout", "commitlike"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Checkout("commitlike"); err == nil {
+					t.Error("expected an error from checkout, got none")
+				}
+			},
+		},
+		{
+			name: "rev-parse calls git rev-parse successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, []byte("revision"), nil
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"rev-parse", "commitlike"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				revision, err := underTest.RevParse("commitlike")
+				if err != nil {
+					t.Errorf("expected no error from rev-parse, got %v", err)
+				}
+				if revision != "revision" {
+					t.Errorf("incorrect response from rev-parse, expected revision got %s", revision)
+				}
+			},
+		},
+		{
+			name: "rev-parse calls git rev-parse unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"rev-parse", "commitlike"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if _, err := underTest.RevParse("commitlike"); err == nil {
+					t.Error("expected an error from rev-parse, got none")
+				}
+			},
+		},
+		{
+			name: "checking out new branch calls git branch successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"checkout", "-b", "branch"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.CheckoutNewBranch("branch"); err != nil {
+					t.Errorf("expected no error from checking out new branch, got %v", err)
+				}
+			},
+		},
+		{
+			name: "checking out new  branch calls git branch unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"checkout", "-b", "branch"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.CheckoutNewBranch("branch"); err == nil {
+					t.Error("expected an error from checking out new branch, got none")
+				}
+			},
+		},
+		{
+			name: "merge calls git merge successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, nil
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"merge", "--no-ff", "--no-stat", "-m merge", "commitlike"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				completed, err := underTest.Merge("commitlike")
+				if err != nil {
+					t.Errorf("expected no error from merge, got %v", err)
+				}
+				if !completed {
+					t.Error("expected merge to complete correctly")
+				}
+			},
+		},
+		{
+			name: "merge calls git merge unsuccessfully but aborts",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							for _, arg := range args {
+								if arg == "--abort" {
+									return true, nil, nil
+								}
+							}
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"merge", "--no-ff", "--no-stat", "-m merge", "commitlike"}, {"merge", "--abort"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				completed, err := underTest.Merge("commitlike")
+				if err != nil {
+					t.Errorf("expected no error from merge, got %v", err)
+				}
+				if completed {
+					t.Error("expected merge to not complete correctly")
+				}
+			},
+		},
+		{
+			name: "merge calls git merge unsuccessfully and cant abort",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"merge", "--no-ff", "--no-stat", "-m merge", "commitlike"}, {"merge", "--abort"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				completed, err := underTest.Merge("commitlike")
+				if err == nil {
+					t.Error("expected an error from merge, got none")
+				}
+				if completed {
+					t.Error("expected merge to not complete correctly")
+				}
+			},
+		},
+		{
+			name: "am calls git am successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, nil
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"am", "--3way", "path"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Am("path"); err != nil {
+					t.Errorf("expected no error from am, got %v", err)
+				}
+			},
+		},
+		{
+			name: "am calls git am unsuccessfully but aborts",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							for _, arg := range args {
+								if arg == "--abort" {
+									return true, nil, nil
+								}
+							}
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"am", "--3way", "path"}, {"am", "--abort"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Am("path"); err == nil {
+					t.Error("expected an error from am, got none")
+				}
+			},
+		},
+		{
+			name: "am calls git am unsuccessfully and cant abort",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"am", "--3way", "path"}, {"am", "--abort"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Am("path"); err == nil {
+					t.Error("expected an error from am, got none")
+				}
+			},
+		},
+		{
+			name: "push calls git push successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					remoteURL: "git.com",
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"push", "git.com", "branch"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Push("branch"); err != nil {
+					t.Errorf("expected no error from push, got %v", err)
+				}
+			},
+		},
+		{
+			name: "push calls git push unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+					remoteURL: "git.com",
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"push", "git.com", "branch"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Push("branch"); err == nil {
+					t.Error("expected an error from push, got none")
+				}
+			},
+		},
+		{
+			name: "checking out pull request calls git fetch and checkout successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					remoteURL: "git.com",
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRetries, []runWithRetries{{retries: 3, args: []string{"fetch", "git.com", "pull/123/head:pull123"}}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+					if actual, expected := e.recordedRuns, [][]string{{"checkout", "pull123"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.CheckoutPullRequest(123); err != nil {
+					t.Errorf("expected no error from push, got %v", err)
+				}
+			},
+		},
+		{
+			name: "checking out pull request calls git fetch unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runWithRetriesHandlers: []func(retries int, args ...string) (handled bool, output []byte, err error){
+						func(retries int, args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+					remoteURL: "git.com",
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRetries, []runWithRetries{{retries: 3, args: []string{"fetch", "git.com", "pull/123/head:pull123"}}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+					var nothing [][]string
+					if actual, expected := e.recordedRuns, nothing; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.CheckoutPullRequest(123); err == nil {
+					t.Error("expected an error from push, got none")
+				}
+			},
+		},
+		{
+			name: "config calls git config successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"config", "key", "value"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Config("key", "value"); err != nil {
+					t.Errorf("expected no error from config, got %v", err)
+				}
+			},
+		},
+		{
+			name: "config calls git config unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"config", "key", "value"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if err := underTest.Config("key", "value"); err == nil {
+					t.Error("expected an error from config, got none")
+				}
+			},
+		},
+		{
+			name: "log calls git log successfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, []byte("log"), nil
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"log", "--oneline"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				log, err := underTest.Log()
+				if err != nil {
+					t.Errorf("expected no error from log, got %v", err)
+				}
+				if log != "log" {
+					t.Errorf("incorrect response from log, expected log got %s", log)
+				}
+			},
+		},
+		{
+			name: "log calls git log unsuccessfully",
+			generator: func() (executor gitExecutor, check func(t *testing.T)) {
+				e := &pluggableGitExecutor{
+					runHandlers: []func(args ...string) (handled bool, output []byte, err error){
+						func(args ...string) (handled bool, output []byte, err error) {
+							return true, nil, errors.New("fail!")
+						},
+					},
+				}
+				return e, func(t *testing.T) {
+					if actual, expected := e.recordedRuns, [][]string{{"log", "--oneline"}}; !reflect.DeepEqual(actual, expected) {
+						t.Errorf("incorrect set of git calls: %v", diff.ObjectReflectDiff(actual, expected))
+					}
+				}
+			},
+			run: func(underTest Repo, t *testing.T) {
+				if _, err := underTest.Log(); err == nil {
+					t.Error("expected an error from log, got none")
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			executor, check := testCase.generator()
+			testCase.run(Repo{logger: logrus.WithField("test-case", testCase.name), executor: executor}, t)
+			check(t)
+		})
+	}
+}
+
+type initializeOutput struct {
+	initial bool
+	cache   cacheInteractor
+	err     error
+}
+
+type cloneOutput struct {
+	cache cacheInteractor
+	err   error
+}
+
+type fakeInitializer struct {
+	initializeOutputs map[string]initializeOutput
+
+	lastClone    int
+	cloneOutputs []cloneOutput
+}
+
+func (i *fakeInitializer) initialize(orgRepo string) (bool, cacheInteractor, error) {
+	if output, exists := i.initializeOutputs[orgRepo]; exists {
+		return output.initial, output.cache, output.err
+	}
+	return false, nil, nil
+}
+
+func (i *fakeInitializer) initializeClone() (cacheInteractor, error) {
+	output := i.cloneOutputs[i.lastClone]
+	i.lastClone++
+	return output.cache, output.err
+}
+
+func TestClient_Clone(t *testing.T) {
+	initializer := &fakeInitializer{
+		initializeOutputs: map[string]initializeOutput{
+			"org/repo":  {initial: true, cache: &cacheDirInteractor{cacheDir: "global"}, err: nil},
+			"org/other": {initial: false, cache: &cacheDirInteractor{cacheDir: "globalOther"}, err: nil},
+		},
+		cloneOutputs: []cloneOutput{
+			{cache: &cacheDirInteractor{cacheDir: "local"}, err: nil},
+			{cache: &cacheDirInteractor{cacheDir: "localOther"}, err: nil},
+		},
+	}
+
+	executors := map[string]map[string]*pluggableGitExecutor{
+		"org/repo": {
+			"global": &pluggableGitExecutor{
+				remoteURL: "server.com/repo",
+			},
+			"local": &pluggableGitExecutor{},
+		},
+		"org/other": {
+			"globalOther": &pluggableGitExecutor{
+				remoteURL: "server.com/other",
+			},
+			"localOther": &pluggableGitExecutor{},
+		},
+	}
+	factory := func(repo string, interactor cacheInteractor) gitExecutor {
+		if options, exist := executors[repo]; exist {
+			if executor, exists := options[interactor.dir()]; exists {
+				return executor
+			}
+		}
+		t.Errorf("asked for a executor for repo %q on dir %q, none exists", repo, interactor.dir())
+		return nil
+	}
+
+	client := Client{
+		logger:          logrus.WithField("test-case", "clone"),
+		executorFactory: factory,
+		initializer:     initializer,
+		repoLocks:       make(map[string]*sync.Mutex),
+	}
+
+	_, err := client.Clone("org/repo")
+	if err != nil {
+		t.Errorf("failed to clone first repo: %v", err)
+	}
+	if actual, expected := executors["org/repo"]["global"].recordedRetries, []runWithRetries{
+		{retries: 3, args: []string{"clone", "--mirror", "server.com/repo", "global"}},
+		{retries: 3, args: []string{"fetch"}},
+	}; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("incorrect set of global git calls: %v", diff.ObjectReflectDiff(actual, expected))
+	}
+	if actual, expected := executors["org/repo"]["local"].recordedRuns, [][]string{{"clone", "global", "local"}}; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("incorrect set of local git calls: %v", diff.ObjectReflectDiff(actual, expected))
+	}
+
+	_, err = client.Clone("org/other")
+	if err != nil {
+		t.Errorf("failed to clone second repo: %v", err)
+	}
+	if actual, expected := executors["org/other"]["globalOther"].recordedRetries, []runWithRetries{
+		{retries: 3, args: []string{"fetch"}},
+	}; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("incorrect set of global git calls: %v", diff.ObjectReflectDiff(actual, expected))
+	}
+	if actual, expected := executors["org/other"]["localOther"].recordedRuns, [][]string{{"clone", "globalOther", "localOther"}}; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("incorrect set of local git calls: %v", diff.ObjectReflectDiff(actual, expected))
+	}
+
+}
+
+func TestExecutorFor(t *testing.T) {
+	remote, err := url.Parse("https://server.somewhere.com/foo/bar")
+	if err != nil {
+		t.Fatalf("got unexpected error parsing URL: %v", err)
+	}
+
+	originalRemote := *remote
+
+	git := "git"
+	executor := executorFor(git, remote)("org/repo", &cacheDirInteractor{cacheDir: "somewhere"})
+
+	newRemote := *remote
+	if actual, expected := newRemote, originalRemote; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("creating executor mutated seed URL: %s", diff.ObjectReflectDiff(actual, expected))
+	}
+
+	if actual, expected := "https://server.somewhere.com/foo/bar/org/repo", executor.remote(); !reflect.DeepEqual(actual, expected) {
+		t.Errorf("executor has incorrect remote: %s", diff.ObjectReflectDiff(actual, expected))
+	}
+}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,8 +31,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 )
-
-const github = "github.com"
 
 // Client can clone repos. It keeps a local cache, so successive clones of the
 // same repo should be quick. Create with NewClient. Be sure to clean it up.
@@ -52,7 +51,7 @@ type Client struct {
 	git string
 	// base is the base path for git clone calls. For users it will be set to
 	// GitHub, but for tests set it to a directory with git repos.
-	base string
+	base *url.URL
 
 	// The mutex protects repoLocks which protect individual repos. This is
 	// necessary because Clone calls for the same repo are racy. Rather than
@@ -69,7 +68,7 @@ func (c *Client) Clean() error {
 
 // NewClient returns a client that talks to GitHub. It will fail if git is not
 // in the PATH.
-func NewClient() (*Client, error) {
+func NewClient(base *url.URL) (*Client, error) {
 	g, err := exec.LookPath("git")
 	if err != nil {
 		return nil, err
@@ -82,7 +81,7 @@ func NewClient() (*Client, error) {
 		logger:    logrus.WithField("client", "git"),
 		dir:       t,
 		git:       g,
-		base:      fmt.Sprintf("https://%s", github),
+		base:      base,
 		repoLocks: make(map[string]*sync.Mutex),
 	}, nil
 }
@@ -90,7 +89,7 @@ func NewClient() (*Client, error) {
 // SetRemote sets the remote for the client. This is not thread-safe, and is
 // useful for testing. The client will clone from remote/org/repo, and Repo
 // objects spun out of the client will also hit that path.
-func (c *Client) SetRemote(remote string) {
+func (c *Client) SetRemote(remote *url.URL) {
 	c.base = remote
 }
 
@@ -107,6 +106,11 @@ func (c *Client) getCredentials() (string, string) {
 	c.credLock.RLock()
 	defer c.credLock.RUnlock()
 	return c.user, string(c.tokenGenerator())
+}
+
+// GetBase returns Client.base as a *url.URL
+func (c *Client) GetBase() *url.URL {
+	return c.base
 }
 
 func (c *Client) lockRepo(repo string) {
@@ -138,7 +142,11 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 	base := c.base
 	user, pass := c.getCredentials()
 	if user != "" && pass != "" {
-		base = fmt.Sprintf("https://%s:%s@%s", user, pass, github)
+		gitURL, err := Remote(c.base, user, pass)
+		if err != nil {
+			return nil, err
+		}
+		base = gitURL
 	}
 	cache := filepath.Join(c.dir, repo) + ".git"
 	if _, err := os.Stat(cache); os.IsNotExist(err) {
@@ -147,7 +155,7 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 		if err := os.MkdirAll(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
-		remote := fmt.Sprintf("%s/%s", base, repo)
+		remote := fmt.Sprintf("%s/%s", base.Path, repo)
 		if b, err := retryCmd(c.logger, "", c.git, "clone", "--mirror", remote, cache); err != nil {
 			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
 		}
@@ -187,7 +195,7 @@ type Repo struct {
 	// git is the path to the git binary.
 	git string
 	// base is the base path for remote git fetch calls.
-	base string
+	base *url.URL
 	// repo is the full repo name: "org/repo".
 	repo string
 	// user is used for pushing to the remote repo.
@@ -288,16 +296,21 @@ func (r *Repo) Push(repo, branch string) error {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
 	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, repo, branch)
-	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, github, r.user, repo)
-	co := r.gitCommand("push", remote, branch)
-	_, err := co.CombinedOutput()
+
+	remote, err := Remote(r.base, r.user, r.pass, r.user, repo)
+	if err != nil {
+		return fmt.Errorf("Remote error: %v", err)
+	}
+
+	co := r.gitCommand("push", remote.String(), branch)
+	_, err = co.CombinedOutput()
 	return err
 }
 
 // CheckoutPullRequest does exactly that.
 func (r *Repo) CheckoutPullRequest(number int) error {
 	r.logger.Infof("Fetching and checking out %s#%d.", r.repo, number)
-	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
+	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base.String()+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
 		return fmt.Errorf("git fetch failed for PR %d: %v. output: %s", number, err, string(b))
 	}
 	co := r.gitCommand("checkout", fmt.Sprintf("pull%d", number))
@@ -314,6 +327,13 @@ func (r *Repo) Config(key, value string) error {
 		return fmt.Errorf("git config %s %s failed: %v. output: %s", key, value, err, string(b))
 	}
 	return nil
+}
+
+// Remote builds a remote url from user, pasword, and a slice of path items
+func Remote(base *url.URL, user string, pass string, pathItems ...string) (*url.URL, error) {
+	base.User = url.UserPassword(user, pass)
+	base.Path = strings.Join(pathItems, "/")
+	return base, nil
 }
 
 // retryCmd will retry the command a few times with backoff. Use this for any

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -18,7 +18,6 @@ limitations under the License.
 package git
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -32,26 +31,176 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type gitExecutor interface {
+	run(args ...string) ([]byte, error)
+	runWithRetries(retries int, args ...string) ([]byte, error)
+	remote() string
+}
+
+func newLiteralGitExecutor(dir, git string, remoteURL *url.URL) gitExecutor {
+	return &literalGitExecutor{
+		logger: logrus.WithFields(logrus.Fields{
+			"client": "git",
+			"dir":    dir,
+		}),
+		dir:       dir,
+		git:       git,
+		remoteURL: remoteURL,
+	}
+}
+
+type literalGitExecutor struct {
+	// logger will be used to log git operations
+	logger *logrus.Entry
+	// rootCacheDir is the location of the git cache for this repo.
+	dir string
+	// git is the path to the git binary.
+	git string
+	// base is the base path for git clone calls. For users it will be set to
+	// GitHub, but for tests set it to a directory with git repos.
+	remoteURL *url.URL
+}
+
+// run will pass the args to git and run the command
+func (e *literalGitExecutor) run(args ...string) ([]byte, error) {
+	var b []byte
+	var err error
+	logger := e.logger.WithField("args", strings.Join(args, " "))
+	c := exec.Command(e.git, args...)
+	c.Dir = e.dir
+	b, err = c.CombinedOutput()
+	if err != nil {
+		logger.WithError(err).Warningf("Running command returned error %v with output %s.", err, string(b))
+	} else {
+		logger.Info("Ran command.")
+	}
+
+	return b, err
+}
+
+// run will pass the args to git and run the command, retrying the specified
+// number of times with an exponential backoff in between
+func (e *literalGitExecutor) runWithRetries(retries int, args ...string) ([]byte, error) {
+	var b []byte
+	var err error
+	sleepyTime := time.Second
+	logger := e.logger.WithField("args", strings.Join(args, " "))
+	for i := 0; i < retries; i++ {
+		b, err = e.run(args...)
+		if err != nil {
+			logger.WithField("attempt", i).Warning("Running command failed, retrying...")
+			time.Sleep(sleepyTime)
+			sleepyTime *= 2
+			continue
+		}
+		break
+	}
+	if err != nil {
+		logger.Error("Failed to run command.")
+	}
+	return b, err
+}
+
+// remote exposes the remote URL for use in commands against the remote
+func (e *literalGitExecutor) remote() string {
+	return e.remoteURL.String()
+}
+
+type cacheInteractor interface {
+	walk(func(baseDir string) filepath.WalkFunc) error
+	operateOnFileData(path string, work func(contents []byte, err error) error) error
+	cacheCleaner
+	dir() string
+}
+
+type cacheCleaner interface {
+	clean() error
+}
+
+type cacheDirInteractor struct {
+	// cacheDir is the directory where a repository cache is cloned
+	cacheDir string
+}
+
+// walk allows consumers to walk around in our files while having knowledge of
+// our root rootCacheDir but not leaking that information out unless they really want to
+func (i *cacheDirInteractor) walk(walkFn func(baseDir string) filepath.WalkFunc) error {
+	return filepath.Walk(i.cacheDir, walkFn(i.cacheDir))
+}
+
+// operateOnFileData allows consumers to do work on the contents of a specific file
+// in our repository without knowing where it is on disk
+func (i *cacheDirInteractor) operateOnFileData(path string, work func(contents []byte, err error) error) error {
+	return work(ioutil.ReadFile(filepath.Join(i.cacheDir, path)))
+}
+
+func (i *cacheDirInteractor) clean() error {
+	return os.RemoveAll(i.cacheDir)
+}
+
+func (i *cacheDirInteractor) dir() string {
+	return i.cacheDir
+}
+
+type cacheInitializer interface {
+	initialize(orgRepo string) (bool, cacheInteractor, error)
+	initializeClone() (cacheInteractor, error)
+}
+
+type cacheDirInitializer struct {
+	// rootCacheDir is the root directory for the cache
+	rootCacheDir string
+}
+
+// initialize ensures that the directory to be used by the cache exists
+// and returns whether this is a fresh cache and an interactor for it
+func (i *cacheDirInitializer) initialize(orgRepo string) (bool, cacheInteractor, error) {
+	globalCache := filepath.Join(i.rootCacheDir, orgRepo)
+	interactor := &cacheDirInteractor{cacheDir: globalCache}
+	_, initialErr := os.Stat(globalCache)
+	if os.IsNotExist(initialErr) {
+		// We ignore this error since we can handle it
+		initialErr = nil
+		// Cache miss, clone it now.
+		if createErr := os.MkdirAll(globalCache, os.ModePerm); createErr != nil && !os.IsExist(createErr) {
+			return false, nil, createErr
+		}
+		return true, interactor, nil
+	}
+	return false, interactor, initialErr
+}
+
+// initializeClone creates a new cache for use for downstream copies of the
+// shared cache
+func (i *cacheDirInitializer) initializeClone() (cacheInteractor, error) {
+	localCache, err := ioutil.TempDir("", "git")
+	return &cacheDirInteractor{cacheDir: localCache}, err
+}
+
+// executorFor returns an executor for a cached repo
+func executorFor(git string, remote *url.URL) func(orgRepo string, interactor cacheInteractor) gitExecutor {
+	return func(orgRepo string, interactor cacheInteractor) gitExecutor {
+		// do not copy seed remote URL
+		newRemote := *remote
+		newRemote.Path = fmt.Sprintf("%s/%s", newRemote.Path, orgRepo)
+		return newLiteralGitExecutor(interactor.dir(), git, &newRemote)
+	}
+}
+
 // Client can clone repos. It keeps a local cache, so successive clones of the
 // same repo should be quick. Create with NewClient. Be sure to clean it up.
 type Client struct {
 	// logger will be used to log git operations and must be set.
 	logger *logrus.Entry
 
-	credLock sync.RWMutex
-	// user is used when pushing or pulling code if specified.
-	user string
+	// initializer knows how to initialize cached repos
+	initializer cacheInitializer
 
-	// needed to generate the token.
-	tokenGenerator func() []byte
+	// executorFactory knows how to create git executors
+	executorFactory func(repo string, interactor cacheInteractor) gitExecutor
 
-	// dir is the location of the git cache.
-	dir string
-	// git is the path to the git binary.
-	git string
-	// base is the base path for git clone calls. For users it will be set to
-	// GitHub, but for tests set it to a directory with git repos.
-	base *url.URL
+	// cleaner knows how to clean up the shared cache
+	cleaner cacheCleaner
 
 	// The mutex protects repoLocks which protect individual repos. This is
 	// necessary because Clone calls for the same repo are racy. Rather than
@@ -63,54 +212,27 @@ type Client struct {
 
 // Clean removes the local repo cache. The Client is unusable after calling.
 func (c *Client) Clean() error {
-	return os.RemoveAll(c.dir)
+	return c.cleaner.clean()
 }
 
 // NewClient returns a client that talks to GitHub. It will fail if git is not
 // in the PATH.
-func NewClient(base *url.URL) (*Client, error) {
-	g, err := exec.LookPath("git")
+func NewClient(remote *url.URL) (*Client, error) {
+	git, err := exec.LookPath("git")
 	if err != nil {
 		return nil, err
 	}
-	t, err := ioutil.TempDir("", "git")
+	cache, err := ioutil.TempDir("", "git")
 	if err != nil {
 		return nil, err
 	}
 	return &Client{
-		logger:    logrus.WithField("client", "git"),
-		dir:       t,
-		git:       g,
-		base:      base,
-		repoLocks: make(map[string]*sync.Mutex),
+		logger:          logrus.WithField("client", "git"),
+		executorFactory: executorFor(git, remote),
+		initializer:     &cacheDirInitializer{rootCacheDir: cache},
+		cleaner:         &cacheDirInteractor{cacheDir: cache},
+		repoLocks:       make(map[string]*sync.Mutex),
 	}, nil
-}
-
-// SetRemote sets the remote for the client. This is not thread-safe, and is
-// useful for testing. The client will clone from remote/org/repo, and Repo
-// objects spun out of the client will also hit that path.
-func (c *Client) SetRemote(remote *url.URL) {
-	c.base = remote
-}
-
-// SetCredentials sets credentials in the client to be used for pushing to
-// or pulling from remote repositories.
-func (c *Client) SetCredentials(user string, tokenGenerator func() []byte) {
-	c.credLock.Lock()
-	defer c.credLock.Unlock()
-	c.user = user
-	c.tokenGenerator = tokenGenerator
-}
-
-func (c *Client) getCredentials() (string, string) {
-	c.credLock.RLock()
-	defer c.credLock.RUnlock()
-	return c.user, string(c.tokenGenerator())
-}
-
-// GetBase returns Client.base as a *url.URL
-func (c *Client) GetBase() *url.URL {
-	return c.base
 }
 
 func (c *Client) lockRepo(repo string) {
@@ -139,89 +261,74 @@ func (c *Client) Clone(repo string) (*Repo, error) {
 	c.lockRepo(repo)
 	defer c.unlockRepo(repo)
 
-	base := c.base
-	user, pass := c.getCredentials()
-	if user != "" && pass != "" {
-		gitURL, err := Remote(c.base, user, pass)
-		if err != nil {
-			return nil, err
-		}
-		base = gitURL
+	// Ensure shared cache exists and is up-to-date
+	initial, cache, err := c.initializer.initialize(repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cache for repo %s: %v", repo, err)
 	}
-	cache := filepath.Join(c.dir, repo) + ".git"
-	if _, err := os.Stat(cache); os.IsNotExist(err) {
-		// Cache miss, clone it now.
-		c.logger.Infof("Cloning %s for the first time.", repo)
-		if err := os.MkdirAll(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
-			return nil, err
-		}
-		remote := fmt.Sprintf("%s/%s", base.Path, repo)
-		if b, err := retryCmd(c.logger, "", c.git, "clone", "--mirror", remote, cache); err != nil {
+
+	executor := c.executorFactory(repo, cache)
+	if initial {
+		if b, err := executor.runWithRetries(3, "clone", "--mirror", executor.remote(), cache.dir()); err != nil {
 			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
 		}
-	} else if err != nil {
-		return nil, err
-	} else {
-		// Cache hit. Do a git fetch to keep updated.
-		c.logger.Infof("Fetching %s.", repo)
-		if b, err := retryCmd(c.logger, cache, c.git, "fetch"); err != nil {
-			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
-		}
 	}
-	t, err := ioutil.TempDir("", "git")
+
+	if b, err := executor.runWithRetries(3, "fetch"); err != nil {
+		return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
+	}
+
+	localCache, err := c.initializer.initializeClone()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize local cache for repo %s: %v", repo, err)
 	}
-	if b, err := exec.Command(c.git, "clone", cache, t).CombinedOutput(); err != nil {
+
+	localExecutor := c.executorFactory(repo, localCache)
+	if b, err := localExecutor.run("clone", cache.dir(), localCache.dir()); err != nil {
 		return nil, fmt.Errorf("git repo clone error: %v. output: %s", err, string(b))
 	}
+
 	return &Repo{
-		Dir:    t,
-		logger: c.logger,
-		git:    c.git,
-		base:   base,
-		repo:   repo,
-		user:   user,
-		pass:   pass,
+		logger: c.logger.WithFields(logrus.Fields{
+			"repo": repo,
+		}),
+		executor: localExecutor,
+		cache:    localCache,
 	}, nil
 }
 
 // Repo is a clone of a git repository. Create with Client.Clone, and don't
 // forget to clean it up after.
 type Repo struct {
-	// Dir is the location of the git repo.
-	Dir string
-
-	// git is the path to the git binary.
-	git string
-	// base is the base path for remote git fetch calls.
-	base *url.URL
-	// repo is the full repo name: "org/repo".
-	repo string
-	// user is used for pushing to the remote repo.
-	user string
-	// pass is used for pushing to the remote repo.
-	pass string
+	executor gitExecutor
+	cache    cacheInteractor
 
 	logger *logrus.Entry
 }
 
 // Clean deletes the repo. It is unusable after calling.
 func (r *Repo) Clean() error {
-	return os.RemoveAll(r.Dir)
+	return r.cache.clean()
 }
 
-func (r *Repo) gitCommand(arg ...string) *exec.Cmd {
-	cmd := exec.Command(r.git, arg...)
-	cmd.Dir = r.Dir
-	return cmd
+// Walk allows for downstream consumers to touch files in this
+// repo while being aware of the base rootCacheDir without us exposing
+// the directories directly.
+func (r *Repo) Walk(input func(baseDir string) filepath.WalkFunc) error {
+	return r.cache.walk(input)
+}
+
+// OperateOnFileData allows for downstream consumers to touch
+// files in this repo while being aware of the base rootCacheDir without
+// us exposing the directories directly.
+func (r *Repo) OperateOnFileData(path string, work func(contents []byte, err error) error) error {
+	return r.cache.operateOnFileData(path, work)
 }
 
 // Checkout runs git checkout.
 func (r *Repo) Checkout(commitlike string) error {
-	r.logger.Infof("Checkout %s.", commitlike)
-	co := r.gitCommand("checkout", commitlike)
-	if b, err := co.CombinedOutput(); err != nil {
+	r.logger.WithField("commitlike", commitlike).Info("Checking out revision.")
+	if b, err := r.executor.run("checkout", commitlike); err != nil {
 		return fmt.Errorf("error checking out %s: %v. output: %s", commitlike, err, string(b))
 	}
 	return nil
@@ -229,8 +336,8 @@ func (r *Repo) Checkout(commitlike string) error {
 
 // RevParse runs git rev-parse.
 func (r *Repo) RevParse(commitlike string) (string, error) {
-	r.logger.Infof("RevParse %s.", commitlike)
-	b, err := r.gitCommand("rev-parse", commitlike).CombinedOutput()
+	r.logger.WithField("commitlike", commitlike).Info("Parsing revision.")
+	b, err := r.executor.run("rev-parse", commitlike)
 	if err != nil {
 		return "", fmt.Errorf("error rev-parsing %s: %v. output: %s", commitlike, err, string(b))
 	}
@@ -239,9 +346,8 @@ func (r *Repo) RevParse(commitlike string) (string, error) {
 
 // CheckoutNewBranch creates a new branch and checks it out.
 func (r *Repo) CheckoutNewBranch(branch string) error {
-	r.logger.Infof("Create and checkout %s.", branch)
-	co := r.gitCommand("checkout", "-b", branch)
-	if b, err := co.CombinedOutput(); err != nil {
+	r.logger.WithField("branch", branch).Info("Creating and checking out new branch.")
+	if b, err := r.executor.run("checkout", "-b", branch); err != nil {
 		return fmt.Errorf("error checking out %s: %v. output: %s", branch, err, string(b))
 	}
 	return nil
@@ -250,16 +356,16 @@ func (r *Repo) CheckoutNewBranch(branch string) error {
 // Merge attempts to merge commitlike into the current branch. It returns true
 // if the merge completes. It returns an error if the abort fails.
 func (r *Repo) Merge(commitlike string) (bool, error) {
-	r.logger.Infof("Merging %s.", commitlike)
-	co := r.gitCommand("merge", "--no-ff", "--no-stat", "-m merge", commitlike)
+	logger := r.logger.WithField("commitlike", commitlike)
+	logger.Info("Merging revision.")
 
-	b, err := co.CombinedOutput()
+	b, err := r.executor.run("merge", "--no-ff", "--no-stat", "-m merge", commitlike)
 	if err == nil {
 		return true, nil
 	}
-	r.logger.WithError(err).Warningf("Merge failed with output: %s", string(b))
+	logger.WithError(err).Warningf("Merge failed with output: %s", string(b))
 
-	if b, err := r.gitCommand("merge", "--abort").CombinedOutput(); err != nil {
+	if b, err := r.executor.run("merge", "--abort"); err != nil {
 		return false, fmt.Errorf("error aborting merge for commitlike %s: %v. output: %s", commitlike, err, string(b))
 	}
 
@@ -270,16 +376,16 @@ func (r *Repo) Merge(commitlike string) (bool, error) {
 // by performing a three-way merge (similar to git cherry-pick). It returns
 // an error if the patch cannot be applied.
 func (r *Repo) Am(path string) error {
-	r.logger.Infof("Applying %s.", path)
-	co := r.gitCommand("am", "--3way", path)
-	b, err := co.CombinedOutput()
+	logger := r.logger.WithField("path", path)
+	logger.Infof("Applying patch from path.")
+	b, err := r.executor.run("am", "--3way", path)
 	if err == nil {
 		return nil
 	}
 	output := string(b)
-	r.logger.WithError(err).Warningf("Patch apply failed with output: %s", output)
-	if b, abortErr := r.gitCommand("am", "--abort").CombinedOutput(); err != nil {
-		r.logger.WithError(abortErr).Warningf("Aborting patch apply failed with output: %s", string(b))
+	logger.WithError(err).Warningf("Patch apply failed with output: %s", output)
+	if b, abortErr := r.executor.run("am", "--abort"); abortErr != nil {
+		logger.WithError(abortErr).Warningf("Aborting patch apply failed with output: %s", string(b))
 	}
 	applyMsg := "The copy of the patch that failed is found in: .git/rebase-apply/patch"
 	if strings.Contains(output, applyMsg) {
@@ -291,30 +397,19 @@ func (r *Repo) Am(path string) error {
 
 // Push pushes over https to the provided owner/repo#branch using a password
 // for basic auth.
-func (r *Repo) Push(repo, branch string) error {
-	if r.user == "" || r.pass == "" {
-		return errors.New("cannot push without credentials - configure your git client")
-	}
-	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, repo, branch)
-
-	remote, err := Remote(r.base, r.user, r.pass, r.user, repo)
-	if err != nil {
-		return fmt.Errorf("Remote error: %v", err)
-	}
-
-	co := r.gitCommand("push", remote.String(), branch)
-	_, err = co.CombinedOutput()
+func (r *Repo) Push(branch string) error {
+	r.logger.WithFields(logrus.Fields{"branch": branch}).Info("Pushing to remote branch.")
+	_, err := r.executor.run("push", r.executor.remote(), branch)
 	return err
 }
 
 // CheckoutPullRequest does exactly that.
 func (r *Repo) CheckoutPullRequest(number int) error {
-	r.logger.Infof("Fetching and checking out %s#%d.", r.repo, number)
-	if b, err := retryCmd(r.logger, r.Dir, r.git, "fetch", r.base.String()+"/"+r.repo, fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
+	r.logger.WithFields(logrus.Fields{"pr": number}).Info("Checking out pull request.")
+	if b, err := r.executor.runWithRetries(3, "fetch", r.executor.remote(), fmt.Sprintf("pull/%d/head:pull%d", number, number)); err != nil {
 		return fmt.Errorf("git fetch failed for PR %d: %v. output: %s", number, err, string(b))
 	}
-	co := r.gitCommand("checkout", fmt.Sprintf("pull%d", number))
-	if b, err := co.CombinedOutput(); err != nil {
+	if b, err := r.executor.run("checkout", fmt.Sprintf("pull%d", number)); err != nil {
 		return fmt.Errorf("git checkout failed for PR %d: %v. output: %s", number, err, string(b))
 	}
 	return nil
@@ -323,36 +418,19 @@ func (r *Repo) CheckoutPullRequest(number int) error {
 // Config runs git config.
 func (r *Repo) Config(key, value string) error {
 	r.logger.Infof("Running git config %s %s", key, value)
-	if b, err := r.gitCommand("config", key, value).CombinedOutput(); err != nil {
+	if b, err := r.executor.run("config", key, value); err != nil {
 		return fmt.Errorf("git config %s %s failed: %v. output: %s", key, value, err, string(b))
 	}
 	return nil
 }
 
-// Remote builds a remote url from user, pasword, and a slice of path items
-func Remote(base *url.URL, user string, pass string, pathItems ...string) (*url.URL, error) {
-	base.User = url.UserPassword(user, pass)
-	base.Path = strings.Join(pathItems, "/")
-	return base, nil
-}
-
-// retryCmd will retry the command a few times with backoff. Use this for any
-// commands that will be talking to GitHub, such as clones or fetches.
-func retryCmd(l *logrus.Entry, dir, cmd string, arg ...string) ([]byte, error) {
-	var b []byte
-	var err error
-	sleepyTime := time.Second
-	for i := 0; i < 3; i++ {
-		c := exec.Command(cmd, arg...)
-		c.Dir = dir
-		b, err = c.CombinedOutput()
-		if err != nil {
-			l.Warningf("Running %s %v returned error %v with output %s.", cmd, arg, err, string(b))
-			time.Sleep(sleepyTime)
-			sleepyTime *= 2
-			continue
-		}
-		break
+// Log returns the git log, one line per commit.
+func (r *Repo) Log() (string, error) {
+	r.logger.Info("Running git log --oneline")
+	b, err := r.executor.run("log", "--oneline")
+	output := string(b)
+	if err != nil {
+		return output, fmt.Errorf("git log --oneline failed: %v. output: %s", err, output)
 	}
-	return b, err
+	return output, nil
 }

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -18,11 +18,13 @@ package git_test
 
 import (
 	"bytes"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/git/localgit"
 )
 
@@ -131,5 +133,56 @@ func TestCheckoutPR(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(r.Dir, "wow")); err != nil {
 		t.Errorf("Didn't find file in PR after checking out: %v", err)
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	gitURL, _ := url.Parse("https://github.mycorp.com")
+	t.Logf("Verifying client is created with correct base endpoint.")
+	a, err := git.NewClient(gitURL)
+	if err != nil {
+		t.Fatalf("Error creating new client: %+v", err)
+	}
+	if a.GetBase() != gitURL {
+		t.Errorf("NewClient base was different than expected: %v", err)
+	}
+}
+
+func TestRemote(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      *url.URL
+		user      string
+		pass      string
+		pathItems string
+		expected  string
+		err       bool
+	}{
+		{
+			name:      "A valid remote url, with user, and password, no path",
+			base:      &url.URL{Scheme: "https", Host: "github.com"},
+			user:      "user",
+			pass:      "pass",
+			pathItems: "",
+			expected:  "https://user:pass@github.com",
+		},
+		{
+			name:      "A valid remote url, with user, password, organization, and repository",
+			base:      &url.URL{Scheme: "https", Host: "github.com"},
+			user:      "user",
+			pass:      "pass",
+			pathItems: "user/repo",
+			expected:  "https://user:pass@github.com/user/repo",
+		},
+	}
+
+	for _, test := range tests {
+		testURL, err := git.Remote(test.base, test.user, test.pass, test.pathItems)
+		if err != nil {
+			t.Fatalf("Error creating git remote: %+v", err)
+		}
+		if test.expected != testURL.String() {
+			t.Errorf(`git remote did not match expected remote: expected: "%v" actual: "%v"`, test.expected, testURL)
+		}
 	}
 }

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -14,17 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// this needs to be in git_test to not cause an import cycle
 package git_test
 
 import (
-	"bytes"
-	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
+	"strings"
 	"testing"
 
-	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/git/localgit"
 )
 
@@ -83,13 +79,11 @@ func TestClone(t *testing.T) {
 			t.Errorf("Cleaning repo: %v", err)
 		}
 	}()
-	log := exec.Command("git", "log", "--oneline")
-	log.Dir = r3.Dir
-	if b, err := log.CombinedOutput(); err != nil {
+	if b, err := r3.Log(); err != nil {
 		t.Fatalf("git log: %v, %s", err, string(b))
 	} else {
 		t.Logf("git log output: %s", string(b))
-		if len(bytes.Split(bytes.TrimSpace(b), []byte("\n"))) != 2 {
+		if len(strings.Split(strings.TrimSpace(b), "\n")) != 2 {
 			t.Error("Wrong number of commits in git log output. Expected 2")
 		}
 	}
@@ -131,58 +125,13 @@ func TestCheckoutPR(t *testing.T) {
 	if err := r.CheckoutPullRequest(123); err != nil {
 		t.Fatalf("Checking out PR: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(r.Dir, "wow")); err != nil {
-		t.Errorf("Didn't find file in PR after checking out: %v", err)
-	}
-}
 
-func TestNewClient(t *testing.T) {
-	gitURL, _ := url.Parse("https://github.mycorp.com")
-	t.Logf("Verifying client is created with correct base endpoint.")
-	a, err := git.NewClient(gitURL)
-	if err != nil {
-		t.Fatalf("Error creating new client: %+v", err)
-	}
-	if a.GetBase() != gitURL {
-		t.Errorf("NewClient base was different than expected: %v", err)
-	}
-}
-
-func TestRemote(t *testing.T) {
-	tests := []struct {
-		name      string
-		base      *url.URL
-		user      string
-		pass      string
-		pathItems string
-		expected  string
-		err       bool
-	}{
-		{
-			name:      "A valid remote url, with user, and password, no path",
-			base:      &url.URL{Scheme: "https", Host: "github.com"},
-			user:      "user",
-			pass:      "pass",
-			pathItems: "",
-			expected:  "https://user:pass@github.com",
-		},
-		{
-			name:      "A valid remote url, with user, password, organization, and repository",
-			base:      &url.URL{Scheme: "https", Host: "github.com"},
-			user:      "user",
-			pass:      "pass",
-			pathItems: "user/repo",
-			expected:  "https://user:pass@github.com/user/repo",
-		},
-	}
-
-	for _, test := range tests {
-		testURL, err := git.Remote(test.base, test.user, test.pass, test.pathItems)
+	if err := r.OperateOnFileData("wow", func(contents []byte, err error) error {
 		if err != nil {
-			t.Fatalf("Error creating git remote: %+v", err)
+			t.Error("Didn't find file in PR after checking out")
 		}
-		if test.expected != testURL.String() {
-			t.Errorf(`git remote did not match expected remote: expected: "%v" actual: "%v"`, test.expected, testURL)
-		}
+		return nil
+	}); err != nil {
+		t.Errorf("Failed to operate on files in the repo: %v", err)
 	}
 }

--- a/prow/git/localgit/BUILD.bazel
+++ b/prow/git/localgit/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     name = "go_default_library",
     srcs = ["localgit.go"],
     importpath = "k8s.io/test-infra/prow/git/localgit",
-    deps = ["//prow/git:go_default_library"],
+    deps = [
+        "//prow/git:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -21,6 +21,7 @@ package localgit
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,7 +49,7 @@ func New() (*LocalGit, *git.Client, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	c, err := git.NewClient()
+	c, err := git.NewClient(&url.URL{Host: "https://github.com"})
 	if err != nil {
 		os.RemoveAll(t)
 		return nil, nil, err
@@ -60,7 +61,11 @@ func New() (*LocalGit, *git.Client, error) {
 
 	c.SetCredentials("", getSecret)
 
-	c.SetRemote(t)
+	c.SetRemote(&url.URL{
+		Scheme: "file",
+		Host:   "",
+		Path:   t,
+	})
 	return &LocalGit{
 		Dir: t,
 		Git: g,

--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//prow/git/localgit:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	prowConf "k8s.io/test-infra/prow/config"
@@ -513,12 +514,8 @@ func TestLoadRepoOwners(t *testing.T) {
 		}
 		ro := r.(*RepoOwners)
 
-		if ro.baseDir == "" {
-			t.Errorf("Expected 'baseDir' to be populated.")
-			continue
-		}
 		if (ro.RepoAliases != nil) != test.aliasesFileExists {
-			t.Errorf("Expected 'RepoAliases' to be poplulated: %t, but got %t.", test.aliasesFileExists, ro.RepoAliases != nil)
+			t.Errorf("Expected 'RepoAliases' to be populated: %t, but got %t.", test.aliasesFileExists, ro.RepoAliases != nil)
 			continue
 		}
 		if ro.enableMDYAML != test.mdEnabled {
@@ -539,7 +536,7 @@ func TestLoadRepoOwners(t *testing.T) {
 				}
 			}
 			if !reflect.DeepEqual(expected, converted) {
-				t.Errorf("Expected %s to be:\n%+v\ngot:\n%+v.", field, expected, converted)
+				t.Errorf("Did not get expected %s: %s.", field, diff.ObjectReflectDiff(expected, converted))
 			}
 		}
 		check("approvers", test.expectedApprovers, ro.approvers)
@@ -610,7 +607,7 @@ func TestLoadRepoAliases(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(got, test.expectedRepoAliases) {
-			t.Errorf("[%s] Expected RepoAliases: %#v, but got: %#v.", test.name, test.expectedRepoAliases, got)
+			t.Errorf("[%s] Got unexpected RepoAliases: %s.", test.name, diff.ObjectReflectDiff(test.expectedRepoAliases, got))
 		}
 		cleanup()
 	}


### PR DESCRIPTION
These changes refactor the `git` client to:

 - not expose the internals of the caching and directory structure to
   downstream users
 - allow for dependency injection in order to test correct interaction
   with the `git` binary when making actions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes #11219 

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 
@yastij @apesternikov @midnightconman 