### PR TITLE
change timeout in kops e2e tests

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -115,7 +115,7 @@ presubmits:
         - --repo=k8s.io/release
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
-        - --timeout=75
+        - --timeout=85
         - --scenario=kubernetes_e2e
         - --
         - --aws
@@ -131,7 +131,7 @@ presubmits:
         - --provider=aws
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190214-f4092ae69-master
         name: ""

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -87,7 +87,7 @@ presubmits:
         - --kops-build
         - --provider=aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -126,7 +126,7 @@ presubmits:
         - --kops-build
         - --provider=aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -165,7 +165,7 @@ presubmits:
         - --kops-build
         - --provider=aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -204,7 +204,7 @@ presubmits:
         - --kops-build
         - --provider=aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
+        - "--timeout=85"
         - --scenario=kubernetes_e2e
         - --
         - --aws
@@ -43,7 +43,7 @@ presubmits:
         - --provider=aws
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=65m
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true


### PR DESCRIPTION
currently it is difficult to get kops e2e tests pass because it will always timeout.

https://gubernator.k8s.io/builds/kubernetes-jenkins/pr-logs/pull/74141/pull-kubernetes-e2e-kops-aws/

Basically we have two options: 1) increase timeout 2) start debugging why some parts of the test is slow, and try to fix these slow tests. 

I think this is needed that we can turn kops presubmit tests back 

/cc @BenTheElder @justinsb 