### PR TITLE
add optional pull-kubernetes-e2e-kind

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -453,6 +453,92 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-aks-engine-azure,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-jenkins
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15000000000
+      timeout: 2400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+          --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-e2e-gce-device-plugin-gpu

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -1,3 +1,77 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2400000000000 #40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-kind-master
   interval: 1h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2569,6 +2569,11 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
+- name: pull-kubernetes-e2e-kind
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kind
+  num_columns_recent: 20
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 10
 - name: pull-kubernetes-e2e-gce-100-performance
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-100-performance
   days_of_results: 60
@@ -7052,6 +7057,11 @@ dashboards:
 
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
+  - name: pull-kubernetes-e2e-kind
+    test_group_name: pull-kubernetes-e2e-kind
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: bentheelder+alerts@google.com
   - name: pull-kubernetes-cross
     test_group_name: pull-kubernetes-cross
     base_options: width=10


### PR DESCRIPTION
Per request in #sig-cluster-lifeycle, this is an **optional**, **manually requested**, **non-blocking** presubmit using [kind](https://sigs.k8s.io/kind).

Currently it will run the non-serial conformance tests to give fast feedback (should be something like < 20m)

cc @fabriziopandini @neolit123 