### PR TITLE
capa: Update CAPA job/grid config e2e->integration

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.13
         command:
         - "./scripts/ci-bazel-build.sh"
-  - name: pull-cluster-api-provider-aws-bazel-e2e
+  - name: pull-cluster-api-provider-aws-bazel-integration
     always_run: true
     optional: true
     decorate: true
@@ -42,7 +42,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master # needs bazel 0.18+
         command:
         - "runner.sh"
-        - "./scripts/ci-bazel-e2e.sh"
+        - "./scripts/ci-bazel-integration.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2485,8 +2485,8 @@ test_groups:
 - name: pull-cluster-api-provider-aws-bazel-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-test
   num_columns_recent: 20
-- name: pull-cluster-api-provider-aws-bazel-e2e
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-e2e
+- name: pull-cluster-api-provider-aws-bazel-integration
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-integration
   num_columns_recent: 20
 - name: pull-cluster-api-provider-azure-bazel-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-azure-bazel-verify
@@ -5879,8 +5879,8 @@ dashboards:
     test_group_name: pull-cluster-api-provider-aws-bazel-build
   - name: bazel-pr-test
     test_group_name: pull-cluster-api-provider-aws-bazel-test
-  - name: bazel-pr-e2e
-    test_group_name: pull-cluster-api-provider-aws-bazel-e2e
+  - name: bazel-pr-integration
+    test_group_name: pull-cluster-api-provider-aws-bazel-integration
   - name: test-creds
     test_group_name: periodic-cluster-api-provider-aws-test-creds
 


### PR DESCRIPTION
This patch updates the cluster API provider for AWS's job configs (https://github.com/kubernetes/test-infra/pull/9974) that were previously labelled as e2e to integration. The corresponding test-grid configs have been updated as well.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/603

/hold
/cc @detiber 