### PR TITLE
boskos: Remove glog from AWS janitor

### DIFF
--- a/maintenance/aws-janitor/resources/BUILD.bazel
+++ b/maintenance/aws-janitor/resources/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/iam:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/route53:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/maintenance/aws-janitor/resources/nat_gateway.go
+++ b/maintenance/aws-janitor/resources/nat_gateway.go
@@ -23,8 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 )
 
 // VPCs: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeVpcs
@@ -48,7 +48,7 @@ func (NATGateway) MarkAndSweep(sess *session.Session, acct string, region string
 			if set.Mark(g) {
 				inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
 				if _, err := svc.DeleteNatGateway(inp); err != nil {
-					glog.Warningf("%v: delete failed: %v", g.ARN(), err)
+					klog.Warningf("%v: delete failed: %v", g.ARN(), err)
 				}
 			}
 		}

--- a/maintenance/aws-janitor/resources/route53.go
+++ b/maintenance/aws-janitor/resources/route53.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
@@ -182,7 +181,7 @@ func (Route53ResourceRecordSets) ListAll(sess *session.Session, acct, region str
 				return true
 			})
 			if err != nil {
-				glog.Errorf("couldn't describe route53 resources for %q in %q zone %q: %v", acct, region, *z.Id, err)
+				klog.Errorf("couldn't describe route53 resources for %q in %q zone %q: %v", acct, region, *z.Id, err)
 			}
 
 		}


### PR DESCRIPTION
This patch fixes an issue where there were dangling instances of glog dependencies.

/area boskos
/assign @detiber @vincepri