### PR TITLE
Remove the stale `Report` field in build postsubmit

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -3,7 +3,6 @@ postsubmits:
   - name: post-test-infra-build-smoke
     agent: knative-build
     decorate: true
-    report: true
     build_spec:
       steps:
       - name: first


### PR DESCRIPTION
This field has been migrated to `Skip_Report` and is default to false (report: true) now

/assign @fejta 