### PR TITLE
Allow report postsubmit jobs for k8s prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -473,6 +473,10 @@ tide:
 push_gateway:
   endpoint: pushgateway
 
+github_reporter: 
+  job_types_to_report:
+  - presubmit
+  - postsubmit
 
 presets:
 # credential presets


### PR DESCRIPTION
To enable after https://github.com/kubernetes/test-infra/pull/11168

/assign @fejta @cjwagner 