### PR TITLE
Add label for French language

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -271,6 +271,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="language/en" href="#language/en">`language/en`</a> | Issues or PRs related to English language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/fr" href="#language/fr">`language/fr`</a> | Issues or PRs related to French language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/ja" href="#language/ja">`language/ja`</a> | Issues or PRs related to Japanese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/ko" href="#language/ko">`language/ko`</a> | Issues or PRs related to Korean language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/no" href="#language/no">`language/no`</a> | Issues or PRs related to Norwegian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1002,6 +1002,12 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: e9b3f9
+        description: Issues or PRs related to French language
+        name: language/fr
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
         description: Issues or PRs related to Japanese language
         name: language/ja
         target: both


### PR DESCRIPTION
This PR adds a label, `language/fr`, for French language content. 

This is exciting, because it means we've got a new French localization in progress! https://github.com/kubernetes/website/pull/12548

/cc @kubernetes/sig-contributor-experience-pr-reviews
