### PR TITLE
Change pod pending timeout's state from aborted to error

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -411,8 +411,8 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			// Pod is stuck in pending state longer than maxPodPending
 			// abort the job, and talk to Github
 			pj.SetComplete()
-			pj.Status.State = prowapi.AbortedState
-			pj.Status.Description = "Job aborted."
+			pj.Status.State = prowapi.ErrorState
+			pj.Status.Description = "Pod pending timeout."
 
 		default:
 			// Pod is running. Do nothing.

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1109,11 +1109,11 @@ func TestSyncPendingJob(t *testing.T) {
 					},
 				},
 			},
-			expectedState:    prowapi.AbortedState,
+			expectedState:    prowapi.ErrorState,
 			expectedNumPods:  1,
 			expectedComplete: true,
 			expectedReport:   true,
-			expectedURL:      "nightmare/aborted",
+			expectedURL:      "nightmare/error",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
As discussed with Steve(stevekuznetsov) and Cole(cjwagner), the prow status for pending pod timeout should be "error" instead of aborted.
Pod pending timeout usually indicates problems, instead of expected abortions.
Aborted state should be used for actually aborted jobs, such as abortion caused by re-runs.