### PR TITLE
initialize kubetest2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -118,6 +118,7 @@ filegroup(
         "//jobs:all-srcs",
         "//kettle:all-srcs",
         "//kubetest:all-srcs",
+        "//kubetest2:all-srcs",
         "//label_sync:all-srcs",
         "//logexporter/cmd:all-srcs",
         "//maintenance/aws-janitor:all-srcs",

--- a/kubetest2/BUILD.bazel
+++ b/kubetest2/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/kubetest2",
+    visibility = ["//visibility:private"],
+    deps = ["//kubetest2/pkg/app/shim:go_default_library"],
+)
+
+go_binary(
+    name = "kubetest2",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//kubetest2/kubetest2-kind:all-srcs",
+        "//kubetest2/pkg/app:all-srcs",
+        "//kubetest2/pkg/process:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/OWNERS
+++ b/kubetest2/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- BenTheElder
+- krzyzacy
+
+labels:
+# TODO(bentheelder): should we add a kubetest2 label?
+- area/kubetest

--- a/kubetest2/README.md
+++ b/kubetest2/README.md
@@ -1,0 +1,11 @@
+# kubetest2
+
+kubetest2 is intended to be the next significant iteration of [kubetest].
+
+This project is a stub currently, this doc will contain more details in the future.
+
+See also [the initial design doc] shared with kubernetes-sig-testing@googlegroups.com
+and kubernetes-dev@googlegroups.com
+
+[kubetest]: https://github.com/kubernetes/test-infra/tree/master/kubtest
+[the initial design doc]: https://docs.google.com/document/d/1Dc7xg9lq4cxdDuz20YZjunuL5eju2WIXwO32praC5hs/

--- a/kubetest2/kubetest2-kind/BUILD.bazel
+++ b/kubetest2/kubetest2-kind/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/kubetest2/kubetest2-kind",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "kubetest2-kind",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//kubetest2/kubetest2-kind/deployer:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/kubetest2-kind/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-kind/deployer/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "k8s.io/test-infra/kubetest2/kubetest2-kind/deployer",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/kubetest2-kind/deployer/doc.go
+++ b/kubetest2/kubetest2-kind/deployer/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app implements the kubetest2 kind deployer
+package deployer
+
+// TODO(bentheelder): actually implement!

--- a/kubetest2/kubetest2-kind/main.go
+++ b/kubetest2/kubetest2-kind/main.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+func main() {
+	/*
+		TODO(bentheelder):
+		- create the deployer interface package
+		- implement the high level kubetest2 app as a package
+		- import the package here
+		- implement the deployer for kind in a package
+		- load the kind deployer here
+		- call the kubetest2 app here with the kind deployer selected
+	*/
+	panic("unimplemented, come back later!")
+}

--- a/kubetest2/main.go
+++ b/kubetest2/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"k8s.io/test-infra/kubetest2/pkg/app/shim"
+)
+
+func main() {
+	shim.Main()
+}

--- a/kubetest2/pkg/app/BUILD.bazel
+++ b/kubetest2/pkg/app/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "k8s.io/test-infra/kubetest2/pkg/app",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//kubetest2/pkg/app/shim:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/pkg/app/doc.go
+++ b/kubetest2/pkg/app/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app implements the kubetest2 high level application logic
+package app
+
+// TODO(bentheelder): actually implement!

--- a/kubetest2/pkg/app/shim/BUILD.bazel
+++ b/kubetest2/pkg/app/shim/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "const.go",
+        "deployers.go",
+        "doc.go",
+        "shim.go",
+    ],
+    importpath = "k8s.io/test-infra/kubetest2/pkg/app/shim",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//kubetest2/pkg/process:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/pkg/app/shim/const.go
+++ b/kubetest2/pkg/app/shim/const.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shim
+
+// BinaryName is the name of the binary
+const BinaryName = "kubetest2"

--- a/kubetest2/pkg/app/shim/deployers.go
+++ b/kubetest2/pkg/app/shim/deployers.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shim
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// FindDeployer locates the binary implementing the named deployer
+// TODO(bentheelder): move this to another package?
+func FindDeployer(name string) (path string, err error) {
+	binary := fmt.Sprintf("%s-%s", BinaryName, name)
+	path, err = exec.LookPath(binary)
+	if err != nil {
+		return "", errors.Errorf("%#v not found in PATH, could not locate %#v deployer", binary, name)
+	}
+	return path, err
+}
+
+// FindDeployers looks for all deployers in PATH, returning a map of the
+// deployer name to the first matching binary found in path
+func FindDeployers() map[string]string {
+	nameToPath := make(map[string]string)
+	prefix := fmt.Sprintf("%s-", BinaryName)
+
+	// search every directory in PATH for kubetest2-* binaries
+	searchPaths := filepath.SplitList(os.Getenv("PATH"))
+	for _, dir := range searchPaths {
+		// mimic LookPath() for nicer results
+		if dir == "" {
+			// Unix shell semantics: path element "" means "."
+			dir = "."
+		}
+
+		// list all files in the directory
+		files, err := ioutil.ReadDir(dir)
+
+		// ignore bad directories in PATH
+		if os.IsNotExist(err) {
+			continue
+		}
+
+		// check every file in the directory against the prefix
+		for _, f := range files {
+			// ignore directories
+			if f.IsDir() {
+				continue
+			}
+			// ensure the prefix matches
+			fileName := f.Name()
+			if !strings.HasPrefix(fileName, prefix) {
+				continue
+			}
+			// convert the file name to a deployer name
+			// TODO(bentheelder): handle PATHEXT on windows
+			name := strings.TrimPrefix(fileName, prefix)
+			// only keep the first result
+			if _, foundAlready := nameToPath[name]; foundAlready {
+				continue
+			}
+			// use FindDeployer / LookPath to ensure consistency
+			path, err := FindDeployer(name)
+			if err != nil {
+				continue
+			}
+			nameToPath[name] = path
+		}
+	}
+	return nameToPath
+}

--- a/kubetest2/pkg/app/shim/doc.go
+++ b/kubetest2/pkg/app/shim/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package shim implements the kubetest2 root command logic, "shimming" to
+// deployer specific binaries
+package shim

--- a/kubetest2/pkg/app/shim/shim.go
+++ b/kubetest2/pkg/app/shim/shim.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shim
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/test-infra/kubetest2/pkg/process"
+)
+
+// Main implements the kubtest2 root binary entrypoint
+func Main() {
+	if err := Run(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// Run instantiates and executes the shim cobra command, returning the result
+func Run() error {
+	return NewCommand().Execute()
+}
+
+var usageLong = `kubetest2 is a tool for kubernetes end to end testing.
+
+It orchestrates creating clusters, building kubernetes, deleting clusters, running tests, etc.
+
+kubetest2 should be called with a deployer like: 'kubetest2 kind --help'
+
+For more information see: https://github.com/kubernetes/test-infra/tree/master/kubetest2`
+
+// NewCommand returns a new cobra.Command for building the base image
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           fmt.Sprintf("%s [deployer]", BinaryName),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runE,
+	}
+
+	// enable our custom help function, which will list known deployers
+	cmd.SetHelpFunc(help)
+
+	// we want all flags to be passed through without parsing
+	cmd.DisableFlagParsing = true
+
+	return cmd
+}
+
+// runE implements the actual command logic
+func runE(cmd *cobra.Command, args []string) error {
+	// there should be at least one argument (the deployer) unless the user
+	// is asking for help on the shim itself
+	if len(args) < 1 {
+		return cmd.Help()
+	}
+
+	// gracefully handle -h or --help if it is the only argument
+	if len(args) == 1 {
+		// check for -h, --help
+		flags := pflag.NewFlagSet(BinaryName, pflag.ContinueOnError)
+		help := flags.BoolP("help", "h", false, "")
+		// we don't care about errors, only if -h / --help was set
+		_ = flags.Parse(args)
+		if *help {
+			return cmd.Help()
+		}
+	}
+
+	// otherwise find and execute the deployer with the remaining arguments
+	deployerName := args[0]
+	deployer, err := FindDeployer(deployerName)
+	if err != nil {
+		cmd.Printf("Error: could not find kubetest2 deployer %#v\n", deployerName)
+		cmd.Println()
+		usage(cmd, args)
+		return err
+	}
+	return process.Exec(deployer, args[1:], os.Environ())
+}
+
+// custom help info, includes usage()
+func help(cmd *cobra.Command, args []string) {
+	cmd.Println(usageLong)
+	cmd.Println()
+	usage(cmd, args)
+}
+
+// the usage subset of help info, attempts to identify and list known deployers
+func usage(cmd *cobra.Command, args []string) {
+	deployers := FindDeployers()
+	cmd.Println("Usage:")
+	cmd.Printf("  %s [deployer] [flags]\n", BinaryName)
+	cmd.Println()
+	cmd.Println("Detected Deployers:")
+	for deployer := range deployers {
+		cmd.Printf("  %s\n", deployer)
+	}
+	cmd.Println()
+	cmd.Println("For more help, run kubetest2 [deployer] --help")
+}

--- a/kubetest2/pkg/process/BUILD.bazel
+++ b/kubetest2/pkg/process/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "exec.go",
+    ],
+    importpath = "k8s.io/test-infra/kubetest2/pkg/process",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/pkg/process/doc.go
+++ b/kubetest2/pkg/process/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package process contains helpers for executing processes
+package process

--- a/kubetest2/pkg/process/exec.go
+++ b/kubetest2/pkg/process/exec.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+)
+
+// Exec generally mimics syscall.Exec behavior, but using a child process
+// isntead to make testing etc. easier
+func Exec(argv0 string, args []string, env []string) error {
+	// construct command from inputs
+	cmd := exec.Command(argv0, args...)
+	cmd.Env = env
+
+	// inherit all standard file descriptors, as if `syscall.Exec`ed
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// setup listener to forward all signals
+	// TODO(bentheelder): what should this buffer size be?
+	signals := make(chan os.Signal, 5)
+	signal.Notify(signals)
+	defer close(signals)
+
+	// start the process
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// set up a channel to monitor for when it exits
+	wait := make(chan error, 1)
+	go func() {
+		wait <- cmd.Wait()
+		close(wait)
+	}()
+
+	// pass all signals to the subcommand until it exits, return the result
+	for {
+		select {
+		case sig := <-signals:
+			// TODO(bentheelder): can this actually fail? should we log this?
+			cmd.Process.Signal(sig)
+		case err := <-wait:
+			return err
+		}
+	}
+}


### PR DESCRIPTION
See the [design doc](https://docs.google.com/document/d/1Dc7xg9lq4cxdDuz20YZjunuL5eju2WIXwO32praC5hs/), which was circulated through SIG-Testing.

This will be developed in parallel to the existing [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest), initially we will use it for non-critical jobs only.

This PR currently:
- Creates the directory and README
- Implements a `kubetest2` shim for `kubetest2 deployer ...` -> `kubetest2-deployer ...`
- Stubs out some of the project layout

Installation is done via `go get -u k8s.io/test-infra/kubetest2/...` or `go install k8s.io/test-infra/kubetest2/...` which installs both the root `kubetest2` command and the deployer(s).

Next up I intend to:
- add the deployer interface
- implement the high level application logic to use the deployer interface
- implement the deployer interface for `kind`

Further follow ups will flesh out testing logic, more deployers, documentation, etc.

/assign @krzyzacy 