### PR TITLE
Enable prometheus server in gce killer for testing

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -35,6 +35,8 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
       - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
+      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Set everywhere if it works
+      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/74213

This is to check that the prometheus server works in 100 node clusters.
If everything is fine I will try enabling in bigger clusters. 

