### PR TITLE
Convert/transfer latest GCS results for any testgrid group to ResultStore

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -6,12 +6,16 @@ go_library(
         "convert.go",
         "download.go",
         "main.go",
+        "upload.go",
     ],
     importpath = "k8s.io/test-infra/experiment/resultstore",
     visibility = ["//visibility:private"],
     deps = [
+        "//prow/flagutil:go_default_library",
+        "//testgrid/config:go_default_library",
         "//testgrid/resultstore:go_default_library",
         "//testgrid/util/gcs:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/experiment/resultstore/download.go
+++ b/experiment/resultstore/download.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"cloud.google.com/go/storage"
 	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
@@ -30,21 +31,21 @@ type downloadResult struct {
 	suiteMetas   []gcs.SuitesMeta
 }
 
-func download(ctx context.Context, opt options) (*downloadResult, error) {
+func storageClient(ctx context.Context, account string) (*storage.Client, error) {
 	var creds []string
-	if opt.account != "" {
-		creds = append(creds, opt.account)
+	if account != "" {
+		creds = append(creds, account)
 	}
-	client, err := gcs.ClientWithCreds(ctx, creds...)
-	if err != nil {
-		return nil, fmt.Errorf("client: %v", err)
-	}
+	return gcs.ClientWithCreds(ctx, creds...)
+}
+
+func download(ctx context.Context, client *storage.Client, path gcs.Path) (*downloadResult, error) {
 
 	build := gcs.Build{
-		Bucket:     client.Bucket(opt.path.Bucket()),
+		Bucket:     client.Bucket(path.Bucket()),
 		Context:    ctx,
-		Prefix:     trailingSlash(opt.path.Object()),
-		BucketPath: opt.path.Bucket(),
+		Prefix:     trailingSlash(path.Object()),
+		BucketPath: path.Bucket(),
 	}
 
 	fmt.Println("Read started...")

--- a/experiment/resultstore/upload.go
+++ b/experiment/resultstore/upload.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Resultstore converts --build=gs://prefix/JOB/NUMBER from prow's pod-tuils to a ResultStore invocation suite, which it optionally will --upload=gcp-project.
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/test-infra/testgrid/resultstore"
+	"k8s.io/test-infra/testgrid/util/gcs"
+)
+
+func resultstoreClient(ctx context.Context, account string, secret resultstore.Secret) (*resultstore.Client, error) {
+	conn, err := resultstore.Connect(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	rsClient := resultstore.NewClient(conn).WithContext(ctx)
+	if secret != "" {
+		rsClient = rsClient.WithSecret(secret)
+	} else {
+		secret := resultstore.NewSecret()
+		fmt.Println("Secret:", secret)
+		rsClient = rsClient.WithSecret(secret)
+	}
+	return rsClient, nil
+}
+
+// upload the result downloaded from path into project.
+func upload(rsClient *resultstore.Client, project string, path gcs.Path, result downloadResult) (string, error) {
+	inv, target, test := convert(
+		project,
+		"Results of "+path.String(),
+		path,
+		result,
+	)
+	print(inv.To(), test.To())
+
+	if project == "" {
+		return "", nil
+	}
+
+	targetID := test.Name
+	const configID = resultstore.Default
+	invName, err := rsClient.Invocations().Create(inv)
+	if err != nil {
+		return "", fmt.Errorf("create invocation: %v", err)
+	}
+	targetName, err := rsClient.Targets(invName).Create(targetID, target)
+	if err != nil {
+		return resultstore.URL(invName), fmt.Errorf("create target: %v", err)
+	}
+	url := resultstore.URL(targetName)
+	_, err = rsClient.Configurations(invName).Create(configID)
+	if err != nil {
+		return url, fmt.Errorf("create configuration: %v", err)
+	}
+	ctName, err := rsClient.ConfiguredTargets(targetName, configID).Create()
+	if err != nil {
+		return url, fmt.Errorf("create configured target: %v", err)
+	}
+	_, err = rsClient.Actions(ctName).Create("primary", test)
+	if err != nil {
+		return url, fmt.Errorf("create action: %v", err)
+	}
+	return url, nil
+}

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -18,4 +18,5 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-go vet $(go list ./... | grep -v 'k8s.io/test-infra/testgrid')
+# TODO(fejta): check in testgrid pb.go files
+bazel run //:govet -- $(bazel run //:go -- list ./... | grep -v -E 'k8s.io/test-infra/(testgrid|experiment/resultstore)')


### PR DESCRIPTION
* Fix `gcs.Finished()` to detect when a build is still running (regression from https://github.com/kubernetes/test-infra/blob/765b67db69e13ff6e420e6d2f914a3fe44a17c44/testgrid/cmd/updater/main.go#L576-L581 )

ref https://github.com/kubernetes/test-infra/issues/11009

/assign @michelle192837 @krzyzacy @Katharine