### PR TITLE
Lower qps limits in kubelet for node-throughput test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -153,7 +153,7 @@ presets:
   - name: MAX_PODS_PER_NODE
     value: "128"
   - name: KUBELET_TEST_ARGS
-    value: "--enable-debugging-handlers --kube-api-qps=100 --kube-api-burst=100"
+    value: "--enable-debugging-handlers"
   - name: KUBEPROXY_TEST_ARGS
     value: "--profiling"
   - name: SCHEDULER_TEST_ARGS


### PR DESCRIPTION
To get the baseline from where we currently are.