### PR TITLE
Update build to v20190222-1af0455

### DIFF
--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20190125-2aca69d
+        image: gcr.io/k8s-prow/build:v20190222-1af0455
         args:
         - --all-contexts
         - --tot-url=http://tot


### PR DESCRIPTION
Let's try updating build to the same version as plank without reverting anything, as this has never used the test-infra/prow/kube client, and deals with a small number of jobs.

/assign @cjwagner @Katharine @BenTheElder @stevekuznetsov 


https://github.com/kubernetes/test-infra/blob/0d1df36e6588acc7dc8c730cc68123e4e25f4ae0/prow/cmd/build/main.go#L143

https://github.com/kubernetes/test-infra/blob/0d1df36e6588acc7dc8c730cc68123e4e25f4ae0/prow/kube/config.go#L115

ref ref #11430