### PR TITLE
Build a version of planter that contains cross toolchains

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:stretch
 
 # Includes everything needed to build and test github.com/kubernetes/kubernetes
 # and github.com/kubernetes/test-infra with bazel and run bazel as the host UID

--- a/planter/Dockerfile-cross
+++ b/planter/Dockerfile-cross
@@ -1,0 +1,31 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASEIMAGE
+
+FROM $BASEIMAGE
+
+# Add the crossbuild-essential packages to the planter image.
+# debian:stretch doesn't have the s390x package.
+# Instead we download from Ubuntu, like kube-cross does.
+RUN apt-get update && apt-get install -y gnupg \
+    && echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
+    && apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    crossbuild-essential-armhf \
+    crossbuild-essential-arm64 \
+    crossbuild-essential-ppc64el \
+    crossbuild-essential-s390x \
+    && rm -rf /var/lib/apt/lists/*

--- a/planter/Makefile
+++ b/planter/Makefile
@@ -14,14 +14,16 @@
 
 # note: sync this with planter.sh!
 # this should be bazel version - planter sub version
-BAZEL_VERSION ?= 0.21.0
+BAZEL_VERSION ?= 0.22.0
 IMAGE_NAME ?= gcr.io/k8s-testimages/planter
 TAG = $(BAZEL_VERSION)
 
 image:
 	docker build --build-arg BAZEL_VERSION=$(BAZEL_VERSION) -t "$(IMAGE_NAME):$(TAG)" . --pull
+	docker build --build-arg BASEIMAGE="$(IMAGE_NAME):$(TAG)" -t "$(IMAGE_NAME):$(TAG)-cross" -f Dockerfile-cross .
 
 push: image
 	docker push "$(IMAGE_NAME):$(TAG)"
+	docker push "$(IMAGE_NAME):$(TAG)-cross"
 
 .PHONY: image push

--- a/planter/README.md
+++ b/planter/README.md
@@ -28,8 +28,10 @@ Planter respects the following environment variables:
 
  - `TAG`: The Planter image tag. This will default to the current stable
    version used to build Kubernetes, but you may override it with EG
-   `TAG=0.9.0 ./planter.sh bazel build //...`
-   - These should now match bazel release versions eg `0.8.0rc2`
+   `TAG=0.21.0 ./planter.sh bazel build //...`
+   - These should match bazel release versions eg `0.23.0rc1`
+ - `CROSS`: If set, a larger Planter image which contains the
+   crossbuild-essential packages will be used.
  - `DRY_RUN`: If set, Planter will only echo the Docker command that would have
    been run.
  - `HOME`: Your home directory. This will be mounted in to the container.

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -18,6 +18,8 @@
 #
 # Environment variable options:
 # - $TAG can be overridden to choose a bazel version eg `TAG=0.8.0 planter.sh ...`
+# - $CROSS can be set to use the larger image containing the
+#   crossbuild-essential packages.
 # - Alternatively $IMAGE or $IMAGE_NAME can be overridden to set the exact image
 # - $NO_PULL will disable pulling the image before running if set
 # - $DOCKER_EXTRA can be set to supply extra args in the docker call
@@ -30,7 +32,7 @@
 # Then you can build with:
 # $ cd $GOPATH/src/k8s.io/kubernetes
 # $ $GOPATH/src/k8s.io/test-infra/planter/planter.sh make bazel-release
-# 
+#
 # or build a specific binary like:
 # $ cd $GOPATH/src/k8s.io/kubernetes
 # $ $GOPATH/src/k8s.io/test-infra/planter/planter.sh bazel build //cmd/kubectl
@@ -42,8 +44,8 @@ set -o nounset
 # these can be overridden but otherwise default to the current stable image
 # used to build kubernetes from the master branch
 IMAGE_NAME="${IMAGE_NAME:-gcr.io/k8s-testimages/planter}"
-TAG="${TAG:-0.21.0}"
-IMAGE=${IMAGE:-${IMAGE_NAME}:${TAG}}
+TAG="${TAG:-0.22.0}"
+IMAGE=${IMAGE:-${IMAGE_NAME}:${TAG}${CROSS+-cross}}
 
 # We want to mount our bazel workspace and the bazel cache
 # - WORKSPACE is assumed to be in your current git repo, or alternatively $PWD


### PR DESCRIPTION
This plays nicely with https://github.com/kubernetes/kubernetes/pull/73930.

The crossbuild-essential packages add about 500 MB to the image, so it probably makes sense to have two versions of the `planter` image.

/assign @BenTheElder 