### PR TITLE
Allow a blacklist for added presubmits in the reconciler

### DIFF
--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//prow/plugins:go_default_library",
         "//prow/statusreconciler:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/statusreconciler/BUILD.bazel
+++ b/prow/statusreconciler/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//prow/plugins:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Until a more elegant solution is added, we should allow for an admin to
configure a blacklist for presubmit additions in the status reconciler.
Large repos with thousands of open pull requests do not work with the
status reconciler's optimistic job triggering.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 