### PR TITLE
kubeadm: add kind based tests for older branches

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -454,6 +454,8 @@ presubmits:
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-aks-engine-azure,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    branches:
+    - release-1.12
     cluster: security
     context: pull-security-kubernetes-e2e-kind
     decorate: true
@@ -487,6 +489,272 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+          --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.13
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-jenkins
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15000000000
+      timeout: 2400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+          --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.14
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-jenkins
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15000000000
+      timeout: 2400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+          --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-jenkins
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15000000000
+      timeout: 2400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
+        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
+        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    skip_branches:
+    - release-1.14
+    - release-1.13
+    - release-1.12
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -1,78 +1,243 @@
-presubmits:
-  kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-kind
-    optional: true
-    always_run: false
-    decorate: true
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-    decoration_config:
-      timeout: 2400000000000 #40m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: kubeadm
-      base_ref: master
-      path_alias: k8s.io/kubeadm
-    - org: kubernetes-sigs
-      repo: kind
-      base_ref: master
-      path_alias: sigs.k8s.io/kind
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # kind specific args
-        - --provider=skeleton
-        - --deployment=kind
-        - --kind-binary-version=build
-        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
-        # generic e2e test args
-        - --build=bazel
-        - --up
-        - --test
-        - --check-version-skew=false
-        - --down
-        # specific e2e test args
-        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
-        - --ginkgo-parallel
-        - --timeout=30m
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        # kind needs /lib/modules and cgroups from the host
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        resources:
-          requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
+# periodic jobs
 
 periodics:
+- name: ci-kubernetes-e2e-kubeadm-kind-1-12
+  interval: 4h
+  decorate: true
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.12
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
+      imagePullPolicy: Always
+      env:
+      # for bazel caching
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # kind specific args
+      - --provider=skeleton
+      - --deployment=kind
+      - --kind-binary-version=build
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+      # generic e2e test args
+      - --build=bazel
+      - --up
+      - --test
+      - --check-version-skew=false
+      - --down
+      # specific e2e test args
+      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --ginkgo-parallel
+      - --timeout=30m
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
+- name: ci-kubernetes-e2e-kubeadm-kind-1-13
+  interval: 4h
+  decorate: true
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.13
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
+      imagePullPolicy: Always
+      env:
+      # for bazel caching
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # kind specific args
+      - --provider=skeleton
+      - --deployment=kind
+      - --kind-binary-version=build
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+      # generic e2e test args
+      - --build=bazel
+      - --up
+      - --test
+      - --check-version-skew=false
+      - --down
+      # specific e2e test args
+      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --ginkgo-parallel
+      - --timeout=30m
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
+- name: ci-kubernetes-e2e-kubeadm-kind-1-14
+  interval: 4h
+  decorate: true
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.14
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+      imagePullPolicy: Always
+      env:
+      # for bazel caching
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # kind specific args
+      - --provider=skeleton
+      - --deployment=kind
+      - --kind-binary-version=build
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+      # generic e2e test args
+      - --build=bazel
+      - --up
+      - --test
+      - --check-version-skew=false
+      - --down
+      # specific e2e test args
+      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --ginkgo-parallel
+      - --timeout=30m
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
 - name: ci-kubernetes-e2e-kubeadm-kind-master
   interval: 1h
   decorate: true
@@ -151,3 +316,305 @@ periodics:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+
+# presubmit jobs
+
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    branches:
+    - release-1.12
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2400000000000 #40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    branches:
+    - release-1.13
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2400000000000 #40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    branches:
+    - release-1.14
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2400000000000 #40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    skip_branches:
+    - release-1.14 # per-release job
+    - release-1.13 # per-release job
+    - release-1.12 # per-release job
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2400000000000 #40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=build
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2114,7 +2114,7 @@ test_groups:
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm64
 - name: periodic-multi-platform-kubeadm-packet-arm64
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-packet-arm64
-# kubeadm tests
+# kubeadm-gce tests
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11
 - name: ci-kubernetes-e2e-kubeadm-gce-1-12
@@ -2125,8 +2125,15 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-14
 - name: ci-kubernetes-e2e-kubeadm-gce-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master
+# kubeadm-kind tests
 - name: ci-kubernetes-e2e-kubeadm-kind-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-master
+- name: ci-kubernetes-e2e-kubeadm-kind-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-1-14
+- name: ci-kubernetes-e2e-kubeadm-kind-1-13
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-1-13
+- name: ci-kubernetes-e2e-kubeadm-kind-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kind-1-12
 # kubeadm x-on-y tests
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
@@ -5791,7 +5798,7 @@ dashboards:
 
 - name: sig-cluster-lifecycle-all
   dashboard_tab:
-# kubeadm tests
+# kubeadm-gce tests
   - name: kubeadm-gce-1.11
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11
   - name: kubeadm-gce-1.12
@@ -5811,9 +5818,32 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
     alert_stale_results_hours: 24
-    num_failures_to_alert: 4 # Runs every 6h. Alert when it's been failing for 24 hours
+    num_failures_to_alert: 6 # Runs every 2h. Alert when it's been failing for 12 hours
+# kubeadm-kind tests
+  - name: kubeadm-kind-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kind-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kind-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
   - name: kubeadm-kind-master
     test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 12 # Runs every 1h. Alert when it's been failing for 12 hours
 # kubeadm x-on-y tests
   - name: kubeadm-gce-1.11-on-1.12
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12


### PR DESCRIPTION
- add kubeadm-kind-{1.14, 1.13, 1.12}
- add email notifications
- add presubmit branch jobs

/assign @krzyzacy @BenTheElder 
cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

/kind feature
/priority important-longterm
