### PR TITLE
Migrating gke 5000 to clusterloader

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -301,7 +301,9 @@ periodics:
     containers:
     - args:
       - --timeout=1080
-      - --bare
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
       - --cluster=gke-scale-cluster
@@ -316,7 +318,16 @@ periodics:
       - --gke-environment=staging
       - '--gke-shape={"default":{"Nodes":4999,"MachineType":"n1-standard-1"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-32"}}'
       - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:Performance\]
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=5000
+      - --test-cmd-args=--provider=gke
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
       - --timeout=1030m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190211-76e197f51-master


### PR DESCRIPTION
Migrating `ci-kubernetes-e2e-gke-scale-performance` to cluster loader.