### PR TITLE
Add http proxy to httpTransport used for fetching kubernetes releases

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -33,6 +33,7 @@ var httpTransport *http.Transport
 
 func init() {
 	httpTransport = new(http.Transport)
+	httpTransport.Proxy = http.ProxyFromEnvironment
 	httpTransport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 }
 


### PR DESCRIPTION
The `http.transport` currently used in kubetest for fetching the kubernetes release doesn't allow usage of a proxy. 
When using kubetest in an air-gapped cluster or CI environment, this means that the environment variables `HTTP_PROXY` and `HTTPS_PROXY`, that would used by `curl`, are ignored by kubetest, making it impossible to download the release.

This patch adds the `http.ProxyFromEnvironment` method from the standard library to the `http.transport`. This method is used when fetching the k8s release and redirects traffic over the proxies set by the environment variables mentioned before. When no environment variables are set, or the `NO_PROXY` environment variable is set to the url used for fetching the release, kubetest should fetch the release as before.

/area kubetest