### PR TITLE
kubetest/kind: use the log level of "debug"

### DIFF
--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -51,7 +51,7 @@ const (
 
 	kindClusterNameDefault = "kind-kubetest"
 
-	flagLogLevel = "--loglevel=info"
+	flagLogLevel = "--loglevel=debug"
 )
 
 var (


### PR DESCRIPTION
This should print "docker exec" calls and eventually
other useful debug info for e2e tests.

"info" is mostly silent for the time being.

/kind feature
/priority important-longterm
/assign @BenTheElder 
