### PR TITLE
add e2e test for alb ingress controller

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
         args:
         - make
         - lint
-  - name: pull-aws-alb-ingress-controller-test
+  - name: pull-aws-alb-ingress-controller-unit-test
     always_run: true
     decorate: true
     labels:
@@ -25,7 +25,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test
+        - unit-test
         volumeMounts:
         - name: coveralls
           mountPath: /etc/coveralls-token
@@ -34,3 +34,21 @@ presubmits:
       - name: coveralls
         secret:
           secretName: k8s-aws-alb-ingress-coveralls-token
+  - name: pull-aws-alb-ingress-controller-e2e-test
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190214-f4092ae69-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - e2e-test
+        securityContext:
+          privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3350,8 +3350,11 @@ test_groups:
 - name: pull-aws-alb-ingress-controller-lint
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-alb-ingress-controller-lint
   num_columns_recent: 30
-- name: pull-aws-alb-ingress-controller-test
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-alb-ingress-controller-test
+- name: pull-aws-alb-ingress-controller-unit-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-alb-ingress-controller-unit-test
+  num_columns_recent: 30
+- name: pull-aws-alb-ingress-controller-e2e-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-aws-alb-ingress-controller-e2e-test
   num_columns_recent: 30
 - name: pull-cloud-provider-aws-check
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-aws-check
@@ -5734,9 +5737,12 @@ dashboards:
   - name: lint
     test_group_name: pull-aws-alb-ingress-controller-lint
     description: "aws alb ingress controller code lint"
-  - name: test
-    test_group_name: pull-aws-alb-ingress-controller-test
-    description: "aws alb ingress controller tests"
+  - name: unit test
+    test_group_name: pull-aws-alb-ingress-controller-unit-test
+    description: "aws alb ingress controller unit tests"
+  - name: e2e test
+    test_group_name: pull-aws-alb-ingress-controller-e2e-test
+    description: "aws alb ingress controller e2e tests"
 
 - name: sig-aws-cloud-provider-aws
   dashboard_tab:


### PR DESCRIPTION
The purpose of this PR:
add e2e test for sig-project: alb ingress controller

issue in sig-project: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/856