### PR TITLE
Define environment variables PROW_CLUSTER_OVERRIDE and BUILD_CLUSTER_OVERRIDE

### DIFF
--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -24,8 +24,8 @@ docker_tag="v${build_date}-${git_commit}"
 cat <<EOF
 STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-gcr.io/k8s-testimages}
 STABLE_PROW_REPO ${PROW_REPO_OVERRIDE:-gcr.io/k8s-prow}
-STABLE_PROW_CLUSTER gke_k8s-prow_us-central1-f_prow
-STABLE_BUILD_CLUSTER gke_k8s-prow-builds_us-central1-f_prow
+STABLE_PROW_CLUSTER ${PROW_CLUSTER_OVERRIDE:-gke_k8s-prow_us-central1-f_prow}
+STABLE_BUILD_CLUSTER ${BUILD_CLUSTER_OVERRIDE:-gke_k8s-prow-builds_us-central1-f_prow}
 STABLE_BUILD_GIT_COMMIT ${git_commit}
 DOCKER_TAG ${docker_tag}
 EOF

--- a/prow/build_test_update.md
+++ b/prow/build_test_update.md
@@ -82,7 +82,9 @@ Once your deployment files are updated, please update these resources on your cl
 
 ```shell
 # Set the kubectl context you want to use
-export STABLE_PROW_CLUSTER=gke_my-project_my-zone_my-cluster # or whatever the correct value is
+export PROW_CLUSTER_OVERRIDE=gke_my-project_my-zone_my-cluster # or whatever the correct value is
+export BUILD_CLUSTER_OVERRIDE=gke_my-project_my-zone_my-cluster # or whatever the correct value is
+
 # Generally just do
 bazel run //prow/cluster:production.apply # deploy everything
 


### PR DESCRIPTION
These environment variables can be used to override the default cluster when running bazel deploy.