### PR TITLE
Add a configurable announcement banner to Spyglass

### DIFF
--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -1,3 +1,10 @@
+#announcement {
+  background-color: #424242;
+  padding: 10px;
+  text-align: center;
+  font-size: 16px;
+}
+
 .lens-card.mdl-card {
   width: calc(100% - 30px);
   align-content: center;

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -12,6 +12,11 @@
 
 {{define "content"}}
 {{$source:=.Source}}
+{{if .Announcement}}
+<div id="announcement">
+  {{.Announcement}}
+</div>
+{{end}}
 <div id="lens-container">
   {{if or .JobHistLink .ArtifactsLink .PRHistLink}}
   <div id="links-card" class="mdl-card mdl-shadow--2dp lens-card">

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -241,6 +241,10 @@ type Spyglass struct {
 	// If left empty, the link will be not be shown. Otherwise, a GCS path (with no
 	// prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.
 	GCSBrowserPrefix string `json:"gcs_browser_prefix,omitempty"`
+	// If set, Announcement is used as a Go HTML template string to be displayed at the top of
+	// each spyglass page. Using HTML in the template is acceptable.
+	// Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
+	Announcement string `json:"announcement,omitempty"`
 }
 
 // Deck holds config for deck.


### PR DESCRIPTION
This PR adds a Spyglass configuration option to show a templated announcement banner. The intent is to use this to show a gubernator migration message, though as the page that users will generally land on when coming from GitHub it may also have other uses.

While no configuration is set in this PR (since we have not actually migrated yet), you could specify a string like this:

`announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass. For now, the old page is <a href='https://gubernator.k8s.io/build/{{.ArtifactPath}}'>still available</a>. Please send feedback to sig-testing."`

![image](https://user-images.githubusercontent.com/110792/52822723-640f4d80-3067-11e9-9076-ab7cc6a6c652.png)

/cc @BenTheElder 