### PR TITLE
add back the --dry-run=false flag for sinker and horologium

### DIFF
--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -35,6 +35,7 @@ spec:
         image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
         args:
         - --job-config-path=/etc/job-config
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,6 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
+        - --dry-run=false
         image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
         volumeMounts:
         - mountPath: /etc/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -239,6 +239,8 @@ spec:
       containers:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
+        args:
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -321,6 +323,8 @@ spec:
       containers:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
+        args:
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
after https://github.com/kubernetes/test-infra/pull/11267
/hold

/assign @cjwagner 