### PR TITLE
Add a record.FinalSHA field to hold the end state of a cloned ref

### DIFF
--- a/prow/pod-utils/clone/types.go
+++ b/prow/pod-utils/clone/types.go
@@ -22,11 +22,16 @@ import (
 
 // Record is a trace of what the desired
 // git state was, what steps we took to get there,
-// and whether or not we were successful.
+// what our final state ended up being, and
+// whether or not we were successful.
 type Record struct {
 	Refs     prowapi.Refs `json:"refs"`
 	Commands []Command    `json:"commands"`
 	Failed   bool         `json:"failed"`
+
+	// FinalSHA is the SHA from ultimate state of a cloned ref
+	// This is used to populate RepoCommit in started.json properly
+	FinalSHA string `json:"final_sha,omitempty"`
 }
 
 // Command is a trace of a command executed


### PR DESCRIPTION
Will make initupload understand records after https://github.com/kubernetes/test-infra/pull/11304 gets in

c.f. https://github.com/kubernetes/test-infra/issues/10359

Also not sure if how to properly write test for this? (seems I don't have control over the fake commit SHA, and if I stub that out that will defeat the purpose of the function?)

/assign @cjwagner @stevekuznetsov @fejta 
cc @BenTheElder 