### PR TITLE
Set LOG_DUMP_SYSTEMD_JOURNAL in all scalability tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -17,8 +17,6 @@ periodics:
       - --timeout=140
       - --scenario=kubernetes_e2e
       - --
-      # TODO(mm4tt): Set it everywhere once it's confirmed to be working.
-      - --env=LOG_DUMP_SYSTEMD_JOURNAL=true
       - --check-leaked-resources
       - --cluster=e2e-big
       - --extract=ci/latest

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -40,6 +40,8 @@ presets:
   # Allow one node to not be ready after cluster creation.
   - name: ALLOWED_NOTREADY_NODES
     value: 1
+  - name: LOG_DUMP_SYSTEMD_JOURNAL
+    value: "true"
 ### kubemark-gce-big
 - labels:
     preset-e2e-kubemark-gce-big: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -15,8 +15,6 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      - # TODO(mm4tt): Set it everywhere once it's confirmed to be working.
-      - --env=LOG_DUMP_SYSTEMD_JOURNAL=true
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
Everything seems to be working in 5k node cluster, it should be fine to enable it everywhere.

Recent 5k correctness run, with LOG_DUMP_SYSTEMD_JOURNAL enabled, passed and systemd logs were successfully dumped on both master and node machines. 

![wmvabigjdcp](https://user-images.githubusercontent.com/2604887/52851324-1e5d8e00-3116-11e9-8e8c-f48293442ed3.png)
![dqyskk4dd7t](https://user-images.githubusercontent.com/2604887/52851327-1f8ebb00-3116-11e9-896c-1d03da76aa20.png)
