### PR TITLE
bump gcloud-in-go version for boskos janitor

### DIFF
--- a/boskos/janitor/Dockerfile
+++ b/boskos/janitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/gcloud-in-go:v20180725-a495f0247
+FROM gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
 
 ADD ["janitor", \
      "janitor.py", \


### PR DESCRIPTION
In order to accommodate https://github.com/kubernetes/test-infra/pull/11324

/assign @jlowdermilk  