### PR TITLE
Plugin Parameters to Change Github URL

### DIFF
--- a/prow/plugins/approve/BUILD.bazel
+++ b/prow/plugins/approve/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/approve",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",
@@ -24,6 +25,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -19,6 +19,7 @@ package approve
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
@@ -171,6 +173,7 @@ func TestHandle(t *testing.T) {
 		needsIssue          bool
 		lgtmActsAsApprove   bool
 		reviewActsAsApprove bool
+		githubLinkURL       *url.URL
 
 		expectDelete    bool
 		expectComment   bool
@@ -190,6 +193,7 @@ func TestHandle(t *testing.T) {
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -222,6 +226,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -258,6 +263,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -293,6 +299,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -330,6 +337,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:    false,
 			expectToggle:    true,
@@ -368,6 +376,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -387,6 +396,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -429,6 +439,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -448,6 +459,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -467,6 +479,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          true,
 			lgtmActsAsApprove:   true,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -504,6 +517,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -523,6 +537,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          true,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -541,6 +556,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  false,
@@ -579,6 +595,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   true,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -618,6 +635,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -633,6 +651,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -665,6 +684,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -701,6 +721,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -737,6 +758,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -778,6 +800,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -819,6 +842,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  false,
@@ -856,6 +880,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  true,
 			expectToggle:  true,
@@ -894,6 +919,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  false,
@@ -930,6 +956,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: true,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -963,6 +990,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			needsIssue:          false,
 			lgtmActsAsApprove:   false,
 			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
 
 			expectDelete:  false,
 			expectToggle:  true,
@@ -979,6 +1007,40 @@ The pull request process is described [here](https://git.k8s.io/community/contri
 Needs approval from an approver in each of these files:
 
 - ~~[c/OWNERS](https://github.com/org/repo/blob/dev/c/OWNERS)~~ [cjwagner]
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":[]} -->`,
+		},
+		{
+			name:                "different GitHub link URL",
+			branch:              "dev",
+			hasLabel:            false,
+			files:               []string{"c/c.go"},
+			comments:            []github.IssueComment{},
+			reviews:             []github.Review{},
+			selfApprove:         true,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.mycorp.com"},
+
+			expectDelete:  false,
+			expectToggle:  true,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
+
+The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
+
+<details >
+Needs approval from an approver in each of these files:
+
+- ~~[c/OWNERS](https://github.mycorp.com/org/repo/blob/dev/c/OWNERS)~~ [cjwagner]
 
 Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
@@ -1019,6 +1081,9 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			logrus.WithField("plugin", "approve"),
 			fghc,
 			fr,
+			config.GitHubOptions{
+				LinkURL: test.githubLinkURL,
+			},
 			&plugins.Approve{
 				Repos:               []string{"org/repo"},
 				RequireSelfApproval: &rsa,
@@ -1265,7 +1330,7 @@ func TestHandleGenericComment(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state) error {
 		gotState = pr
 		handled = true
 		return nil
@@ -1292,6 +1357,12 @@ func TestHandleGenericComment(t *testing.T) {
 
 	for _, test := range tests {
 		test.commentEvent.Repo = repo
+		githubConfig := config.GitHubOptions{
+			LinkURL: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+			},
+		}
 		config := &plugins.Configuration{}
 		config.Approve = append(config.Approve, plugins.Approve{
 			Repos:             []string{test.commentEvent.Repo.Owner.Login},
@@ -1301,6 +1372,7 @@ func TestHandleGenericComment(t *testing.T) {
 			logrus.WithField("plugin", "approve"),
 			fghc,
 			fakeOwnersClient{},
+			githubConfig,
 			config,
 			&test.commentEvent,
 		)
@@ -1473,7 +1545,7 @@ func TestHandleReview(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, config config.GitHubOptions, opts *plugins.Approve, pr *state) error {
 		gotState = pr
 		handled = true
 		return nil
@@ -1505,6 +1577,12 @@ func TestHandleReview(t *testing.T) {
 	for _, test := range tests {
 		test.reviewEvent.Repo = repo
 		test.reviewEvent.PullRequest = pr
+		githubConfig := config.GitHubOptions{
+			LinkURL: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+			},
+		}
 		config := &plugins.Configuration{}
 		irs := !test.reviewActsAsApprove
 		config.Approve = append(config.Approve, plugins.Approve{
@@ -1516,6 +1594,7 @@ func TestHandleReview(t *testing.T) {
 			logrus.WithField("plugin", "approve"),
 			fghc,
 			fakeOwnersClient{},
+			githubConfig,
 			config,
 			&test.reviewEvent,
 		)
@@ -1631,7 +1710,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state) error {
 		gotState = pr
 		handled = true
 		return nil
@@ -1654,6 +1733,12 @@ func TestHandlePullRequest(t *testing.T) {
 			logrus.WithField("plugin", "approve"),
 			fghc,
 			fakeOwnersClient{},
+			config.GitHubOptions{
+				LinkURL: &url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+				},
+			},
 			&plugins.Configuration{},
 			&test.prEvent,
 		)

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -428,23 +429,21 @@ func (ap Approvers) UnapprovedFiles() sets.String {
 }
 
 // GetFiles returns owners files that still need approval.
-func (ap Approvers) GetFiles(org, repo, branch string) []File {
+func (ap Approvers) GetFiles(baseURL *url.URL, branch string) []File {
 	allOwnersFiles := []File{}
 	filesApprovers := ap.GetFilesApprovers()
 	for _, file := range ap.owners.GetOwnersSet().List() {
 		if len(filesApprovers[file]) == 0 {
 			allOwnersFiles = append(allOwnersFiles, UnapprovedFile{
+				baseURL:  baseURL,
 				filepath: file,
-				org:      org,
-				repo:     repo,
 				branch:   branch,
 			})
 		} else {
 			allOwnersFiles = append(allOwnersFiles, ApprovedFile{
+				baseURL:   baseURL,
 				filepath:  file,
 				approvers: filesApprovers[file],
-				org:       org,
-				repo:      repo,
 				branch:    branch,
 			})
 		}
@@ -540,19 +539,17 @@ type File interface {
 
 // ApprovedFile contains the information of a an approved file.
 type ApprovedFile struct {
+	baseURL  *url.URL
 	filepath string
 	// approvers is the set of users that approved this file change.
 	approvers sets.String
-	org       string
-	repo      string
 	branch    string
 }
 
 // UnapprovedFile contains the information of a an unapproved file.
 type UnapprovedFile struct {
+	baseURL  *url.URL
 	filepath string
-	org      string
-	repo     string
 	branch   string
 }
 
@@ -561,7 +558,11 @@ func (a ApprovedFile) String() string {
 	if strings.HasSuffix(a.filepath, ".md") {
 		fullOwnersPath = a.filepath
 	}
-	link := fmt.Sprintf("https://github.com/%s/%s/blob/%s/%v", a.org, a.repo, a.branch, fullOwnersPath)
+	link := fmt.Sprintf("%s/blob/%s/%v",
+		a.baseURL.String(),
+		a.branch,
+		fullOwnersPath,
+	)
 	return fmt.Sprintf("- ~~[%s](%s)~~ [%v]\n", fullOwnersPath, link, strings.Join(a.approvers.List(), ","))
 }
 
@@ -570,7 +571,11 @@ func (ua UnapprovedFile) String() string {
 	if strings.HasSuffix(ua.filepath, ".md") {
 		fullOwnersPath = ua.filepath
 	}
-	link := fmt.Sprintf("https://github.com/%s/%s/blob/%s/%v", ua.org, ua.repo, ua.branch, fullOwnersPath)
+	link := fmt.Sprintf("%s/blob/%s/%v",
+		ua.baseURL.String(),
+		ua.branch,
+		fullOwnersPath,
+	)
 	return fmt.Sprintf("- **[%s](%s)**\n", fullOwnersPath, link)
 }
 
@@ -593,7 +598,8 @@ func GenerateTemplate(templ, name string, data interface{}) (string, error) {
 // 	- a suggested list of people from each OWNERS files that can fully approve the PR
 // 	- how an approver can indicate their approval
 // 	- how an approver can cancel their approval
-func GetMessage(ap Approvers, org, repo, branch string) *string {
+func GetMessage(ap Approvers, linkURL *url.URL, org, repo, branch string) *string {
+	linkURL.Path = org + "/" + repo
 	message, err := GenerateTemplate(`{{if (and (not .ap.RequirementsMet) (call .ap.ManuallyApproved )) }}
 Approval requirements bypassed by manually added approval.
 
@@ -629,10 +635,10 @@ The pull request process is described [here](https://git.k8s.io/community/contri
 <details {{if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}open{{end}}>
 Needs approval from an approver in each of these files:
 
-{{range .ap.GetFiles .org .repo .branch}}{{.}}{{end}}
+{{range .ap.GetFiles .baseURL .branch}}{{.}}{{end}}
 Approvers can indicate their approval by writing `+"`/approve`"+` in a comment
 Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
-</details>`, "message", map[string]interface{}{"ap": ap, "org": org, "repo": repo, "branch": branch})
+</details>`, "message", map[string]interface{}{"ap": ap, "baseURL": linkURL, "org": org, "repo": repo, "branch": branch})
 	if err != nil {
 		ap.owners.log.WithError(err).Errorf("Error generating message.")
 		return nil


### PR DESCRIPTION
This change adds a `github` config block to `plugins.yaml`. The current options are `link_url` and `api_link_url`. This means that we can override the github.com links that the `approve` plugin comments on PRs. This also adds a `github_link_url` config option to `approve` config blocks... this can be overridden like so:

plugins.yaml
```
github:
  link_url: https://github.corp.com
```

or like this:
plugins.yaml
```
github:
  link_url: https://github.corp.com

approve:
- repos:
  - org/secure-repo
  github_link_url: https://security.github.corp.com
```

components: plugins, plugins/approve

Starts to fix https://github.com/kubernetes/test-infra/issues/11226

Thank you for any reviews and comments. :smile: 