### PR TITLE
Make gerrit skip reporting aborted jobs

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -306,6 +306,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		if _, err := c.kc.CreateProwJob(pj); err != nil {
 			logger.WithError(err).Errorf("fail to create prowjob %v", pj)
 		} else {
+			logger.Infof("Triggered Prowjob %s", jSpec.spec.Job)
 			triggeredJobs = append(triggeredJobs, jSpec.spec.Job)
 		}
 	}

--- a/prow/gerrit/reporter/reporter.go
+++ b/prow/gerrit/reporter/reporter.go
@@ -66,6 +66,12 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 		return false
 	}
 
+	if pj.Status.State == v1.AbortedState {
+		// aborted (new patchset)
+		logrus.WithField("prowjob", pj.ObjectMeta.Name).Info("PJ aborted")
+		return false
+	}
+
 	// has gerrit metadata (scheduled by gerrit adapter)
 	if pj.ObjectMeta.Annotations[client.GerritID] == "" ||
 		pj.ObjectMeta.Annotations[client.GerritInstance] == "" ||
@@ -117,7 +123,7 @@ func (c *Client) Report(pj *v1.ProwJob) error {
 	}
 
 	// generate an aggregated report:
-	total := len(pjsOnRevision)
+	total := 0
 	success := 0
 	message := ""
 
@@ -127,6 +133,11 @@ func (c *Client) Report(pj *v1.ProwJob) error {
 			return nil
 		}
 
+		if pjOnRevision.Status.State == v1.AbortedState {
+			continue
+		}
+
+		total++
 		if pjOnRevision.Status.State == v1.SuccessState {
 			success++
 		}


### PR DESCRIPTION
Also trying to figure out why presubmit got triggered twice - we are base off patchset creation time which shouldn't really change but did? gerrit bug? Adding some logs...

/assign @amwat 