### PR TITLE
hack/update-deps.sh: use -delete instead of -exec rm '{}' \;

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -41,7 +41,7 @@ prune-vendor() {
     -not -iname "COPYING*" \
     -not -iname "LICENSE*" \
     -not -iname "NOTICE*" \
-    -exec rm '{}' \;
+    -delete
 }
 
 rm -rf vendor


### PR DESCRIPTION
super minor improvement, but I wanted to backport what I found while working on ~the same script for kind...

`-exec rm '{}' \;` will exec one `rm` for each file
`-exec rm '{}' +` is faster as it will combine to as many as it can fit in argv per call
`-delete` will just delete within `find` and avoid the overhead of spawning a process to delete at all.

https://linux.die.net/man/1/find

/assign @fejta 
