### PR TITLE
Update hook to v20190223-df9fffb

### DIFF
--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190125-2aca69d
+        image: gcr.io/k8s-prow/hook:v20190223-df9fffb
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
Let's keep everything else on the earlier 0222 commit for now.

/assign @BenTheElder @cjwagner 
/cc @Katharine @stevekuznetsov 
/hold

ref https://github.com/kubernetes/test-infra/pull/11460 https://github.com/kubernetes/test-infra/issues/11430