### PR TITLE
Update branchprotector, grandmatriarch, needs-rebase, tot to v20190222-cdb4877

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190125-2aca69d
+            image: gcr.io/k8s-prow/branchprotector:v20190222-cdb4877
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190125-2aca69d
+        image: gcr.io/k8s-prow/grandmatriarch:v20190222-cdb4877
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190125-2aca69d
+        image: gcr.io/k8s-prow/needs-rebase:v20190222-cdb4877
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190125-2aca69d
+        image: gcr.io/k8s-prow/tot:v20190222-cdb4877
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json


### PR DESCRIPTION
These do not use a kubernetes client

/assign @BenTheElder @Katharine @cjwagner @stevekuznetsov 

/hold
Cole suggested updating hook first, but getting this ready

ref https://github.com/kubernetes/test-infra/issues/11430