### PR TITLE
Add a big banner for Spyglass to Gubernator

### DIFF
--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -4,6 +4,15 @@ body {
     margin: 0;
     scroll-behavior: smooth;
 }
+#page-top-banner {
+    text-align: center;
+    padding: 15px;
+    background-color: #ffeb00;
+    font-weight: bold;
+}
+#page-top-banner a {
+    color: #0027ff;
+}
 #header {
     background-color: #3f51b5;
     color: white;

--- a/gubernator/templates/base.html
+++ b/gubernator/templates/base.html
@@ -15,6 +15,8 @@
   ga('send', 'pageview');
 </script>
 % endblock
+% block banner
+% endblock
 <div id="header" class="container">
 <a href="/"><img src="{{'logo.svg'|static}}"></a>
 % block header

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -8,6 +8,13 @@
 <link rel="icon" type="image/png" href="{{'favicon-green.png'|static}}" />
 % endif
 % endblock
+% block banner
+% if spyglass_link
+<div id="page-top-banner">
+	This job view page is being replaced by Spyglass soon. <a href="{{spyglass_link}}">Check out the new job view</a>.
+</div>
+% endif
+% endblock
 % block header
 <h1>{% if pr and pr != "batch"  %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes"%}{{repo}} {% endif %}PR #{{pr}}</a> {% endif %}
 	% if testgrid_query


### PR DESCRIPTION
More eye-catching than the old link.

![image](https://user-images.githubusercontent.com/110792/53051542-1d4b9a00-3451-11e9-80d3-2324f94e4bae.png)

/cc @fejta 