### PR TITLE
boskos: AWS janitor region via env var

### DIFF
--- a/maintenance/aws-janitor/cmd/aws-resources-list/BUILD.bazel
+++ b/maintenance/aws-janitor/cmd/aws-resources-list/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//maintenance/aws-janitor/account:go_default_library",
+        "//maintenance/aws-janitor/regions:go_default_library",
         "//maintenance/aws-janitor/resources:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
     ],

--- a/maintenance/aws-janitor/cmd/aws-resources-list/main.go
+++ b/maintenance/aws-janitor/cmd/aws-resources-list/main.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"k8s.io/test-infra/maintenance/aws-janitor/account"
+	"k8s.io/test-infra/maintenance/aws-janitor/regions"
 	"k8s.io/test-infra/maintenance/aws-janitor/resources"
 )
 
-const (
-	region = "us-east-1"
+var (
+	region = flag.String("region", regions.Default, "")
 )
 
 func main() {
@@ -35,14 +36,14 @@ func main() {
 	resourceKinds := append(resources.RegionalTypeList, resources.GlobalTypeList...)
 
 	session := session.Must(session.NewSession())
-	acct, err := account.GetAccount(session, region)
+	acct, err := account.GetAccount(session, *region)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error retrieving account: %v", err)
 		os.Exit(1)
 	}
 
 	for _, r := range resourceKinds {
-		set, err := r.ListAll(session, acct, region)
+		set, err := r.ListAll(session, acct, *region)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", r, err)
 			continue

--- a/maintenance/aws-janitor/main.go
+++ b/maintenance/aws-janitor/main.go
@@ -32,6 +32,7 @@ import (
 
 var (
 	maxTTL = flag.Duration("ttl", 24*time.Hour, "Maximum time before we attempt deletion of a resource. Set to 0s to nuke all non-default resources.")
+	region = flag.String("region", regions.Default, "")
 	path   = flag.String("path", "", "S3 path to store mark data in (required)")
 )
 
@@ -77,7 +78,7 @@ func main() {
 	}
 
 	for _, typ := range resources.GlobalTypeList {
-		if err := typ.MarkAndSweep(sess, acct, "us-east-1", res); err != nil {
+		if err := typ.MarkAndSweep(sess, acct, *region, res); err != nil {
 			klog.Errorf("Error sweeping %T: %v", typ, err)
 			return
 		}

--- a/maintenance/aws-janitor/regions/regions.go
+++ b/maintenance/aws-janitor/regions/regions.go
@@ -17,13 +17,21 @@ limitations under the License.
 package regions
 
 import (
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // Default is the region we use when no region is applicable
-const Default = "us-east-1"
+var Default string
+
+func init() {
+	if Default = os.Getenv("AWS_DEFAULT_REGION"); Default == "" {
+		Default = "us-east-1"
+	}
+}
 
 // GetAll retrieves all regions from the AWS API
 func GetAll(sess *session.Session) ([]string, error) {

--- a/maintenance/aws-janitor/resources/dhcp_options.go
+++ b/maintenance/aws-janitor/resources/dhcp_options.go
@@ -131,6 +131,10 @@ func defaultLookingDHCPOptions(dhcp *ec2.DhcpOptions, region string) bool {
 		switch *conf.Key {
 		case "domain-name":
 			var domain string
+			// TODO(akutz): Should this be updated to regions.Default, or is
+			// this relying on the default region for EC2 for North America?
+			// Because EC2's default region changed from us-east-1 to us-east-2
+			// depending on when the account was created.
 			if region == "us-east-1" {
 				domain = "ec2.internal"
 			} else {

--- a/maintenance/aws-janitor/s3/BUILD.bazel
+++ b/maintenance/aws-janitor/s3/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/maintenance/aws-janitor/s3",
     visibility = ["//visibility:public"],
     deps = [
+        "//maintenance/aws-janitor/regions:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",

--- a/maintenance/aws-janitor/s3/s3.go
+++ b/maintenance/aws-janitor/s3/s3.go
@@ -23,10 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-)
 
-const (
-	defaultRegion = "us-east-1"
+	"k8s.io/test-infra/maintenance/aws-janitor/regions"
 )
 
 type Path struct {
@@ -45,14 +43,14 @@ func GetPath(sess *session.Session, s string) (*Path, error) {
 		return nil, fmt.Errorf("Scheme %q != 's3'", url.Scheme)
 	}
 
-	svc := s3.New(sess, &aws.Config{Region: aws.String(defaultRegion)})
+	svc := s3.New(sess, &aws.Config{Region: aws.String(regions.Default)})
 
 	resp, err := svc.GetBucketLocation(&s3.GetBucketLocationInput{Bucket: aws.String(url.Host)})
 	if err != nil {
 		return nil, err
 	}
 
-	region := defaultRegion
+	region := regions.Default
 	if resp.LocationConstraint != nil {
 		region = *resp.LocationConstraint
 	}


### PR DESCRIPTION
This patch updates the AWS janitor for boskos to get AWS's default region from the environment variable `AWS_DEFAULT_REGION`. If the environment variable has an empty value, the value defaults to the previous default of `us-east-1`.

/area boskos
/cc @liztio @detiber @vincepri 