### PR TITLE
Scalability tests: don't override kube-proxy metrics-bind-address in 1.11-1.13

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -140,6 +140,8 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=e2e-big-beta
+      # Don't override metrics-bind-address in 1.13
+      - --env=KUBEPROXY_TEST_ARGS=--profiling
       - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-nodes=100
@@ -183,6 +185,8 @@ periodics:
       # Use default kube-qps and kube-api-burst flag values.
       - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling
       - --env=SCHEDULER_TEST_ARGS=--profiling
+      # Don't override metrics-bind-address in 1.12
+      - --env=KUBEPROXY_TEST_ARGS=--profiling
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
       - --gcp-nodes=100
@@ -226,6 +230,8 @@ periodics:
       # Use default kube-qps and kube-api-burst flag values.
       - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling
       - --env=SCHEDULER_TEST_ARGS=--profiling
+      # Don't override metrics-bind-address in 1.11
+      - --env=KUBEPROXY_TEST_ARGS=--profiling
       - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
       - --gcp-nodes=100


### PR DESCRIPTION
This should fix the https://github.com/kubernetes/kubernetes/issues/74123 issues.

The metrics-bind-address format has changed after 1.13, currently it's `IP` (and this is what we set in presets, see https://github.com/kubernetes/test-infra/pull/11281), but it used to be `IP:port` and that's why test fails in 1.11-1.13