### PR TITLE
deck: Allow wildcard glob searches on job name

### DIFF
--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -24,7 +24,7 @@
         <li><select id="author"><option>all authors</option></select></li>
         <li>
           <div class="fuzzy-search" id="job">
-            <input class="fuzzy-search-input" placeholder="Search job name" type="text" id="job-input">
+            <input class="fuzzy-search-input" placeholder="Search job name, accepts '*' wildcards" type="text" id="job-input">
             <ul id="job-list" class="fuzzy-search-list"></ul>
           </div>
         </li>


### PR DESCRIPTION
Build names don't follow a strict hierarchy and when jobs are reproduced
in a consistent way across many repos Deck makes it difficult to see
those jobs as a unit. A common desire is to see "all unit jobs" or
"all e2e jobs". In OpenShift one pattern is a common job definition
across many tens of of repositories of the form 'pull-ci-REPO-e2e-aws'
which verifies that for each repo that they pass the same e2e test
suite when their current contents are merged. To better support this
use case it should be easier to see "all e2e-aws" jobs.

Add wildcard glob support to job name to allow someone to search for
`*e2e-aws` (which would select all jobs ending in `e2e-aws`), or all
sub series `*e2e*` (selecting all jobs that contain `e2e`). The
implementation splits the search string into segments, escapes their
parts for regex safety, then joins them with `.*`.

I considered full regexp syntax, but couldn't come up with a non
contrived use case that glob search didn't do almost as well for less
conceptual overload.

![image](https://www.dropbox.com/s/ucejcsod2mqecdm/Screenshot%202019-02-23%2020.41.58.png?raw=1)