### PR TITLE
AWS janitor clean -all option

### DIFF
--- a/maintenance/aws-janitor/BUILD.bazel
+++ b/maintenance/aws-janitor/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//maintenance/aws-janitor/s3:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",
         "//boskos/common/aws:go_default_library",
-        "//maintenance/aws-janitor/account:go_default_library",
         "//maintenance/aws-janitor/regions:go_default_library",
         "//maintenance/aws-janitor/resources:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",

--- a/maintenance/aws-janitor/main.go
+++ b/maintenance/aws-janitor/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
 	"k8s.io/klog"
 	"k8s.io/test-infra/maintenance/aws-janitor/account"
 	"k8s.io/test-infra/maintenance/aws-janitor/regions"
@@ -31,9 +32,10 @@ import (
 )
 
 var (
-	maxTTL = flag.Duration("ttl", 24*time.Hour, "Maximum time before we attempt deletion of a resource. Set to 0s to nuke all non-default resources.")
-	region = flag.String("region", regions.Default, "")
-	path   = flag.String("path", "", "S3 path to store mark data in (required)")
+	maxTTL   = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
+	region   = flag.String("region", regions.Default, "The default AWS region")
+	path     = flag.String("path", "", "S3 path for mark data (required when -all=false)")
+	cleanAll = flag.Bool("all", false, "Clean all resources (ignores -path)")
 )
 
 func main() {
@@ -48,48 +50,58 @@ func main() {
 	// to delete.
 	sess := session.Must(session.NewSessionWithOptions(session.Options{Config: aws.Config{MaxRetries: aws.Int(100)}}))
 
+	if *cleanAll {
+		if err := resources.CleanAll(sess, *region); err != nil {
+			klog.Fatalf("Error cleaning all resources: %v", err)
+		}
+	} else if ok, err := markAndSweep(sess); err != nil {
+		klog.Fatalf("Error marking and sweeping resources: %v", err)
+	} else if !ok {
+		os.Exit(1)
+	}
+}
+
+func markAndSweep(sess *session.Session) (bool, error) {
 	s3p, err := s3path.GetPath(sess, *path)
 	if err != nil {
-		klog.Fatalf("--path %q isn't a valid S3 path: %v", *path, err)
+		return false, errors.Wrapf(err, "-path %q isn't a valid S3 path", *path)
 	}
+
 	acct, err := account.GetAccount(sess, regions.Default)
 	if err != nil {
-		klog.Fatalf("Error getting current user: %v", err)
+		return false, errors.Wrap(err, "Error getting current user")
 	}
 	klog.V(1).Infof("account: %s", acct)
-	regions, err := regions.GetAll(sess)
+
+	regionList, err := regions.GetAll(sess)
 	if err != nil {
-		klog.Fatalf("Error getting available regions: %v", err)
+		return false, errors.Wrap(err, "Error getting available regions")
 	}
-	klog.Infof("Regions: %+v", regions)
+	klog.Infof("Regions: %+v", regionList)
 
 	res, err := resources.LoadSet(sess, s3p, *maxTTL)
 	if err != nil {
-		klog.Fatalf("Error loading %q: %v", *path, err)
+		return false, errors.Wrapf(err, "Error loading %q", *path)
 	}
 
-	for _, region := range regions {
+	for _, region := range regionList {
 		for _, typ := range resources.RegionalTypeList {
 			if err := typ.MarkAndSweep(sess, acct, region, res); err != nil {
-				klog.Errorf("Error sweeping %T: %v", typ, err)
-				return
+				return false, errors.Wrapf(err, "Error sweeping %T", typ)
 			}
 		}
 	}
 
 	for _, typ := range resources.GlobalTypeList {
 		if err := typ.MarkAndSweep(sess, acct, *region, res); err != nil {
-			klog.Errorf("Error sweeping %T: %v", typ, err)
-			return
+			return false, errors.Wrapf(err, "Error sweeping %T", typ)
 		}
 	}
 
 	swept := res.MarkComplete()
 	if err := res.Save(sess, s3p); err != nil {
-		klog.Fatalf("Error saving %q: %v", *path, err)
+		return false, errors.Wrapf(err, "Error saving %q", *path)
 	}
 
-	if swept > 0 {
-		os.Exit(1)
-	}
+	return swept == 0, nil
 }

--- a/maintenance/aws-janitor/resources/BUILD.bazel
+++ b/maintenance/aws-janitor/resources/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "addresses.go",
         "asg.go",
+        "clean.go",
         "dhcp_options.go",
         "elb.go",
         "iam_instance_profiles.go",
@@ -26,6 +27,8 @@ go_library(
     importpath = "k8s.io/test-infra/maintenance/aws-janitor/resources",
     visibility = ["//visibility:public"],
     deps = [
+        "//maintenance/aws-janitor/account:go_default_library",
+        "//maintenance/aws-janitor/regions:go_default_library",
         "//maintenance/aws-janitor/s3:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",

--- a/maintenance/aws-janitor/resources/clean.go
+++ b/maintenance/aws-janitor/resources/clean.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+	"k8s.io/test-infra/maintenance/aws-janitor/account"
+	"k8s.io/test-infra/maintenance/aws-janitor/regions"
+)
+
+// CleanAll cleans all of the resources for all of the regions visible to
+// the provided AWS session.
+func CleanAll(sess *session.Session, region string) error {
+	acct, err := account.GetAccount(sess, region)
+	if err != nil {
+		return errors.Wrap(err, "Failed to retrieve account")
+	}
+	klog.V(1).Infof("Account: %s", acct)
+
+	regionList, err := regions.GetAll(sess)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't retrieve list of regions")
+	}
+	klog.Infof("Regions: %+v", regionList)
+
+	for _, r := range regionList {
+		for _, typ := range RegionalTypeList {
+			set, err := typ.ListAll(sess, acct, r)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to list resources of type %T", typ)
+			}
+			if err := typ.MarkAndSweep(sess, acct, r, set); err != nil {
+				return errors.Wrapf(err, "Couldn't sweep resources of type %T", typ)
+			}
+		}
+	}
+
+	for _, typ := range GlobalTypeList {
+		set, err := typ.ListAll(sess, acct, regions.Default)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to list resources of type %T", typ)
+		}
+		if err := typ.MarkAndSweep(sess, acct, regions.Default, set); err != nil {
+			return errors.Wrapf(err, "Couldn't sweep resources of type %T", typ)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This patch updates the AWS janitor command with the new flag `-all`. Executing the command with `-all` cleans all visible resources, bypassing the mark and sweep logic. When `-all` is specified, the S3 `-path` flag is ignored.

Additionally, a `CleanAll` function has been placed into the `k8s.io/test-infra/maintenance/aws-janitor/resources` package. This function is used by both the AWS janitor (when run with `-all`) and the AWS janitor for Boskos.

/area aws-janitor
/assign @detiber @krzyzacy 