### PR TITLE
Update sig-windows job with env var KUBE_VERBOSE

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -16,6 +16,8 @@ presets:
     value: https://raw.githubusercontent.com/Azure/acs-engine/master/scripts/build-windows-k8s.sh
   - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
     value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-ws2019
+  - name: KUBE_VERBOSE
+    value: 0
   volumes:
   - name: azure-cred
     secret:


### PR DESCRIPTION
KUBE_VERBOSE=0 should quiet down the output generated by make when building hyperkube/windows binaries.