### PR TITLE
Removing ci-kubernetes-e2e-gke-small-performance

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -73,45 +73,6 @@ periodics:
       - --use-logexporter
 
 # gke
-# Temporary job for clusterloader gke 100 nodes test.
-# TODO(krzysied): Remove the job when the testing is done.
-- cron: "0 */3 * * 1,2,3,4,5" # Run every 3h from Mon to Fri.
-  name: ci-kubernetes-e2e-gke-small-performance
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --repo=k8s.io/kubernetes=master
-      - --repo=k8s.io/perf-tests=master
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --cluster=gke-small-cluster
-      - --deployment=gke
-      - --extract=gke-default
-      - --gcp-node-image=gci
-      - --gcp-project-type=scalability-project
-      - --gcp-zone=us-east1-b
-      - --gke-create-command=container clusters create --quiet --enable-ip-alias --create-subnetwork name=ip-alias-subnet --cluster-ipv4-cidr=/12 --services-ipv4-cidr=/19
-      - --gke-environment=prod
-      - '--gke-shape={"default":{"Nodes":99,"MachineType":"n1-standard-1"},"heapster-pool":{"Nodes":1,"MachineType":"n1-standard-2"}}'
-      - --provider=gke
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-      - --test-cmd-args=cluster-loader2
-      - --test-cmd-args=--nodes=100
-      - --test-cmd-args=--provider=gke
-      - --test-cmd-args=--report-dir=/workspace/_artifacts
-      - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-name=ClusterLoaderV2
-      - --timeout=120m
-      - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190214-f4092ae69-master
-
 - cron: '1 8 * * 0' # Run at 00:01PST (8:01 UTC) on sunday
   name: ci-kubernetes-e2e-gke-large-performance
   tags:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -360,8 +360,6 @@ test_groups:
   days_of_results: 60
   num_columns_recent: 3
   num_failures_to_alert: 1
-- name: ci-kubernetes-e2e-gke-small-performance
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-small-performance
 - name: ci-kubernetes-e2e-gci-gce-es-logging
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-es-logging
 - name: ci-kubernetes-e2e-gci-gce-sd-logging
@@ -6570,8 +6568,6 @@ dashboards:
     test_group_name: ci-perf-tests-kubemark-100-benchmark
   - name: cluster-loader
     test_group_name: ci-perf-tests-e2e-gce-clusterloader
-  - name: ci-kubernetes-e2e-gke-small-performance
-    test_group_name: ci-kubernetes-e2e-gke-small-performance
 
 - name: sig-scalability-benchmarks
   dashboard_tab:


### PR DESCRIPTION
Removing temporary job for gke clusterloader verification.