### PR TITLE
Remove CSIMigration=false alpha gate flag from stable (<v1.14) k8s test jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -3762,7 +3762,7 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/k8s-stable2
       - --timeout=180m
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
@@ -5360,7 +5360,7 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/k8s-stable1
       - --timeout=180m
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
@@ -7270,7 +7270,7 @@ periodics:
       - --extract=ci/k8s-stable3
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
 - tags:

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -1099,7 +1099,7 @@ jobs:
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
     sigOwners: ['sig-gcp']
 
@@ -1139,7 +1139,7 @@ jobs:
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
     sigOwners: ['sig-gcp']
 
@@ -1179,7 +1179,7 @@ jobs:
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true
     sigOwners: ['sig-gcp']
 
 # The following settings are used by cluster e2e tests.


### PR DESCRIPTION
Fixes test runs here:
https://testgrid.k8s.io/sig-release-1.13-blocking#gce-cos-1.13-alphafeatures
https://testgrid.k8s.io/sig-release-1.12-blocking#gce-cos-1.12-alphafeatures

/assign @krzyzacy @tpepper 