### PR TITLE
Don't pass around possibly-nil configurations

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -566,15 +566,15 @@ func (r RequireMatchingLabel) Describe() string {
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
-func (c *Configuration) TriggerFor(org, repo string) *Trigger {
+func (c *Configuration) TriggerFor(org, repo string) Trigger {
 	for _, tr := range c.Triggers {
 		for _, r := range tr.Repos {
 			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
-				return &tr
+				return tr
 			}
 		}
 	}
-	return nil
+	return Trigger{}
 }
 
 // EnabledReposForPlugin returns the orgs and repos that have enabled the passed plugin.

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -32,7 +32,7 @@ var okToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 var testAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
 var retestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 
-func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericCommentEvent) error {
+func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCommentEvent) error {
 	org := gc.Repo.Owner.Login
 	repo := gc.Repo.Name
 	number := gc.Number
@@ -118,8 +118,8 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericC
 	return runAndSkipJobs(c, pr, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
 }
 
-func HonorOkToTest(trigger *plugins.Trigger) bool {
-	return trigger == nil || !trigger.IgnoreOkToTest
+func HonorOkToTest(trigger plugins.Trigger) bool {
+	return !trigger.IgnoreOkToTest
 }
 
 type GitHubClient interface {

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -873,11 +873,11 @@ func TestHandleGenericComment(t *testing.T) {
 		// In some cases handleGenericComment can be called twice for the same event.
 		// For instance on Issue/PR creation and modification.
 		// Let's call it twice to ensure idempotency.
-		if err := handleGenericComment(c, &trigger, event); err != nil {
+		if err := handleGenericComment(c, trigger, event); err != nil {
 			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 		}
 		validate(tc.name, fakeProwJobClient.Fake.Actions(), g, tc, t)
-		if err := handleGenericComment(c, &trigger, event); err != nil {
+		if err := handleGenericComment(c, trigger, event); err != nil {
 			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 		}
 		validate(tc.name, fakeProwJobClient.Fake.Actions(), g, tc, t)

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -97,7 +97,7 @@ func TestTrusted(t *testing.T) {
 					Name: label,
 				})
 			}
-			_, actual, err := TrustedPullRequest(g, &trigger, tc.author, "kubernetes-incubator", "random-repo", 1, labels)
+			_, actual, err := TrustedPullRequest(g, trigger, tc.author, "kubernetes-incubator", "random-repo", 1, labels)
 			if err != nil {
 				t.Fatalf("Didn't expect error: %s", err)
 			}
@@ -327,7 +327,7 @@ func TestHandlePullRequest(t *testing.T) {
 			TrustedOrg:     "org",
 			OnlyOrgMembers: true,
 		}
-		if err := handlePR(c, &trigger, pr); err != nil {
+		if err := handlePR(c, trigger, pr); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}
 		var numStarted int


### PR DESCRIPTION
The Trigger configuration is a well-formed Go struct that follows best
practices and is perfectly usable in the empty form. Every field in the
configuration must be set to enable some functionality, so the default
state of an uninitialized struct is the same as if a user did not have
any configuration at all.

Instead of passing around pointers and checking to see if the
configuration is missing, we should just use the default values as they
were intended.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 