### PR TITLE
Add JobURLConfig option to Plank

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -52,6 +52,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *February 26, 2019* The `job_url_prefix` option from `plank` has been deprecated in
+    favor of the new `job_url_prefix_config` option which allows configuration on a global,
+    organization or repo level. `job_url_prefix` will be removed in September 2019.
  - *February 13, 2019* `horologium` and `sinker` deployments will soon require `--dry-run=false` in production, please set this before March 15. At that time flag will default to --dry-run=true instead of --dry-run=false.
  - *February 1, 2019* Now that `hook` and `tide` will no longer post "Skipped" statuses
    for jobs that do not need to run, it is not possible to require those statuses with

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -177,6 +177,7 @@ type Plank struct {
 	// Deprecated, use JobURLPrefixConfig instead
 	// JobURLPrefix is the host and path prefix under
 	// which job details will be viewable
+	// TODO @alvaroaleman: Remove in September 2019
 	JobURLPrefix string `json:"job_url_prefix,omitempty"`
 	// JobURLPrefixConfig is the host and path prefix under which job details
 	// will be viewable. Use `*` as key for your global default.

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1844,7 +1844,7 @@ github_reporter:
 	}
 }
 
-func TestPlankJobUrlPrefix(t *testing.T) {
+func TestPlankJobURLPrefix(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		plank                Plank
@@ -1852,48 +1852,59 @@ func TestPlankJobUrlPrefix(t *testing.T) {
 		expectedJobURLPrefix string
 	}{
 		{
-			name:                 "Nil refs returns jobUrlPrefix",
-			plank:                Plank{jobURLPrefix: "https://my-prow"},
+			name:                 "Nil refs returns jobURLPrefix",
+			plank:                Plank{JobURLPrefix: "https://my-prow"},
 			expectedJobURLPrefix: "https://my-prow",
 		},
 		{
-			name:                 "No overrideJobUrlPrefix returns jobURLPrefix",
-			plank:                Plank{jobURLPrefix: "https://my-prow"},
+			name:                 "No OverrideJobURLPrefix returns jobURLPrefix",
+			plank:                Plank{JobURLPrefix: "https://my-prow"},
 			refs:                 &prowapi.Refs{Org: "my-org", Repo: "my-repo"},
 			expectedJobURLPrefix: "https://my-prow",
 		},
 		{
 			name: "No matching refs returns jobURLPrefx",
 			plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https://my-alternate-prow"},
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https://my-alternate-prow"},
 				},
 			},
 			refs:                 &prowapi.Refs{Org: "my-default-org", Repo: "my-default-repo"},
 			expectedJobURLPrefix: "https://my-prow",
 		},
 		{
-			name: "Matching repo returns overrideJobUrlPrefix from repo",
+			name: "Matching repo returns OverrideJobURLPrefix from repo",
 			plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
 					"my-alternate-org": {
-						url:   "https://my-third-prow",
-						repos: map[string]string{"my-repo": "https://my-alternate-prow"}}},
+						URL:   "https://my-third-prow",
+						Repos: map[string]string{"my-repo": "https://my-alternate-prow"}}},
 			},
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-repo"},
 			expectedJobURLPrefix: "https://my-alternate-prow",
 		},
 		{
-			name: "Matching org and not matching repo returns overrideJobUrlPrefix from org",
+			name: "Matching org and not matching repo returns OverrideJobURLPrefix from org",
 			plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
 					"my-alternate-org": {
-						url:   "https://my-third-prow",
-						repos: map[string]string{"my-repo": "https://my-alternate-prow"}}},
+						URL:   "https://my-third-prow",
+						Repos: map[string]string{"my-repo": "https://my-alternate-prow"}}},
 			},
+			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"},
+			expectedJobURLPrefix: "https://my-third-prow",
+		},
+		{
+			name: "Matching org and repo returns OverrideJobURLPrefix from org",
+			plank: Plank{
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-alternate-org": {
+						URL: "https://my-third-prow",
+					}}},
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"},
 			expectedJobURLPrefix: "https://my-third-prow",
 		},
@@ -1901,8 +1912,8 @@ func TestPlankJobUrlPrefix(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if prefix := tc.plank.JobURLPrefix(tc.refs); prefix != tc.expectedJobURLPrefix {
-				t.Errorf("expected JobUrlPrefix to be '%s' but was '%s'", tc.expectedJobURLPrefix, prefix)
+			if prefix := tc.plank.GetJobURLPrefix(tc.refs); prefix != tc.expectedJobURLPrefix {
+				t.Errorf("expected JobURLPrefix to be %q but was %q", tc.expectedJobURLPrefix, prefix)
 			}
 		})
 	}
@@ -1910,99 +1921,99 @@ func TestPlankJobUrlPrefix(t *testing.T) {
 
 func TestValidateComponentConfig(t *testing.T) {
 	testCases := []struct {
-		Name       string
-		config     *Config
-		errEpexted bool
+		name        string
+		config      *Config
+		errExpected bool
 	}{
 		{
-			Name: "Empty jobURLPrefix and overrideJobUrlPrefixes, err",
+			name: "Empty JobURLPrefix and OverrideJobURLPrefixes, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https://my-alternate-prow"},
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https://my-alternate-prow"},
 				},
 			}}},
-			errEpexted: true,
+			errExpected: true,
 		},
 		{
-			Name:       "No overrides, valid url,  no err",
-			config:     &Config{ProwConfig: ProwConfig{Plank: Plank{jobURLPrefix: "https://my-prow"}}},
-			errEpexted: false,
+			name:        "No overrides, valid URL,  no err",
+			config:      &Config{ProwConfig: ProwConfig{Plank: Plank{JobURLPrefix: "https://my-prow"}}},
+			errExpected: false,
 		},
 		{
-			Name:       "No overrides, invalid url,  err",
-			config:     &Config{ProwConfig: ProwConfig{Plank: Plank{jobURLPrefix: "https:// my-prow"}}},
-			errEpexted: true,
+			name:        "No overrides, invalid URL,  err",
+			config:      &Config{ProwConfig: ProwConfig{Plank: Plank{JobURLPrefix: "https:// my-prow"}}},
+			errExpected: true,
 		},
 		{
-			Name: "Org override, valid urls, no err",
+			name: "Org override, valid URLs, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https://my-alternate-prow"},
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https://my-alternate-prow"},
 				},
 			}}},
-			errEpexted: false,
+			errExpected: false,
 		},
 		{
-			Name: "Org override, invalid jobUrlPrefix, err",
+			name: "Org override, invalid jobURLPrefix, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https:// my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https://my-alternate-prow"},
+				JobURLPrefix: "https:// my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https://my-alternate-prow"},
 				},
 			}}},
-			errEpexted: true,
+			errExpected: true,
 		},
 		{
-			Name: "Org override, invalid org url, err",
+			name: "Org override, invalid org URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https:// my-alternate-prow"},
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https:// my-alternate-prow"},
 				},
 			}}},
-			errEpexted: true,
+			errExpected: true,
 		},
 		{
-			Name: "Org override, invalid urls, err",
+			name: "Org override, invalid URLs, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https:// my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
-					"my-org": {url: "https:// my-alternate-prow"},
+				JobURLPrefix: "https:// my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
+					"my-org": {URL: "https:// my-alternate-prow"},
 				},
 			}}},
-			errEpexted: true,
+			errExpected: true,
 		},
 		{
-			Name: "Repo override, valid urls, no err",
+			name: "Repo override, valid URLs, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
 					"my-org": {
-						url:   "https://my-alternate-prow",
-						repos: map[string]string{"my-repo": "https://my-third-prow"}},
+						URL:   "https://my-alternate-prow",
+						Repos: map[string]string{"my-repo": "https://my-third-prow"}},
 				},
 			}}},
-			errEpexted: false,
+			errExpected: false,
 		},
 		{
-			Name: "Repo override, invalid repo url, err",
+			name: "Repo override, invalid repo URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				jobURLPrefix: "https://my-prow",
-				overrideJobUrlPrefix: map[string]*overrideJobUrlPrefix{
+				JobURLPrefix: "https://my-prow",
+				OverrideJobURLPrefix: map[string]*overrideJobURLPrefix{
 					"my-org": {
-						url:   "https://my-alternate-prow",
-						repos: map[string]string{"my-repo": "https:// my-third-prow"}},
+						URL:   "https://my-alternate-prow",
+						Repos: map[string]string{"my-repo": "https:// my-third-prow"}},
 				},
 			}}},
-			errEpexted: true,
+			errExpected: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			if hasErr := tc.config.validateComponentConfig() != nil; hasErr != tc.errEpexted {
-				t.Errorf("expected err: %t but was %t", tc.errEpexted, hasErr)
+		t.Run(tc.name, func(t *testing.T) {
+			if hasErr := tc.config.validateComponentConfig() != nil; hasErr != tc.errExpected {
+				t.Errorf("expected err: %t but was %t", tc.errExpected, hasErr)
 			}
 		})
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1853,15 +1853,15 @@ func TestPlankJobURLPrefix(t *testing.T) {
 	}{
 		{
 			name:                 "Nil refs returns default JobURLPrefix",
-			plank:                Plank{JobURLPrefixConfig: map[string]JobURLPrefixConfig{"*": {URL: "https://my-prow"}}},
+			plank:                Plank{JobURLPrefixConfig: map[string]string{"*": "https://my-prow"}},
 			expectedJobURLPrefix: "https://my-prow",
 		},
 		{
 			name: "No matching refs returns default JobURLPrefx",
 			plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*":      {URL: "https://my-prow"},
-					"my-org": {URL: "https://my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*":      "https://my-prow",
+					"my-org": "https://my-alternate-prow",
 				},
 			},
 			refs:                 &prowapi.Refs{Org: "my-default-org", Repo: "my-default-repo"},
@@ -1870,12 +1870,10 @@ func TestPlankJobURLPrefix(t *testing.T) {
 		{
 			name: "Matching repo returns JobURLPrefix from repo",
 			plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-prow"},
-					"my-alternate-org": {
-						URL:   "https://my-third-prow",
-						Repos: map[string]string{"my-repo": "https://my-alternate-prow"},
-					},
+				JobURLPrefixConfig: map[string]string{
+					"*":                        "https://my-prow",
+					"my-alternate-org":         "https://my-third-prow",
+					"my-alternate-org/my-repo": "https://my-alternate-prow",
 				},
 			},
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-repo"},
@@ -1884,12 +1882,10 @@ func TestPlankJobURLPrefix(t *testing.T) {
 		{
 			name: "Matching org and not matching repo returns JobURLPrefix from org",
 			plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-prow"},
-					"my-alternate-org": {
-						URL:   "https://my-third-prow",
-						Repos: map[string]string{"my-repo": "https://my-alternate-prow"},
-					},
+				JobURLPrefixConfig: map[string]string{
+					"*":                        "https://my-prow",
+					"my-alternate-org":         "https://my-third-prow",
+					"my-alternate-org/my-repo": "https://my-alternate-prow",
 				},
 			},
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"},
@@ -1898,11 +1894,9 @@ func TestPlankJobURLPrefix(t *testing.T) {
 		{
 			name: "Matching org without url returns default JobURLPrefix",
 			plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-prow"},
-					"my-alternate-org": {
-						Repos: map[string]string{"my-repo": "https://my-alternate-prow"},
-					},
+				JobURLPrefixConfig: map[string]string{
+					"*":                        "https://my-prow",
+					"my-alternate-org/my-repo": "https://my-alternate-prow",
 				},
 			},
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"},
@@ -1929,8 +1923,8 @@ func TestValidateComponentConfig(t *testing.T) {
 			name: `JobURLPrefix and JobURLPrefixConfig["*"].URL set, err`,
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
 				JobURLPrefix: "https://my-default-prow",
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*": "https://my-alternate-prow",
 				},
 			}}},
 			errExpected: true,
@@ -1939,42 +1933,30 @@ func TestValidateComponentConfig(t *testing.T) {
 			name: `JobURLPrefix and JobURLPrefixConfig["*"].URL unset, no err`,
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
 				JobURLPrefix: "https://my-default-prow",
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"my-other-org": {URL: "https://my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"my-other-org": "https://my-alternate-prow",
 				},
 			}}},
 			errExpected: false,
 		},
 		{
-			name: `JobURLPrefixConfig["*"].Repos set, err`,
-			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {
-						URL:   "https://my-alternate-prow",
-						Repos: map[string]string{"my-repo": "https://my-third-prow"},
-					},
-				},
-			}}},
-			errExpected: true,
-		},
-		{
 			name: "Valid default URL, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{"*": {URL: "https://my-prow"}}}}},
+				JobURLPrefixConfig: map[string]string{"*": "https://my-prow"}}}},
 			errExpected: false,
 		},
 		{
 			name: "Invalid default URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{"*": {URL: "https:// my-prow"}}}}},
+				JobURLPrefixConfig: map[string]string{"*": "https:// my-prow"}}}},
 			errExpected: true,
 		},
 		{
 			name: "Org config, valid URLs, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*":      {URL: "https://my-prow"},
-					"my-org": {URL: "https://my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*":      "https://my-prow",
+					"my-org": "https://my-alternate-prow",
 				},
 			}}},
 			errExpected: false,
@@ -1982,9 +1964,9 @@ func TestValidateComponentConfig(t *testing.T) {
 		{
 			name: "Org override, invalid default jobURLPrefix URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*":      {URL: "https:// my-prow"},
-					"my-org": {URL: "https://my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*":      "https:// my-prow",
+					"my-org": "https://my-alternate-prow",
 				},
 			}}},
 			errExpected: true,
@@ -1992,9 +1974,9 @@ func TestValidateComponentConfig(t *testing.T) {
 		{
 			name: "Org override, invalid org URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*":      {URL: "https://my-prow"},
-					"my-org": {URL: "https:// my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*":      "https://my-prow",
+					"my-org": "https:// my-alternate-prow",
 				},
 			}}},
 			errExpected: true,
@@ -2002,9 +1984,9 @@ func TestValidateComponentConfig(t *testing.T) {
 		{
 			name: "Org override, invalid URLs, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*":      {URL: "https:// my-prow"},
-					"my-org": {URL: "https:// my-alternate-prow"},
+				JobURLPrefixConfig: map[string]string{
+					"*":      "https:// my-prow",
+					"my-org": "https:// my-alternate-prow",
 				},
 			}}},
 			errExpected: true,
@@ -2012,25 +1994,21 @@ func TestValidateComponentConfig(t *testing.T) {
 		{
 			name: "Repo override, valid URLs, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-prow"},
-					"my-org": {
-						URL:   "https://my-alternate-prow",
-						Repos: map[string]string{"my-repo": "https://my-third-prow"}},
-				},
-			}}},
+				JobURLPrefixConfig: map[string]string{
+					"*":              "https://my-prow",
+					"my-org":         "https://my-alternate-prow",
+					"my-org/my-repo": "https://my-third-prow",
+				}}}},
 			errExpected: false,
 		},
 		{
 			name: "Repo override, invalid repo URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]JobURLPrefixConfig{
-					"*": {URL: "https://my-prow"},
-					"my-org": {
-						URL:   "https://my-alternate-prow",
-						Repos: map[string]string{"my-repo": "https:// my-third-prow"}},
-				},
-			}}},
+				JobURLPrefixConfig: map[string]string{
+					"*":              "https://my-prow",
+					"my-org":         "https://my-alternate-prow",
+					"my-org/my-repo": "https:// my-third-prow",
+				}}}},
 			errExpected: true,
 		},
 	}

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -247,12 +247,12 @@ func ProwJobFields(pj *prowapi.ProwJob) logrus.Fields {
 //
 // TODO(fejta): consider moving default JobURLTemplate and JobURLPrefix out of plank
 func JobURL(plank config.Plank, pj prowapi.ProwJob, log *logrus.Entry) string {
-	if pj.Spec.DecorationConfig != nil && plank.JobURLPrefix != "" {
+	if pj.Spec.DecorationConfig != nil && plank.JobURLPrefix(pj.Spec.Refs) != "" {
 		spec := downwardapi.NewJobSpec(pj.Spec, pj.Status.BuildID, pj.Name)
 		gcsConfig := pj.Spec.DecorationConfig.GCSConfiguration
 		_, gcsPath, _ := gcsupload.PathsForJob(gcsConfig, &spec, "")
 
-		prefix, _ := url.Parse(plank.JobURLPrefix)
+		prefix, _ := url.Parse(plank.JobURLPrefix(pj.Spec.Refs))
 		prefix.Path = path.Join(prefix.Path, gcsConfig.Bucket, gcsPath)
 		return prefix.String()
 	}

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -247,12 +247,12 @@ func ProwJobFields(pj *prowapi.ProwJob) logrus.Fields {
 //
 // TODO(fejta): consider moving default JobURLTemplate and JobURLPrefix out of plank
 func JobURL(plank config.Plank, pj prowapi.ProwJob, log *logrus.Entry) string {
-	if pj.Spec.DecorationConfig != nil && plank.JobURLPrefix(pj.Spec.Refs) != "" {
+	if pj.Spec.DecorationConfig != nil && plank.GetJobURLPrefix(pj.Spec.Refs) != "" {
 		spec := downwardapi.NewJobSpec(pj.Spec, pj.Status.BuildID, pj.Name)
 		gcsConfig := pj.Spec.DecorationConfig.GCSConfiguration
 		_, gcsPath, _ := gcsupload.PathsForJob(gcsConfig, &spec, "")
 
-		prefix, _ := url.Parse(plank.JobURLPrefix(pj.Spec.Refs))
+		prefix, _ := url.Parse(plank.GetJobURLPrefix(pj.Spec.Refs))
 		prefix.Path = path.Join(prefix.Path, gcsConfig.Bucket, gcsPath)
 		return prefix.String()
 	}

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -628,7 +628,7 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcslib",
 			plank: config.Plank{
-				JobURLPrefix: "https://gubernator.com/build",
+				JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "https://gubernator.com/build"}},
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -628,7 +628,7 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcslib",
 			plank: config.Plank{
-				JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "https://gubernator.com/build"}},
+				JobURLPrefixConfig: map[string]string{"*": "https://gubernator.com/build"},
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -628,7 +628,7 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcslib",
 			plank: config.Plank{
-				jobURLPrefix: "https://gubernator.com/build",
+				JobURLPrefix: "https://gubernator.com/build",
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -628,7 +628,7 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcslib",
 			plank: config.Plank{
-				JobURLPrefix: "https://gubernator.com/build",
+				jobURLPrefix: "https://gubernator.com/build",
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,

--- a/prow/pubsub/reporter/reporter.go
+++ b/prow/pubsub/reporter/reporter.go
@@ -125,6 +125,6 @@ func (c *Client) generateMessageFromPJ(pj *prowapi.ProwJob) *ReportMessage {
 		RunID:   pubSubMap[PubSubRunIDLabel],
 		Status:  pj.Status.State,
 		URL:     pj.Status.URL,
-		GCSPath: strings.Replace(pj.Status.URL, c.config().Plank.JobURLPrefix, GCSPrefix, 1),
+		GCSPath: strings.Replace(pj.Status.URL, c.config().Plank.JobURLPrefix(pj.Spec.Refs), GCSPrefix, 1),
 	}
 }

--- a/prow/pubsub/reporter/reporter.go
+++ b/prow/pubsub/reporter/reporter.go
@@ -125,6 +125,6 @@ func (c *Client) generateMessageFromPJ(pj *prowapi.ProwJob) *ReportMessage {
 		RunID:   pubSubMap[PubSubRunIDLabel],
 		Status:  pj.Status.State,
 		URL:     pj.Status.URL,
-		GCSPath: strings.Replace(pj.Status.URL, c.config().Plank.JobURLPrefix(pj.Spec.Refs), GCSPrefix, 1),
+		GCSPath: strings.Replace(pj.Status.URL, c.config().Plank.GetJobURLPrefix(pj.Spec.Refs), GCSPrefix, 1),
 	}
 }

--- a/prow/pubsub/reporter/reporter_test.go
+++ b/prow/pubsub/reporter/reporter_test.go
@@ -149,7 +149,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 		c: &config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "guber/",
+					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "guber/"}},
 				},
 			},
 		},

--- a/prow/pubsub/reporter/reporter_test.go
+++ b/prow/pubsub/reporter/reporter_test.go
@@ -149,7 +149,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 		c: &config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					jobURLPrefix: "guber/",
+					JobURLPrefix: "guber/",
 				},
 			},
 		},

--- a/prow/pubsub/reporter/reporter_test.go
+++ b/prow/pubsub/reporter/reporter_test.go
@@ -149,7 +149,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 		c: &config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "guber/"}},
+					JobURLPrefixConfig: map[string]string{"*": "guber/"},
 				},
 			},
 		},

--- a/prow/pubsub/reporter/reporter_test.go
+++ b/prow/pubsub/reporter/reporter_test.go
@@ -149,7 +149,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 		c: &config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "guber/",
+					jobURLPrefix: "guber/",
 				},
 			},
 		},

--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -72,7 +72,7 @@ func (s *Spyglass) prowToGCS(prowKey string) (string, error) {
 	}
 
 	url := job.Status.URL
-	prefix := s.config().Plank.JobURLPrefix(job.Spec.Refs)
+	prefix := s.config().Plank.GetJobURLPrefix(job.Spec.Refs)
 	if !strings.HasPrefix(url, prefix) {
 		return "", fmt.Errorf("unexpected job URL %q when finding GCS path: expected something starting with %q", url, prefix)
 	}

--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -72,7 +72,7 @@ func (s *Spyglass) prowToGCS(prowKey string) (string, error) {
 	}
 
 	url := job.Status.URL
-	prefix := s.config().Plank.JobURLPrefix
+	prefix := s.config().Plank.JobURLPrefix(job.Spec.Refs)
 	if !strings.HasPrefix(url, prefix) {
 		return "", fmt.Errorf("unexpected job URL %q when finding GCS path: expected something starting with %q", url, prefix)
 	}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -543,7 +543,7 @@ func TestRunPath(t *testing.T) {
 		fca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					jobURLPrefix: "http://magic/view/gcs/",
+					JobURLPrefix: "http://magic/view/gcs/",
 				},
 			},
 		})
@@ -775,7 +775,7 @@ func TestProwToGCS(t *testing.T) {
 			c: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						jobURLPrefix: tc.configPrefix,
+						JobURLPrefix: tc.configPrefix,
 					},
 				},
 			},
@@ -1064,7 +1064,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 		c: config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					jobURLPrefix: "https://gubernator.example.com/build/",
+					JobURLPrefix: "https://gubernator.example.com/build/",
 				},
 			},
 		},

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -543,7 +543,7 @@ func TestRunPath(t *testing.T) {
 		fca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "http://magic/view/gcs/",
+					jobURLPrefix: "http://magic/view/gcs/",
 				},
 			},
 		})
@@ -775,7 +775,7 @@ func TestProwToGCS(t *testing.T) {
 			c: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						JobURLPrefix: tc.configPrefix,
+						jobURLPrefix: tc.configPrefix,
 					},
 				},
 			},
@@ -1064,7 +1064,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 		c: config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "https://gubernator.example.com/build/",
+					jobURLPrefix: "https://gubernator.example.com/build/",
 				},
 			},
 		},

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -543,7 +543,7 @@ func TestRunPath(t *testing.T) {
 		fca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "http://magic/view/gcs/"}},
+					JobURLPrefixConfig: map[string]string{"*": "http://magic/view/gcs/"},
 				},
 			},
 		})
@@ -775,7 +775,7 @@ func TestProwToGCS(t *testing.T) {
 			c: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: tc.configPrefix}},
+						JobURLPrefixConfig: map[string]string{"*": tc.configPrefix},
 					},
 				},
 			},
@@ -1064,7 +1064,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 		c: config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "https://gubernator.example.com/build/"}},
+					JobURLPrefixConfig: map[string]string{"*": "https://gubernator.example.com/build/"},
 				},
 			},
 		},

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -543,7 +543,7 @@ func TestRunPath(t *testing.T) {
 		fca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "http://magic/view/gcs/",
+					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "http://magic/view/gcs/"}},
 				},
 			},
 		})
@@ -775,7 +775,7 @@ func TestProwToGCS(t *testing.T) {
 			c: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						JobURLPrefix: tc.configPrefix,
+						JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: tc.configPrefix}},
 					},
 				},
 			},
@@ -1064,7 +1064,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 		c: config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					JobURLPrefix: "https://gubernator.example.com/build/",
+					JobURLPrefixConfig: map[string]config.JobURLPrefixConfig{"*": {URL: "https://gubernator.example.com/build/"}},
 				},
 			},
 		},


### PR DESCRIPTION
As we have some private and some public repos being tested via the same Prow instance, we need a way to configure `JobURLPrefix` on a per-repo basis or we will be stuck with `job_url_template` forever.

/assign @stevekuznetsov 