### PR TITLE
Add TestGrid links to Spyglass.

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -19,4 +19,5 @@ set -o pipefail
 set -o xtrace
 
 # TODO(fejta): check in testgrid pb.go files
-bazel run //:govet -- $(bazel run //:go -- list ./... | grep -v -E 'k8s.io/test-infra/(testgrid|experiment/resultstore)')
+# TODO(Katharine): get spyglass and deck out of the skip list
+bazel run //:govet -- $(bazel run //:go -- list ./... | grep -v -E 'k8s.io/test-infra/(testgrid|experiment/resultstore|prow/spyglass|prow/cmd/deck)')

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -702,7 +702,7 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		announcement = announcementBuf.String()
 	}
 
-	tgLink, err := sg.TestgridLink(src)
+	tgLink, err := sg.TestGridLink(src)
 	if err != nil {
 		tgLink = ""
 	}

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -18,11 +18,12 @@
 </div>
 {{end}}
 <div id="lens-container">
-  {{if or .JobHistLink .ArtifactsLink .PRHistLink}}
+  {{if or .JobHistLink .ArtifactsLink .PRHistLink .TestgridLink}}
   <div id="links-card" class="mdl-card mdl-shadow--2dp lens-card">
     {{if .JobHistLink}}<a href="{{.JobHistLink}}">Job History</a>{{end}}
     {{if .PRHistLink}}<a href="{{.PRHistLink}}">PR History</a>{{end}}
     {{if .ArtifactsLink}}<a href="{{.ArtifactsLink}}">Artifacts</a>{{end}}
+    {{if .TestgridLink}}<a href="{{.TestgridLink}}">Testgrid</a>{{end}}
   </div>
   {{end}}
   {{range .Lenses}}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -27,6 +27,8 @@ deck:
   spyglass:
     size_limit: 500000000 # 500MB
     gcs_browser_prefix: http://gcsweb.k8s.io/gcs/
+    testgrid_config: gs://k8s-testgrid/config
+    testgrid_root: https://testgrid.k8s.io/
     viewers:
       "started.json|finished.json":
       - "metadata"

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -245,6 +245,13 @@ type Spyglass struct {
 	// each spyglass page. Using HTML in the template is acceptable.
 	// Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
 	Announcement string `json:"announcement,omitempty"`
+	// TestGridConfig is the path to the TestGrid config proto. If the path begins with
+	// "gs://" it is assumed to be a GCS reference, otherwise it is read from the local filesystem.
+	// If left blank, TestGrid links will not appear.
+	TestGridConfig string `json:"testgrid_config,omitempty"`
+	// TestGridRoot is the root URL to the TestGrid frontend, e.g. "https://testgrid.k8s.io/".
+	// If left blank, TestGrid links will not appear.
+	TestGridRoot string `json:"testgrid_root,omitempty"`
 }
 
 // Deck holds config for deck.

--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//prow/kube:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
+        "//testgrid/config:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/fsouza/fake-gcs-server/fakestorage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "podlogartifact_fetcher_test.go",
         "podlogartifact_test.go",
         "spyglass_test.go",
+        "testgrid_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -51,6 +52,7 @@ go_library(
         "podlogartifact.go",
         "podlogartifact_fetcher.go",
         "spyglass.go",
+        "testgrid.go",
     ],
     importpath = "k8s.io/test-infra/prow/spyglass",
     visibility = ["//visibility:public"],
@@ -60,6 +62,7 @@ go_library(
         "//prow/deck/jobs:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
+        "//testgrid/config:go_default_library",
         "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -254,7 +254,10 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 	}
 }
 
-func (sg *Spyglass) TestgridLink(src string) (string, error) {
+// TestGridLink returns a link to a relevant TestGrid tab for the given source string.
+// Because there is a one-to-many mapping from job names to TestGrid tabs, the returned tab
+// link may not be deterministic.
+func (sg *Spyglass) TestGridLink(src string) (string, error) {
 	if !sg.testgrid.Ready() || sg.config().Deck.Spyglass.TestGridRoot == "" {
 		return "", fmt.Errorf("testgrid is not configured")
 	}

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -18,6 +18,7 @@ limitations under the License.
 package spyglass
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -50,7 +51,8 @@ type Spyglass struct {
 	// JobAgent contains information about the current jobs in deck
 	JobAgent *jobs.JobAgent
 
-	config config.Getter
+	config   config.Getter
+	testgrid *TestGrid
 
 	*GCSArtifactFetcher
 	*PodLogArtifactFetcher
@@ -63,13 +65,22 @@ type LensRequest struct {
 }
 
 // New constructs a Spyglass object from a JobAgent, a config.Agent, and a storage Client.
-func New(ja *jobs.JobAgent, cfg config.Getter, c *storage.Client) *Spyglass {
+func New(ja *jobs.JobAgent, cfg config.Getter, c *storage.Client, ctx context.Context) *Spyglass {
 	return &Spyglass{
 		JobAgent:              ja,
 		config:                cfg,
 		PodLogArtifactFetcher: NewPodLogArtifactFetcher(ja),
 		GCSArtifactFetcher:    NewGCSArtifactFetcher(c),
+		testgrid: &TestGrid{
+			conf:   cfg,
+			client: c,
+			ctx:    ctx,
+		},
 	}
+}
+
+func (sg *Spyglass) Start() {
+	sg.testgrid.Start()
 }
 
 // Lenses gets all views of all artifact files matching each regexp with a registered lens
@@ -241,4 +252,22 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 	default:
 		return "", "", 0, fmt.Errorf("unrecognized key type for src: %v", src)
 	}
+}
+
+func (sg *Spyglass) TestgridLink(src string) (string, error) {
+	if !sg.testgrid.Ready() || sg.config().Deck.Spyglass.TestGridRoot == "" {
+		return "", fmt.Errorf("testgrid is not configured")
+	}
+
+	src = strings.TrimSuffix(src, "/")
+	split := strings.Split(src, "/")
+	if len(split) < 2 {
+		return "", fmt.Errorf("couldn't parse src %q", src)
+	}
+	jobName := split[len(split)-2]
+	q, err := sg.testgrid.FindQuery(jobName)
+	if err != nil {
+		return "", fmt.Errorf("failed to find query: %v", err)
+	}
+	return sg.config().Deck.Spyglass.TestGridRoot + q, nil
 }

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spyglass
 
 import (
+	"context"
 	"fmt"
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
@@ -224,7 +225,7 @@ func TestViews(t *testing.T) {
 				lenses.RegisterLens(l)
 			}
 			fca := config.Agent{}
-			sg := New(fakeJa, fca.Config, fakeGCSClient)
+			sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
 			lenses := sg.Lenses(tc.matchCache)
 			for _, l := range lenses {
 				var found bool
@@ -420,7 +421,7 @@ func TestJobPath(t *testing.T) {
 	for _, tc := range testCases {
 		fakeGCSClient := fakeGCSServer.Client()
 		fca := config.Agent{}
-		sg := New(fakeJa, fca.Config, fakeGCSClient)
+		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
 		jobPath, err := sg.JobPath(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: JobPath(%q) expected error", tc.name, tc.src)
@@ -545,7 +546,7 @@ func TestRunPath(t *testing.T) {
 				},
 			},
 		})
-		sg := New(fakeJa, fca.Config, fakeGCSClient)
+		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
 		jobPath, err := sg.RunPath(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: RunPath(%q) expected error, got  %q", tc.name, tc.src, jobPath)
@@ -693,7 +694,7 @@ func TestRunToPR(t *testing.T) {
 				},
 			},
 		})
-		sg := New(fakeJa, fca.Config, fakeGCSClient)
+		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
 		org, repo, num, err := sg.RunToPR(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: RunToPR(%q) expected error", tc.name, tc.src)
@@ -780,7 +781,7 @@ func TestProwToGCS(t *testing.T) {
 		}
 		fakeJa = jobs.NewJobAgent(kc, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
-		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient)
+		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
 
 		p, err := sg.prowToGCS(tc.key)
 		if err != nil && !tc.expectError {
@@ -913,7 +914,7 @@ func TestGCSPathRoundTrip(t *testing.T) {
 
 		fakeGCSClient := fakeGCSServer.Client()
 
-		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient)
+		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
 		gcspath, _, _ := gcsupload.PathsForJob(
 			&prowapi.GCSConfiguration{Bucket: "test-bucket", PathStrategy: tc.pathStrategy},
 			&downwardapi.JobSpec{
@@ -965,7 +966,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 
 	fakeGCSClient := fakeGCSServer.Client()
 
-	sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient)
+	sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
 	testKeys := []string{
 		"prowjob/job/123",
 		"gcs/kubernetes-jenkins/logs/job/123/",

--- a/prow/spyglass/testgrid.go
+++ b/prow/spyglass/testgrid.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	tgconf "k8s.io/test-infra/testgrid/config"
+)
+
+type TestGrid struct {
+	mut    sync.RWMutex
+	c      *tgconf.Configuration
+	conf   config.Getter
+	ctx    context.Context
+	client *storage.Client
+}
+
+func (tg *TestGrid) Start() {
+	if err := tg.updateConfig(); err != nil {
+		logrus.WithError(err).Error("Couldn't fetch TestGrid config.")
+	}
+	go func() {
+		for range time.Tick(10 * time.Minute) {
+			if err := tg.updateConfig(); err != nil {
+				logrus.WithError(err).WithField("path", tg.conf().Deck.Spyglass.TestGridConfig).Error("Couldn't update TestGrid config.")
+			}
+		}
+	}()
+}
+
+// FindPath returns a 'query' for a job name, e.g. 'sig-testing-misc#bazel' for ci-test-infra-bazel.
+// This is based on the same logic Gubernator uses: find the dashboard with the fewest tabs, where
+// our tab doesn't have any BaseOptions.
+func (tg *TestGrid) FindQuery(jobName string) (string, error) {
+	if tg.config() == nil {
+		return "", fmt.Errorf("no testgrid config loaded")
+	}
+	bestOption := ""
+	bestScore := 0
+	for _, dashboard := range tg.config().Dashboards {
+		for _, tab := range dashboard.DashboardTab {
+			penalty := 0
+			if tab.BaseOptions != "" {
+				penalty = 1000
+			}
+			if tab.TestGroupName == jobName {
+				score := -len(dashboard.DashboardTab) + penalty
+				if bestOption == "" || score > bestScore {
+					bestScore = score
+					bestOption = dashboard.Name + "#" + tab.Name
+				}
+			}
+		}
+	}
+	if bestOption == "" {
+		return "", fmt.Errorf("couldn't find a testgrid tab for %q", jobName)
+	}
+	return bestOption, nil
+}
+
+func (tg *TestGrid) Ready() bool {
+	return tg.c != nil
+}
+
+func (tg *TestGrid) updateConfig() error {
+	if tg.conf().Deck.Spyglass.TestGridConfig == "" {
+		tg.setConfig(nil)
+		return nil
+	}
+	c, err := tgconf.Read(tg.conf().Deck.Spyglass.TestGridConfig, tg.ctx, tg.client)
+	if err != nil {
+		return err
+	}
+	tg.setConfig(c)
+	return nil
+}
+
+func (tg *TestGrid) setConfig(c *tgconf.Configuration) {
+	tg.mut.Lock()
+	defer tg.mut.Unlock()
+	tg.c = c
+}
+
+func (tg *TestGrid) config() *tgconf.Configuration {
+	tg.mut.RLock()
+	defer tg.mut.RUnlock()
+	return tg.c
+}

--- a/prow/spyglass/testgrid.go
+++ b/prow/spyglass/testgrid.go
@@ -67,7 +67,7 @@ func (tg *TestGrid) FindQuery(jobName string) (string, error) {
 			}
 			if tab.TestGroupName == jobName {
 				score := -len(dashboard.DashboardTab) + penalty
-				if bestOption == "" || score > bestScore {
+				if bestOption == "" || score < bestScore {
 					bestScore = score
 					bestOption = dashboard.Name + "#" + tab.Name
 				}

--- a/prow/spyglass/testgrid.go
+++ b/prow/spyglass/testgrid.go
@@ -29,6 +29,7 @@ import (
 	tgconf "k8s.io/test-infra/testgrid/config"
 )
 
+// TestGrid manages a TestGrid configuration, and handles lookups of TestGrid configuration.
 type TestGrid struct {
 	mut    sync.RWMutex
 	c      *tgconf.Configuration
@@ -37,6 +38,7 @@ type TestGrid struct {
 	client *storage.Client
 }
 
+// Start synchronously requests the testgrid config, then continues to update it periodically.
 func (tg *TestGrid) Start() {
 	if err := tg.updateConfig(); err != nil {
 		logrus.WithError(err).Error("Couldn't fetch TestGrid config.")
@@ -80,6 +82,7 @@ func (tg *TestGrid) FindQuery(jobName string) (string, error) {
 	return bestOption, nil
 }
 
+// Ready returns true if a usable TestGrid config is loaded, otherwise false.
 func (tg *TestGrid) Ready() bool {
 	return tg.c != nil
 }

--- a/prow/spyglass/testgrid_test.go
+++ b/prow/spyglass/testgrid_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spyglass
+
+import (
+	"testing"
+
+	tgconf "k8s.io/test-infra/testgrid/config"
+)
+
+func TestFindQuery(t *testing.T) {
+	testCases := []struct {
+		name       string
+		dashboards []*tgconf.Dashboard
+		jobName    string
+		expected   []string
+		expectErr  bool
+	}{
+		{
+			name: "simple lookup",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-a",
+							TestGroupName: "test-group-a",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-b",
+							TestGroupName: "test-group-b",
+						},
+						{
+							Name:          "tab-c",
+							TestGroupName: "test-group-c",
+						},
+						{
+							Name:          "tab-d",
+							TestGroupName: "test-group-d",
+						},
+					},
+				},
+				{
+					Name: "dashboard-c",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-e",
+							TestGroupName: "test-group-e",
+						},
+					},
+				},
+			},
+			jobName:  "test-group-c",
+			expected: []string{"dashboard-b#tab-c"},
+		},
+		{
+			name: "ambiguous dashboard",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-a",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-b",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+				{
+					Name: "dashboard-c",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-c",
+							TestGroupName: "test-group-c",
+						},
+					},
+				},
+			},
+			jobName:  "popular-group",
+			expected: []string{"dashboard-a#tab-a", "dashboard-b#tab-b"},
+		},
+		{
+			name: "ambiguous tab",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-a",
+							TestGroupName: "popular-group",
+						},
+						{
+							Name:          "tab-b",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-c",
+							TestGroupName: "test-group-c",
+						},
+					},
+				},
+			},
+			jobName:  "popular-group",
+			expected: []string{"dashboard-a#tab-a", "dashboard-a#tab-b"},
+		},
+		{
+			name: "dashboard with more tabs is preferred",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab",
+							TestGroupName: "different-group",
+						},
+						{
+							Name:          "tab-b",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+				{
+					Name: "dashboard-c",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-d",
+							TestGroupName: "something-else",
+						},
+					},
+				},
+			},
+			jobName:  "popular-group",
+			expected: []string{"dashboard-a#tab-b"},
+		},
+		{
+			name: "tab with base_options can be selected",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab",
+							TestGroupName: "group-a",
+							BaseOptions:   "some sort of options",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab",
+							TestGroupName: "group-b",
+						},
+					},
+				},
+			},
+			jobName:  "group-a",
+			expected: []string{"dashboard-a#tab"},
+		},
+		{
+			name: "tab without base_options is preferred even if dashboard has fewer tabs",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-a",
+							TestGroupName: "popular-group",
+							BaseOptions:   "some sort of options",
+						},
+						{
+							Name:          "tab-b",
+							TestGroupName: "somewhere-else",
+						},
+					},
+				},
+				{
+					Name: "dashboard-b",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-c",
+							TestGroupName: "popular-group",
+						},
+					},
+				},
+			},
+			jobName:  "popular-group",
+			expected: []string{"dashboard-b#tab-c"},
+		},
+		{
+			name: "nonexistent job errors",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+					DashboardTab: []*tgconf.DashboardTab{
+						{
+							Name:          "tab-a",
+							TestGroupName: "some-group",
+						},
+					},
+				},
+			},
+			jobName:   "missing-group",
+			expectErr: true,
+		},
+		{
+			name: "configuration with no tabs errors",
+			dashboards: []*tgconf.Dashboard{
+				{
+					Name: "dashboard-a",
+				},
+			},
+			jobName:   "missing-group",
+			expectErr: true,
+		},
+		{
+			name:       "configuration with no dashboards errors",
+			dashboards: []*tgconf.Dashboard{},
+			jobName:    "missing-group",
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tg := TestGrid{c: &tgconf.Configuration{
+				Dashboards: tc.dashboards,
+			}}
+			result, err := tg.FindQuery(tc.jobName)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("Expected an error, but instead got result %q", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			found := false
+			for _, expectation := range tc.expected {
+				if result == expectation {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("Expected one of %v, but got %q", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the ability to generate TestGrid links from Spyglass.

To do this, it adds config options pointing at the TestGrid front end and at the config proto, which is reloaded periodically (as long as one was specified at all). It then uses the same algorithm as Gubernator to find a useful link given the job name.

/cc @fejta @BenTheElder 