### PR TITLE
Fix NPE in the labels plugin helpProvider

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -44,7 +44,9 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	labels := []string{"kind", "priority", "area"}
-	labels = append(labels, config.Label.AdditionalLabels...)
+	if config.Label != nil {
+		labels = append(labels, config.Label.AdditionalLabels...)
+	}
 	var formattedLabels []string
 	for _, label := range labels {
 		formattedLabels = append(formattedLabels, fmt.Sprintf(`"%s/*"`, label))


### PR DESCRIPTION
This fixes an NPE that occurs when visiting deck/plugin-help or deck/command-help and the plugin config has no `label` key