### PR TITLE
Github to GitHub

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -268,3 +268,16 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-experimental
         command:
         - ./hack/verify-file-perms.sh
+
+  - name: pull-test-infra-verify-github-spelling
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-experimental
+        command:
+        - ./hack/verify-github-spelling.sh

--- a/experiment/bootstrap/paths_test.go
+++ b/experiment/bootstrap/paths_test.go
@@ -70,7 +70,7 @@ func TestPRPaths(t *testing.T) {
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
-	reposGithub, err := ParseRepos([]string{"github.com/foo/bar=master:0efa7e1b,2001:8b376c6c"})
+	reposGitHub, err := ParseRepos([]string{"github.com/foo/bar=master:0efa7e1b,2001:8b376c6c"})
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestPRPaths(t *testing.T) {
 			Name:  "normal-github",
 			Base:  "/base",
 			Job:   "some-job",
-			Repos: reposGithub,
+			Repos: reposGitHub,
 			Build: "1337",
 			Expected: &Paths{
 				Artifacts:     filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337", "artifacts"),

--- a/experiment/tracer/trace.go
+++ b/experiment/tracer/trace.go
@@ -85,7 +85,7 @@ func (l linesByTimestamp) String() string {
 	return fmt.Sprintf("[%s]", log)
 }
 
-// ic is the prefix of a URL fragment for a Github comment.
+// ic is the prefix of a URL fragment for a GitHub comment.
 // The URL fragment has the following format:
 //
 // issuecomment-#id

--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -29,7 +29,7 @@ only updates after the webhook is added will be shown on the dashboard.
 
 # Deployment
 
-- Visit /config on the new deployment to configure Github [OAuth logins](https://github.com/settings/applications)
+- Visit /config on the new deployment to configure GitHub [OAuth logins](https://github.com/settings/applications)
   and webhook secrets.
 
 # GCS Layout
@@ -131,5 +131,5 @@ the different types of jobs:
 
 # Migrations
 
-1. 2018-01-09: Github webhook and oauth secrets must be reconfigured. Visit
+1. 2018-01-09: GitHub webhook and oauth secrets must be reconfigured. Visit
    /config on your deployment to enter the new values.

--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -39,10 +39,10 @@ def classify_issue(repo, number):
         payload: a dict, see full description for classify below.
         last_event_timestamp: the timestamp of the most recent event.
     """
-    ancestor = models.GithubResource.make_key(repo, number)
+    ancestor = models.GitHubResource.make_key(repo, number)
     logging.info('finding webhooks for %s %s', repo, number)
-    event_keys = list(models.GithubWebhookRaw.query(ancestor=ancestor)
-        .order(models.GithubWebhookRaw.timestamp)
+    event_keys = list(models.GitHubWebhookRaw.query(ancestor=ancestor)
+        .order(models.GitHubWebhookRaw.timestamp)
         .fetch(keys_only=True))
 
     logging.info('classifying %s %s (%d events)', repo, number, len(event_keys))

--- a/gubernator/github/handlers.py
+++ b/gubernator/github/handlers.py
@@ -48,7 +48,7 @@ def make_signature(body):
     return 'sha1=' + hmac_instance.hexdigest()
 
 
-class GithubHandler(webapp2.RequestHandler):
+class GitHubHandler(webapp2.RequestHandler):
     """
     Handle POSTs delivered using GitHub's webhook interface. Posts are
     authenticated with HMAC signatures and a shared secret.
@@ -76,7 +76,7 @@ class GithubHandler(webapp2.RequestHandler):
 
         parent = None
         if number:
-            parent = models.GithubResource.make_key(repo, number)
+            parent = models.GitHubResource.make_key(repo, number)
 
         kwargs = {}
         timestamp = self.request.headers.get('x-timestamp')
@@ -84,7 +84,7 @@ class GithubHandler(webapp2.RequestHandler):
             kwargs['timestamp'] = datetime.datetime.strptime(
                 timestamp, '%Y-%m-%d %H:%M:%S.%f')
 
-        webhook = models.GithubWebhookRaw(
+        webhook = models.GitHubWebhookRaw(
             parent=parent,
             repo=repo,
             number=number,
@@ -136,12 +136,12 @@ class Events(BaseHandler):
         number = int(self.request.get('number', 0)) or None
         count = int(self.request.get('count', 500))
         if repo is not None and number is not None:
-            q = models.GithubWebhookRaw.query(
-                models.GithubWebhookRaw.repo == repo,
-                models.GithubWebhookRaw.number == number)
+            q = models.GitHubWebhookRaw.query(
+                models.GitHubWebhookRaw.repo == repo,
+                models.GitHubWebhookRaw.number == number)
         else:
-            q = models.GithubWebhookRaw.query()
-        q = q.order(models.GithubWebhookRaw.timestamp)
+            q = models.GitHubWebhookRaw.query()
+        q = q.order(models.GitHubWebhookRaw.timestamp)
         events, next_cursor, more = q.fetch_page(count, start_cursor=cursor)
         out = []
         for event in events:
@@ -189,9 +189,9 @@ class Timeline(BaseHandler):
             self.response.write('<pre>%s</pre>' % traceback.format_exc())
 
     def emit_events(self, repo, number):
-        ancestor = models.GithubResource.make_key(repo, number)
-        events = list(models.GithubWebhookRaw.query(ancestor=ancestor)
-            .order(models.GithubWebhookRaw.timestamp))
+        ancestor = models.GitHubResource.make_key(repo, number)
+        events = list(models.GitHubWebhookRaw.query(ancestor=ancestor)
+            .order(models.GitHubWebhookRaw.timestamp))
 
         self.response.write('<h3>Distilled Events</h3>')
         self.response.write('<pre>')
@@ -228,8 +228,8 @@ class Timeline(BaseHandler):
         repo = self.request.get('repo')
         number = self.request.get('number')
         if self.request.get('format') == 'json':
-            ancestor = models.GithubResource.make_key(repo, number)
-            events = list(models.GithubWebhookRaw.query(ancestor=ancestor))
+            ancestor = models.GitHubResource.make_key(repo, number)
+            events = list(models.GitHubWebhookRaw.query(ancestor=ancestor))
             self.response.headers['content-type'] = 'application/json'
             self.response.write(json.dumps([e.body for e in events], indent=True))
             return

--- a/gubernator/github/index.yaml
+++ b/gubernator/github/index.yaml
@@ -2,7 +2,7 @@ indexes:
 
 # This index allows us to iterate through events sorted by timestamp,
 # without fetching all the events into memory first.
-- kind: GithubWebhookRaw
+- kind: GitHubWebhookRaw
   ancestor: yes
   properties:
   - name: timestamp
@@ -17,7 +17,7 @@ indexes:
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
 
-- kind: GithubWebhookRaw
+- kind: GitHubWebhookRaw
   properties:
   - name: event
   - name: timestamp

--- a/gubernator/github/main.py
+++ b/gubernator/github/main.py
@@ -29,7 +29,7 @@ class Warmup(webapp2.RequestHandler):
 
 app = webapp2.WSGIApplication([
     ('/_ah/warmup', Warmup),
-    (r'/webhook', handlers.GithubHandler),
+    (r'/webhook', handlers.GitHubHandler),
     (r'/events', handlers.Events),
     (r'/status', handlers.Status),
     (r'/timeline', handlers.Timeline),

--- a/gubernator/github/main_test.py
+++ b/gubernator/github/main_test.py
@@ -60,7 +60,7 @@ class AppTest(TestBase):
             body = json.dumps(body)
         signature = handlers.make_signature(body)
         resp = app.post('/webhook', body,
-            {'X-Github-Event': event,
+            {'X-GitHub-Event': event,
              'X-Hub-Signature': signature})
         for task in self.taskqueue.get_filtered_tasks():
             deferred.run(task.payload)
@@ -68,7 +68,7 @@ class AppTest(TestBase):
 
     def test_webhook(self):
         self.get_response('test', {'action': 'blah'})
-        hooks = list(models.GithubWebhookRaw.query())
+        hooks = list(models.GitHubWebhookRaw.query())
         self.assertEqual(len(hooks), 1)
         self.assertIsNotNone(hooks[0].timestamp)
 
@@ -76,12 +76,12 @@ class AppTest(TestBase):
         body = json.dumps({'action': 'blah'})
         signature = handlers.make_signature(body + 'foo')
         app.post('/webhook', body,
-            {'X-Github-Event': 'test',
+            {'X-GitHub-Event': 'test',
              'X-Hub-Signature': signature}, status=400)
 
     def test_webhook_missing_sig(self):
         app.post('/webhook', '{}',
-            {'X-Github-Event': 'test'}, status=400)
+            {'X-GitHub-Event': 'test'}, status=400)
 
     def test_webhook_unicode(self):
         self.get_response('test', {'action': u'blah\u03BA'})

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -19,16 +19,16 @@ import json
 import google.appengine.ext.ndb as ndb
 
 
-class GithubResource(ndb.Model):
+class GitHubResource(ndb.Model):
     # A key holder used to define an entitygroup for
     # each Issue/PR, for easy ancestor queries.
     @staticmethod
     def make_key(repo, number):
-        return ndb.Key(GithubResource, '%s %s' % (repo, number))
+        return ndb.Key(GitHubResource, '%s %s' % (repo, number))
 
 
 def shrink(body):
-    """Recursively remove Github API urls from an object to make it more human-readable."""
+    """Recursively remove GitHub API urls from an object to make it more human-readable."""
     toremove = []
     for key, value in body.iteritems():
         if isinstance(value, basestring):
@@ -47,7 +47,7 @@ def shrink(body):
     return body
 
 
-class GithubWebhookRaw(ndb.Model):
+class GitHubWebhookRaw(ndb.Model):
     repo = ndb.StringProperty()
     number = ndb.IntegerProperty(indexed=False)
     event = ndb.StringProperty()

--- a/gubernator/github/periodic_sync.py
+++ b/gubernator/github/periodic_sync.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Periodically synchronize our Datastore view of PRs with Github.
+"""Periodically synchronize our Datastore view of PRs with GitHub.
 
 Various things can cause the local status of a PR to diverge from upstream:
 dropped hooks from bugs in the app, upstream GitHub bugs (webhooks aren't
@@ -26,13 +26,13 @@ and clutter out real items, decreasing signal-to-noise ratio and user trust.
 To handle these, on a regular schedule we perform a reconciliation step:
 - for each repository that we're tracking:
   - A = all open PRs from Datastore
-  - B = all open PRs from Github
+  - B = all open PRs from GitHub
   - A-B is the set of improperly open PRs. For each PR, add a synthetic
     webhook event to Datastore with state=closed, and reprocess.
   - B-A is the set of improperly closed or missing PRs. Again, inject a
     synthetic webhook with the details received from GitHub and reprocess.
 
-This requires a Github token set like other secrets with /config in the root.
+This requires a GitHub token set like other secrets with /config in the root.
 Total token usage is low: number of open PRs / 100 PRs per list call.
 As of 2018-01-10, 1666 open PRs in the k8s org translates into ~56 list calls.
 """
@@ -79,9 +79,9 @@ def get_prs_from_github(token, repo):
 
 
 def inject_event_and_reclassify(repo, number, action, body):
-    # this follows similar code as handlers.GithubHandler
-    parent = models.GithubResource.make_key(repo, number)
-    hook = models.GithubWebhookRaw(
+    # this follows similar code as handlers.GitHubHandler
+    parent = models.GitHubResource.make_key(repo, number)
+    hook = models.GitHubWebhookRaw(
         parent=parent, repo=repo, number=number, event='pull_request',
         body=json.dumps({'action': action, 'pull_request': body}, sort_keys=True))
     hook.put()

--- a/gubernator/github_auth.py
+++ b/gubernator/github_auth.py
@@ -37,7 +37,7 @@ class Endpoint(view_base.BaseHandler):
                 self.abort(500,
                            body_template=(
                            'An admin must <a href="/config">'
-                           'configure Github secrets</a> for %r first.'
+                           'configure GitHub secrets</a> for %r first.'
                            % self.request.host))
         client = self.app.config[client_key]
         return client['id'], client['secret']

--- a/gubernator/github_auth_test.py
+++ b/gubernator/github_auth_test.py
@@ -37,7 +37,7 @@ app = webtest.TestApp(main.app)
 VEND_URL = 'https://github.com/login/oauth/access_token'
 USER_URL = 'https://api.github.com/user'
 
-class TestGithubAuth(unittest.TestCase):
+class TestGitHubAuth(unittest.TestCase):
     def setUp(self):
         app.reset()
         self.testbed.init_app_identity_stub()
@@ -89,7 +89,7 @@ class TestGithubAuth(unittest.TestCase):
             'redirect_uri': ['http://localhost/github_auth/done'],
             'client_id': [CLIENT_ID]})
 
-        # 2) Github redirects back
+        # 2) GitHub redirects back
         resp = self.do_phase2(resp)
         self.assertIn('Welcome, foo', resp)
 

--- a/gubernator/templates/config.html
+++ b/gubernator/templates/config.html
@@ -4,7 +4,7 @@
 % endblock
 % block content
 <form method="post">
-<p>These values come from the <a href="https://github.com/settings/developers">OAuth Apps Tab</a> on Github.
+<p>These values come from the <a href="https://github.com/settings/developers">OAuth Apps Tab</a> on GitHub.
 <p>New apps should be registered with "Homepage URL" set to https://{{hostname}} and "Authorization callback URL" set to https://{{hostname}}/github_auth.
 <p>GitHub OAuth Client Id: <input type="text" name="github_id"><br>
 GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
@@ -22,9 +22,9 @@ Alternate OAuth Host (optional, for custom domains, like "g8r.k8s.io:443"): <inp
 <h2>OAuth secrets set!</h2>
 % endif
 % if webhook_set
-<h2>Github Webhook secret set!</h2>
+<h2>GitHub Webhook secret set!</h2>
 % endif
 % if token_set
-<h2>Github Token set!</h2>
+<h2>GitHub Token set!</h2>
 % endif
 % endblock

--- a/hack/verify-github-spelling.sh
+++ b/hack/verify-github-spelling.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+failed="false"
+for file in $(  find . \( -not -path '*vendor*' -and -not -path '*.git*' -and -not -path '*hack/verify-github-spelling.sh*' \) -type f )
+do
+  if grep -q 'Github' "${file}"; then
+      echo "[ERROR] ${file}: contains mis-spelling 'Github'"
+      failed="true"
+  fi
+done
+
+if [[ "${failed}" == "true" ]]; then
+    exit 1
+fi

--- a/pkg/ghclient/core_test.go
+++ b/pkg/ghclient/core_test.go
@@ -30,15 +30,15 @@ func setForTest(client *Client) {
 	client.tokenReserve = 50
 }
 
-// fakeGithub is a fake go-github client that doubles as a test instance representation. This fake
+// fakeGitHub is a fake go-github client that doubles as a test instance representation. This fake
 // client keeps track of the number of API calls made in order to test retry behavior and also allows
 // the number of pages of results to be configured.
-type fakeGithub struct {
-	// name is a string representation of this fakeGithub instance.
+type fakeGitHub struct {
+	// name is a string representation of this fakeGitHub instance.
 	name string
-	// hits is a count of the number of API calls made to fakeGithub.
+	// hits is a count of the number of API calls made to fakeGitHub.
 	hits int
-	// hitsBeforeResponse is the number of hits that should be received before fakeGithub responds without error.
+	// hitsBeforeResponse is the number of hits that should be received before fakeGitHub responds without error.
 	hitsBeforeResponse int
 	// shouldSucceed indicates if the githubutil client should get a valid response.
 	shouldSucceed bool
@@ -49,14 +49,14 @@ type fakeGithub struct {
 }
 
 // checkHits verifies that the githubutil client made the correct number of retries before returning.
-func (f *fakeGithub) checkHits() bool {
+func (f *fakeGitHub) checkHits() bool {
 	if f.shouldSucceed {
 		return f.hits-f.pages+1 == f.hitsBeforeResponse
 	}
 	return f.hitsBeforeResponse > f.hits
 }
 
-func (f *fakeGithub) call() ([]interface{}, *github.Response, error) {
+func (f *fakeGitHub) call() ([]interface{}, *github.Response, error) {
 	f.hits++
 	if f.hits >= f.hitsBeforeResponse {
 		return []interface{}{f.listOpts.Page},
@@ -67,7 +67,7 @@ func (f *fakeGithub) call() ([]interface{}, *github.Response, error) {
 }
 
 func TestRetryAndPagination(t *testing.T) {
-	tests := []*fakeGithub{
+	tests := []*fakeGitHub{
 		{name: "no retries", hitsBeforeResponse: 1, shouldSucceed: true, pages: 1},
 		{name: "max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 1},
 		{name: "1 too many retries needed", hitsBeforeResponse: 7, shouldSucceed: false, pages: 1},

--- a/prow/cmd/branchprotector/README.md
+++ b/prow/cmd/branchprotector/README.md
@@ -59,7 +59,7 @@ editor and then send out a PR. When the PR merges prow pushes the updated config
 
 #### Fields
 
-See [`branch_protection.go`] and Github's [protection api] for a complete list of fields allowed
+See [`branch_protection.go`] and GitHub's [protection api] for a complete list of fields allowed
 inside `branch-protection` and their meanings. The format is:
 
 ```yaml

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -265,7 +265,7 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 			logrus.WithError(err).Fatal("Could not read cookie secret file.")
 		}
 
-		var githubOAuthConfig config.GithubOAuthConfig
+		var githubOAuthConfig config.GitHubOAuthConfig
 		if err := yaml.Unmarshal(githubOAuthConfigRaw, &githubOAuthConfig); err != nil {
 			logrus.WithError(err).Fatal("Error unmarshalling github oauth config")
 		}
@@ -281,7 +281,7 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 			logrus.Fatal("Cookie secret should not be empty")
 		}
 		cookie := sessions.NewCookieStore(decodedSecret)
-		githubOAuthConfig.InitGithubOAuthConfig(cookie)
+		githubOAuthConfig.InitGitHubOAuthConfig(cookie)
 
 		goa := githuboauth.NewAgent(&githubOAuthConfig, logrus.WithField("client", "githuboauth"))
 		oauthClient := &oauth2.Config{
@@ -317,8 +317,8 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 			prStatusAgent.HandlePrStatus(prStatusAgent)))
 		// Handles login request.
 		mux.Handle("/github-login", goa.HandleLogin(oauthClient))
-		// Handles redirect from Github OAuth server.
-		mux.Handle("/github-login/redirect", goa.HandleRedirect(oauthClient, githuboauth.NewGithubClientGetter()))
+		// Handles redirect from GitHub OAuth server.
+		mux.Handle("/github-login/redirect", goa.HandleRedirect(oauthClient, githuboauth.NewGitHubClientGetter()))
 	}
 
 	// optionally inject http->https redirect handler when behind loadbalancer
@@ -969,7 +969,7 @@ func handleFavicon(staticFilesLocation string, cfg config.Getter) http.HandlerFu
 	}
 }
 
-func isValidatedGitOAuthConfig(githubOAuthConfig *config.GithubOAuthConfig) bool {
+func isValidatedGitOAuthConfig(githubOAuthConfig *config.GitHubOAuthConfig) bool {
 	return githubOAuthConfig.ClientID != "" && githubOAuthConfig.ClientSecret != "" &&
 		githubOAuthConfig.RedirectURL != "" &&
 		githubOAuthConfig.FinalRedirectURL != ""

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -149,7 +149,7 @@ function redraw(prData: UserData): void {
     if (prData && prData.Login) {
         loadPrStatus(prData);
     } else {
-        forceGithubLogin();
+        forceGitHubLogin();
     }
 }
 
@@ -319,7 +319,7 @@ function createSearchCard(): HTMLElement {
     inputContainer.appendChild(actionCtn);
 
     const title = document.createElement("h6");
-    title.textContent = "Github search query";
+    title.textContent = "GitHub search query";
     const infoBtn = createIcon("info", "More information about the search query", ["search-info"], true);
     const titleCtn = document.createElement("div");
     titleCtn.appendChild(title);
@@ -359,13 +359,13 @@ function getFullPRContext(builds: Job[], contexts: Context[]): UnifiedContext[] 
     if (builds) {
         for (const build of builds) {
             let discrepancy = null;
-            // If Github context exits, check if mismatch or not.
+            // If GitHub context exits, check if mismatch or not.
             if (contextMap.has(build.context)) {
                 const githubContext = contextMap.get(build.context)!;
-                // TODO (qhuynh96): ProwJob's states and Github contexts states
+                // TODO (qhuynh96): ProwJob's states and GitHub contexts states
                 // are not equivalent in some states.
                 if (githubContext.state !== build.state) {
-                    discrepancy = "Github context and Prow Job states mismatch";
+                    discrepancy = "GitHub context and Prow Job states mismatch";
                 }
             }
             contextMap.set(build.context, {
@@ -1152,7 +1152,7 @@ function createPRCard(pr: PullRequest, builds: UnifiedContext[] = [], queries: P
 /**
  * Redirect to initiate github login flow.
  */
-function forceGithubLogin(): void {
+function forceGitHubLogin(): void {
     window.location.href = window.location.origin + "/github-login";
 }
 

--- a/prow/cmd/deck/template/pr.html
+++ b/prow/cmd/deck/template/pr.html
@@ -13,9 +13,9 @@
 {{end}}
 {{define "extra content"}}
 <dialog id="search-dialog" class="pr-status-dialog mdl-dialog">
-  <h4 class="mdl-dialog__title">Github search query</h4>
+  <h4 class="mdl-dialog__title">GitHub search query</h4>
   <div class="mdl-dialog__content">
-    <p>You can query for <strong>pull requests</strong> using Github search syntax.</p>
+    <p>You can query for <strong>pull requests</strong> using GitHub search syntax.</p>
     <p>Notice:</p>
     <ol>
       <li>

--- a/prow/cmd/jenkins-operator/README.md
+++ b/prow/cmd/jenkins-operator/README.md
@@ -7,7 +7,7 @@ as a backend for running jobs.
 
 A Jenkins master needs to be provided via `--jenkins-url` in order for
 the operator to make requests to. By default, `--dry-run` is set to `true`
-so the operator will not make any mutating requests to Jenkins, Github,
+so the operator will not make any mutating requests to Jenkins, GitHub,
 and Kubernetes, but you most probably want to set it to `false`.
 The Jenkins operator expects to read the Prow configuration by default
 in `/etc/config/config.yaml` which can be configured with `--config-path`.
@@ -32,9 +32,9 @@ will spin up to handle all Jenkins builds. Defaulted to 20.
 jobs that have been superseded by jobs for newer commits. By default,
 this is set to `false`.
 * `job_url_template` is a Golang-templated URL that shows up in the Details
-button next to the Github job status context. A ProwJob is provided as input
+button next to the GitHub job status context. A ProwJob is provided as input
 to the template.
-* `report_template` is a Golang-templated message that shows up in Github in
+* `report_template` is a Golang-templated message that shows up in GitHub in
 case of a job failure. A ProwJob is provided as input to the template.
 
 ### Security
@@ -137,16 +137,16 @@ The Jenkins operator acts as a Kubernetes client since it manages ProwJobs
 backed by Jenkins builds. It is expected to run as a pod inside a Kubernetes
 cluster and so it uses the in-cluster client config.
 
-## Github integration
+## GitHub integration
 
-The operator needs to talk to Github for updating commit statuses and
+The operator needs to talk to GitHub for updating commit statuses and
 adding comments about failed tests. Note that this functionality may
 potentially move into its own service, then the Jenkins operator will
-not need to contact the Github API. The required options are already
+not need to contact the GitHub API. The required options are already
 defaulted:
-* `github-token-path` set to `/etc/github/oauth`. This is the Github bot
+* `github-token-path` set to `/etc/github/oauth`. This is the GitHub bot
 oauth token that is used for updating job statuses and adding comments
-in Github.
+in GitHub.
 * `github-endpoint` set to `https://api.github.com`.
 
 

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -58,7 +58,7 @@ func (o *options) getPullRequest() (*github.PullRequest, error) {
 	}
 	pr, err := o.githubClient.GetPullRequest(o.org, o.repo, o.pullNumber)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch PullRequest from Github: %v", err)
+		return nil, fmt.Errorf("failed to fetch PullRequest from GitHub: %v", err)
 	}
 	o.pullRequest = pr
 	return pr, nil
@@ -149,7 +149,7 @@ func gatherOptions() options {
 	fs.IntVar(&o.pullNumber, "pull-number", 0, "Git pull number under test")
 	fs.StringVar(&o.pullSha, "pull-sha", "", "Git pull SHA under test")
 	fs.StringVar(&o.pullAuthor, "pull-author", "", "Git pull author under test")
-	o.github.AddFlagsWithoutDefaultGithubTokenPath(fs)
+	o.github.AddFlagsWithoutDefaultGitHubTokenPath(fs)
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -174,7 +174,7 @@ func main() {
 	}
 	o.githubClient, err = o.github.GitHubClient(secretAgent, false)
 	if err != nil {
-		logrus.Fatalf("failed to get Github client: %v", err)
+		logrus.Fatalf("failed to get GitHub client: %v", err)
 	}
 
 	var pjs prowapi.ProwJobSpec

--- a/prow/cmd/mkpj/main_test.go
+++ b/prow/cmd/mkpj/main_test.go
@@ -68,12 +68,12 @@ func TestOptions_Validate(t *testing.T) {
 func TestDefaultPR(t *testing.T) {
 	author := "Bernardo Soares"
 	sha := "Esther Greenwood"
-	fakeGithubClient := &fakegithub.FakeClient{}
-	fakeGithubClient.PullRequests = map[int]*github.PullRequest{2: {
+	fakeGitHubClient := &fakegithub.FakeClient{}
+	fakeGitHubClient.PullRequests = map[int]*github.PullRequest{2: {
 		User: github.User{Login: author},
 		Head: github.PullRequestBranch{SHA: sha},
 	}}
-	o := &options{pullNumber: 2, githubClient: fakeGithubClient}
+	o := &options{pullNumber: 2, githubClient: fakeGitHubClient}
 	pjs := &prowapi.ProwJobSpec{Refs: &prowapi.Refs{Pulls: []prowapi.Pull{{Number: 2}}}}
 	if err := o.defaultPR(pjs); err != nil {
 		t.Fatalf("Expected no err when defaulting PJ, but got %v", err)
@@ -109,11 +109,11 @@ func TestDefaultBaseRef(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			fakeGithubClient := &fakegithub.FakeClient{}
-			fakeGithubClient.PullRequests = map[int]*github.PullRequest{2: {Base: github.PullRequestBranch{
+			fakeGitHubClient := &fakegithub.FakeClient{}
+			fakeGitHubClient.PullRequests = map[int]*github.PullRequest{2: {Base: github.PullRequestBranch{
 				SHA: test.prBaseSha,
 			}}}
-			o := &options{pullNumber: test.pullNumber, githubClient: fakeGithubClient}
+			o := &options{pullNumber: test.pullNumber, githubClient: fakeGitHubClient}
 			pjs := &prowapi.ProwJobSpec{Refs: &prowapi.Refs{BaseRef: test.baseRef}}
 			if err := o.defaultBaseRef(pjs); err != nil {
 				t.Fatalf("Error when calling defaultBaseRef: %v", err)

--- a/prow/cmd/peribolos/README.md
+++ b/prow/cmd/peribolos/README.md
@@ -1,6 +1,6 @@
 # Peribolos Documentation
 
-Peribolos allows the org settings, teams and memberships to be declared in a yaml file. Github is then updated to match the declared configuration.
+Peribolos allows the org settings, teams and memberships to be declared in a yaml file. GitHub is then updated to match the declared configuration.
 
 See the [kubernetes/org] repo, in particular the [merge] and [`update.sh`] parts of that repo for this tool in action.
 

--- a/prow/cmd/phony/README.md
+++ b/prow/cmd/phony/README.md
@@ -34,4 +34,4 @@ If you are testing `hook` and successfully sent the webhook from `phony`, you sh
 {"author":"","component":"hook","event-GUID":"GUID","event-type":"pull_request","level":"info","msg":"Pull request .","org":"","pr":0,"repo":"","time":"2018-05-29T11:38:57-07:00","url":""}
 ```
 
-A list of supported events can be found in the [Github API Docs](https://developer.github.com/v3/activity/events/types/).
+A list of supported events can be found in the [GitHub API Docs](https://developer.github.com/v3/activity/events/types/).

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -754,7 +754,7 @@ func ensureConfigMap(kc *kubernetes.Clientset, ns, name, key string) error {
 
 func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	skipGithub := fs.Bool("skip-github", false, "Do not add github webhooks if set")
+	skipGitHub := fs.Bool("skip-github", false, "Do not add github webhooks if set")
 	opt := addFlags(fs)
 	fs.Parse(os.Args[1:])
 
@@ -793,7 +793,7 @@ func main() {
 		logrus.WithError(err).Fatal("Could not deploy prow")
 	}
 
-	if !*skipGithub {
+	if !*skipGitHub {
 		fmt.Println("Checking github credentials...")
 		// create github client
 		token, err := githubToken(opt.githubTokenPath)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -73,7 +73,7 @@ type ProwConfig struct {
 	BranchProtection BranchProtection      `json:"branch-protection,omitempty"`
 	Orgs             map[string]org.Config `json:"orgs,omitempty"`
 	Gerrit           Gerrit                `json:"gerrit,omitempty"`
-	GithubReporter   GithubReporter        `json:"github_reporter,omitempty"`
+	GitHubReporter   GitHubReporter        `json:"github_reporter,omitempty"`
 
 	// TODO: Move this out of the main config.
 	JenkinsOperators []JenkinsOperator `json:"jenkins_operators,omitempty"`
@@ -172,7 +172,7 @@ type Controller struct {
 	MaxGoroutines int `json:"max_goroutines,omitempty"`
 
 	// AllowCancellations enables aborting presubmit jobs for commits that
-	// have been superseded by newer commits in Github pull requests.
+	// have been superseded by newer commits in GitHub pull requests.
 	AllowCancellations bool `json:"allow_cancellations,omitempty"`
 }
 
@@ -236,8 +236,8 @@ type JenkinsOperator struct {
 	LabelSelector labels.Selector `json:"-"`
 }
 
-// GithubReporter holds the config for report behavior in github
-type GithubReporter struct {
+// GitHubReporter holds the config for report behavior in github
+type GitHubReporter struct {
 	// JobTypesToReport is used to determine which type of prowjob
 	// should be reported to github
 	//
@@ -794,14 +794,14 @@ func parseProwConfig(c *Config) error {
 		c.Gerrit.RateLimit = 5
 	}
 
-	if len(c.GithubReporter.JobTypesToReport) == 0 {
+	if len(c.GitHubReporter.JobTypesToReport) == 0 {
 		// TODO(krzyzacy): The default will be changed to presubmit + postsubmit by April.
-		c.GithubReporter.JobTypesToReport = append(c.GithubReporter.JobTypesToReport, prowapi.PresubmitJob)
+		c.GitHubReporter.JobTypesToReport = append(c.GitHubReporter.JobTypesToReport, prowapi.PresubmitJob)
 	}
 
 	// validate entries are valid job types
 	// Currently only presubmit and postsubmit can be reported to github
-	for _, t := range c.GithubReporter.JobTypesToReport {
+	for _, t := range c.GitHubReporter.JobTypesToReport {
 		if t != prowapi.PresubmitJob && t != prowapi.PostsubmitJob {
 			return fmt.Errorf("invalid job_types_to_report: %v", t)
 		}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1782,7 +1782,7 @@ func TestSecretAgentLoading(t *testing.T) {
 
 }
 
-func TestValidGithubReportType(t *testing.T) {
+func TestValidGitHubReportType(t *testing.T) {
 	var testCases = []struct {
 		name        string
 		prowConfig  string
@@ -1837,8 +1837,8 @@ github_reporter:
 		}
 
 		if err == nil {
-			if !reflect.DeepEqual(cfg.GithubReporter.JobTypesToReport, tc.expectTypes) {
-				t.Errorf("tc %s: expected %#v\n!=\nactual %#v", tc.name, tc.expectTypes, cfg.GithubReporter.JobTypesToReport)
+			if !reflect.DeepEqual(cfg.GitHubReporter.JobTypesToReport, tc.expectTypes) {
+				t.Errorf("tc %s: expected %#v\n!=\nactual %#v", tc.name, tc.expectTypes, cfg.GitHubReporter.JobTypesToReport)
 			}
 		}
 	}

--- a/prow/config/githuboauth.go
+++ b/prow/config/githuboauth.go
@@ -28,9 +28,9 @@ type Cookie struct {
 	Secret string `json:"secret,omitempty"`
 }
 
-// GithubOAuthConfig is a config for requesting users access tokens from Github API. It also has
-// a Cookie Store that retains user credentials deriving from Github API.
-type GithubOAuthConfig struct {
+// GitHubOAuthConfig is a config for requesting users access tokens from GitHub API. It also has
+// a Cookie Store that retains user credentials deriving from GitHub API.
+type GitHubOAuthConfig struct {
 	ClientID         string   `json:"client_id"`
 	ClientSecret     string   `json:"client_secret"`
 	RedirectURL      string   `json:"redirect_url"`
@@ -40,9 +40,9 @@ type GithubOAuthConfig struct {
 	CookieStore *sessions.CookieStore `json:"-"`
 }
 
-// InitGithubOAuthConfig creates an OAuthClient using GithubOAuth config and a Cookie Store
+// InitGitHubOAuthConfig creates an OAuthClient using GitHubOAuth config and a Cookie Store
 // to retain user credentials.
-func (gac *GithubOAuthConfig) InitGithubOAuthConfig(cookie *sessions.CookieStore) {
+func (gac *GitHubOAuthConfig) InitGitHubOAuthConfig(cookie *sessions.CookieStore) {
 	gob.Register(&oauth2.Token{})
 	gac.CookieStore = cookie
 }

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -58,7 +58,7 @@ type TideRepoContextPolicy struct {
 // TideContextPolicyOptions holds the default policy, and any org overrides.
 type TideContextPolicyOptions struct {
 	TideContextPolicy
-	// Github Orgs
+	// GitHub Orgs
 	Orgs map[string]TideOrgContextPolicy `json:"orgs,omitempty"`
 }
 
@@ -66,11 +66,11 @@ type TideContextPolicyOptions struct {
 type Tide struct {
 	// SyncPeriodString compiles into SyncPeriod at load time.
 	SyncPeriodString string `json:"sync_period,omitempty"`
-	// SyncPeriod specifies how often Tide will sync jobs with Github. Defaults to 1m.
+	// SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
 	SyncPeriod time.Duration `json:"-"`
 	// StatusUpdatePeriodString compiles into StatusUpdatePeriod at load time.
 	StatusUpdatePeriodString string `json:"status_update_period,omitempty"`
-	// StatusUpdatePeriod specifies how often Tide will update Github status contexts.
+	// StatusUpdatePeriod specifies how often Tide will update GitHub status contexts.
 	// Defaults to the value of SyncPeriod.
 	StatusUpdatePeriod time.Duration `json:"-"`
 	// Queries represents a list of GitHub search queries that collectively
@@ -92,7 +92,7 @@ type Tide struct {
 	PRStatusBaseURL string `json:"pr_status_base_url,omitempty"`
 
 	// BlockerLabel is an optional label that is used to identify merge blocking
-	// Github issues.
+	// GitHub issues.
 	// Leave this blank to disable this feature and save 1 API token per sync loop.
 	BlockerLabel string `json:"blocker_label,omitempty"`
 

--- a/prow/docs/pr_status_setup.md
+++ b/prow/docs/pr_status_setup.md
@@ -5,14 +5,14 @@ This document helps configure [PR Status endpoints](https://prow.k8s.io/pr).
 PR status is an OAuth App that query pull requests on behalf of the authenticated users.
 Therefore, some secret pieces of information are needed to authorize users for the app. The following
 steps will show you how to setup an oauth app that works with PR Status.
-1. Create your Github Oauth application 
+1. Create your GitHub Oauth application 
 
     https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
     
     The callback url should be:
     
     `<PROW_BASE_URL>/github-login/redirect`
-2. Create a secret file for github oauth that has the following content. The information can be found in the [Github OAuth developer settings](https://github.com/settings/developers):
+2. Create a secret file for github oauth that has the following content. The information can be found in the [GitHub OAuth developer settings](https://github.com/settings/developers):
     
     ```
     client_id: <APP_CLIENT_ID>
@@ -58,7 +58,7 @@ steps will show you how to setup an oauth app that works with PR Status.
 6. Set the flag `--oauth-url=/github-login` on the deck deployment.
 
 ## Run PR Status endpoint locally
-Firstly, you will need a Github OAuth app. Please visit step 1 - 3 above. 
+Firstly, you will need a GitHub OAuth app. Please visit step 1 - 3 above. 
 
 When testing locally, pass the path to your secrets to `deck` using the `--github-oauth-config-file`  and `--cookie-secret` flags.
 

--- a/prow/external-plugins/cherrypicker/README.md
+++ b/prow/external-plugins/cherrypicker/README.md
@@ -2,7 +2,7 @@
 
 Cherrypicker is an external prow plugin that can also run as a standalone bot.
 It automates cherry-picking merged PRs into different branches. Cherrypicks are
-triggered from comments in Github PRs that need to be cherrypicked.
+triggered from comments in GitHub PRs that need to be cherrypicked.
 
 ```
 /cherrypick release-1.10

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -60,7 +60,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 	fs.BoolVar(&o.prowAssignments, "use-prow-assignments", true, "Use prow commands to assign cherrypicked PRs.")
-	fs.BoolVar(&o.allowAll, "allow-all", false, "Allow anybody to use automated cherrypicks by skipping Github organization membership checks.")
+	fs.BoolVar(&o.allowAll, "allow-all", false, "Allow anybody to use automated cherrypicks by skipping GitHub organization membership checks.")
 	for _, group := range []flagutil.OptionGroup{&o.github} {
 		group.AddFlags(fs)
 	}

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -347,7 +347,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	}
 	s.log.WithFields(l.Data).WithField("duration", time.Since(startClone)).Info("Cloned and checked out target branch.")
 
-	// Fetch the patch from Github
+	// Fetch the patch from GitHub
 	localPath, err := s.getPatch(org, repo, targetBranch, num)
 	if err != nil {
 		return err
@@ -383,12 +383,12 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	}
 	// Push the new branch in the bot's fork.
 	if err := push(repo, newBranch); err != nil {
-		resp := fmt.Sprintf("failed to push cherry-picked changes in Github: %v", err)
+		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
 		s.log.WithFields(l.Data).Info(resp)
 		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
 	}
 
-	// Open a PR in Github.
+	// Open a PR in GitHub.
 	title = fmt.Sprintf("[%s] %s", targetBranch, title)
 	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d", num)
 	if s.prowAssignments {
@@ -434,7 +434,7 @@ func (s *Server) ensureForkExists(org, repo string) error {
 			return fmt.Errorf("cannot fork %s/%s: %v", org, repo, err)
 		}
 		if err := waitForRepo(s.botName, repo, s.ghc); err != nil {
-			return fmt.Errorf("fork of %s/%s cannot show up on Github: %v", org, repo, err)
+			return fmt.Errorf("fork of %s/%s cannot show up on GitHub: %v", org, repo, err)
 		}
 		s.repos = append(s.repos, github.Repo{FullName: fork, Fork: true})
 	}
@@ -442,7 +442,7 @@ func (s *Server) ensureForkExists(org, repo string) error {
 }
 
 func waitForRepo(owner, name string, ghc githubClient) error {
-	// Wait for at most 5 minutes for the fork to appear on Github.
+	// Wait for at most 5 minutes for the fork to appear on GitHub.
 	after := time.After(5 * time.Minute)
 	tick := time.Tick(5 * time.Second)
 
@@ -461,7 +461,7 @@ func waitForRepo(owner, name string, ghc githubClient) error {
 				return nil
 			}
 		case <-after:
-			return fmt.Errorf("timed out waiting for %s to appear on Github%s", owner+"/"+name, ghErr)
+			return fmt.Errorf("timed out waiting for %s to appear on GitHub%s", owner+"/"+name, ghErr)
 		}
 	}
 }

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -65,8 +65,8 @@ The plugin reacts to commit changes on PRs in addition to periodically scanning 
 		nil
 }
 
-// HandleEvent handles a Github PR event to determine if the "needs-rebase"
-// label needs to be added or removed. It depends on Github mergeability check
+// HandleEvent handles a GitHub PR event to determine if the "needs-rebase"
+// label needs to be added or removed. It depends on GitHub mergeability check
 // to decide the need for a rebase.
 func HandleEvent(log *logrus.Entry, ghc githubClient, pre *github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionSynchronize && pre.Action != github.PullRequestActionReopened {
@@ -97,7 +97,7 @@ func HandleEvent(log *logrus.Entry, ghc githubClient, pre *github.PullRequestEve
 
 // HandleAll checks all orgs and repos that enabled this plugin for open PRs to
 // determine if the "needs-rebase" label needs to be added or removed. It
-// depends on Github's mergeability check to decide the need for a rebase.
+// depends on GitHub's mergeability check to decide the need for a rebase.
 func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuration) error {
 	log.Info("Checking all PRs.")
 	orgs, repos := config.EnabledReposForExternalPlugin(PluginName)
@@ -158,7 +158,7 @@ func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuratio
 
 // takeAction adds or removes the "needs-rebase" label based on the current
 // state of the PR (hasLabel and mergeable). It also handles adding and
-// removing Github comments notifying the PR author that a rebase is needed.
+// removing GitHub comments notifying the PR author that a rebase is needed.
 func takeAction(log *logrus.Entry, ghc githubClient, org, repo string, num int, author string, hasLabel, mergeable bool) error {
 	if !mergeable && !hasLabel {
 		if err := ghc.AddLabel(org, repo, num, labels.NeedsRebase); err != nil {

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Refresh retries Github status updates for stale PR statuses.
+// Refresh retries GitHub status updates for stale PR statuses.
 package main
 
 import (

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -41,7 +41,7 @@ var refreshRe = regexp.MustCompile(`(?mi)^/refresh\s*$`)
 
 func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The refresh plugin is used for refreshing status contexts in PRs. Useful in case Github breaks down.`,
+		Description: `The refresh plugin is used for refreshing status contexts in PRs. Useful in case GitHub breaks down.`,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/refresh",
@@ -168,7 +168,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 	jenkinsConfig := s.configAgent.Config().JenkinsOperators
 	kubeReport := s.configAgent.Config().Plank.ReportTemplate
-	reportTypes := s.configAgent.Config().GithubReporter.JobTypesToReport
+	reportTypes := s.configAgent.Config().GitHubReporter.JobTypesToReport
 	for _, pj := range pjutil.GetLatestProwJobs(presubmits, prowapi.PresubmitJob) {
 		var reportTemplate *template.Template
 		switch pj.Spec.Agent {

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -40,21 +40,21 @@ func (o *GitHubOptions) AddFlags(fs *flag.FlagSet) {
 	o.addFlags(true, fs)
 }
 
-// AddFlagsWithoutDefaultGithubTokenPath injects GitHub options into the given
+// AddFlagsWithoutDefaultGitHubTokenPath injects GitHub options into the given
 // Flagset without setting a default for for the githubTokenPath, allowing to
-// use an anonymous Github client
-func (o *GitHubOptions) AddFlagsWithoutDefaultGithubTokenPath(fs *flag.FlagSet) {
+// use an anonymous GitHub client
+func (o *GitHubOptions) AddFlagsWithoutDefaultGitHubTokenPath(fs *flag.FlagSet) {
 	o.addFlags(false, fs)
 }
 
-func (o *GitHubOptions) addFlags(wantDefaultGithubTokenPath bool, fs *flag.FlagSet) {
+func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagSet) {
 	o.endpoint = NewStrings("https://api.github.com")
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
-	defaultGithubTokenPath := ""
-	if wantDefaultGithubTokenPath {
-		defaultGithubTokenPath = "/etc/github/oauth"
+	defaultGitHubTokenPath := ""
+	if wantDefaultGitHubTokenPath {
+		defaultGitHubTokenPath = "/etc/github/oauth"
 	}
-	fs.StringVar(&o.TokenPath, "github-token-path", defaultGithubTokenPath, "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.TokenPath, "github-token-path", defaultGitHubTokenPath, "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.deprecatedTokenFile, "github-token-file", "", "DEPRECATED: use -github-token-path instead.  -github-token-file may be removed anytime after 2019-01-01.")
 }
 

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -131,10 +131,10 @@ kubectl create secret generic oauth-token --from-file=oauth=/path/to/oauth/secre
 
 #### Bot account
 
-The bot account used by prow must be granted owner level access to the Github
+The bot account used by prow must be granted owner level access to the GitHub
 orgs that prow will operate on. Note that events triggered by this account are
 ignored by some prow plugins. It is prudent to use a different bot account for
-other Github automation that prow should interact with to prevent events from
+other GitHub automation that prow should interact with to prevent events from
 being ignored unjustly.
 
 ### Add the prow components to the cluster

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2345,7 +2345,7 @@ func (c *Client) ListCollaborators(org, repo string) ([]User, error) {
 
 // CreateFork creates a fork for the authenticated user. Forking a repository
 // happens asynchronously. Therefore, we may have to wait a short period before
-// accessing the git objects. If this takes longer than 5 minutes, Github
+// accessing the git objects. If this takes longer than 5 minutes, GitHub
 // recommends contacting their support.
 //
 // See https://developer.github.com/v3/repos/forks/#create-a-fork

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -354,7 +354,7 @@ func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
 	}, nil
 }
 
-// ListTeamMembers return a fake team with a single "sig-lead" Github teammember
+// ListTeamMembers return a fake team with a single "sig-lead" GitHub teammember
 func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]github.TeamMember, error) {
 	if role != github.RoleAll {
 		return nil, fmt.Errorf("unsupported role %v (only all supported)", role)

--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package report contains helpers for writing comments and updating
-// statuses in Github.
+// statuses in GitHub.
 package report
 
 import (
@@ -33,9 +33,9 @@ const (
 	commentTag = "<!-- test report -->"
 )
 
-// GithubClient provides a client interface to report job status updates
-// through Github comments.
-type GithubClient interface {
+// GitHubClient provides a client interface to report job status updates
+// through GitHub comments.
+type GitHubClient interface {
 	BotName() (string, error)
 	CreateStatus(org, repo, ref string, s github.Status) error
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
@@ -44,10 +44,10 @@ type GithubClient interface {
 	EditComment(org, repo string, ID int, comment string) error
 }
 
-// prowjobStateToGithubStatus maps prowjob status to github states.
-// Github states can be one of error, failure, pending, or success.
+// prowjobStateToGitHubStatus maps prowjob status to github states.
+// GitHub states can be one of error, failure, pending, or success.
 // https://developer.github.com/v3/repos/statuses/#create-a-status
-func prowjobStateToGithubStatus(pjState prowapi.ProwJobState) (string, error) {
+func prowjobStateToGitHubStatus(pjState prowapi.ProwJobState) (string, error) {
 	switch pjState {
 	case prowapi.TriggeredState:
 		return github.StatusPending, nil
@@ -82,10 +82,10 @@ func truncate(in string) string {
 }
 
 // reportStatus should be called on any prowjob status changes
-func reportStatus(ghc GithubClient, pj prowapi.ProwJob) error {
+func reportStatus(ghc GitHubClient, pj prowapi.ProwJob) error {
 	refs := pj.Spec.Refs
 	if pj.Spec.Report {
-		contextState, err := prowjobStateToGithubStatus(pj.Status.State)
+		contextState, err := prowjobStateToGitHubStatus(pj.Status.State)
 		if err != nil {
 			return err
 		}
@@ -126,9 +126,9 @@ func ShouldReport(pj prowapi.ProwJob, validTypes []prowapi.ProwJobType) bool {
 	return true
 }
 
-// Report is creating/updating/removing reports in Github based on the state of
+// Report is creating/updating/removing reports in GitHub based on the state of
 // the provided ProwJob.
-func Report(ghc GithubClient, reportTemplate *template.Template, pj prowapi.ProwJob, validTypes []prowapi.ProwJobType) error {
+func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.ProwJob, validTypes []prowapi.ProwJobType) error {
 	if ghc == nil {
 		return fmt.Errorf("trying to report pj %s, but found empty github client", pj.ObjectMeta.Name)
 	}

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -25,19 +25,19 @@ import (
 )
 
 const (
-	// GithubReporterName is the name for github reporter
-	GithubReporterName = "github-reporter"
+	// GitHubReporterName is the name for github reporter
+	GitHubReporterName = "github-reporter"
 )
 
 // Client is a github reporter client
 type Client struct {
-	gc          report.GithubClient
+	gc          report.GitHubClient
 	config      config.Getter
 	reportAgent v1.ProwJobAgent
 }
 
 // NewReporter returns a reporter client
-func NewReporter(gc report.GithubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
+func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
 	return &Client{
 		gc:          gc,
 		config:      cfg,
@@ -47,7 +47,7 @@ func NewReporter(gc report.GithubClient, cfg config.Getter, reportAgent v1.ProwJ
 
 // GetName returns the name of the reporter
 func (c *Client) GetName() string {
-	return GithubReporterName
+	return GitHubReporterName
 }
 
 // ShouldReport returns if this prowjob should be reported by the github reporter
@@ -74,5 +74,5 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 // Report will report via reportlib
 func (c *Client) Report(pj *v1.ProwJob) error {
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	return report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GithubReporter.JobTypesToReport)
+	return report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GitHubReporter.JobTypesToReport)
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	// EventGUID is sent by Github in a header of every webhook request.
+	// EventGUID is sent by GitHub in a header of every webhook request.
 	// Used as a log field across prow.
 	EventGUID = "event-GUID"
 	// PrLogField is the number of a PR.
@@ -199,7 +199,7 @@ type PullRequestEvent struct {
 	// and deserialize later as this is a polymorphic field
 	Changes json.RawMessage `json:"changes"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -403,7 +403,7 @@ type IssueEvent struct {
 	// Label is specified for IssueActionLabeled and IssueActionUnlabeled events.
 	Label Label `json:"label"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -437,7 +437,7 @@ type IssueCommentEvent struct {
 	Comment IssueComment            `json:"comment"`
 	Repo    Repo                    `json:"repository"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -513,7 +513,7 @@ type StatusEvent struct {
 	Sender      User   `json:"sender,omitempty"`
 	Repo        Repo   `json:"repository,omitempty"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -539,7 +539,7 @@ type PushEvent struct {
 	Sender User `json:"sender"`
 	Repo   Repo `json:"repository"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -589,7 +589,7 @@ type ReviewEvent struct {
 	Repo        Repo              `json:"repository"`
 	Review      Review            `json:"review"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 
@@ -636,7 +636,7 @@ type ReviewCommentEvent struct {
 	Repo        Repo                     `json:"repository"`
 	Comment     ReviewComment            `json:"comment"`
 
-	// GUID is included in the header of the request received by Github.
+	// GUID is included in the header of the request received by GitHub.
 	GUID string
 }
 

--- a/prow/github/webhooks.go
+++ b/prow/github/webhooks.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ValidateWebhook ensures that the provided request conforms to the
-// format of a Github webhook and the payload can be validated with
+// format of a GitHub webhook and the payload can be validated with
 // the provided hmac secret. It returns the event type, the event guid,
 // the payload of the request, whether the webhook is valid or not,
 // and finally the resultant HTTP status code

--- a/prow/githuboauth/githuboauth_test.go
+++ b/prow/githuboauth/githuboauth_test.go
@@ -48,13 +48,13 @@ func (c *MockOAuthClient) AuthCodeURL(state string, opts ...oauth2.AuthCodeOptio
 	return "mock-auth-url"
 }
 
-func getMockConfig(cookie *sessions.CookieStore) *config.GithubOAuthConfig {
+func getMockConfig(cookie *sessions.CookieStore) *config.GitHubOAuthConfig {
 	clientID := "mock-client-id"
 	clientSecret := "mock-client-secret"
 	redirectURL := "/uni-test/redirect-url"
 	scopes := []string{}
 
-	return &config.GithubOAuthConfig{
+	return &config.GitHubOAuthConfig{
 		ClientID:         clientID,
 		ClientSecret:     clientSecret,
 		RedirectURL:      redirectURL,
@@ -65,7 +65,7 @@ func getMockConfig(cookie *sessions.CookieStore) *config.GithubOAuthConfig {
 	}
 }
 
-func createMockStateToken(config *config.GithubOAuthConfig) string {
+func createMockStateToken(config *config.GitHubOAuthConfig) string {
 	stateToken := xsrftoken.Generate(config.ClientSecret, "", "")
 	state := hex.EncodeToString([]byte(stateToken))
 
@@ -208,11 +208,11 @@ func TestHandleLogoutWithLoginSession(t *testing.T) {
 	}
 }
 
-type fakeGithubClient struct {
+type fakeGitHubClient struct {
 	login string
 }
 
-func (fgc *fakeGithubClient) GetUser(login string) (*github.User, error) {
+func (fgc *fakeGitHubClient) GetUser(login string) (*github.User, error) {
 	return &github.User{
 		Login: &fgc.login,
 	}, nil
@@ -222,8 +222,8 @@ type fakeGetter struct {
 	login string
 }
 
-func (fgc *fakeGetter) GetGithubClient(accessToken string, dryRun bool) GithubClientWrapper {
-	return &fakeGithubClient{login: fgc.login}
+func (fgc *fakeGetter) GetGitHubClient(accessToken string, dryRun bool) GitHubClientWrapper {
+	return &fakeGitHubClient{login: fgc.login}
 }
 
 func TestHandleRedirectWithInvalidState(t *testing.T) {

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -219,7 +219,7 @@ func (c *Controller) Sync() error {
 
 	var reportErrs []error
 	reportTemplate := c.config().ReportTemplate
-	reportTypes := c.cfg().GithubReporter.JobTypesToReport
+	reportTypes := c.cfg().GitHubReporter.JobTypesToReport
 	for report := range reportCh {
 		if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 			reportErrs = append(reportErrs, err)
@@ -279,7 +279,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, jbs map[string]Build)
 		}
 		toCancel := pjs[cancelIndex]
 		// Allow aborting presubmit jobs for commits that have been superseded by
-		// newer commits in Github pull requests.
+		// newer commits in GitHub pull requests.
 		if c.config().AllowCancellations {
 			build, buildExists := jbs[toCancel.ObjectMeta.Name]
 			// Avoid cancelling enqueued builds.
@@ -389,7 +389,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, reports chan<- prowapi.P
 			pj.Status.URL = b.String()
 		}
 	}
-	// Report to Github.
+	// Report to GitHub.
 	reports <- pj
 	if prevState != pj.Status.State {
 		c.log.WithFields(pjutil.ProwJobFields(&pj)).
@@ -430,7 +430,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 		pj.Status.State = prowapi.PendingState
 		pj.Status.Description = "Jenkins job enqueued."
 	}
-	// Report to Github.
+	// Report to GitHub.
 	reports <- pj
 
 	if prevState != pj.Status.State {

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -164,7 +164,7 @@ func (c *Controller) setPreviousReportState(pj prowapi.ProwJob) error {
 	if latestPJ.Status.PrevReportStates == nil {
 		latestPJ.Status.PrevReportStates = map[string]prowapi.ProwJobState{}
 	}
-	latestPJ.Status.PrevReportStates[reporter.GithubReporterName] = latestPJ.Status.State
+	latestPJ.Status.PrevReportStates[reporter.GitHubReporterName] = latestPJ.Status.State
 	_, err = c.kc.ReplaceProwJob(latestPJ.ObjectMeta.Name, latestPJ)
 	return err
 }
@@ -235,7 +235,7 @@ func (c *Controller) Sync() error {
 	var reportErrs []error
 	if !c.skipReport {
 		reportTemplate := c.config().Plank.ReportTemplate
-		reportTypes := c.config().GithubReporter.JobTypesToReport
+		reportTypes := c.config().GitHubReporter.JobTypesToReport
 		for report := range reportCh {
 			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 				reportErrs = append(reportErrs, err)
@@ -285,7 +285,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]coreapi
 		}
 		toCancel := pjs[cancelIndex]
 		// Allow aborting presubmit jobs for commits that have been superseded by
-		// newer commits in Github pull requests.
+		// newer commits in GitHub pull requests.
 		if c.config().Plank.AllowCancellations {
 			if pod, exists := pm[toCancel.ObjectMeta.Name]; exists {
 				if client, ok := c.pkcs[toCancel.ClusterAlias()]; !ok {
@@ -416,7 +416,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			}
 
 			// Pod is stuck in pending state longer than maxPodPending
-			// abort the job, and talk to Github
+			// abort the job, and talk to GitHub
 			pj.SetComplete()
 			pj.Status.State = prowapi.ErrorState
 			pj.Status.Description = "Pod pending timeout."

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -455,7 +455,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedNumPods:    map[string]int{"default": 1},
 			expectedReport:     true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
-				reporter.GithubReporterName: prowapi.PendingState,
+				reporter.GitHubReporterName: prowapi.PendingState,
 			},
 			expectedURL: "blabla/pending",
 		},
@@ -557,7 +557,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedPodHasName: true,
 			expectedReport:     true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
-				reporter.GithubReporterName: prowapi.PendingState,
+				reporter.GitHubReporterName: prowapi.PendingState,
 			},
 			expectedURL: "some/pending",
 		},
@@ -602,7 +602,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedNumPods: map[string]int{"default": 1},
 			expectedReport:  true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
-				reporter.GithubReporterName: prowapi.PendingState,
+				reporter.GitHubReporterName: prowapi.PendingState,
 			},
 			expectedURL: "beer/pending",
 		},
@@ -624,7 +624,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedComplete: true,
 			expectedReport:   true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
-				reporter.GithubReporterName: prowapi.ErrorState,
+				reporter.GitHubReporterName: prowapi.ErrorState,
 			},
 		},
 		{
@@ -702,7 +702,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectedNumPods: map[string]int{"default": 1},
 			expectedReport:  true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
-				reporter.GithubReporterName: prowapi.PendingState,
+				reporter.GitHubReporterName: prowapi.PendingState,
 			},
 			expectedURL:     "foo/pending",
 			expectedBuildID: "0987654321",

--- a/prow/pluginhelp/hook/hook_test.go
+++ b/prow/pluginhelp/hook/hook_test.go
@@ -33,9 +33,9 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-type fakeGithubClient map[string][]string
+type fakeGitHubClient map[string][]string
 
-func (fghc fakeGithubClient) GetRepos(org string, _ bool) ([]github.Repo, error) {
+func (fghc fakeGitHubClient) GetRepos(org string, _ bool) ([]github.Repo, error) {
 	var repos []github.Repo
 	for _, repo := range fghc[org] {
 		repos = append(repos, github.Repo{FullName: fmt.Sprintf("%s/%s", org, repo)})
@@ -52,7 +52,7 @@ func (fpa fakePluginAgent) Config() *plugins.Configuration {
 
 func TestGeneratePluginHelp(t *testing.T) {
 	orgToRepos := map[string][]string{"org1": {"repo1", "repo2", "repo3"}, "org2": {"repo1"}}
-	fghc := fakeGithubClient(orgToRepos)
+	fghc := fakeGitHubClient(orgToRepos)
 
 	normalHelp := map[string]pluginhelp.PluginHelp{
 		"org-plugin": {Description: "org-plugin", Config: map[string]string{"": "overall config"}},

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -98,7 +98,7 @@ func newTestReviewTime(t time.Time, user, body string, state github.ReviewState)
 	return r
 }
 
-func newFakeGithubClient(hasLabel, humanApproved bool, files []string, comments []github.IssueComment, reviews []github.Review) *fakegithub.FakeClient {
+func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments []github.IssueComment, reviews []github.Review) *fakegithub.FakeClient {
 	labels := []string{"org/repo#1:lgtm"}
 	if hasLabel {
 		labels = append(labels, fmt.Sprintf("org/repo#%v:approved", prNumber))
@@ -1007,7 +1007,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 	}
 
 	for _, test := range tests {
-		fghc := newFakeGithubClient(test.hasLabel, test.humanApproved, test.files, test.comments, test.reviews)
+		fghc := newFakeGitHubClient(test.hasLabel, test.humanApproved, test.files, test.comments, test.reviews)
 		branch := "master"
 		if test.branch != "" {
 			branch = test.branch

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -31,21 +31,21 @@ import (
 	"k8s.io/test-infra/prow/repoowners"
 )
 
-type fakeGithubClient struct {
+type fakeGitHubClient struct {
 	pr        *github.PullRequest
 	changes   []github.PullRequestChange
 	requested []string
 }
 
-func newFakeGithubClient(pr *github.PullRequest, filesChanged []string) *fakeGithubClient {
+func newFakeGitHubClient(pr *github.PullRequest, filesChanged []string) *fakeGitHubClient {
 	changes := make([]github.PullRequestChange, 0, len(filesChanged))
 	for _, name := range filesChanged {
 		changes = append(changes, github.PullRequestChange{Filename: name})
 	}
-	return &fakeGithubClient{pr: pr, changes: changes}
+	return &fakeGitHubClient{pr: pr, changes: changes}
 }
 
-func (c *fakeGithubClient) RequestReview(org, repo string, number int, logins []string) error {
+func (c *fakeGitHubClient) RequestReview(org, repo string, number int, logins []string) error {
 	if org != "org" {
 		return errors.New("org should be 'org'")
 	}
@@ -59,7 +59,7 @@ func (c *fakeGithubClient) RequestReview(org, repo string, number int, logins []
 	return nil
 }
 
-func (c *fakeGithubClient) GetPullRequestChanges(org, repo string, num int) ([]github.PullRequestChange, error) {
+func (c *fakeGitHubClient) GetPullRequestChanges(org, repo string, num int) ([]github.PullRequestChange, error) {
 	if org != "org" {
 		return nil, errors.New("org should be 'org'")
 	}
@@ -72,7 +72,7 @@ func (c *fakeGithubClient) GetPullRequestChanges(org, repo string, num int) ([]g
 	return c.changes, nil
 }
 
-func (c *fakeGithubClient) GetPullRequest(org, repo string, num int) (*github.PullRequest, error) {
+func (c *fakeGitHubClient) GetPullRequest(org, repo string, num int) (*github.PullRequest, error) {
 	return c.pr, nil
 }
 
@@ -260,7 +260,7 @@ func TestHandleWithExcludeApproversOnlyReviewers(t *testing.T) {
 	for _, tc := range testcases {
 		pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
 		repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-		fghc := newFakeGithubClient(&pr, tc.filesChanged)
+		fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 
 		if err := handle(
 			fghc, froc, logrus.WithField("plugin", PluginName),
@@ -302,7 +302,7 @@ func TestHandleWithoutExcludeApproversNoReviewers(t *testing.T) {
 	for _, tc := range testcases {
 		pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
 		repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-		fghc := newFakeGithubClient(&pr, tc.filesChanged)
+		fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 
 		if err := handle(
 			fghc, froc, logrus.WithField("plugin", PluginName),
@@ -423,7 +423,7 @@ func TestHandleWithoutExcludeApproversMixed(t *testing.T) {
 	for _, tc := range testcases {
 		pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
 		repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-		fghc := newFakeGithubClient(&pr, tc.filesChanged)
+		fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 		if err := handle(
 			fghc, froc, logrus.WithField("plugin", PluginName),
 			&tc.reviewerCount, nil, tc.maxReviewerCount, false, &repo, &pr,
@@ -525,7 +525,7 @@ func TestHandleOld(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-			fghc := newFakeGithubClient(&pr, tc.filesChanged)
+			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 
 			err := handle(
 				fghc, froc, logrus.WithField("plugin", PluginName),
@@ -588,7 +588,7 @@ func TestHandlePullRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}, Body: tc.body}
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-			fghc := newFakeGithubClient(&pr, tc.filesChanged)
+			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 			config := plugins.Blunderbuss{
 				ReviewerCount:    &tc.reviewerCount,
 				FileWeightCount:  nil,
@@ -678,7 +678,7 @@ func TestHandleGenericComment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
-			fghc := newFakeGithubClient(&pr, tc.filesChanged)
+			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
 			config := plugins.Blunderbuss{
 				ReviewerCount:    &tc.reviewerCount,

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -113,7 +113,7 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, c
 	if hasCherryPickApprovedLabel {
 		if hasCherryPickUnapprovedLabel {
 			if err := gc.RemoveLabel(org, repo, pr.Number, labels.CpUnapproved); err != nil {
-				log.WithError(err).Errorf("Github failed to remove the following label: %s", labels.CpUnapproved)
+				log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labels.CpUnapproved)
 			}
 		}
 		cp.PruneComments(func(comment github.IssueComment) bool {
@@ -129,7 +129,7 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, c
 
 	// only add the label and comment if none of the approved and unapproved labels are present
 	if err := gc.AddLabel(org, repo, pr.Number, labels.CpUnapproved); err != nil {
-		log.WithError(err).Errorf("Github failed to add the following label: %s", labels.CpUnapproved)
+		log.WithError(err).Errorf("GitHub failed to add the following label: %s", labels.CpUnapproved)
 	}
 
 	formattedComment := plugins.FormatSimpleResponse(pr.PullRequest.User.Login, commentBody)

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -300,7 +300,7 @@ func (a Approve) ConsiderReviewState() bool {
 type Lgtm struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`
-	// ReviewActsAsLgtm indicates that a Github review of "approve" or "request changes"
+	// ReviewActsAsLgtm indicates that a GitHub review of "approve" or "request changes"
 	// acts as adding or removing the lgtm label
 	ReviewActsAsLgtm bool `json:"review_acts_as_lgtm,omitempty"`
 	// StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
@@ -309,7 +309,7 @@ type Lgtm struct {
 	// WARNING: This disables the security mechanism that prevents a malicious member (or
 	// compromised GitHub account) from merging arbitrary code. Use with caution.
 	//
-	// StickyLgtmTeam specifies the Github team whose members are trusted with sticky LGTM,
+	// StickyLgtmTeam specifies the GitHub team whose members are trusted with sticky LGTM,
 	// which eliminates the need to re-lgtm minor fixes/updates.
 	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
 }
@@ -338,7 +338,7 @@ type Trigger struct {
 	TrustedOrg string `json:"trusted_org,omitempty"`
 	// JoinOrgURL is a link that redirects users to a location where they
 	// should be able to read more about joining the organization in order
-	// to become trusted members. Defaults to the Github link of TrustedOrg.
+	// to become trusted members. Defaults to the GitHub link of TrustedOrg.
 	JoinOrgURL string `json:"join_org_url,omitempty"`
 	// OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.
 	// By default, trigger also include repo collaborators.

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -51,10 +51,10 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
 	return &pluginhelp.PluginHelp{
-			Description: "The heart plugin celebrates certain Github actions with the reaction emojis. Emojis are added to pull requests that make additions to OWNERS or OWNERS_ALIASES files and to comments left by specified \"adorees\".",
+			Description: "The heart plugin celebrates certain GitHub actions with the reaction emojis. Emojis are added to pull requests that make additions to OWNERS or OWNERS_ALIASES files and to comments left by specified \"adorees\".",
 			Config: map[string]string{
 				"": fmt.Sprintf(
-					"The heart plugin is configured to react to comments,  satisfying the regular expression %s, left by the following Github users: %s.",
+					"The heart plugin is configured to react to comments,  satisfying the regular expression %s, left by the following GitHub users: %s.",
 					config.Heart.CommentRegexp,
 					strings.Join(config.Heart.Adorees, ", "),
 				),

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -115,7 +115,7 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 	// If PR has help label and we're asking for it to be removed, remove label
 	if hasHelp && helpRemoveRe.MatchString(e.Body) {
 		if err := gc.RemoveLabel(org, repo, e.Number, labels.Help); err != nil {
-			log.WithError(err).Errorf("Github failed to remove the following label: %s", labels.Help)
+			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labels.Help)
 		}
 
 		botName, err := gc.BotName()
@@ -127,7 +127,7 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 		// if it has the good-first-issue label, remove it too
 		if hasGoodFirstIssue {
 			if err := gc.RemoveLabel(org, repo, e.Number, labels.GoodFirstIssue); err != nil {
-				log.WithError(err).Errorf("Github failed to remove the following label: %s", labels.GoodFirstIssue)
+				log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labels.GoodFirstIssue)
 			}
 			cp.PruneComments(shouldPrune(log, botName, goodFirstIssueMsgPruneMatch))
 		}
@@ -143,12 +143,12 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 		}
 
 		if err := gc.AddLabel(org, repo, e.Number, labels.GoodFirstIssue); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", labels.GoodFirstIssue)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labels.GoodFirstIssue)
 		}
 
 		if !hasHelp {
 			if err := gc.AddLabel(org, repo, e.Number, labels.Help); err != nil {
-				log.WithError(err).Errorf("Github failed to add the following label: %s", labels.Help)
+				log.WithError(err).Errorf("GitHub failed to add the following label: %s", labels.Help)
 			}
 		}
 
@@ -162,7 +162,7 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 			log.WithError(err).Errorf("Failed to create comment \"%s\".", helpMsg)
 		}
 		if err := gc.AddLabel(org, repo, e.Number, labels.Help); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", labels.Help)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labels.Help)
 		}
 
 		return nil
@@ -172,7 +172,7 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 	// remove just the good-first-issue label
 	if hasGoodFirstIssue && helpGoodFirstIssueRemoveRe.MatchString(e.Body) {
 		if err := gc.RemoveLabel(org, repo, e.Number, labels.GoodFirstIssue); err != nil {
-			log.WithError(err).Errorf("Github failed to remove the following label: %s", labels.GoodFirstIssue)
+			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labels.GoodFirstIssue)
 		}
 
 		botName, err := gc.BotName()

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -163,7 +163,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 		}
 
 		if err := gc.AddLabel(org, repo, e.Number, RepoLabelsExisting[labelToAdd]); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", labelToAdd)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labelToAdd)
 		}
 	}
 
@@ -180,7 +180,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 		}
 
 		if err := gc.RemoveLabel(org, repo, e.Number, labelToRemove); err != nil {
-			log.WithError(err).Errorf("Github failed to remove the following label: %s", labelToRemove)
+			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labelToRemove)
 		}
 	}
 

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -103,7 +103,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Config:      configInfo,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/lgtm [cancel] or Github Review action",
+		Usage:       "/lgtm [cancel] or GitHub Review action",
 		Description: "Adds or removes the 'lgtm' label which is typically used to gate merging.",
 		Featured:    true,
 		WhoCanUse:   "Collaborators on the repository. '/lgtm cancel' can be used additionally by the PR author.",

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -53,14 +53,14 @@ type fakeRepoOwners struct {
 }
 
 type fakePruner struct {
-	GithubClient  *fakegithub.FakeClient
+	GitHubClient  *fakegithub.FakeClient
 	IssueComments []github.IssueComment
 }
 
 func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {
 	for _, comment := range fp.IssueComments {
 		if shouldPrune(comment) {
-			fp.GithubClient.IssueCommentsDeleted = append(fp.GithubClient.IssueCommentsDeleted, comment.Body)
+			fp.GitHubClient.IssueCommentsDeleted = append(fp.GitHubClient.IssueCommentsDeleted, comment.Body)
 		}
 	}
 }
@@ -292,7 +292,7 @@ func TestLGTMComment(t *testing.T) {
 			StoreTreeHash: true,
 		})
 		fp := &fakePruner{
-			GithubClient:  fc,
+			GitHubClient:  fc,
 			IssueComments: fc.IssueComments[5],
 		}
 		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -446,7 +446,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
 		pc := &plugins.Configuration{}
 		fp := &fakePruner{
-			GithubClient:  fc,
+			GitHubClient:  fc,
 			IssueComments: fc.IssueComments[5],
 		}
 		if err := handleGenericComment(fc, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -612,7 +612,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 			StoreTreeHash: tc.storeTreeHash,
 		})
 		fp := &fakePruner{
-			GithubClient:  fc,
+			GitHubClient:  fc,
 			IssueComments: fc.IssueComments[5],
 		}
 		if err := handlePullRequestReview(fc, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -1078,7 +1078,7 @@ func TestRemoveTreeHashComment(t *testing.T) {
 	}
 	fc.IssueLabelsAdded = []string{"kubernetes/kubernetes#101:" + LGTMLabel}
 	fp := &fakePruner{
-		GithubClient:  fc,
+		GitHubClient:  fc,
 		IssueComments: fc.IssueComments[101],
 	}
 	handle(false, pc, &fakeOwnersClient{}, rc, fc, logrus.WithField("plugin", PluginName), fp)

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -123,13 +123,13 @@ func handleOne(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEv
 		for _, label := range lifecycleLabels {
 			if label != lbl && github.HasLabel(label, labels) {
 				if err := gc.RemoveLabel(org, repo, number, label); err != nil {
-					log.WithError(err).Errorf("Github failed to remove the following label: %s", label)
+					log.WithError(err).Errorf("GitHub failed to remove the following label: %s", label)
 				}
 			}
 		}
 
 		if err := gc.AddLabel(org, repo, number, lbl); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", lbl)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", lbl)
 		}
 	}
 

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -37,7 +37,7 @@ var (
 	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
 	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
-	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
+	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q with ID: %d."
 	clearKeyword     = "clear"
 )
 

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -35,7 +35,7 @@ const pluginName = "milestonestatus"
 var (
 	statusRegex      = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
 	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to add status labels. If you believe you should be able to issue the /status command, please contact your %s and have them propose you as an additional delegate for this responsibility."
-	milestoneTeamMsg = "The milestone maintainers team is the Github team %q with ID: %d."
+	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q with ID: %d."
 	statusMap        = map[string]string{
 		"approved-for-milestone": "status/approved-for-milestone",
 		"in-progress":            "status/in-progress",
@@ -59,7 +59,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	}
 
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The milestonestatus plugin allows members of the milestone maintainers Github team to specify the 'status/*' label that should apply to a pull request.",
+		Description: "The milestonestatus plugin allows members of the milestone maintainers GitHub team to specify the 'status/*' label that should apply to a pull request.",
 		Config: func() map[string]string {
 			configMap := make(map[string]string)
 			for _, repo := range enabledRepos {
@@ -76,7 +76,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Usage:       "/status (approved-for-milestone|in-progress|in-review)",
 		Description: "Applies the 'status/' label to a PR.",
 		Featured:    false,
-		WhoCanUse:   "Members of the milestone maintainers Github team can use the '/status' command. This team is specified in the config by providing the Github team's ID.",
+		WhoCanUse:   "Members of the milestone maintainers GitHub team can use the '/status' command. This team is specified in the config by providing the GitHub team's ID.",
 		Examples:    []string{"/status approved-for-milestone", "/status in-progress", "/status in-review"},
 	})
 	return pluginHelp, nil

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -111,7 +111,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 			continue
 		}
 		if err := ghc.AddLabel(org, repo, number, labelToAdd); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", labelToAdd)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labelToAdd)
 		}
 	}
 

--- a/prow/plugins/sigmention/sigmention.go
+++ b/prow/plugins/sigmention/sigmention.go
@@ -60,11 +60,11 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
-			Description: `The sigmention plugin responds to SIG (Special Interest Group) Github team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
+			Description: `The sigmention plugin responds to SIG (Special Interest Group) GitHub team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
 <ol><li> The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.</li>
-<li> If the user who mentioned the Github team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger Github notifications.</li></ol>`,
+<li> If the user who mentioned the GitHub team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger GitHub notifications.</li></ol>`,
 			Config: map[string]string{
-				"": fmt.Sprintf("Labels added by the plugin are triggered by mentions of Github teams matching the following regexp:\n%s", config.SigMention.Regexp),
+				"": fmt.Sprintf("Labels added by the plugin are triggered by mentions of GitHub teams matching the following regexp:\n%s", config.SigMention.Regexp),
 			},
 		},
 		nil
@@ -118,14 +118,14 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		}
 		if !github.HasLabel(sigLabel, labels) {
 			if err := gc.AddLabel(org, repo, e.Number, sigLabel); err != nil {
-				log.WithError(err).Errorf("Github failed to add the following label: %s", sigLabel)
+				log.WithError(err).Errorf("GitHub failed to add the following label: %s", sigLabel)
 			}
 		}
 
 		if len(sigMatch) > 2 {
 			if kindLabel, ok := kindMap[sigMatch[2]]; ok && !github.HasLabel(kindLabel, labels) {
 				if err := gc.AddLabel(org, repo, e.Number, kindLabel); err != nil {
-					log.WithError(err).Errorf("Github failed to add the following label: %s", kindLabel)
+					log.WithError(err).Errorf("GitHub failed to add the following label: %s", kindLabel)
 				}
 			}
 		}

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -51,11 +51,11 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The skip plugin allows users to clean up Github stale commit statuses for non-blocking jobs on a PR.",
+		Description: "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/skip",
-		Description: "Cleans up Github stale commit statuses for non-blocking jobs on a PR.",
+		Description: "Cleans up GitHub stale commit statuses for non-blocking jobs on a PR.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can trigger this command on a PR.",
 		Examples:    []string{"/skip"},

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -41,7 +41,7 @@ type githubClient interface {
 }
 
 type client struct {
-	GithubClient githubClient
+	GitHubClient githubClient
 	SlackClient  slackClient
 	SlackConfig  plugins.Slack
 }
@@ -53,7 +53,7 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	configInfo := map[string]string{
-		"": fmt.Sprintf("SIG mentions on Github are reiterated for the following SIG Slack channels: %s.", strings.Join(config.Slack.MentionChannels, ", ")),
+		"": fmt.Sprintf("SIG mentions on GitHub are reiterated for the following SIG Slack channels: %s.", strings.Join(config.Slack.MentionChannels, ", ")),
 	}
 	for _, repo := range enabledRepos {
 		parts := strings.Split(repo, "/")
@@ -78,9 +78,9 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 	}
 	return &pluginhelp.PluginHelp{
-			Description: `The slackevents plugin reacts to various Github events by commenting in Slack channels.
+			Description: `The slackevents plugin reacts to various GitHub events by commenting in Slack channels.
 <ol><li>The plugin can create comments to alert on manual merges. Manual merges are merges made by a normal user instead of a bot or trusted user.</li>
-<li>The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from Github.</li></ol>`,
+<li>The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from GitHub.</li></ol>`,
 			Config: configInfo,
 		},
 		nil
@@ -88,7 +88,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 
 func handleComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	c := client{
-		GithubClient: pc.GitHubClient,
+		GitHubClient: pc.GitHubClient,
 		SlackConfig:  pc.PluginConfig.Slack,
 		SlackClient:  pc.SlackClient,
 	}
@@ -97,7 +97,7 @@ func handleComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 
 func handlePush(pc plugins.Agent, pe github.PushEvent) error {
 	c := client{
-		GithubClient: pc.GitHubClient,
+		GitHubClient: pc.GitHubClient,
 		SlackConfig:  pc.PluginConfig.Slack,
 		SlackClient:  pc.SlackClient,
 	}
@@ -157,7 +157,7 @@ func stringInArray(str string, list []string) bool {
 
 func echoToSlack(pc client, e github.GenericCommentEvent) error {
 	// Ignore bot comments and comments that aren't new.
-	botName, err := pc.GithubClient.BotName()
+	botName, err := pc.GitHubClient.BotName()
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func echoToSlack(pc client, e github.GenericCommentEvent) error {
 			continue
 		}
 
-		msg := fmt.Sprintf("%s was mentioned by %s (<@%s>) on Github. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
+		msg := fmt.Sprintf("%s was mentioned by %s (<@%s>) on GitHub. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
 		if err := pc.SlackClient.WriteMessage(msg, sig); err != nil {
 			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %v", sig, msg, err)
 		}

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -290,7 +290,7 @@ func TestComment(t *testing.T) {
 			SentMessages: make(map[string][]string),
 		}
 		client := client{
-			GithubClient: &fakegithub.FakeClient{},
+			GitHubClient: &fakegithub.FakeClient{},
 			SlackClient:  fakeSlackClient,
 			SlackConfig:  plugins.Slack{MentionChannels: []string{"sig-node", "sig-api-machinery"}},
 		}

--- a/prow/plugins/stage/stage.go
+++ b/prow/plugins/stage/stage.go
@@ -106,13 +106,13 @@ func handleOne(gc stageClient, log *logrus.Entry, e *github.GenericCommentEvent,
 		for _, label := range stageLabels {
 			if label != lbl && github.HasLabel(label, labels) {
 				if err := gc.RemoveLabel(org, repo, number, label); err != nil {
-					log.WithError(err).Errorf("Github failed to remove the following label: %s", label)
+					log.WithError(err).Errorf("GitHub failed to remove the following label: %s", label)
 				}
 			}
 		}
 
 		if err := gc.AddLabel(org, repo, number, lbl); err != nil {
-			log.WithError(err).Errorf("Github failed to add the following label: %s", lbl)
+			log.WithError(err).Errorf("GitHub failed to add the following label: %s", lbl)
 		}
 	}
 

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -59,7 +59,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		if trigger.TrustedOrg != "" {
 			org = trigger.TrustedOrg
 		}
-		configInfo[orgRepo] = fmt.Sprintf("The trusted Github organization for this repository is %q.", org)
+		configInfo[orgRepo] = fmt.Sprintf("The trusted GitHub organization for this repository is %q.", org)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -127,7 +127,7 @@ func IssueLabelsAddedContain(arr []string, str string) bool {
 	return false
 }
 
-func newFakeGithubClient(files []string, pr int) *fakegithub.FakeClient {
+func newFakeGitHubClient(files []string, pr int) *fakegithub.FakeClient {
 	var changes []github.PullRequestChange
 	for _, file := range files {
 		changes = append(changes, github.PullRequestChange{Filename: file})
@@ -279,7 +279,7 @@ func TestHandle(t *testing.T) {
 			},
 			Repo: github.Repo{FullName: "org/repo"},
 		}
-		fghc := newFakeGithubClient(test.filesChanged, pr)
+		fghc := newFakeGitHubClient(test.filesChanged, pr)
 		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -71,25 +71,25 @@ type PullRequestWithContexts struct {
 // It will serve a list of open pull requests owned by the user.
 type DashboardAgent struct {
 	repos []string
-	goac  *config.GithubOAuthConfig
+	goac  *config.GitHubOAuthConfig
 
 	log *logrus.Entry
 }
 
-// Label represents a Github label.
+// Label represents a GitHub label.
 type Label struct {
 	ID   githubql.ID
 	Name githubql.String
 }
 
-// Context represent a Github status check context.
+// Context represent a GitHub status check context.
 type Context struct {
 	Context     string
 	Description string
 	State       string
 }
 
-// PullRequest holds the GraphQL response data for a Github pull request.
+// PullRequest holds the GraphQL response data for a GitHub pull request.
 type PullRequest struct {
 	Number githubql.Int
 	Merged githubql.Boolean
@@ -144,7 +144,7 @@ type searchQuery struct {
 }
 
 // NewDashboardAgent creates a new user dashboard agent .
-func NewDashboardAgent(repos []string, config *config.GithubOAuthConfig, log *logrus.Entry) *DashboardAgent {
+func NewDashboardAgent(repos []string, config *config.GitHubOAuthConfig, log *logrus.Entry) *DashboardAgent {
 	return &DashboardAgent{
 		repos: repos,
 		goac:  config,
@@ -168,7 +168,7 @@ func invalidateGitHubSession(w http.ResponseWriter, r *http.Request, session *se
 }
 
 // HandlePrStatus returns a http handler function that handles request to /pr-status
-// endpoint. The handler takes user access token stored in the cookie to query to Github on behalf
+// endpoint. The handler takes user access token stored in the cookie to query to GitHub on behalf
 // of the user and serve the data in return. The Query handler is passed to the method so as it
 // can be mocked in the unit test..
 func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) http.HandlerFunc {
@@ -339,7 +339,7 @@ func (da *DashboardAgent) GetHeadContexts(ghc githubClient, pr PullRequest) ([]C
 	return contexts, nil
 }
 
-// ConstructSearchQuery returns the Github search query string for PRs that are open and authored
+// ConstructSearchQuery returns the GitHub search query string for PRs that are open and authored
 // by the user passed. The search is scoped to repositories that are configured with either Prow or
 // Tide.
 func (da *DashboardAgent) ConstructSearchQuery(login string) string {

--- a/prow/prstatus/prstatus_test.go
+++ b/prow/prstatus/prstatus_test.go
@@ -75,7 +75,7 @@ func newMockQueryHandler(prs []PullRequest, contextMap map[int][]Context) *MockQ
 	}
 }
 
-func createMockAgent(repos []string, config *config.GithubOAuthConfig) *DashboardAgent {
+func createMockAgent(repos []string, config *config.GitHubOAuthConfig) *DashboardAgent {
 	return &DashboardAgent{
 		repos: repos,
 		goac:  config,
@@ -86,7 +86,7 @@ func createMockAgent(repos []string, config *config.GithubOAuthConfig) *Dashboar
 func TestHandlePrStatusWithoutLogin(t *testing.T) {
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
-	mockConfig := &config.GithubOAuthConfig{
+	mockConfig := &config.GitHubOAuthConfig{
 		CookieStore: mockCookieStore,
 	}
 	mockAgent := createMockAgent(repos, mockConfig)
@@ -122,7 +122,7 @@ func TestHandlePrStatusWithInvalidToken(t *testing.T) {
 	logrus.SetLevel(logrus.ErrorLevel)
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
-	mockConfig := &config.GithubOAuthConfig{
+	mockConfig := &config.GitHubOAuthConfig{
 		CookieStore: mockCookieStore,
 	}
 	mockAgent := createMockAgent(repos, mockConfig)
@@ -158,7 +158,7 @@ func TestHandlePrStatusWithInvalidToken(t *testing.T) {
 func TestHandlePrStatusWithLogin(t *testing.T) {
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
-	mockConfig := &config.GithubOAuthConfig{
+	mockConfig := &config.GitHubOAuthConfig{
 		CookieStore: mockCookieStore,
 	}
 	mockAgent := createMockAgent(repos, mockConfig)
@@ -307,7 +307,7 @@ func TestHandlePrStatusWithLogin(t *testing.T) {
 func TestGetHeadContexts(t *testing.T) {
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
-	mockConfig := &config.GithubOAuthConfig{
+	mockConfig := &config.GitHubOAuthConfig{
 		CookieStore: mockCookieStore,
 	}
 	mockAgent := createMockAgent(repos, mockConfig)
@@ -379,7 +379,7 @@ func TestGetHeadContexts(t *testing.T) {
 func TestConstructSearchQuery(t *testing.T) {
 	repos := []string{"mock/repo", "kubernetes/test-infra", "foo/bar"}
 	mockCookieStore := sessions.NewCookieStore([]byte("secret-key"))
-	mockConfig := &config.GithubOAuthConfig{
+	mockConfig := &config.GitHubOAuthConfig{
 		CookieStore: mockCookieStore,
 	}
 	mockAgent := createMockAgent(repos, mockConfig)

--- a/prow/pubsub/reporter/reporter.go
+++ b/prow/pubsub/reporter/reporter.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package reporter contains helpers for publishing statues to Pub
-// statuses in Github.
+// statuses in GitHub.
 package reporter
 
 import (

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -38,7 +38,7 @@ import (
 const (
 	ownersFileName  = "OWNERS"
 	aliasesFileName = "OWNERS_ALIASES"
-	// Github's api uses "" (empty) string as basedir by convention but it's clearer to use "/"
+	// GitHub's api uses "" (empty) string as basedir by convention but it's clearer to use "/"
 	baseDirConvention = ""
 )
 

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -110,12 +110,12 @@ type cacheOptions struct {
 	ownersFileChanged        bool
 }
 
-type fakeGithubClient struct {
+type fakeGitHubClient struct {
 	Collaborators []string
 	ref           string
 }
 
-func (f *fakeGithubClient) ListCollaborators(org, repo string) ([]github.User, error) {
+func (f *fakeGitHubClient) ListCollaborators(org, repo string) ([]github.User, error) {
 	result := make([]github.User, 0, len(f.Collaborators))
 	for _, login := range f.Collaborators {
 		result = append(result, github.User{Login: login})
@@ -123,7 +123,7 @@ func (f *fakeGithubClient) ListCollaborators(org, repo string) ([]github.User, e
 	return result, nil
 }
 
-func (f *fakeGithubClient) GetRef(org, repo, ref string) (string, error) {
+func (f *fakeGitHubClient) GetRef(org, repo, ref string) (string, error) {
 	return f.ref, nil
 }
 
@@ -234,7 +234,7 @@ labels:
 		// mark this entry is cache
 		entry.owners.baseDir = "cache"
 	}
-	ghc := &fakeGithubClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}}
+	ghc := &fakeGitHubClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}}
 	ghc.ref, err = localGit.RevParse("org", "repo", "HEAD")
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot get commit SHA: %v", err)
@@ -1053,7 +1053,7 @@ func TestCanonicalize(t *testing.T) {
 			expectedPath: "",
 		},
 		{
-			name:         "Github Style Input (No Root)",
+			name:         "GitHub Style Input (No Root)",
 			path:         "a/b/c/d.txt",
 			expectedPath: "a/b/c/d.txt",
 		},

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -147,7 +147,7 @@ func partitionTime(start, end time.Time, count, goalSize int) time.Time {
 // dateToken generates a GitHub search query token for the specified date range.
 // See: https://help.github.com/articles/understanding-the-search-syntax/#query-for-dates
 func dateToken(start, end time.Time) string {
-	// Github's GraphQL API silently fails if you provide it with an invalid time
+	// GitHub's GraphQL API silently fails if you provide it with an invalid time
 	// string.
 	// Dates before 1970 (unix epoch) are considered invalid.
 	startString, endString := "*", "*"

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -855,7 +855,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 					log.WithError(err).Warning("Merge failed: PR was modified.")
 					break
 				} else if _, ok = err.(github.UnmergablePRBaseChangedError); ok {
-					// Github complained that the base branch was modified. This is a
+					// GitHub complained that the base branch was modified. This is a
 					// strange error because the API doesn't even allow the request to
 					// specify the base branch sha, only the head sha.
 					// We suspect that github is complaining because we are making the
@@ -869,7 +869,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 						backoff *= 2
 					}
 				} else if _, ok = err.(github.UnauthorizedToPushError); ok {
-					// Github let us know that the token used cannot push to the branch.
+					// GitHub let us know that the token used cannot push to the branch.
 					// Even if the robot is set up to have write access to the repo, an
 					// overzealous branch protection setting will not allow the robot to
 					// push to a specific branch.
@@ -877,7 +877,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 					// We won't be able to merge the other PRs.
 					return augmentError(err, pr)
 				} else if _, ok = err.(github.MergeCommitsForbiddenError); ok {
-					// Github let us know that the merge method configured for this repo
+					// GitHub let us know that the merge method configured for this repo
 					// is not allowed by other repo settings, so we should let the admins
 					// know that the configuration needs to be updated.
 					log.WithError(err).Error("Merge failed: Tide needs to be configured to use the 'rebase' merge method for this repo or the repo needs to allow merge commits.")
@@ -893,7 +893,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 			} else {
 				log.Info("Merged.")
 				merged = append(merged, int(pr.Number))
-				// If we have more PRs to merge, sleep to give Github time to recalculate
+				// If we have more PRs to merge, sleep to give GitHub time to recalculate
 				// mergeability.
 				if i+1 < len(prs) {
 					time.Sleep(time.Second * 3)
@@ -1327,7 +1327,7 @@ func (pr *PullRequest) logFields() logrus.Fields {
 // not commit date so if commits are reordered non-chronologically on the PR
 // branch the 'last' commit isn't necessarily the logically last commit.
 // We list multiple commits with the query to increase our chance of success,
-// but if we don't find the head commit we have to ask Github for it
+// but if we don't find the head commit we have to ask GitHub for it
 // specifically (this costs an API token).
 func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Context, error) {
 	for _, node := range pr.Commits.Nodes {
@@ -1336,12 +1336,12 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 		}
 	}
 	// We didn't get the head commit from the query (the commits must not be
-	// logically ordered) so we need to specifically ask Github for the status
+	// logically ordered) so we need to specifically ask GitHub for the status
 	// and coerce it to a graphql type.
 	org := string(pr.Repository.Owner.Login)
 	repo := string(pr.Repository.Name)
 	// Log this event so we can tune the number of commits we list to minimize this.
-	log.Warnf("'last' %d commits didn't contain logical last commit. Querying Github...", len(pr.Commits.Nodes))
+	log.Warnf("'last' %d commits didn't contain logical last commit. Querying GitHub...", len(pr.Commits.Nodes))
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the combined status: %v", err)

--- a/robots/coverage/cmd/diff/diff.go
+++ b/robots/coverage/cmd/diff/diff.go
@@ -77,7 +77,7 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	postContent, isCoverageLow := diff.ContentForGithubPost(baseProfiles, newProfiles, flags.jobName, flags.threshold)
+	postContent, isCoverageLow := diff.ContentForGitHubPost(baseProfiles, newProfiles, flags.jobName, flags.threshold)
 
 	var file io.WriteCloser
 	if flags.outputFile == "-" {

--- a/robots/coverage/diff/view.go
+++ b/robots/coverage/diff/view.go
@@ -60,8 +60,8 @@ func makeTable(baseCovList, newCovList *calculation.CoverageList, coverageThresh
 	return strings.Join(rows, "\n"), isCoverageLow
 }
 
-// ContentForGithubPost constructs the message covbot posts
-func ContentForGithubPost(baseProfiles, newProfiles []*cover.Profile, jobName string, coverageThreshold float32) (
+// ContentForGitHubPost constructs the message covbot posts
+func ContentForGitHubPost(baseProfiles, newProfiles []*cover.Profile, jobName string, coverageThreshold float32) (
 	string, bool) {
 
 	rows := []string{

--- a/robots/coverage/docs/design.md
+++ b/robots/coverage/docs/design.md
@@ -100,14 +100,14 @@ use 'local-presubmit' will run the presubmit workflow without posting result on 
 ## Covbot
 As mentioned in the presubmit workflow section, covbot is the short name for the robot github 
 account used to report code coverage change results. It can be created as a regular github 
-account - it does not need to be named covbot as that name is already taken on Github. It only need a 
+account - it does not need to be named covbot as that name is already taken on GitHub. It only need a 
 comment access to the repo it need to be run on. If the repo is private, it also need read access. 
   
 After the robot account is created, download the github token and supply the path to the token 
 file to code coverage binary, as the value for parameter "github-token"
 
 # Usage with container based CI/CD system
-We pack the test coverage feature in a container, that is triggered to run by a CI/CD system such as [prow](https://github.com/kubernetes/test-infra/tree/master/prow), in response to Github events such as pulls and merges.
+We pack the test coverage feature in a container, that is triggered to run by a CI/CD system such as [prow](https://github.com/kubernetes/test-infra/tree/master/prow), in response to GitHub events such as pulls and merges.
 
 Here is [an example of a dockerfile](https://github.com/kubernetes/test-infra/blob/a1e910ae6811a1821ad98fa28e6fad03972a8c20/coverage/Dockerfile) using [Docker](https://www.docker.com/). 
 Here is [an example of a Makefile](https://github.com/kubernetes/test-infra/blob/a1e910ae6811a1821ad98fa28e6fad03972a8c20/coverage/Makefile) that builds and pushes the docker image on [Google Container Registry](https://cloud.google.com/container-registry/).
@@ -115,10 +115,10 @@ Here is [an example of a Makefile](https://github.com/kubernetes/test-infra/blob
 ## Usage with prow
 Prow is tested working well with this Code Coverage tool. It's usage is described below
 
-- Prow can be used as the system to handle Github events mentioned in the two workflows. 
+- Prow can be used as the system to handle GitHub events mentioned in the two workflows. 
 - Prow, in both workflows, supplies the flags and secrets for the binary, clones the repository, and uploads logs & artifacts to GCS bucket.
 
-  - The pre-submit prow job is triggered by any new commit to a PR. At the end of the binary run, it can return a pass or fail status context to Github. [Tide](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tide) can use that status to block PR with low coverage.
+  - The pre-submit prow job is triggered by any new commit to a PR. At the end of the binary run, it can return a pass or fail status context to GitHub. [Tide](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tide) can use that status to block PR with low coverage.
 
   - The post-submit prow job is triggered by merge events to the base branch.
 

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -68,8 +68,8 @@ func optionsFromFlags() options {
 	var o options
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	o.github.AddFlags(fs)
-	fs.StringVar(&o.repo, "repo", "", "Github repo")
-	fs.StringVar(&o.org, "org", "", "Github org")
+	fs.StringVar(&o.repo, "repo", "", "GitHub repo")
+	fs.StringVar(&o.org, "org", "", "GitHub org")
 	fs.StringVar(&o.branch, "branch", "", "Repo branch to merge into")
 	fs.StringVar(&o.source, "source", "", "The user:branch to merge from")
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2724,6 +2724,9 @@ test_groups:
 - name: pull-test-infra-verify-codegen
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-codegen
   num_columns_recent: 20
+- name: pull-test-infra-verify-github-spelling
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-github-spelling
+  num_columns_recent: 20
 - name: pull-cloud-provider-vsphere-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-vsphere-test
   num_columns_recent: 20
@@ -7207,6 +7210,9 @@ dashboards:
     base_options: width=10
   - name: verify-codegen
     test_group_name: pull-test-infra-verify-codegen
+    base_options: width=10
+  - name: verify-spelling
+    test_group_name: pull-test-infra-verify-github-spelling
     base_options: width=10
 
 - name: presubmits-cluster-registry

--- a/triage/render.js
+++ b/triage/render.js
@@ -244,7 +244,7 @@ function renderSpans(text, spans) {
   return out;
 }
 
-function makeGithubIssue(id, text, owner, latestBuilds) {
+function makeGitHubIssue(id, text, owner, latestBuilds) {
   let title = `Failure cluster [${id.slice(0, 8)}...]`;
   let body = `### Failure cluster [${id}](https://go.k8s.io/triage#{id})
 
@@ -308,7 +308,7 @@ function renderCluster(top, cluster) {
   var latestBuilds = renderLatest(latest, id);
 
   fileBug.addEventListener('click', () => {
-    let [title, body] = makeGithubIssue(id, text, owner, latestBuilds);
+    let [title, body] = makeGitHubIssue(id, text, owner, latestBuilds);
     title = encodeURIComponent(title);
     body = encodeURIComponent(body);
     fileBug.href = `https://github.com/kubernetes/kubernetes/issues/new?body=${body}&title=${title}`;

--- a/velodrome/README.md
+++ b/velodrome/README.md
@@ -17,18 +17,18 @@ It is comprised of three components:
   * a Grafana instance to display graphs based on these metrics
   * and an nginx to proxy all of these services in a single URL.
 
-2. A SQL Database containing a copy of the issues, events, and PRs in Github
+2. A SQL Database containing a copy of the issues, events, and PRs in GitHub
 repositories. It is used for calculating statistics about developer
 productivity. It has the following components:
-  * [Fetcher](fetcher/): fetches Github data and stores in a SQL database
+  * [Fetcher](fetcher/): fetches GitHub data and stores in a SQL database
   * [SQL Proxy](mysql/): SQL Proxy deployment to Cloud SQL
-  * [Transform](transform/): Transform SQL (Github db) into valuable metrics
+  * [Transform](transform/): Transform SQL (GitHub db) into valuable metrics
 
 3. Other monitoring tools, only one for the moment:
   * [token-counter](token-counter/): Monitors RateLimit usage of your github
     tokens
 
-Github statistics
+GitHub statistics
 =================
 
 Here is how the github statistics are communicating between each other:
@@ -38,7 +38,7 @@ Here is how the github statistics are communicating between each other:
 -> pushes to
 * External components
 
-Github* <= Fetcher -> Cloud SQL* <= Transform -> InfluxDb
+GitHub* <= Fetcher -> Cloud SQL* <= Transform -> InfluxDb
 ```
 
 Other metrics/monitoring components
@@ -64,7 +64,7 @@ Naming convention
 
 To disambiguate how each word is used, let's give a description of the naming
 convention used by velodrome:
-- Organization: This has the same meaning as the Github Organization. This is
+- Organization: This has the same meaning as the GitHub Organization. This is
   holding multiple repositories. e.g. In `github.com/istio/manager`, the
   organization is `istio`.
 - Repository can be either the last part of the github repository URL (i.e. in

--- a/velodrome/fetcher/README.md
+++ b/velodrome/fetcher/README.md
@@ -17,7 +17,7 @@ All of these resources will allow us to:
 The model is described more precisely in [../sql](../sql/).
 
 Fetcher only downloads what is not already in the SQL database by trying to find
-the latest events it knows about. It will poll from Github on a regular basis,
+the latest events it knows about. It will poll from GitHub on a regular basis,
 and this can be configured with the `--frequency` flag.
 
 There is no set-up required as `fetcher` will create the github database if it

--- a/velodrome/fetcher/client.go
+++ b/velodrome/fetcher/client.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Client can be used to run commands again Github API
+// Client can be used to run commands again GitHub API
 type Client struct {
 	Token     string
 	TokenFile string
@@ -71,8 +71,8 @@ func (client *Client) CheckFlags() error {
 	return nil
 }
 
-// getGithubClient create the github client that we use to communicate with github
-func (client *Client) getGithubClient() (*github.Client, error) {
+// getGitHubClient create the github client that we use to communicate with github
+func (client *Client) getGitHubClient() (*github.Client, error) {
 	if client.githubClient != nil {
 		return client.githubClient, nil
 	}
@@ -98,7 +98,7 @@ func (client *Client) getGithubClient() (*github.Client, error) {
 // limitsCheckAndWait make sure we have not reached the limit or wait
 func (client *Client) limitsCheckAndWait() {
 	var sleep time.Duration
-	githubClient, err := client.getGithubClient()
+	githubClient, err := client.getGitHubClient()
 	if err != nil {
 		glog.Error("Failed to get RateLimits: ", err)
 		sleep = time.Minute
@@ -131,11 +131,11 @@ func (client *Client) RepositoryName() string {
 	return fmt.Sprintf("%s/%s", client.Org, client.Project)
 }
 
-// FetchIssues from Github, until 'latest' time
+// FetchIssues from GitHub, until 'latest' time
 func (client *Client) FetchIssues(latest time.Time, c chan *github.Issue) {
 	opt := &github.IssueListByRepoOptions{Since: latest, Sort: "updated", State: "all", Direction: "asc"}
 
-	githubClient, err := client.getGithubClient()
+	githubClient, err := client.getGitHubClient()
 	if err != nil {
 		close(c)
 		glog.Error(err)
@@ -188,7 +188,7 @@ func hasID(events []*github.IssueEvent, ID int) bool {
 func (client *Client) FetchIssueEvents(issueID int, latest *int, c chan *github.IssueEvent) {
 	opt := &github.ListOptions{PerPage: 100}
 
-	githubClient, err := client.getGithubClient()
+	githubClient, err := client.getGitHubClient()
 	if err != nil {
 		close(c)
 		glog.Error(err)
@@ -230,7 +230,7 @@ func (client *Client) FetchIssueEvents(issueID int, latest *int, c chan *github.
 func (client *Client) FetchIssueComments(issueID int, latest time.Time, c chan *github.IssueComment) {
 	opt := &github.IssueListCommentsOptions{Since: latest, Sort: "updated", Direction: "asc"}
 
-	githubClient, err := client.getGithubClient()
+	githubClient, err := client.getGitHubClient()
 	if err != nil {
 		close(c)
 		glog.Error(err)
@@ -272,7 +272,7 @@ func (client *Client) FetchIssueComments(issueID int, latest time.Time, c chan *
 func (client *Client) FetchPullComments(issueID int, latest time.Time, c chan *github.PullRequestComment) {
 	opt := &github.PullRequestListCommentsOptions{Since: latest, Sort: "updated", Direction: "asc"}
 
-	githubClient, err := client.getGithubClient()
+	githubClient, err := client.getGitHubClient()
 	if err != nil {
 		close(c)
 		glog.Error(err)

--- a/velodrome/fetcher/comments_test.go
+++ b/velodrome/fetcher/comments_test.go
@@ -144,22 +144,22 @@ func TestUpdateComments(t *testing.T) {
 			},
 			newIssueComments: map[int][]*github.IssueComment{
 				3: {
-					makeGithubIssueComment(2, "IssueBody", "SomeLogin",
+					makeGitHubIssueComment(2, "IssueBody", "SomeLogin",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
-					makeGithubIssueComment(3, "AnotherBody", "AnotherLogin",
+					makeGitHubIssueComment(3, "AnotherBody", "AnotherLogin",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},
 			},
 			newPullComments: map[int][]*github.PullRequestComment{
 				2: {
-					makeGithubPullComment(4, "Body", "Login",
+					makeGitHubPullComment(4, "Body", "Login",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.February, 1, 19, 30, 0, 0, time.UTC)),
 				},
 				3: {
-					makeGithubPullComment(5, "SecondBody", "OtherLogin",
+					makeGitHubPullComment(5, "SecondBody", "OtherLogin",
 						time.Date(2000, time.December, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.November, 1, 19, 30, 0, 0, time.UTC)),
 				},
@@ -190,22 +190,22 @@ func TestUpdateComments(t *testing.T) {
 			},
 			newIssueComments: map[int][]*github.IssueComment{
 				3: {
-					makeGithubIssueComment(2, "IssueBody", "SomeLogin",
+					makeGitHubIssueComment(2, "IssueBody", "SomeLogin",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
-					makeGithubIssueComment(3, "AnotherBody", "AnotherLogin",
+					makeGitHubIssueComment(3, "AnotherBody", "AnotherLogin",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},
 			},
 			newPullComments: map[int][]*github.PullRequestComment{
 				2: {
-					makeGithubPullComment(4, "Body", "Login",
+					makeGitHubPullComment(4, "Body", "Login",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.February, 1, 19, 30, 0, 0, time.UTC)),
 				},
 				3: {
-					makeGithubPullComment(5, "SecondBody", "OtherLogin",
+					makeGitHubPullComment(5, "SecondBody", "OtherLogin",
 						time.Date(2000, time.December, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.November, 1, 19, 30, 0, 0, time.UTC)),
 				},
@@ -228,7 +228,7 @@ func TestUpdateComments(t *testing.T) {
 			newIssueComments: map[int][]*github.IssueComment{},
 			newPullComments: map[int][]*github.PullRequestComment{
 				12: {
-					makeGithubPullComment(1, "IssueBody", "SomeLogin",
+					makeGitHubPullComment(1, "IssueBody", "SomeLogin",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},

--- a/velodrome/fetcher/conversion_test.go
+++ b/velodrome/fetcher/conversion_test.go
@@ -53,7 +53,7 @@ func makeIssue(number int,
 	}
 }
 
-func makeGithubIssue(number int,
+func makeGitHubIssue(number int,
 	title, body, state, user, prURL string,
 	comments int,
 	isPullRequest bool,
@@ -94,7 +94,7 @@ func TestNewIssue(t *testing.T) {
 	}{
 		// Only mandatory
 		{
-			gIssue: makeGithubIssue(1, "Title", "", "State", "User", "",
+			gIssue: makeGitHubIssue(1, "Title", "", "State", "User", "",
 				5, false,
 				time.Date(1900, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
@@ -107,7 +107,7 @@ func TestNewIssue(t *testing.T) {
 		},
 		// All fields
 		{
-			gIssue: makeGithubIssue(1, "Title", "Body", "State", "User",
+			gIssue: makeGitHubIssue(1, "Title", "Body", "State", "User",
 				"PRLink", 5, true,
 				time.Date(1900, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
@@ -169,7 +169,7 @@ func makeIssueEvent(
 	}
 }
 
-func makeGithubIssueEvent(
+func makeGitHubIssueEvent(
 	eventID int,
 	label, event, assignee, actor string,
 	createdAt time.Time) *github.IssueEvent {
@@ -206,7 +206,7 @@ func TestNewIssueEvent(t *testing.T) {
 	}{
 		// Only mandatory
 		{
-			gIssueEvent: makeGithubIssueEvent(1, "", "Event", "", "",
+			gIssueEvent: makeGitHubIssueEvent(1, "", "Event", "", "",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID: 2,
 			mIssueEvent: makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
@@ -214,7 +214,7 @@ func TestNewIssueEvent(t *testing.T) {
 		},
 		// All fields
 		{
-			gIssueEvent: makeGithubIssueEvent(1, "Label", "Event", "Assignee", "Actor",
+			gIssueEvent: makeGitHubIssueEvent(1, "Label", "Event", "Assignee", "Actor",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID: 2,
 			mIssueEvent: makeIssueEvent(1, 2, "Label", "Event", "Assignee", "Actor", "full/repo",
@@ -274,7 +274,7 @@ func TestNewLabels(t *testing.T) {
 	}
 }
 
-func makeGithubIssueComment(id int, body, login string, createdAt, updatedAt time.Time) *github.IssueComment {
+func makeGitHubIssueComment(id int, body, login string, createdAt, updatedAt time.Time) *github.IssueComment {
 	var user *github.User
 	if login != "" {
 		user = &github.User{Login: &login}
@@ -288,7 +288,7 @@ func makeGithubIssueComment(id int, body, login string, createdAt, updatedAt tim
 	}
 }
 
-func makeGithubPullComment(id int, body, login string, createdAt, updatedAt time.Time) *github.PullRequestComment {
+func makeGitHubPullComment(id int, body, login string, createdAt, updatedAt time.Time) *github.PullRequestComment {
 	var user *github.User
 	if login != "" {
 		user = &github.User{Login: &login}
@@ -322,7 +322,7 @@ func TestNewIssueComment(t *testing.T) {
 		expectedComment *sql.Comment
 	}{
 		{
-			gComment: makeGithubIssueComment(1, "Body", "Login",
+			gComment: makeGitHubIssueComment(1, "Body", "Login",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID: 12,
@@ -331,7 +331,7 @@ func TestNewIssueComment(t *testing.T) {
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC), false),
 		},
 		{
-			gComment: makeGithubIssueComment(1, "Body", "",
+			gComment: makeGitHubIssueComment(1, "Body", "",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID: 12,
@@ -358,7 +358,7 @@ func TestNewPullComment(t *testing.T) {
 		expectedComment *sql.Comment
 	}{
 		{
-			gComment: makeGithubPullComment(1, "Body", "Login",
+			gComment: makeGitHubPullComment(1, "Body", "Login",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID:    12,
@@ -368,7 +368,7 @@ func TestNewPullComment(t *testing.T) {
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC), true),
 		},
 		{
-			gComment: makeGithubPullComment(1, "Body", "",
+			gComment: makeGitHubPullComment(1, "Body", "",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC),
 				time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			issueID:    12,

--- a/velodrome/fetcher/issue-events_test.go
+++ b/velodrome/fetcher/issue-events_test.go
@@ -133,7 +133,7 @@ func TestUpdateEvents(t *testing.T) {
 			},
 			new: map[int][]*github.IssueEvent{
 				2: {
-					makeGithubIssueEvent(2, "Label", "Event", "Assignee", "Actor",
+					makeGitHubIssueEvent(2, "Label", "Event", "Assignee", "Actor",
 						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},
 			},
@@ -156,9 +156,9 @@ func TestUpdateEvents(t *testing.T) {
 			},
 			new: map[int][]*github.IssueEvent{
 				2: {
-					makeGithubIssueEvent(1, "", "EventNameChanged", "", "",
+					makeGitHubIssueEvent(1, "", "EventNameChanged", "", "",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
-					makeGithubIssueEvent(3, "Label", "Event", "Assignee", "",
+					makeGitHubIssueEvent(3, "Label", "Event", "Assignee", "",
 						time.Date(2002, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},
 			},
@@ -181,7 +181,7 @@ func TestUpdateEvents(t *testing.T) {
 			},
 			new: map[int][]*github.IssueEvent{
 				2: {
-					makeGithubIssueEvent(1, "", "EventNameOther", "", "",
+					makeGitHubIssueEvent(1, "", "EventNameOther", "", "",
 						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 				},
 			},

--- a/velodrome/fetcher/issues_test.go
+++ b/velodrome/fetcher/issues_test.go
@@ -131,7 +131,7 @@ func TestUpdateIssues(t *testing.T) {
 					time.Time{}),
 			},
 			new: []*github.Issue{
-				makeGithubIssue(2, "Super Title", "Body", "NoState", "Login", "", 0, false,
+				makeGitHubIssue(2, "Super Title", "Body", "NoState", "Login", "", 0, false,
 					time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Time{}),
@@ -165,12 +165,12 @@ func TestUpdateIssues(t *testing.T) {
 					time.Time{}),
 			},
 			new: []*github.Issue{
-				makeGithubIssue(2, "Super Title", "Body", "NoState", "Login", "",
+				makeGitHubIssue(2, "Super Title", "Body", "NoState", "Login", "",
 					0, false,
 					time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Time{}),
-				makeGithubIssue(3, "Title", "Body", "State", "John", "",
+				makeGitHubIssue(3, "Title", "Body", "State", "John", "",
 					0, false,
 					time.Date(2002, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -204,7 +204,7 @@ func TestUpdateIssues(t *testing.T) {
 					time.Time{}),
 			},
 			new: []*github.Issue{
-				makeGithubIssue(1, "Super Title", "Body", "NoState", "Login", "",
+				makeGitHubIssue(1, "Super Title", "Body", "NoState", "Login", "",
 					0, false,
 					time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 					time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/velodrome/grafana-stack/dashboards/monitoring.json
+++ b/velodrome/grafana-stack/dashboards/monitoring.json
@@ -863,7 +863,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Github Token usage",
+          "title": "GitHub Token usage",
           "tooltip": {
             "msResolution": false,
             "shared": false,

--- a/velodrome/token-counter/README.md
+++ b/velodrome/token-counter/README.md
@@ -4,7 +4,7 @@ Overview
 Token-counter is a program that polls github to see how much of a token's
 ratelimit has been used.
 
-Github doesn't report how many requests you've used, and instead reports
+GitHub doesn't report how many requests you've used, and instead reports
 how many request you have left before the rate-limit resets.
 In order to do that, we poll more and more aggressively as we get near to the reset
 time. Once the reset happens, we compute the difference between `Limit` and

--- a/velodrome/token-counter/token-counter.go
+++ b/velodrome/token-counter/token-counter.go
@@ -51,8 +51,8 @@ type TokenHandler struct {
 	login    string
 }
 
-// GetGithubClient creates a client for each token
-func GetGithubClient(token string) *github.Client {
+// GetGitHubClient creates a client for each token
+func GetGitHubClient(token string) *github.Client {
 	return github.NewClient(
 		oauth2.NewClient(
 			oauth2.NoContext,
@@ -80,7 +80,7 @@ func CreateTokenHandler(tokenStream io.Reader, influxdb *InfluxDB) (*TokenHandle
 	if err != nil {
 		return nil, err
 	}
-	client := GetGithubClient(strings.TrimSpace(string(token)))
+	client := GetGitHubClient(strings.TrimSpace(string(token)))
 	login, err := GetUsername(client) // Get user name for token
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (t TokenHandler) Process() {
 			glog.Error("Failed to get CoreRate: ", err)
 			continue
 		}
-		// There is a bug in Github. They seem to reset the Remaining value before resetting the Reset value.
+		// There is a bug in GitHub. They seem to reset the Remaining value before resetting the Reset value.
 		if !newRate.Reset.Time.Equal(lastRate.Reset.Time) || newRate.Remaining > lastRate.Remaining {
 			if err := t.influxdb.Push(
 				"github_token_count",


### PR DESCRIPTION
In working with various functions and methods over the last two weeks, I noticed that some functions use `GitHub` and some use `Github`, it appears that `GitHub` is the winner for popularity right now:

*on master (e126eb0)*
Github: 360
GitHub: 1196

I think it would be nice to avoid confusion for types, functions, etc.