### PR TITLE
kubetest/kind: don't use debug log level for get* commands

### DIFF
--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -158,7 +158,7 @@ func initializeDeployer(ctl *process.Control, buildType string) (*Deployer, erro
 // getKubeConfigPath returns the path to the kubeconfig file.
 func (d *Deployer) getKubeConfigPath() (string, error) {
 	log.Println("kind.go:getKubeConfigPath()")
-	args := []string{"get", "kubeconfig-path", flagLogLevel}
+	args := []string{"get", "kubeconfig-path"}
 
 	// Use a specific cluster name.
 	if d.kindClusterName != "" {
@@ -400,7 +400,7 @@ func (d *Deployer) clusterExists() (bool, error) {
 	log.Printf("kind.go:clusterExists()")
 
 	cmd := exec.Command("kind")
-	cmd.Args = append(cmd.Args, []string{"get", "clusters", flagLogLevel}...)
+	cmd.Args = append(cmd.Args, []string{"get", "clusters"}...)
 	out, err := d.control.Output(cmd)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
If --loglevel=debug is used with "get cluster" or "get kubeconfig-path".
The output includes docker calls.

Remove the usage of loglevel for these commands.

/kind bug
/assign @BenTheElder 
