### PR TITLE
Don't trigger jobs that require manual intervention on reconcile

### DIFF
--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -283,7 +283,7 @@ func addedBlockingPresubmits(old, new map[string][]config.Presubmit) map[string]
 	for repo, oldPresubmits := range old {
 		added[repo] = []config.Presubmit{}
 		for _, newPresubmit := range new[repo] {
-			if !newPresubmit.ContextRequired() {
+			if !newPresubmit.ContextRequired() || newPresubmit.NeedsExplicitTrigger() {
 				continue
 			}
 			var found bool


### PR DESCRIPTION
The status reconciler should not trigger blocking jobs that are
required-if-present, as those should only get run when humans manually
intervene.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 