### PR TITLE
Update prow to v20190223-8cd8823

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -469,10 +469,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 2400000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
-        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
-        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190223-8cd8823
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190223-8cd8823
+        initupload: gcr.io/k8s-prow/initupload:v20190223-8cd8823
+        sidecar: gcr.io/k8s-prow/sidecar:v20190223-8cd8823
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -557,10 +557,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 2400000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
-        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
-        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190223-8cd8823
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190223-8cd8823
+        initupload: gcr.io/k8s-prow/initupload:v20190223-8cd8823
+        sidecar: gcr.io/k8s-prow/sidecar:v20190223-8cd8823
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -645,10 +645,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 2400000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
-        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
-        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190223-8cd8823
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190223-8cd8823
+        initupload: gcr.io/k8s-prow/initupload:v20190223-8cd8823
+        sidecar: gcr.io/k8s-prow/sidecar:v20190223-8cd8823
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -731,10 +731,10 @@ presubmits:
       grace_period: 15000000000
       timeout: 2400000000000
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20190125-2aca69d
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20190125-2aca69d
-        initupload: gcr.io/k8s-prow/initupload:v20190125-2aca69d
-        sidecar: gcr.io/k8s-prow/sidecar:v20190125-2aca69d
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190223-8cd8823
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190223-8cd8823
+        initupload: gcr.io/k8s-prow/initupload:v20190223-8cd8823
+        sidecar: gcr.io/k8s-prow/sidecar:v20190223-8cd8823
     extra_refs:
     - base_ref: master
       org: kubernetes

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190222-cdb4877
+            image: gcr.io/k8s-prow/branchprotector:v20190223-8cd8823
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20190222-cdb4877
+        image: gcr.io/k8s-prow/build:v20190223-8cd8823
         args:
         - --all-contexts
         - --tot-url=http://tot

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190222-cdb4877
+        image: gcr.io/k8s-prow/crier:v20190223-8cd8823
         args:
         - --github-workers=1
         - --report-agent=knative-build

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190222-cdb4877
+        image: gcr.io/k8s-prow/deck:v20190223-8cd8823
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190222-cdb4877
+        image: gcr.io/k8s-prow/grandmatriarch:v20190223-8cd8823
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190223-df9fffb
+        image: gcr.io/k8s-prow/hook:v20190223-8cd8823
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190222-cdb4877
+        image: gcr.io/k8s-prow/horologium:v20190223-8cd8823
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190222-cdb4877
+        image: gcr.io/k8s-prow/needs-rebase:v20190223-8cd8823
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190222-cdb4877
+        image: gcr.io/k8s-prow/plank:v20190223-8cd8823
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20190222-cdb4877
+        image: gcr.io/k8s-prow/sinker:v20190223-8cd8823
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -138,7 +138,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190125-2aca69d
+        image: gcr.io/k8s-prow/hook:v20190223-8cd8823
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -203,7 +203,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190125-2aca69d
+        image: gcr.io/k8s-prow/plank:v20190223-8cd8823
         args:
         - --dry-run=false
         volumeMounts:
@@ -238,7 +238,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190125-2aca69d
+        image: gcr.io/k8s-prow/sinker:v20190223-8cd8823
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -271,7 +271,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190125-2aca69d
+        image: gcr.io/k8s-prow/deck:v20190223-8cd8823
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
@@ -320,7 +320,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190125-2aca69d
+        image: gcr.io/k8s-prow/horologium:v20190223-8cd8823
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -349,7 +349,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190125-2aca69d
+        image: gcr.io/k8s-prow/tide:v20190223-8cd8823
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20190125-2aca69d
+        image: gcr.io/k8s-prow/status-reconciler:v20190223-8cd8823
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190222-cdb4877
+        image: gcr.io/k8s-prow/tide:v20190223-8cd8823
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190222-cdb4877
+        image: gcr.io/k8s-prow/tot:v20190223-8cd8823
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,10 +7,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190125-2aca69d"
-      initupload: "gcr.io/k8s-prow/initupload:v20190125-2aca69d"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190125-2aca69d"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190125-2aca69d"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190223-8cd8823"
+      initupload: "gcr.io/k8s-prow/initupload:v20190223-8cd8823"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190223-8cd8823"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190223-8cd8823"
     gcs_configuration:
       bucket: "kubernetes-jenkins"
       path_strategy: "legacy"


### PR DESCRIPTION
This will put everything at the same version.

Hook (and unused status-reconciler): https://github.com/kubernetes/test-infra/compare/df9fffb...8cd8823

Injected pod-util images: https://github.com/kubernetes/test-infra/compare/2aca69d...8cd8823

Everything else: https://github.com/kubernetes/test-infra/compare/cdb4877...8cd8823

ref #11430 
/assign @cjwagner @BenTheElder 
/hold