### PR TITLE
drop the ginkgo call within kubemark tester, if --test-cmd is set

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -636,6 +636,11 @@ func kubemarkTest(testArgs []string, dump string, o options, deploy deployer) er
 			return err
 		}
 
+		// running test in clusterloader, or other custom commands, skip the ginkgo call
+		if o.testCmd != "" {
+			return nil
+		}
+
 		// TODO(krzyzacy): unsure if the envs in kubemark/util.sh makes a difference to e2e tests
 		//                 will verify and remove (or uncomment) next
 		//util := os.Getenv("WORKSPACE") + "/kubernetes/cluster/kubemark/util.sh"


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/11388

looks like all existing kubemark tests are using clusterloader now

/assign @wojtek-t 
cc @BenTheElder 