### PR TITLE
Shorten api-review label description

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -47,7 +47,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="api-review" href="#api-review">`api-review`</a> | Categorizes an issue or PR as actively needing an API review. See https://git.k8s.io/community/sig-architecture/api-review-process.md| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="api-review" href="#api-review">`api-review`</a> | Categorizes an issue or PR as actively needing an API review.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/licensing" href="#area/licensing">`area/licensing`</a> | Issues or PRs related to Kubernetes licensing| label | |
 | <a id="committee/conduct" href="#committee/conduct">`committee/conduct`</a> | Denotes an issue or PR intended to be handled by the code of conduct committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="committee/product-security" href="#committee/product-security">`committee/product-security`</a> | Denotes an issue or PR intended to be handled by the product security committee.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -9,7 +9,7 @@
 default:
   labels:
     - color: e11d21
-      description: Categorizes an issue or PR as actively needing an API review. See https://git.k8s.io/community/sig-architecture/api-review-process.md
+      description: Categorizes an issue or PR as actively needing an API review.
       name: api-review
       target: both
       prowPlugin: label


### PR DESCRIPTION
Sadly, label descriptions cannot accommodate a description that long.

cc @fejta 