### PR TITLE
Disable prometheus server, it makes the test fail.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -35,8 +35,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
       - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Set everywhere if it works
-      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter


### PR DESCRIPTION
I'm able to reproduce the exact same failure in my personal 100 node
cluster. Will enable it back when I make it work in my cluster.