### PR TITLE
Banner for fejta

### DIFF
--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -1,3 +1,10 @@
+#announcement {
+  background-color: #424242;
+  padding: 10px;
+  text-align: center;
+  font-size: 16px;
+}
+
 .lens-card.mdl-card {
   width: calc(100% - 30px);
   align-content: center;

--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -3,6 +3,28 @@
   padding: 10px;
   text-align: center;
   font-size: 16px;
+  transition: opacity;
+  transition-duration: 3600s;
+  transition-timing-function: ease-in-out;
+}
+
+#announcement > div {
+  animation: shake 0.5s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes shake {
+  0% { transform: translate(1px, 1px) rotate(0deg); }
+  10% { transform: translate(-1px, -2px) rotate(-1deg); }
+  20% { transform: translate(-3px, 0px) rotate(1deg); }
+  30% { transform: translate(3px, 2px) rotate(0deg); }
+  40% { transform: translate(1px, -1px) rotate(1deg); }
+  50% { transform: translate(-1px, 2px) rotate(-1deg); }
+  60% { transform: translate(-3px, 1px) rotate(0deg); }
+  70% { transform: translate(3px, 1px) rotate(-1deg); }
+  80% { transform: translate(-1px, -1px) rotate(1deg); }
+  90% { transform: translate(1px, 2px) rotate(0deg); }
+  100% { transform: translate(1px, -2px) rotate(-1deg); }
 }
 
 .lens-card.mdl-card {

--- a/prow/cmd/deck/static/spyglass/spyglass.css
+++ b/prow/cmd/deck/static/spyglass/spyglass.css
@@ -4,7 +4,7 @@
   text-align: center;
   font-size: 16px;
   transition: opacity;
-  transition-duration: 3600s;
+  transition-duration: 60s;
   transition-timing-function: ease-in-out;
 }
 

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -42,11 +42,6 @@ a:visited {
     margin-left: 24px;
 }
 
-.logo {
-    height: 48px;
-    width: 48px;
-}
-
 h1 {
     font-weight: normal;
     font-size: 2em;

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -21,9 +21,20 @@
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
   <header class="mdl-layout__header"{{if branding.HeaderColor}} style="background-color: {{branding.HeaderColor}};"{{end}}>
     <div class="mdl-layout__header-row">
+      <input type="radio" name="icon-size" checked value="">normal icon
+      <input type="radio" name="icon-size" value="2000px">big icon
       <a href="/"
-         class="logo"><img src="/static/{{or branding.Logo "logo.svg"}}" alt="kubernetes logo" class="logo"/></a>
+         class="logo"><img src="/static/{{or branding.Logo "logo.svg"}}" alt="kubernetes logo" class="logo" id="logo-img"/></a>
       <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
+      <script type="text/javascript">
+        document.getElementsByName('icon-size').forEach((x) => {
+          x.onclick = () => {
+            if (x.checked) {
+              document.getElementById('logo-img').style.width = x.value;
+            }
+          }
+        });
+      </script>
     </div>
   </header>
   <div class="mdl-layout__drawer">

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -12,6 +12,11 @@
 
 {{define "content"}}
 {{$source:=.Source}}
+{{if .Announcement}}
+<div id="announcement">
+  {{.Announcement}}
+</div>
+{{end}}
 <div id="lens-container">
   {{if or .JobHistLink .ArtifactsLink .PRHistLink}}
   <div id="links-card" class="mdl-card mdl-shadow--2dp lens-card">

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -14,8 +14,11 @@
 {{$source:=.Source}}
 {{if .Announcement}}
 <div id="announcement">
-  {{.Announcement}}
+  <div>{{.Announcement}}</div>
 </div>
+<script type="text/javascript">
+  setTimeout(() => document.getElementById('announcement').style.opacity = '0', 120000); // wait two minutes
+</script>
 {{end}}
 <div id="lens-container">
   {{if or .JobHistLink .ArtifactsLink .PRHistLink}}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -241,6 +241,10 @@ type Spyglass struct {
 	// If left empty, the link will be not be shown. Otherwise, a GCS path (with no
 	// prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.
 	GCSBrowserPrefix string `json:"gcs_browser_prefix,omitempty"`
+	// If set, Announcement is used as a Go HTML template string to be displayed at the top of
+	// each spyglass page. Using HTML in the template is acceptable.
+	// Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
+	Announcement string `json:"announcement,omitempty"`
 }
 
 // Deck holds config for deck.


### PR DESCRIPTION
This is a variant of #11299, plus the features @fejta asked for.

>* Increase the default size of the icon to something more reasonable
>* Add an option to make it larger for people with visual impairments.
>* Shake the message to ensure people notice it
>* Fade out the message after a suitable amount of shaking
>* Maximize fade out fps
>* Use a suitably appealing fade out curve, taking inspiration from the first version of Mac OS X genie effect, except considerably slower.

/cc @fejta 
/hold