### PR TITLE
Add auto-commenter for potential api-review PRs

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -1,5 +1,47 @@
 # this file should contain all periodic jobs that use the fejta-bot token
 periodics:
+- name: periodic-api-review-help
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      command:
+      - /commenter
+      args:
+      # pull requests against master branches in the kubernetes org labeled kind/api-change
+      # exclude PRs that are in progress, held, or need rebase (typically aren't ready for API review).
+      # exclude PRs already labeled api-review or tracked in the API review project
+      # exclude PRs that already have the comment text
+      - |-
+        --query=org:kubernetes
+        is:pr
+        base:master
+        label:kind/api-change
+        -label:do-not-merge/work-in-progress
+        -label:do-not-merge/hold
+        -label:needs-rebase
+        -label:api-review
+        -project:kubernetes/13
+        NOT "complete the pre-review checklist and request an API review"
+      - --updated=5m
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=This PR [may require API review](https://git.k8s.io/community/sig-architecture/api-review-process.md#what-apis-need-to-be-reviewed).
+        
+        If so, when the changes are ready, [complete the pre-review checklist and request an API review](https://git.k8s.io/community/sig-architecture/api-review-process.md#mechanics).
+        
+        Status of requested reviews is tracked in the [API Review project](https://github.com/orgs/kubernetes/projects/13).
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
 - name: periodic-test-infra-close
   interval: 1h
   decorate: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2218,6 +2218,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-rotten
 - name: periodic-test-infra-close
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-close
+- name: periodic-api-review-help
+  gcs_prefix: kubernetes-jenkins/logs/periodic-api-review-help
 - name: periodic-test-infra-retester
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-retester
 - name: periodic-secping
@@ -6763,6 +6765,9 @@ dashboards:
   - name: close
     description: Closes rotten issues after 30d of inactivity
     test_group_name: periodic-test-infra-close
+  - name: api-review-help
+    description: Adds API review process description to kind/api-change PRs
+    test_group_name: periodic-api-review-help
   - name: secping
     description: files bugs for SECURITY_CONTACTS
     test_group_name: periodic-secping


### PR DESCRIPTION
Per https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md#mechanics

cc @kubernetes/sig-testing-pr-reviews @kubernetes/sig-contributor-experience-pr-reviews

/cc @fejta 
for commenter config

/cc @cblecker @jdumars 
for comment text

This would currently match 37 issues:

https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+org%3Akubernetes+is%3Apr+base%3Amaster+label%3Akind%2Fapi-change+-label%3Aapi-review+-label%3Ado-not-merge%2Fwork-in-progress+-label%3Ado-not-merge%2Fhold+-label%3Aneeds-rebase&ref=simplesearch