### PR TITLE
Enable full systemd log dump in 5k correctness tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -15,6 +15,8 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
+      - # TODO(mm4tt): Set it everywhere once it's confirmed to be working.
+      - --env=LOG_DUMP_SYSTEMD_JOURNAL=true
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
It seems to be working in 100 node clusters. This change is to test that it doesn't break anything in big clusters.