### PR TITLE
Default sinker and horologium to --dry-run=false for the time being

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -40,12 +40,13 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *February 13, 2019* `horologium` and `sinker` deployments will soon require `--dry-run=false` in production, please set this before March 15. At that time flag will default to --dry-run=true instead of --dry-run=false.
  - *February 1, 2019* Now that `hook` and `tide` will no longer post "Skipped" statuses
    for jobs that do not need to run, it is not possible to require those statuses with
    branch protection. Therefore, it is necessary to run the `branchprotector` from at
    least version `510db59` before upgrading `tide` to that version.
  - *February 1, 2019* `horologium` and `sinker` now support the `--dry-run` flag,
-   so you must pass `--dry-run=false` to keep the previous behavior.
+   so you must pass `--dry-run=false` to keep the previous behavior (see Feb 13 update).
  - *January 31, 2019* `sub` no longer supports the `--masterurl` flag for connecting
    to the infrastructure cluster. Use `--kubeconfig` with `--context` for this.
  - *January 31, 2019* `crier` no longer supports the `--masterurl` flag for connecting

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -54,8 +54,10 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+	"reflect"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	pjfake "k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -397,5 +400,115 @@ func assertSetsEqual(expected, actual sets.String, t *testing.T, prefix string) 
 	}
 	if extra := actual.Difference(expected); extra.Len() > 0 {
 		t.Errorf("%s: found unexpected: %v", prefix, extra.List())
+	}
+}
+
+func TestFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     map[string]string
+		del      sets.String
+		expected func(*options)
+		err      bool
+	}{
+		{
+			name: "minimal flags work",
+		},
+		{
+			name: "config-path defaults to something valid",
+			del:  sets.NewString("--config-path"),
+			expected: func(o *options) {
+				o.configPath = defaultConfigPath
+			},
+		},
+		{
+			name: "require config-path",
+			args: map[string]string{
+				"--config-path": "",
+			},
+			err: true,
+		},
+		{
+			name: "expicitly set --dry-run=false",
+			args: map[string]string{
+				"--dry-run": "false",
+			},
+			expected: func(o *options) {
+				o.dryRun = flagutil.Bool{
+					Explicit: true,
+				}
+			},
+		},
+		{
+			name: "--dry-run=true requires --deck-url",
+			args: map[string]string{
+				"--dry-run":  "true",
+				"--deck-url": "",
+			},
+			err: true,
+		},
+		{
+			name: "explicitly set --dry-run=true",
+			args: map[string]string{
+				"--dry-run":  "true",
+				"--deck-url": "http://whatever",
+			},
+			expected: func(o *options) {
+				o.dryRun = flagutil.Bool{
+					Value:    true,
+					Explicit: true,
+				}
+				o.kubernetes.DeckURI = "http://whatever"
+			},
+		},
+		{
+			name: "dry run defaults to false", // TODO(fejta): change to true in April
+			del:  sets.NewString("--dry-run"),
+			expected: func(o *options) {
+				o.dryRun = flagutil.Bool{}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := &options{
+				configPath: "yo",
+				dryRun: flagutil.Bool{
+					Explicit: true,
+				},
+			}
+			if tc.expected != nil {
+				tc.expected(expected)
+			}
+
+			argMap := map[string]string{
+				"--config-path": "yo",
+				"--dry-run":     "false",
+			}
+			for k, v := range tc.args {
+				argMap[k] = v
+			}
+			for k := range tc.del {
+				delete(argMap, k)
+			}
+
+			var args []string
+			for k, v := range argMap {
+				args = append(args, k+"="+v)
+			}
+			fs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
+			actual := gatherOptions(fs, args...)
+			switch err := actual.Validate(); {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("failed to receive expected error")
+			case !reflect.DeepEqual(*expected, actual):
+				t.Errorf("%#v != expected %#v", actual, *expected)
+			}
+		})
 	}
 }

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "bool.go",
         "doc.go",
         "github.go",
         "k8s_client.go",

--- a/prow/flagutil/bool.go
+++ b/prow/flagutil/bool.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"strconv"
+)
+
+// Bool holds a boolean flag value, tracking whether it was set explicitly.
+type Bool struct {
+	Value    bool
+	Explicit bool
+}
+
+// IsBoolFlag causes golang to consider --foo to mean --foo=true
+func (b *Bool) IsBoolFlag() bool {
+	return true
+}
+
+// String value of the string.
+func (b *Bool) String() string {
+	return strconv.FormatBool(b.Value)
+}
+
+// Set the bool according to the string.
+func (b *Bool) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	b.Explicit = true
+	b.Value = v
+	return nil
+}

--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -40,7 +40,7 @@ type KubernetesOptions struct {
 	kubeconfig   string
 	infraContext string
 
-	deckURI string
+	DeckURI string
 
 	// from resolution
 	resolved                   bool
@@ -54,18 +54,18 @@ func (o *KubernetesOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.buildCluster, "build-cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster. All clusters are used as build clusters. Cannot be combined with --kubeconfig.")
 	fs.StringVar(&o.kubeconfig, "kubeconfig", "", "Path to .kube/config file. If empty, uses the local cluster. All contexts other than the default or whichever is passed to --context are used as build clusters. . Cannot be combined with --build-cluster.")
 	fs.StringVar(&o.infraContext, "context", "", "The name of the kubeconfig context to use for the infrastructure client. If empty and --kubeconfig is not set, uses the local cluster.")
-	fs.StringVar(&o.deckURI, "deck-url", "", "Deck URI for read-only access to the infrastructure cluster.")
+	fs.StringVar(&o.DeckURI, "deck-url", "", "Deck URI for read-only access to the infrastructure cluster.")
 }
 
 // Validate validates Kubernetes options.
 func (o *KubernetesOptions) Validate(dryRun bool) error {
-	if dryRun && o.deckURI == "" {
+	if dryRun && o.DeckURI == "" {
 		return errors.New("a dry-run was requested but required flag -deck-url was unset")
 	}
 
-	if o.deckURI != "" {
-		if _, err := url.ParseRequestURI(o.deckURI); err != nil {
-			return fmt.Errorf("invalid -deck-url URI: %q", o.deckURI)
+	if o.DeckURI != "" {
+		if _, err := url.ParseRequestURI(o.DeckURI); err != nil {
+			return fmt.Errorf("invalid -deck-url URI: %q", o.DeckURI)
 		}
 	}
 
@@ -146,7 +146,7 @@ func (o *KubernetesOptions) ProwJobClient(namespace string, dryRun bool) (prowJo
 	}
 
 	if o.dryRun {
-		return kube.NewDryRunProwJobClient(o.deckURI), nil
+		return kube.NewDryRunProwJobClient(o.DeckURI), nil
 	}
 
 	return o.prowJobClientset.ProwV1().ProwJobs(namespace), nil

--- a/prow/flagutil/kubernetes_cluster_clients_test.go
+++ b/prow/flagutil/kubernetes_cluster_clients_test.go
@@ -76,7 +76,7 @@ func TestKubernetesOptions_Validate(t *testing.T) {
 			name:   "all ok with dry-run",
 			dryRun: true,
 			kubernetes: &KubernetesOptions{
-				deckURI: "https://example.com",
+				DeckURI: "https://example.com",
 			},
 			expectedErr: false,
 		},


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov @krzyzacy 

Also export DeckURI so that we can validate its value, since dry-run depends on it.

There's lots of room to remove code duplication for this config, but would prefer to do that in a follow-up PR (along with other components like plank, etc) after we get prow working.