### PR TITLE
set artifacts flags for kind kubeadm job

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -46,9 +46,10 @@ periodics:
       - --test
       - --check-version-skew=false
       - --down
+      - --dump=${ARTIFACTS}
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --disable-log-dump=true --num-nodes=3
+      - --test_args=--report-dir=${ARTIFACTS} --disable-log-dump=true --num-nodes=3 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --ginkgo-parallel
       - --timeout=30m
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -46,11 +46,11 @@ periodics:
       - --test
       - --check-version-skew=false
       - --down
-      - --dump=${ARTIFACTS}
+      - '"--dump=${ARTIFACTS}"'
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--report-dir=${ARTIFACTS} --disable-log-dump=true --num-nodes=3 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-      - --ginkgo-parallel
+      - '"--test_args=--report-dir=${ARTIFACTS} --disable-log-dump=true --num-nodes=3 --ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Serial\\]|Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]
+      - --ginkgo-parallel"'
       - --timeout=30m
       # we need privileged mode in order to do docker in docker
       securityContext:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/11335 worked, but we also need to set the artifacts related flags (normally the scenario script does this).

note to self for kubetest2 ... these should have sane defaults in the presence of `ARTIFACTS`, we shouldn't need to specify these in CI.