### PR TITLE
Catch invalid labels earlier

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -247,29 +247,28 @@ func (c Configuration) Labels() []Label {
 // TODO(spiffxp): needs to validate labels duped across repos are identical
 // Ensures the config does not duplicate label names between default and repo
 func (c Configuration) validate(orgs string) error {
-	if len(orgs) == 0 {
-		return nil
-	}
-
-	// Generate list of orgs
-	sortedOrgs := strings.Split(orgs, ",")
-	sort.Strings(sortedOrgs)
 	// Check default labels
 	seen, err := validate(c.Default.Labels, "default", make(map[string]string))
 	if err != nil {
 		return fmt.Errorf("invalid config: %v", err)
 	}
+
+	// Generate list of orgs
+	sortedOrgs := strings.Split(orgs, ",")
+	sort.Strings(sortedOrgs)
 	// Check other repos labels
 	for repo, repoconfig := range c.Repos {
 		// Will complain if a label is both in default and repo
 		if _, err := validate(repoconfig.Labels, repo, seen); err != nil {
 			return fmt.Errorf("invalid config: %v", err)
 		}
-		// Warn if repo isn't under orgs
-		data := strings.Split(repo, "/")
-		if len(data) == 2 {
-			if !stringInSortedSlice(data[0], sortedOrgs) {
-				logrus.WithField("orgs", orgs).WithField("org", data[0]).WithField("repo", repo).Warn("Repo isn't inside orgs")
+		// If orgs have been specified, warn if repo isn't under orgs
+		if len(orgs) != 0 {
+			data := strings.Split(repo, "/")
+			if len(data) == 2 {
+				if !stringInSortedSlice(data[0], sortedOrgs) {
+					logrus.WithField("orgs", orgs).WithField("org", data[0]).WithField("repo", repo).Warn("Repo isn't inside orgs")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously the code to verify labels was only being run if
the --orgs flag was passed.  This allowed people to check in
invalid labels (description too long) and not find out about
it until the first time the label-sync job ran.

This change will validate all labels regardless of whether
--orgs is passed in, allowing the hack/update-labels.sh
script to catch invalid labels. The warning about repos not
being in --orgs is only triggered if --orgs is passed in
the first place

ref: https://github.com/kubernetes/test-infra/pull/11418