### PR TITLE
define repo for  cluster-api-provider-vsphere periodic job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -1,5 +1,4 @@
 periodics:
-  #kubernetes-sigs/cluster-api-provider-vsphere:
   - name: ci-cluster-api-provider-vsphere-ova-e2e
     labels:
       preset-dind-enabled: "true"
@@ -7,7 +6,11 @@ periodics:
       preset-cluster-api-provider-vsphere-e2e-creds: "true"
     decorate: true
     interval: 24h
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-vsphere
+      base_ref: master
+      path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190214-f4092ae69-master


### PR DESCRIPTION
periodic job does not has repo by default, need to define it through extra-refs

cc @BenTheElder  @akutz @frapposelli  @sflxn 