### PR TITLE
Improved welcome template message

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -240,8 +240,12 @@ config_updater:
 
 welcome:
 - repos:
-  - kubernetes/test-infra
-  message_template: "Welcome @{{.AuthorLogin}}! It looks like this is your first PR to {{.Org}}/{{.Repo}} 🎉🎉"
+  - kubernetes
+  - kubernetes-client
+  - kubernetes-csi
+  - kubernetes-incubator
+  - kubernetes-sigs
+  message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://git.k8s.io/community/contributors/guide/pull-requests.md) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://go.k8s.io/bot-commands). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>You may want to refer to our [testing guide](https://git.k8s.io/community/contributors/devel/sig-testing/testing.md) if you run into trouble with your tests not passing. <br><br>If you are having difficulty getting your pull request seen, please follow the [recommended escalation practices](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#why-is-my-pull-request-not-getting-reviewed). We want to make sure your contribution gets all the attention it needs! <br><br>Thank you, and welcome to Kubernetes. :smiley:"
 
 require_matching_label:
 - missing_label: needs-kind


### PR DESCRIPTION
According to discussion in #9367, the default welcome message should include links to onboarding documentation to help new contributors.

This is a first pass.
/area prow
/sig testing
/sig contributor-experience
/cc @nikhita
/cc @BenTheElder
/cc @carolynvs