### PR TITLE
Add detiber to owners for maintenance/aws-janitor

### DIFF
--- a/maintenance/aws-janitor/OWNERS
+++ b/maintenance/aws-janitor/OWNERS
@@ -3,3 +3,4 @@
 approvers:
 - liztio
 - justinsb
+- detiber


### PR DESCRIPTION
Request to be added to OWNERS list for the AWS janitor, while @liztio is on sabbatical I will be assisting with issues and reviews for this component.

/assign @krzyzacy 
/assign @justinsb 
/cc @akutz 
