### PR TITLE
Make needs-rebase label red

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -278,7 +278,7 @@ default:
       target: prs
       prowPlugin: trigger
       addedBy: prow
-    - color: BDBDBD
+    - color: e11d21
       description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
       name: needs-rebase
       target: prs


### PR DESCRIPTION
Looking at the tide queries in use today, `needs-rebase` is merge-blocking for all kubernetes orgs, so yeah I think it's time to make it the same shade of red as `do-not-merge/foo` labels (it should really be a `do-not-merge/needs-rebase` label, I will follow up with that)

/hold
I'm using this to verify that @k8s-github-robot can run `label_sync`