### PR TITLE
Fix a panic in triggering

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -132,7 +132,11 @@ func buildAllIfTrusted(c Client, trigger *plugins.Trigger, pr github.PullRequest
 			}
 		}
 		c.Logger.Info("Starting all jobs for updated PR.")
-		return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts)
+		elide := false
+		if trigger != nil {
+			elide = trigger.ElideSkippedContexts
+		}
+		return buildAll(c, &pr.PullRequest, pr.GUID, elide)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3a pc=0x121b9c3]

goroutine 271 [running]:
k8s.io/test-infra/prow/plugins/trigger.buildAllIfTrusted(0x172c9c0, 0xc0003521c0, 0x7f5f3ce89ec8, 0xc0005b54e0, 0xc002804000, 0xc0002e5c20, 0x0, 0xc0058e82b0, 0xb, 0x960, ...)
	prow/plugins/trigger/pull-request.go:135 +0x283
k8s.io/test-infra/prow/plugins/trigger.handlePR(0x172c9c0, 0xc0003521c0, 0x7f5f3ce89ec8, 0xc0005b54e0, 0xc002804000, 0xc0002e5c20, 0x0, 0xc0058e82b0, 0xb, 0x960, ...)
	prow/plugins/trigger/pull-request.go:91 +0x9c4
k8s.io/test-infra/prow/plugins/trigger.handlePullRequest(0xc0003521c0, 0x1725880, 0xc0005b54e0, 0x173d680, 0xc0006dac00, 0xc000891080, 0xc0005b5540, 0xc0027c0a00, 0xc002804000, 0xc00572e900, ...)
	prow/plugins/trigger/trigger.go:140 +0x255
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1(0xc0027b0d90, 0xc000580898, 0xc0053d2c00, 0xc005846414, 0x7, 0x15e8150)
	prow/hook/events.go:174 +0x1e8
created by k8s.io/test-infra/prow/hook.(
```

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 