### PR TITLE
Skip cluster-api presubmits on gh-pages branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
+    skip_branches:
+    - gh-pages
     spec:
       containers:
       - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
@@ -18,6 +20,8 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
+    skip_branches:
+    - gh-pages
     spec:
       containers:
       - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
@@ -33,6 +37,8 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+    skip_branches:
+    - gh-pages
     spec:
       containers:
       - args:
@@ -54,6 +60,8 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
+    skip_branches:
+    - gh-pages
     spec:
       containers:
       - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
@@ -68,6 +76,8 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
+    skip_branches:
+    - gh-pages
     spec:
       containers:
       - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54


### PR DESCRIPTION
The gh-pages branch for sigs.k8s.io/cluster-api is a documentation only branch used for publishing Github Pages, avoid running our presubmit checks on this branch