### PR TITLE
Speed up spyglass log rendering

### DIFF
--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -1,7 +1,10 @@
 body {
     padding-left: 15px;
     padding-bottom: 10px;
-    width: calc(100% - 15px);
+}
+
+html {
+    overflow-x: hidden;
 }
 
 table button {
@@ -21,6 +24,8 @@ table button {
     margin: 0;
     line-height:1.2;
     color: #fff;
+    table-layout: fixed;
+    width: calc(100% - 30px);
     /*background-color: #212121;*/
 }
 .loglines td {
@@ -41,11 +46,18 @@ td {
 tr {
     border: none;
 }
+
 .linenum {
     user-select: none;
     color: rgba(255,255,2552,0.6);
     text-align: right;
     vertical-align: top;
+    width: 50px;
+    text-overflow: ellipsis;
+}
+
+.linetext {
+    width: calc(100% - 50px);
 }
 
 /* ansi colors from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors */

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -57,7 +57,7 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string 
 }
 
 // errRE matches keywords and glog error messages
-var errRE = regexp.MustCompile(`(?i)(\s|^)timed out\b|(\s|^)error(s)?\b|(\s|^)fail(ure|ed)?\b|(\s|^)fatal\b|(\s|^)panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
+var errRE = regexp.MustCompile(`timed out|ERROR:|(\s|^)(FAIL|Failure \[)\b|(\s|^)panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
 
 func init() {
 	lenses.RegisterLens(Lens{})

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -71,7 +71,7 @@ func TestGroupLines(t *testing.T) {
 			name: "Test skip none",
 			lines: []string{
 				"a", "b", "c", "d", "e",
-				"Failed to immanentize the eschaton.",
+				"ERROR: Failed to immanentize the eschaton.",
 				"a", "b", "c", "d", "e",
 			},
 			groups: []LineGroup{
@@ -80,7 +80,7 @@ func TestGroupLines(t *testing.T) {
 					End:        11,
 					Skip:       false,
 					ByteOffset: 0,
-					ByteLength: 55,
+					ByteLength: 62,
 				},
 			},
 		},
@@ -88,7 +88,7 @@ func TestGroupLines(t *testing.T) {
 			name: "Test skip threshold",
 			lines: []string{
 				"a", "b", "c", "d", // skip threshold unmet
-				"a", "b", "c", "d", "e", "Failed to immanentize the eschaton.", "a", "b", "c", "d", "e",
+				"a", "b", "c", "d", "e", "ERROR: Failed to immanentize the eschaton.", "a", "b", "c", "d", "e",
 				"a", "b", "c", "d", "e", // skip threshold met
 			},
 			groups: []LineGroup{
@@ -104,13 +104,13 @@ func TestGroupLines(t *testing.T) {
 					End:        15,
 					Skip:       false,
 					ByteOffset: 8,
-					ByteLength: 55,
+					ByteLength: 62,
 				},
 				{
 					Start:      15,
 					End:        20,
 					Skip:       true,
-					ByteOffset: 64,
+					ByteOffset: 71,
 					ByteLength: 9,
 				},
 			},

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -13,8 +13,8 @@
     {{if $g.Skip}}
       <tbody class="show-skipped" data-artifact="{{$log.ArtifactName}}" data-offset="{{$g.ByteOffset}}" data-length="{{$g.ByteLength}}" data-start-line="{{$g.Start}}">
       <tr>
-        <td></td>
-        <td><button> skipped {{$g.LinesSkipped}} lines <i class="material-icons" style="font-size: 1em; vertical-align: middle;">unfold_more</i></button></td>
+        <td class="linenum"></td>
+        <td class="linetext"><button> skipped {{$g.LinesSkipped}} lines <i class="material-icons" style="font-size: 1em; vertical-align: middle;">unfold_more</i></button></td>
       </tr>
       </tbody>
     {{else}}
@@ -33,7 +33,7 @@
   {{range .}}
     <tr>
       <td class="linenum">{{.Number}}</td>
-      <td>
+      <td class="linetext">
         <span {{if .Highlighted}}class="line-highlighted"{{end}}>
           {{- range .SubLines -}}<span {{if .Highlighted}}class="match-highlighted"{{end}}>{{.Text}}</span>{{- end -}}
         </span>


### PR DESCRIPTION
This PR makes two changes to make spyglass hang less on loading pages with gigantic logs:

- Improve the efficiency with which the layout engine can work
- Be significantly more selective in which lines we highlight

This PR will cause suboptimal rendering if your log has more than 999,999 lines, but this is probably okay.

/cc @BenTheElder 