### PR TITLE
 More go-routines, do not override, require write access

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -12,11 +12,13 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//prow/flagutil:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//testgrid/config:go_default_library",
         "//testgrid/metadata:go_default_library",
         "//testgrid/resultstore:go_default_library",
         "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
@@ -45,5 +47,8 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    deps = ["//testgrid/metadata:go_default_library"],
+    deps = [
+        "//testgrid/metadata:go_default_library",
+        "//testgrid/util/gcs:go_default_library",
+    ],
 )

--- a/experiment/resultstore/convert.go
+++ b/experiment/resultstore/convert.go
@@ -71,7 +71,8 @@ func convertSuiteMeta(suiteMeta gcs.SuitesMeta) resultstore.Suite {
 				Duration: dur(result.Time),
 				Result:   resultstore.Completed,
 			}
-			msg := result.Message()
+			const max = 5000 // truncate messages to this length
+			msg := result.Message(max)
 			switch {
 			case result.Failure != nil:
 				// failing tests have a completed result with an error

--- a/experiment/resultstore/download.go
+++ b/experiment/resultstore/download.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
@@ -41,12 +43,13 @@ func storageClient(ctx context.Context, account string) (*storage.Client, error)
 
 func download(ctx context.Context, client *storage.Client, build gcs.Build) (*downloadResult, error) {
 
-	fmt.Println("Read started...")
+	log := logrus.WithFields(logrus.Fields{"build": build})
+	log.Debug("Read started...")
 	started, err := build.Started()
 	if err != nil {
 		return nil, fmt.Errorf("started: %v", err)
 	}
-	fmt.Println("Read finished...")
+	log.Debug("Read finished...")
 	finished, err := build.Finished()
 	if err != nil {
 		return nil, fmt.Errorf("finished: %v", err)
@@ -55,8 +58,7 @@ func download(ctx context.Context, client *storage.Client, build gcs.Build) (*do
 	ec := make(chan error, 2)
 	artifacts := make(chan string)
 	suitesChan := make(chan gcs.SuitesMeta)
-	fmt.Println("List suites...")
-
+	log.Debug("List suites...")
 	go func() { // err1
 		defer close(artifacts)
 		err := build.Artifacts(artifacts)

--- a/experiment/resultstore/main_test.go
+++ b/experiment/resultstore/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/test-infra/testgrid/metadata"
+	"k8s.io/test-infra/testgrid/util/gcs"
 )
 
 func TestInsertLink(t *testing.T) {
@@ -131,7 +132,7 @@ func TestInsertLink(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			changed, err := insertLink(tc.input, viewURL)
+			changed, err := insertLink(&gcs.Started{Metadata: tc.input}, viewURL)
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/testgrid/cmd/updater/main.go
+++ b/testgrid/cmd/updater/main.go
@@ -117,7 +117,8 @@ func row(jr junit.Result, suite string) (string, Row) {
 	if jr.Time > 0 {
 		r.Metrics[elapsedKey] = jr.Time
 	}
-	if msg := jr.Message(); msg != "" {
+	const max = 140
+	if msg := jr.Message(max); msg != "" {
 		r.Message = msg
 	}
 	switch {

--- a/testgrid/metadata/junit/junit.go
+++ b/testgrid/metadata/junit/junit.go
@@ -58,8 +58,7 @@ type Result struct {
 // Message extracts the message for the junit test case.
 //
 // Will use the first non-empty <failure/>, <skipped/>, <system-err/>, <system-out/> value.
-func (jr Result) Message() string {
-	const max = 140
+func (jr Result) Message(max int) string {
 	var msg string
 	switch {
 	case jr.Failure != nil && *jr.Failure != "":


### PR DESCRIPTION
* Wait for build.Suites() go-routines to finish before returning
* Test for bucket-write access before transferring
* Remove unused update flag
* Make override flag function correctly
* Add --repeat flag to make it run continuously
* Skip pending jobs by default
* Concurrently list builds in a group
* Concurrently transfer builds
* Allow longer error messages
* Better? logging

ref https://github.com/kubernetes/test-infra/issues/11009

/assign @krzyzacy @Katharine 