### PR TITLE
Add api-review label

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -47,6 +47,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="api-review" href="#api-review">`api-review`</a> | Categorizes an issue or PR as actively needing an API review. See https://git.k8s.io/community/sig-architecture/api-review-process.md| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/licensing" href="#area/licensing">`area/licensing`</a> | Issues or PRs related to Kubernetes licensing| label | |
 | <a id="committee/conduct" href="#committee/conduct">`committee/conduct`</a> | Denotes an issue or PR intended to be handled by the code of conduct committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="committee/product-security" href="#committee/product-security">`committee/product-security`</a> | Denotes an issue or PR intended to be handled by the product security committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -8,6 +8,12 @@
 ---
 default:
   labels:
+    - color: e11d21
+      description: Categorizes an issue or PR as actively needing an API review. See https://git.k8s.io/community/sig-architecture/api-review-process.md
+      name: api-review
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: 0052cc
       description: Issues or PRs related to Kubernetes licensing
       name: area/licensing

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -103,6 +103,9 @@ size:
 
 label:
   additional_labels:
+    # This label is used by the API review process
+    # https://git.k8s.io/community/sig-architecture/api-review-process.md#mechanics
+    - api-review
     # These labels are used by Kubeflow
     # TODO(https://github.com/kubernetes/test-infra/issues/8648): Switch
     # to configuring prefixes and not individual labels once  that's supported.


### PR DESCRIPTION
Per https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md#mechanics

(will adjust commands in that doc to `/label api-review` and `/remove-label api-review` to make use of the existing `label` prow plugin

cc @kubernetes/sig-testing-pr-reviews  @kubernetes/sig-contributor-experience-pr-reviews 