### PR TITLE
Optionally upload the testgrid config proto as world-readable

### DIFF
--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -145,7 +145,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 	if err = p.SetURL(u); err != nil {
 		return err
 	}
-	return gcs.Upload(ctx, client, p, bytes)
+	return gcs.Upload(ctx, client, p, bytes, true)
 }
 
 func doOneshot(ctx context.Context, client *storage.Client, opt options) error {

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -51,6 +51,7 @@ type options struct {
 	output             string
 	printText          bool
 	validateConfigFile bool
+	worldReadable      bool
 }
 
 func gatherOptions() (options, error) {
@@ -60,6 +61,7 @@ func gatherOptions() (options, error) {
 	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
 	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")
 	flag.BoolVar(&o.validateConfigFile, "validate-config-file", false, "validate that the given config files are syntactically correct and exit (proto is not written anywhere)")
+	flag.BoolVar(&o.worldReadable, "world-readable", false, "when uploading the proto to GCS, makes it world readable. Has no effect on writing to the local filesystem.")
 	flag.Var(&o.inputs, "yaml", "comma-separated list of input YAML files")
 	flag.Parse()
 	if len(o.inputs) == 0 || o.inputs[0] == "" {
@@ -133,7 +135,7 @@ func readConfig(paths []string) (*Config, error) {
 	return &c, nil
 }
 
-func write(ctx context.Context, client *storage.Client, path string, bytes []byte) error {
+func write(ctx context.Context, client *storage.Client, path string, bytes []byte, worldReadable bool) error {
 	u, err := url.Parse(path)
 	if err != nil {
 		return fmt.Errorf("invalid url %s: %v", path, err)
@@ -145,7 +147,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 	if err = p.SetURL(u); err != nil {
 		return err
 	}
-	return gcs.Upload(ctx, client, p, bytes, true)
+	return gcs.Upload(ctx, client, p, bytes, worldReadable)
 }
 
 func doOneshot(ctx context.Context, client *storage.Client, opt options) error {
@@ -166,7 +168,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options) error {
 	if opt.output != "" {
 		b, err := c.MarshalBytes()
 		if err == nil {
-			err = write(ctx, client, opt.output, b)
+			err = write(ctx, client, opt.output, b, opt.worldReadable)
 		}
 		if err != nil {
 			return fmt.Errorf("could not write config: %v", err)

--- a/testgrid/cmd/updater/main.go
+++ b/testgrid/cmd/updater/main.go
@@ -812,7 +812,7 @@ func updateGroup(ctx context.Context, client *storage.Client, tg config.TestGrou
 		log.Printf("  Not writing %s (%d bytes) to %s", o, len(buf), tgp)
 	} else {
 		log.Printf("  Writing %s (%d bytes) to %s", o, len(buf), tgp)
-		if err := gcs.Upload(ctx, client, tgp, buf); err != nil {
+		if err := gcs.Upload(ctx, client, tgp, buf, false); err != nil {
 			return fmt.Errorf("upload %s to %s failed: %v", o, tgp, err)
 		}
 	}

--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -22,5 +22,6 @@ for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
   bazel run //testgrid/cmd/configurator -- \
     --yaml="$(realpath "$(dirname "${BASH_SOURCE}")"/config.yaml)" \
     --output="${output}" \
-    --oneshot
+    --oneshot \
+    --world-readable
 done

--- a/testgrid/util/gcs/gcs.go
+++ b/testgrid/util/gcs/gcs.go
@@ -119,9 +119,12 @@ func calcCRC(buf []byte) uint32 {
 }
 
 // Upload writes bytes to the specified Path
-func Upload(ctx context.Context, client *storage.Client, path Path, buf []byte) error {
+func Upload(ctx context.Context, client *storage.Client, path Path, buf []byte, worldReadable bool) error {
 	crc := calcCRC(buf)
 	w := client.Bucket(path.Bucket()).Object(path.Object()).NewWriter(ctx)
+	if worldReadable {
+		w.ACL = []storage.ACLRule{{Entity: storage.AllUsers, Role: storage.RoleReader}}
+	}
 	w.SendCRC32C = true
 	// Send our CRC32 to ensure google received the same data we sent.
 	// See checksum example at:


### PR DESCRIPTION
Add an argument to `gcs.Upload` for world-readable, and set it true if `--world-readable` is passed to configurator.

/cc @fejta 