### PR TITLE
Usage of migratestatus has changed

### DIFF
--- a/maintenance/migratestatus/README.md
+++ b/maintenance/migratestatus/README.md
@@ -7,8 +7,11 @@ By default, this tool runs in dry-run mode and doesn't make any modifications.
 Pass `--dry-run=false` to actually change statuses.
 
 ### Usage
+
 ###### Modes
+
 This tool runs in one of three modes. Each mode is defined as a set of conditions on the statuses and an action to take if the conditions are met.
+
 - **copy** mode conditions on PRs that have the context to copy, but not the destination context. For each of these PRs, the 'copy' context's status is copied to the destination context.
 	- `$ ./migratestatus --copy="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
 - **retire** mode can be used to retire an old context with or without replacement. By setting the context's state to "success" the retired context can be ignored.
@@ -17,18 +20,39 @@ This tool runs in one of three modes. Each mode is defined as a set of condition
 	- `$ ./migratestatus --retire="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
 - **move** mode conditions on PRs that have the context to move, but not the destination context. For each of these PRs, a copy and retire action are performed. In other words, the status of the context to move is copied to the 'dest' context and then retired with 'dest' as the replacement.
 	- `$ ./migratestatus --move="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
+
 ###### Flags
+
 The migratestatus binary is run locally and can be built by running `go build` from this directory. The binary accepts the following parameters:
-- `--dry-run` Whether to perform modifying actions. Defaults to true.
-- `--logtostderr` Print logging to stderr. Recommended if you want to see what's
-  happening.
-- `--tokenfile` The file containing the github authentication token to use.
-- `--org` The organization that owns the repository to migrate contexts in. (Kubernetes)
-- `--repo` The repository to migrate contexts in.
-- Exactly one of the following flags must appear. Each indicates a mode and specifies a context:
-	- `--copy` The context to copy.
-	- `--retire` The context to retire.
-	- `--move` The context to move (copy and retire).
-- `--dest` The destination context. This is the context that is copied **to** and/or the context that replaces the retired context. This flag may only be omitted if retire mode is specified and the old context is being retired without a replacement.
+
+```
+Usage of ./migratestatus:
+  -branch-filter string
+    	A regular expression which the PR target branch must match to be modified. (Optional)
+  -continue-on-error
+    	Indicates that the migration should continue if context migration fails for an individual PR.
+  -copy string
+    	Indicates copy mode and specifies the context to copy.
+  -description string
+    	A URL to a page explaining why a context was migrated or retired. (Optional)
+  -dest string
+    	The destination context to copy or move to. For retire mode this is the context that replaced the retired context.
+  -dry-run
+    	Run in dry-run mode, performing no modifying actions. (default true)
+  -github-endpoint value
+    	GitHub's API endpoint (may differ for enterprise). (default https://api.github.com)
+  -github-token-file string
+    	DEPRECATED: use -github-token-path instead.  -github-token-file may be removed anytime after 2019-01-01.
+  -github-token-path string
+    	Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+  -move string
+    	Indicates move mode and specifies the context to move.
+  -org string
+    	The organization that owns the repo.
+  -repo string
+    	The repo needing status migration.
+  -retire string
+    	Indicates retire mode and specifies the context to retire.
+```
 
 Run the binary with the `-h` flag to see the rest of the available flags.


### PR DESCRIPTION
Specifically the github token flags changed. I figured it was just easiest to paste in the usage output.