### PR TITLE
enable override for kubernetes-sigs/kind

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -552,6 +552,7 @@ plugins:
   - yuks
 
   kubernetes-sigs/kind:
+  - override
   - trigger
   - welcome
 


### PR DESCRIPTION
so repo admins can bypass presubmits, notably when the kubernetes/kubernetes master branch breaks against kind, since we're not well monitored yet ...

xref: https://github.com/kubernetes-sigs/kind/issues/321

separately filing a PR to enable more alerts.