### PR TITLE
Deprecate gubernator!

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -42,7 +42,7 @@ import (
 
 var configPath = flag.String("config", "../../../prow/config.yaml", "Path to prow config")
 var jobConfigPath = flag.String("job-config", "../../jobs", "Path to prow job config")
-var gubernatorPath = flag.String("gubernator-path", "https://gubernator.k8s.io", "Path to linked gubernator")
+var deckPath = flag.String("deck-path", "https://prow.k8s.io", "Path to deck")
 var bucket = flag.String("bucket", "kubernetes-jenkins", "Gcs bucket for log upload")
 var k8sProw = flag.Bool("k8s-prow", true, "If the config is for k8s prow cluster")
 
@@ -77,25 +77,25 @@ func TestReportTemplate(t *testing.T) {
 			org:    "o",
 			repo:   "r",
 			number: 4,
-			suffix: "o_r/4",
+			suffix: "?org=o&repo=r&pr=4",
 		},
 		{
 			org:    "kubernetes",
 			repo:   "test-infra",
 			number: 123,
-			suffix: "test-infra/123",
+			suffix: "?org=kubernetes&repo=test-infra&pr=123",
 		},
 		{
 			org:    "kubernetes",
 			repo:   "kubernetes",
 			number: 123,
-			suffix: "123",
+			suffix: "?org=kubernetes&repo=kubernetes&pr=123",
 		},
 		{
 			org:    "o",
 			repo:   "kubernetes",
 			number: 456,
-			suffix: "o_kubernetes/456",
+			suffix: "?org=o&repo=kubernetes&pr=456",
 		},
 	}
 	for _, tc := range testcases {
@@ -116,7 +116,7 @@ func TestReportTemplate(t *testing.T) {
 			t.Errorf("Error executing template: %v", err)
 			continue
 		}
-		expectedPath := *gubernatorPath + "/pr/" + tc.suffix
+		expectedPath := *deckPath + "/pr-history" + tc.suffix
 		if !strings.Contains(b.String(), expectedPath) {
 			t.Errorf("Expected template to contain %s, but it didn't: %s", expectedPath, b.String())
 		}
@@ -141,7 +141,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-pre-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/0/k8s-pre-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/0/k8s-pre-1/1/",
 			k8sOnly: true,
 		},
 		{
@@ -161,7 +161,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "test-infra",
 			job:     "ti-pre-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/test-infra/0/ti-pre-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/test-infra/0/ti-pre-1/1/",
 			k8sOnly: true,
 		},
 		{
@@ -171,7 +171,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-pre-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/foo_kubernetes/0/k8s-pre-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/foo_kubernetes/0/k8s-pre-1/1/",
 		},
 		{
 			name:    "foo-bar presubmit",
@@ -180,7 +180,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "bar",
 			job:     "foo-pre-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/foo_bar/0/foo-pre-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/foo_bar/0/foo-pre-1/1/",
 		},
 		{
 			name:    "k8s postsubmit",
@@ -189,21 +189,21 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-post-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/logs/k8s-post-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/logs/k8s-post-1/1/",
 		},
 		{
 			name:    "k8s periodic",
 			jobType: prowapi.PeriodicJob,
 			job:     "k8s-peri-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/logs/k8s-peri-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/logs/k8s-peri-1/1/",
 		},
 		{
 			name:    "empty periodic",
 			jobType: prowapi.PeriodicJob,
 			job:     "nan-peri-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/logs/nan-peri-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/logs/nan-peri-1/1/",
 		},
 		{
 			name:    "k8s batch",
@@ -212,7 +212,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "kubernetes",
 			job:     "k8s-batch-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/batch/k8s-batch-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/batch/k8s-batch-1/1/",
 			k8sOnly: true,
 		},
 		{
@@ -222,7 +222,7 @@ func TestURLTemplate(t *testing.T) {
 			repo:    "bar",
 			job:     "k8s-batch-1",
 			build:   "1",
-			expect:  *gubernatorPath + "/build/" + *bucket + "/pr-logs/pull/foo_bar/batch/k8s-batch-1/1/",
+			expect:  *deckPath + "/view/" + *bucket + "/pr-logs/pull/foo_bar/batch/k8s-batch-1/1/",
 		},
 	}
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,7 +1,7 @@
 plank:
-  job_url_template: '{{if .Spec.Refs}}{{if eq .Spec.Refs.Org "kubernetes-security"}}https://console.cloud.google.com/storage/browser/kubernetes-security-prow/{{else}}https://gubernator.k8s.io/build/kubernetes-jenkins/{{end}}{{else}}https://gubernator.k8s.io/build/kubernetes-jenkins/{{end}}{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{if and (eq .Spec.Refs.Org "kubernetes-sigs") (ne .Spec.Refs.Repo "poseidon")}}sigs.k8s.io{{else}}{{.Spec.Refs.Org}}{{end}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
-  report_template: '[Full PR test history](https://gubernator.k8s.io/pr/{{if eq .Spec.Refs.Org "kubernetes"}}{{if eq .Spec.Refs.Repo "kubernetes"}}{{else}}{{.Spec.Refs.Repo}}/{{end}}{{else}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.k8s.io/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
-  job_url_prefix: https://gubernator.k8s.io/build/
+  job_url_template: '{{if .Spec.Refs}}{{if eq .Spec.Refs.Org "kubernetes-security"}}https://console.cloud.google.com/storage/browser/kubernetes-security-prow/{{else}}https://prow.k8s.io/view/kubernetes-jenkins/{{end}}{{else}}https://prow.k8s.io/view/kubernetes-jenkins/{{end}}{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{if and (eq .Spec.Refs.Org "kubernetes-sigs") (ne .Spec.Refs.Repo "poseidon")}}sigs.k8s.io{{else}}{{.Spec.Refs.Org}}{{end}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  report_template: '[Full PR test history](https://prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.k8s.io/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
+  job_url_prefix: https://prow.k8s.io/view/
   pod_pending_timeout: 60m
   default_decoration_config:
     timeout: 7200000000000 # 2h
@@ -25,7 +25,6 @@ sinker:
 
 deck:
   spyglass:
-    announcement: "{{if .ArtifactPath}}This job view page will soon replace Gubernator's. For now, you can still <a href='https://gubernator.k8s.io/build/{{.ArtifactPath}}'>visit the Gubernator page</a>. Please send feedback to sig-testing.{{end}}"
     size_limit: 500000000 # 500MB
     gcs_browser_prefix: http://gcsweb.k8s.io/gcs/
     testgrid_config: gs://k8s-testgrid/config
@@ -37,6 +36,7 @@ deck:
       - "buildlog"
       "artifacts/junit.*\\.xml":
       - "junit"
+    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.k8s.io/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to sig-testing."
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -27,7 +27,7 @@ default_test_group:
 
 default_dashboard_tab:
   open_test_template: # The URL template to visit after clicking on a cell
-    url: https://gubernator.k8s.io/build/<gcs_prefix>/<changelist>
+    url: https://prow.k8s.io/view/<gcs_prefix>/<changelist>
   file_bug_template: # The URL template to visit when filing a bug
     url: https://github.com/kubernetes/kubernetes/issues/new
     options:
@@ -38,9 +38,9 @@ default_dashboard_tab:
   attach_bug_template: # The URL template to visit when attaching a bug
     url: # empty
     options: #empty
-  results_text: See these results in Gubernator # Text to show in the about menu as a link to another view of the results
+  results_text: See these results on Prow # Text to show in the about menu as a link to another view of the results
   results_url_template: # The URL template to visit after clicking
-    url: https://gubernator.k8s.io/builds/<gcs_prefix>
+    url: https://prow.k8s.io/job-history/builds/<gcs_prefix>
   code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
   num_columns_recent: 10
   code_search_url_template: # The URL template to visit when searching for changelists

--- a/triage/render.js
+++ b/triage/render.js
@@ -63,27 +63,19 @@ function addElement(parent, type, opts, children) {
   return el;
 }
 
-// Creates a urlsafe slug out of a string-- MUST match Gubernator's slugify function.
-function slugify(inp) {
-  return inp.replace(/[^\w\s-]+/g, '').replace(/\s+/g, '-').toLowerCase();
-}
-
-function gubernatorURLForBuild(build, test) {
+function spyglassURLForBuild(build, test) {
   let buildPath = builds.jobPaths[build.job] + '/' + build.number;
-  var gubernatorURL = 'https://gubernator.k8s.io/build/' + buildPath.slice(5);
+  var spyglassURL = 'https://prow.k8s.io/view/gcs/' + buildPath.slice(5);
   if (build.pr) {
-    gubernatorURL = gubernatorURL.replace(/(\/pr-logs\/pull\/)[^/]*\//, '$1' + build.pr + '/');
+    spyglassURL = spyglassURL.replace(/(\/pr-logs\/pull\/)[^/]*\//, '$1' + build.pr + '/');
   }
-  if (test) {
-    gubernatorURL += '#' + slugify(test);
-  }
-  return gubernatorURL;
+  return spyglassURL;
 }
 
 // Turn a build object into a link with information.
 function buildToHtml(build, test, skipNumber) {
   let started = tsToString(build.started);
-  return `<a href="${gubernatorURLForBuild(build, test)}" target="_blank" rel="noopener">${skipNumber ? "" : build.number} ${started}</a>`;
+  return `<a href="${spyglassURLForBuild(build, test)}" target="_blank" rel="noopener">${skipNumber ? "" : build.number} ${started}</a>`;
 }
 
 // Turn a job and array of build numbers into a list of build links.
@@ -263,7 +255,7 @@ ${text.slice(0, Math.min(text.length, 1500))}
 #### Recent failures:
 `;
   for (let [build, job, test] of latestBuilds) {
-    const url = gubernatorURLForBuild(build, test);
+    const url = spyglassURLForBuild(build, test);
     const started = tsToString(build.started);
     body += `[${started} ${job}](${url})\n`
   }


### PR DESCRIPTION
This PR changes prow and testgrid configuration to point at Prow, and adds a message to the top of Spyglass pages pointing to Gubernator.

This cannot merge before #11274, #11299, #11292 (or similar), #11207, and #11183 have been actually deployed. Most have merged, but are blocked on our ongoing inability to deploy prow.

/assign @BenTheElder @fejta @spiffxp @krzyzacy @cjwagner 
/hold