### PR TITLE
Create prow_push, use it and prow_image everywhere

### DIFF
--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -1,12 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image", "prow_push")
 
-container_bundle(
-    name = "bundle",
+go_binary(
+    name = "ghproxy",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+prow_push(
+    name = "push",
     images = {
         "{STABLE_DOCKER_REPO}/ghproxy:{DOCKER_TAG}": ":image",
         "{STABLE_DOCKER_REPO}/ghproxy:latest": ":image",
@@ -14,18 +18,9 @@ container_bundle(
     },
 )
 
-docker_push(
-    name = "push",
-    bundle = ":bundle",
-)
-
-go_image(
+prow_image(
     name = "image",
     base = "@alpine-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 
@@ -42,12 +37,6 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
-)
-
-go_binary(
-    name = "ghproxy",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/greenhouse/BUILD.bazel
+++ b/greenhouse/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
 
 go_library(
     name = "go_default_library",
@@ -46,10 +46,9 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-go_image(
+prow_image(
     name = "image",
     base = "@alpine-base//image",
-    binary = ":greenhouse",
     visibility = ["//visibility:public"],
 )
 

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -1,52 +1,30 @@
+# Usage:
+#   bazel run //label_sync -- --help # run image locally
+#   bazel run //label_sync:image  # build image
+#   bazel run //label_sync:push  # push image (after building)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("//prow:def.bzl", "prow_image", "prow_push")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-# Usage:
-#   bazel run //label_sync:image  # build image
-#   bazel run //label_sync:push  # push image (after building)
+prow_image(name = "image")
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-
-container_bundle(
-    name = "bundle",
+prow_push(
+    name = "push",
     images = {
-        "{STABLE_DOCKER_REPO}/label_sync:{DOCKER_TAG}": ":label_sync-image",
-        "{STABLE_DOCKER_REPO}/label_sync:latest": ":label_sync-image",
-        "{STABLE_DOCKER_REPO}/label_sync:latest-{BUILD_USER}": ":label_sync-image",
+        "{STABLE_DOCKER_REPO}/label_sync:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/label_sync:latest": ":image",
+        "{STABLE_DOCKER_REPO}/label_sync:latest-{BUILD_USER}": ":image",
     },
 )
 
-docker_push(
-    name = "push",
-    bundle = ":bundle",
-)
-
-# bazel-bin/.../label_sync loads the image into docker
-# bazel-bin/.../label_sync.binary is the binary
-go_image(
-    name = "label_sync-image",
-    base = "@distroless-base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["main_test.go"],
-    data = [
-        "//label_sync:test_examples",
-    ],
+go_binary(
+    name = "label_sync",
     embed = [":go_default_library"],
 )
 
@@ -62,6 +40,15 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = [
+        "//label_sync:test_examples",
+    ],
+    embed = [":go_default_library"],
 )
 
 filegroup(
@@ -80,10 +67,4 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
-)
-
-# Delete after gazelle stops forcing its creation
-go_binary(
-    name = "label_sync",
-    embed = [":go_default_library"],
 )

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
@@ -1,5 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("//prow:def.bzl", "prow_image")
+
+prow_image(name = "aws-janitor-boskos-image")
+
+go_binary(
+    name = "aws-janitor-boskos",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",
@@ -21,12 +29,6 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "aws-janitor-boskos",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -39,9 +41,4 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
-)
-
-go_image(
-    name = "aws-janitor-boskos-image",
-    embed = [":go_default_library"],
 )

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -2,14 +2,15 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("//prow:def.bzl", "prefix", "tags")
+load("//prow:def.bzl", "prefix", "tags", "prow_push")
 load(
     "//def:image.bzl",
     image_tags = "tags",
 )
 
-container_bundle(
-    name = "release",
+prow_push(
+    name = "release-push",
+    bundle_name = "release",
     images = tags(
         "artifact-uploader",
         "branchprotector",
@@ -40,11 +41,6 @@ container_bundle(
     }) + image_tags(**{
         prefix("refresh"): "//prow/external-plugins/refresh:image",
     }),
-)
-
-docker_push(
-    name = "release-push",
-    bundle = ":release",
 )
 
 filegroup(

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -1,34 +1,22 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image", "prow_push")
 
-container_bundle(
-    name = "bundle",
+go_binary(
+    name = "commenter",
+    embed = [":go_default_library"],
+)
+
+prow_image(name = "commenter-image")
+
+prow_push(
+    name = "push",
     images = {
         "{STABLE_DOCKER_REPO}/commenter:{DOCKER_TAG}": ":commenter-image",
         "{STABLE_DOCKER_REPO}/commenter:latest": ":commenter-image",
         "{STABLE_DOCKER_REPO}/commenter:latest-{BUILD_USER}": ":commenter-image",
     },
-)
-
-docker_push(
-    name = "push",
-    bundle = ":bundle",
-)
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-    "go_test",
-)
-
-go_image(
-    name = "commenter-image",
-    base = "@distroless-base//image",
-    embed = [":go_default_library"],
 )
 
 go_library(
@@ -60,10 +48,4 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
     deps = ["//prow/github:go_default_library"],
-)
-
-# Delete after gazelle stops forcing its creation
-go_binary(
-    name = "commenter",
-    embed = [":go_default_library"],
 )

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -1,20 +1,21 @@
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("//prow:def.bzl", "prow_push", "prow_image")
 
-container_bundle(
-    name = "bundle",
-    images = {
-        "{STABLE_DOCKER_REPO}/issue-creator:{DOCKER_TAG}": ":issue-creator-image",
-        "{STABLE_DOCKER_REPO}/issue-creator:latest": ":issue-creator-image",
-        "{STABLE_DOCKER_REPO}/issue-creator:latest-{BUILD_USER}": ":issue-creator-image",
-    },
+go_binary(
+    name = "issue-creator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )
 
-docker_push(
+prow_image(name = "image")
+
+prow_push(
     name = "push",
-    bundle = ":bundle",
+    images = {
+        "{STABLE_DOCKER_REPO}/issue-creator:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/issue-creator:latest": ":image",
+        "{STABLE_DOCKER_REPO}/issue-creator:latest-{BUILD_USER}": ":image",
+    },
 )
 
 go_library(
@@ -26,13 +27,6 @@ go_library(
         "//robots/issue-creator/creator:go_default_library",
         "//robots/issue-creator/sources:go_default_library",
     ],
-)
-
-go_image(
-    name = "issue-creator-image",
-    base = "@distroless-base//image",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -57,11 +51,4 @@ filegroup(
     srcs = [
         "test_owners.csv",
     ],
-)
-
-# Delete after gazelle stops forcing its creation
-go_binary(
-    name = "issue-creator",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )

--- a/robots/pr-labeler/BUILD.bazel
+++ b/robots/pr-labeler/BUILD.bazel
@@ -1,30 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_push", "prow_image")
 
-container_bundle(
-    name = "bundle",
+prow_push(
+    name = "push",
     images = {
-        "{STABLE_DOCKER_REPO}/pr-labeler:{DOCKER_TAG}": ":pr-labeler-image",
-        "{STABLE_DOCKER_REPO}/pr-labeler:latest": ":pr-labeler-image",
-        "{STABLE_DOCKER_REPO}/pr-labeler:latest-{BUILD_USER}": ":pr-labeler-image",
+        "{STABLE_DOCKER_REPO}/pr-labeler:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/pr-labeler:latest": ":image",
+        "{STABLE_DOCKER_REPO}/pr-labeler:latest-{BUILD_USER}": ":image",
     },
 )
 
-docker_push(
-    name = "push",
-    bundle = ":bundle",
-)
-
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-
-go_image(
-    name = "pr-labeler-image",
-    base = "@distroless-base//image",
-    embed = [":go_default_library"],
-)
+prow_image(name = "image")
 
 go_library(
     name = "go_default_library",

--- a/testgrid/cluster/BUILD.bazel
+++ b/testgrid/cluster/BUILD.bazel
@@ -36,7 +36,7 @@ k8s_object(
     cluster = CLUSTER,
     image_chroot = ROOT,
     images = {
-        ROOT + "/updater:latest": "//testgrid/images:updater",
+        ROOT + "/updater:latest": "//testgrid/cmd/updater:image",
     },
     kind = "Deployment",
     namespace = "testgrid",
@@ -48,7 +48,7 @@ k8s_object(
     cluster = CLUSTER,
     image_chroot = ROOT,
     images = {
-        ROOT + "/configurator:latest": "//testgrid/images:configurator",
+        ROOT + "/configurator:latest": "//testgrid/cmd/configurator:image",
     },
     kind = "Deployment",
     namespace = "testgrid",

--- a/testgrid/cmd/configurator/BUILD.bazel
+++ b/testgrid/cmd/configurator/BUILD.bazel
@@ -1,13 +1,15 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
 
 go_binary(
     name = "configurator",
     embed = [":go_default_library"],
     pure = "on",
-    visibility = ["//visibility:public"],
 )
+
+prow_image(name = "image")
 
 go_test(
     name = "go_default_test",

--- a/testgrid/cmd/updater/BUILD.bazel
+++ b/testgrid/cmd/updater/BUILD.bazel
@@ -1,4 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
+
+go_binary(
+    name = "updater",
+    embed = [":go_default_library"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+prow_image(
+    name = "image",
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",
@@ -14,13 +27,6 @@ go_library(
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/vbom.ml/util/sortorder:go_default_library",
     ],
-)
-
-go_binary(
-    name = "updater",
-    embed = [":go_default_library"],
-    pure = "on",
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/testgrid/images/BUILD.bazel
+++ b/testgrid/images/BUILD.bazel
@@ -13,34 +13,17 @@
 # limitations under the License.
 
 load("//def:image.bzl", "tags")
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("//prow:def.bzl", "prow_push")
 
 package(default_visibility = ["//testgrid:__subpackages__"])
 
 # TODO(fejta): move registry to a variable
-container_bundle(
-    name = "images",
-    images = tags(**{
-        "gcr.io/fejta-prod/testgrid/updater": ":updater",
-        "gcr.io/fejta-prod/testgrid/configurator": ":configurator",
-    }),
-)
-
-docker_push(
+prow_push(
     name = "push",
-    bundle = ":images",
-)
-
-go_image(
-    name = "updater",
-    binary = "//testgrid/cmd/updater",
-)
-
-go_image(
-    name = "configurator",
-    binary = "//testgrid/cmd/configurator",
+    images = tags(**{
+        "gcr.io/fejta-prod/testgrid/updater": "//testgrid/cmd/updater:image",
+        "gcr.io/fejta-prod/testgrid/configurator": "//testgrid/cmd/configurator:image",
+    }),
 )
 
 filegroup(


### PR DESCRIPTION
* `prow_push` creates bundle and push targets
  - replace all `contianer_bundle`, `docker_push` rules with this

* Using `prow_image` ensures
  - binary layer sets the right flags to build a linux image
  - push images with correct timestamps


ref https://github.com/kubernetes/test-infra/issues/10297