### PR TITLE
Use Refs.String() Method to populate Repo data in started

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -476,7 +476,13 @@ type Refs struct {
 }
 
 func (r Refs) String() string {
-	rs := []string{fmt.Sprintf("%s:%s", r.BaseRef, r.BaseSHA)}
+	rs := []string{}
+	if r.BaseSHA != "" {
+		rs = append(rs, fmt.Sprintf("%s:%s", r.BaseRef, r.BaseSHA))
+	} else {
+		rs = append(rs, r.BaseRef)
+	}
+
 	for _, pull := range r.Pulls {
 		ref := fmt.Sprintf("%d:%s", pull.Number, pull.SHA)
 

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -192,3 +192,66 @@ func TestDecorationDefaulting(t *testing.T) {
 		})
 	}
 }
+
+func TestRefsToString(t *testing.T) {
+	var tests = []struct {
+		name     string
+		ref      Refs
+		expected string
+	}{
+		{
+			name: "Refs with Pull",
+			ref: Refs{
+				BaseRef: "master",
+				BaseSHA: "deadbeef",
+				Pulls: []Pull{
+					{
+						Number: 123,
+						SHA:    "abcd1234",
+					},
+				},
+			},
+			expected: "master:deadbeef,123:abcd1234",
+		},
+		{
+			name: "Refs with multiple Pulls",
+			ref: Refs{
+				BaseRef: "master",
+				BaseSHA: "deadbeef",
+				Pulls: []Pull{
+					{
+						Number: 123,
+						SHA:    "abcd1234",
+					},
+					{
+						Number: 456,
+						SHA:    "dcba4321",
+					},
+				},
+			},
+			expected: "master:deadbeef,123:abcd1234,456:dcba4321",
+		},
+		{
+			name: "Refs with BaseRef only",
+			ref: Refs{
+				BaseRef: "master",
+			},
+			expected: "master",
+		},
+		{
+			name: "Refs with BaseRef and BaseSHA",
+			ref: Refs{
+				BaseRef: "master",
+				BaseSHA: "deadbeef",
+			},
+			expected: "master:deadbeef",
+		},
+	}
+
+	for _, test := range tests {
+		actual, expected := test.ref.String(), test.expected
+		if actual != expected {
+			t.Errorf("%s: got ref string: %s, but expected: %s", test.name, actual, expected)
+		}
+	}
+}

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -47,10 +47,10 @@ func specToStarted(spec *downwardapi.JobSpec) gcs.Started {
 	started.Repos = map[string]string{}
 
 	if spec.Refs != nil {
-		started.Repos[spec.Refs.Org+"/"+spec.Refs.Repo] = downwardapi.GetRevisionFromRef(spec.Refs)
+		started.Repos[spec.Refs.Org+"/"+spec.Refs.Repo] = spec.Refs.String()
 	}
 	for _, ref := range spec.ExtraRefs {
-		started.Repos[ref.Org+"/"+ref.Repo] = downwardapi.GetRevisionFromRef(&ref)
+		started.Repos[ref.Org+"/"+ref.Repo] = ref.String()
 	}
 
 	return started

--- a/prow/initupload/run_test.go
+++ b/prow/initupload/run_test.go
@@ -51,7 +51,7 @@ func TestSpecToStarted(t *testing.T) {
 				RepoVersion: "abcd1234",
 				Pull:        "123",
 				Repos: map[string]string{
-					"kubernetes/test-infra": "abcd1234",
+					"kubernetes/test-infra": "master:deadbeef,123:abcd1234",
 				},
 			},
 		},
@@ -91,7 +91,7 @@ func TestSpecToStarted(t *testing.T) {
 			expected: gcs.Started{
 				RepoVersion: "deadbeef",
 				Repos: map[string]string{
-					"kubernetes/test-infra": "deadbeef",
+					"kubernetes/test-infra": "master:deadbeef",
 					"kubernetes/release":    "v1.10",
 				},
 			},

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -155,8 +155,8 @@ func EnvForType(jobType prowapi.ProwJobType) []string {
 	}
 }
 
-// GetRevisionFromRef returns a ref or sha from a refs object
-func GetRevisionFromRef(refs *prowapi.Refs) string {
+// getRevisionFromRef returns a ref or sha from a refs object
+func getRevisionFromRef(refs *prowapi.Refs) string {
 	if len(refs.Pulls) > 0 {
 		return refs.Pulls[0].SHA
 	}
@@ -171,9 +171,9 @@ func GetRevisionFromRef(refs *prowapi.Refs) string {
 // GetRevisionFromSpec returns a main ref or sha from a spec object
 func GetRevisionFromSpec(spec *JobSpec) string {
 	if spec.Refs != nil {
-		return GetRevisionFromRef(spec.Refs)
+		return getRevisionFromRef(spec.Refs)
 	} else if len(spec.ExtraRefs) > 0 {
-		return GetRevisionFromRef(&spec.ExtraRefs[0])
+		return getRevisionFromRef(&spec.ExtraRefs[0])
 	}
 	return ""
 }


### PR DESCRIPTION
Follow up https://github.com/kubernetes/test-infra/pull/11304: To make podutils match previous repo field better (https://github.com/kubernetes/test-infra/blob/master/jenkins/bootstrap.py#L1001)

Also this should give us pretty close to the actual Refs struct, as @cjwagner mentioned earlier.

(Also patched up the behavior of Refs.String() a bit and added a test, seems nobody is relying on that so...)

/assign @fejta @cjwagner @stevekuznetsov 