### PR TITLE
Bind kube-proxy metrics on 0.0.0.0 in tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -97,7 +97,8 @@ presets:
   - name: KUBELET_TEST_ARGS
     value: "--enable-debugging-handlers"
   - name: KUBEPROXY_TEST_ARGS
-    value: "--profiling"
+  # TODO(#74011): Remove metrics-bind-address if the default is set.
+    value: "--profiling --metrics-bind-address=0.0.0.0"
   - name: SCHEDULER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
   # Switch off image puller to workaround #44701


### PR DESCRIPTION
The default metrics-bind-address is 127.0.0.1 which doesn't allow to export metrics to prometheus.