### PR TITLE
add Prow configs for container image promoter

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/OWNERS
+++ b/config/jobs/kubernetes/sig-release/cip/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- dims
+- hh
+- listx
+- tpepper

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  kubernetes/k8s.io:
+  - name: pull-k8sio-cip
+    decorate: true
+    skip_report: false
+    run_if_changed: ".*/manifest.yaml"
+    # It's OK to run things concurrently, because we're using "-dry-run".
+    max_concurrency: 10
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/cip-demo-staging/cip:20190401-v1.0.0-3-g44d6169
+        command:
+        - multirun.sh
+        args:
+        - /app/cip-docker-image.binary
+        - k8s-staging-cluster-api/manifest.yaml
+        - k8s-staging-coredns/manifest.yaml
+        - k8s-staging-csi/manifest.yaml
+        env:
+        - name: CIP_GIT_DIR
+          # Pod Utilities already sets pwd to
+          # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
+          # suffice, but it's nice to be explicit.
+          value: "/home/prow/go/src/github.com/kubernetes/k8s.io"

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -71,6 +71,39 @@ postsubmits:
       - name: creds
         secret:
           secretName: pusher-service-account
+  kubernetes/k8s.io:
+  - name: post-k8sio-cip
+    cluster: test-infra-trusted
+    decorate: true
+    run_if_changed: ".*/manifest.yaml"
+    # Never run more than 1 job at a time. This is because we don't want to run
+    # into a case where an older manifest PR merge gets run last (after a newer
+    # one).
+    max_concurrency: 1
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/cip-demo-staging/cip:20190401-v1.0.0-3-g44d6169
+        command:
+        - multirun.sh
+        args:
+        - /app/cip-docker-image.binary
+        - k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        env:
+        - name: CIP_OPTS
+          value: "-dry-run=false"
+        volumeMounts:
+        - name: k8s-gcr-prod-service-account-creds
+          mountPath: /etc/k8s-gcr-prod-service-account
+          readOnly: true
+      volumes:
+      - name: k8s-gcr-prod-service-account-creds
+        secret:
+          secretName: k8s-gcr-prod-service-account
+
 
 periodics:
 - interval: 24h
@@ -319,4 +352,69 @@ periodics:
     - name: config
       configMap:
         name: label-config
-
+# ci-k8sio-cip runs daily, to make sure that the destination GCRs do not deviate
+# away from the intent of the manifest.
+- interval: 24h
+  max_concurrency: 1
+  # This name is the "job name", passed in as "--job=NAME" for mkpj.
+  name: ci-k8sio-cip
+  # Enable Pod Utilities. See https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md.
+  decorate: true
+  extra_refs:
+  # Because of Pod Utilities, we clone the below repo automatically, and, get
+  # dropped into /home/prow/go/src/github.com/kubernetes/k8s.io.
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: master
+  spec:
+    containers:
+    # TODO: Move the official cip image to a more serious location.
+    #
+    # To check the Go binary version in the image, run:
+    #
+    #   docker run --rm -it gcr.io/cip-demo-staging/cip:20190401-v1.0.0-3-g44d6169 "cip -version"
+    #
+    # You can also nspect the /cip folder in the image's filesystem with an
+    # interactive bash session:
+    #
+    #   docker run --rm -it gcr.io/cip-demo-staging/cip:20190401-v1.0.0-3-g44d6169 "cd /cip && bash"
+    - image: gcr.io/cip-demo-staging/cip:20190401-v1.0.0-3-g44d6169
+      command:
+      - multirun.sh
+      args:
+      # This is aided by Pod Utilities because of "decorate: true", which
+      # populates the manifest repo for us. There is also PULL_REFS and
+      # PULL_BASE_SHA defined for us.
+      #
+      # If you run mkpj for this postsubmit, the job will query you for the base
+      # ref to fetch (name of a branch, not a SHA, e.g. "master").
+      - /app/cip-docker-image.binary
+      - k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      env:
+      - name: CIP_OPTS
+        value: "-dry-run=false"
+      # TODO: Uncomment this once
+      # https://github.com/GoogleCloudPlatform/k8s-container-image-promoter/issues/16
+      # lands.
+      #- name: CIP_OPTS
+      #  # Be aggressive about keeping the prod registry clean.
+      #  value: "-delete-extra-tags"
+      volumeMounts:
+      - name: k8s-gcr-prod-service-account-creds
+        mountPath: /etc/k8s-gcr-prod-service-account
+        readOnly: true
+    # Create a volume from a Kubernetes Secret. The Secret can be created as
+    # per: https://kubernetes.io/docs/concepts/configuration/secret/.
+    #
+    # In our case we downloaded a service account secret key file from GCP, then ran
+    #
+    #   kubectl create secret generic k8s-gcr-prod-service-account \
+    #     --from-file=service-account.json=PATH/TO/cip-demo-staging-e881274d0046.json
+    #
+    # and so our secretName is k8s-gcr-prod-service-account.
+    volumes:
+    - name: k8s-gcr-prod-service-account-creds
+      secret:
+        secretName: k8s-gcr-prod-service-account

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -456,6 +456,9 @@ plugins:
   kubernetes/federation:
   - trigger
 
+  kubernetes/k8s.io:
+  - trigger
+
   kubernetes/kops:
   - trigger
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -51,6 +51,10 @@ default_dashboard_tab:
 #
 
 test_groups:
+- name: post-k8sio-cip
+  gcs_prefix: kubernetes-jenkins/logs/post-k8sio-cip
+- name: ci-k8sio-cip
+  gcs_prefix: kubernetes-jenkins/logs/ci-k8sio-cip
 - name: ci-cadvisor-canarypush
   gcs_prefix: kubernetes-jenkins/logs/ci-cadvisor-canarypush
 - name: ci-cadvisor-e2e
@@ -5239,6 +5243,10 @@ dashboards:
     test_group_name: ci-kops-build
   - name: debian-unstable
     test_group_name: ci-kubernetes-build-debian-unstable
+  - name: post-k8sio-cip
+    test_group_name: post-k8sio-cip
+  - name: ci-k8sio-cip
+    test_group_name: ci-k8sio-cip
   - name: periodic-packages-pushed
     test_group_name: periodic-kubernetes-e2e-packages-pushed
   - name: periodic-packages-install-deb


### PR DESCRIPTION
Uploading this to receive feedback about how to merge these configs into the main ones in `test-infra/prow/{config,plugins}.yaml`.

AFAICS the configs `test-infra/prow/{config,plugins}.yaml` hold the monolithic prow configs for all Prow jobs.

Some open questions:
- how do we make Prow only schedule these jobs in a new cluster with a limited set of permissions, as suggested in https://github.com/kubernetes/k8s.io/issues/157#issuecomment-465755277 ?
- where will the promoter manifest (YAML file with a list of Docker images to be promoted) live? (github.com/kubernetes/k8s.io ?)