### PR TITLE
deck: Display a heat map of the last 12 hours of job successes/failures

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "rollup_bundle")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
@@ -18,12 +18,43 @@ ts_library(
 )
 
 ts_library(
+    name = "histogram",
+    srcs = glob(["prow/histogram.ts"]),
+    deps = [
+        ":api",
+    ],
+)
+
+ts_library(
     name = "prow",
-    srcs = glob(["prow/*.ts"]) + ["vendor.d.ts"],
+    srcs = glob(
+        ["prow/*.ts"],
+        exclude = ["prow/histogram*.ts"],
+    ) + ["vendor.d.ts"],
     deps = [
         ":api",
         ":common",
+        ":histogram",
         "@npm//moment",
+    ],
+)
+
+ts_library(
+    name = "prow_test_lib",
+    srcs = ["prow/histogram_test.ts"],
+    deps = [
+        ":histogram",
+        "@npm//@types/jasmine",
+    ],
+)
+
+jasmine_node_test(
+    name = "prow_test",
+    srcs = [
+        ":prow_test_lib",
+    ],
+    deps = [
+        "@npm//jasmine",
     ],
 )
 
@@ -160,6 +191,13 @@ rollup_bundle(
     deps = [
         ":spyglass_common",
         ":spyglass_lens",
+    ],
+)
+
+test_suite(
+    name = "unit_tests",
+    tests = [
+        ":prow_test",
     ],
 )
 

--- a/prow/cmd/deck/static/prow/histogram.ts
+++ b/prow/cmd/deck/static/prow/histogram.ts
@@ -1,0 +1,105 @@
+import {JobState} from "../api/prow";
+
+export class JobHistogram {
+  public start: number;
+  public end: number;
+  private data: JobSample[];
+
+  constructor() {
+      this.data = [];
+      this.start = Number.MAX_SAFE_INTEGER;
+      this.end = 0;
+  }
+  // add adds a sample to the histogram, filtering states that didn't result in success or clear
+  // failure, and updating the range of the histogram data.
+  public add(sample: JobSample) {
+      if (!(sample.state === "success" || sample.state === "failure" || sample.state === "error")) {
+          return;
+      }
+      if (sample.start < this.start) {
+          this.start = sample.start;
+      }
+      if (sample.start > this.end) {
+          this.end = sample.start;
+      }
+      this.data.push(sample);
+  }
+  // buckets assigns all samples between start and end into cols buckets, sorted by
+  // start timestamp, while the buckets themselves are sorted by duration.
+  public buckets(start: number, end: number, cols: number): JobBuckets {
+      this.data.sort((s1, s2) => s1.start - s2.start);
+
+      const buckets: JobSample[][] = [[]];
+      const stride = (end - start) / cols;
+      let next = start + stride;
+      let max = 0;
+      this.data.forEach((sample) => {
+          if (sample.start < start || sample.start > end) {
+              return;
+          }
+          if (sample.duration > max) {
+              max = sample.duration;
+          }
+          if (sample.start < next || sample.start === end) {
+              buckets[buckets.length - 1].push(sample);
+              return;
+          }
+
+          const bucket = buckets[buckets.length - 1];
+          bucket.sort((s1, s2) => s1.duration - s2.duration);
+
+          next = next + stride;
+          while (next < sample.start) {
+              buckets.push([]);
+              next = next + stride;
+          }
+          buckets.push([sample]);
+      });
+      if (buckets.length > 0) {
+          const lastBucket = buckets[buckets.length - 1];
+          lastBucket.sort((s1, s2) => s1.duration - s2.duration);
+      }
+      while (buckets.length < cols) {
+          buckets.push([]);
+      }
+      return new JobBuckets(buckets, start, end, max);
+  }
+  // length returns the number of samples in the histogram.
+  public get length(): number {
+      return this.data.length;
+  }
+}
+
+export class JobSample {
+  constructor(public start: number,
+              public duration: number,
+              public state: JobState,
+              public row: number) {}
+}
+
+export class JobBuckets {
+  constructor(public data: JobSample[][],
+              public start: number,
+              public end: number,
+              public max: number) { }
+
+  public linearChunks(bucket: JobSample[], rows: number): JobSample[][] {
+      const stride = Math.ceil((this.max) / rows);
+      const chunks: JobSample[][] = [];
+      chunks[0] = [];
+      let next = stride;
+      for (const sample of bucket) {
+          if (sample.duration <= next) {
+              chunks[chunks.length - 1].push(sample);
+              continue;
+          }
+          next = next + stride;
+          while (next < sample.duration) {
+              chunks.push([]);
+              next = next + stride;
+          }
+          chunks.push([sample]);
+      }
+      return chunks;
+  }
+}

--- a/prow/cmd/deck/static/prow/histogram_test.ts
+++ b/prow/cmd/deck/static/prow/histogram_test.ts
@@ -1,0 +1,57 @@
+import "jasmine";
+import {JobHistogram, JobSample} from "./histogram";
+
+describe('JobHistogram', () => {
+  it('should do nothing with empty input', () => {
+    const h = new JobHistogram();
+    const buckets = h.buckets(0, 9, 1);
+    expect(buckets.data.length).toEqual(1);
+    expect(buckets.data[0].length).toEqual(0);
+  });
+  it('should filter entries outside start end', () => {
+    const h = new JobHistogram();
+    h.add(new JobSample(10, 100, "failure", 0));
+    h.add(new JobSample(10, 100, "success", 1));
+    h.add(new JobSample(200, 10, "failure", 2));
+    h.add(new JobSample(201, 10, "failure", -1));
+    expect(h.buckets(0, 9, 1).data).toEqual([[]]);
+    expect(h.buckets(0, 9, 2).data).toEqual([[], []]);
+  });
+  it('should create buckets that contain the correct results', () => {
+    const h = new JobHistogram();
+    const samples = [
+      new JobSample(10, 100, "failure", 0),
+      new JobSample(10, 101, "success", 1),
+      new JobSample(200, 11, "failure", 2),
+      new JobSample(201, 10, "failure", -1),
+    ];
+    for (const sample of samples) {
+      h.add(sample);
+    }
+    expect(h.buckets(0, 10, 1).data).toEqual([
+      [samples[0], samples[1]],
+    ]);
+    expect(h.buckets(0, 11, 1).data).toEqual([
+      [samples[0], samples[1]],
+    ]);
+    expect(h.buckets(199, 200, 1).data).toEqual([
+      [samples[2]],
+    ]);
+    expect(h.buckets(0, 201, 2).data).toEqual([
+      [samples[0], samples[1]],
+      [samples[3], samples[2]],
+    ]);
+    expect(h.buckets(0, 202, 2).data).toEqual([
+      [samples[0], samples[1]],
+      [samples[3], samples[2]],
+    ]);
+
+    const swap = samples[0];
+    samples[0] = samples[1];
+    samples[1] = swap;
+    expect(h.buckets(0, 202, 2).data).toEqual([
+      [samples[1], samples[0]],
+      [samples[3], samples[2]],
+    ]);
+  });
+});

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -180,6 +180,42 @@ i.state {
     margin-left: auto;
 }
 
+#job-histogram-content tr {
+    border: 0;
+}
+
+#job-histogram-content td {
+    padding: 0;
+    height: 12px;
+    width: 12px;
+}
+
+#job-histogram-content td.success-10 { background-color: #43A047; }
+#job-histogram-content td.success-9 { background-image: linear-gradient(#43A047 90%, #EF5350 90%); }
+#job-histogram-content td.success-8 { background-image: linear-gradient(#43A047 80%, #EF5350 80%); }
+#job-histogram-content td.success-7 { background-image: linear-gradient(#43A047 70%, #EF5350 70%); }
+#job-histogram-content td.success-6 { background-image: linear-gradient(#43A047 60%, #EF5350 60%); }
+#job-histogram-content td.success-5 { background-image: linear-gradient(#43A047 50%, #EF5350 50%); }
+#job-histogram-content td.success-4 { background-image: linear-gradient(#43A047 40%, #EF5350 40%); }
+#job-histogram-content td.success-3 { background-image: linear-gradient(#43A047 30%, #EF5350 30%); }
+#job-histogram-content td.success-2 { background-image: linear-gradient(#43A047 20%, #EF5350 20%); }
+#job-histogram-content td.success-1 { background-image: linear-gradient(#43A047 10%, #EF5350 10%); }
+#job-histogram-content td.success-0 { background-color: #EF5350; }
+
+#job-histogram-content td.active:hover {
+    opacity: 1 !important;
+    cursor: pointer;
+}
+
+#job-histogram-labels span {
+    padding: 0 6px;
+    font-size: 12px;
+}
+
+#job-histogram-start {
+    float: right;
+}
+
 #job-count {
     float: right;
     font-size: 12px;

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -48,7 +48,9 @@
     <div id="aborted-tooltip" class="mdl-tooltip" for="job-bar-aborted"></div>
     <div id="job-bar-unknown" class="job-bar-state"></div>
     <div id="unknown-tooltip" class="mdl-tooltip" for="job-bar-unknown"></div>
-  </div>
+    </div>
+    <table id="job-histogram"><tbody id="job-histogram-content"></tbody></table>
+    <div id="job-histogram-labels"><span>Now</span><span id="job-histogram-start"></span></div>
   </aside>
   <article>
     <div class="table-container">


### PR DESCRIPTION
When triaging job failures it is common to want to identify correlations in time, which the list of builds not well suited to because it doesn't make quick assessment of the gaps between builds visible.  There are two primary user personas who might want to do this - the user assessing infrastructure problems (`prow admin`) and the user assessing job related problems (`job admin` and `job viewer`).  The job admin wants to know if their changes broke the job, and they almost certainly know the time that their job change went in.  The job viewer wants to know if the job in general is flaky, so they only need a quick glimpse at the total list of jobs.  Deck is replacing gubernator for this sort of listing, so it makes sense for us to ensure that a quick visualization of build status over time exists (vs just build status in aggregate like the job bar provides today).

Use a heat map to display the last 12 hours of the selected runs, newest to oldest, with the
y dimension being the duration of the build, the color of the square being partially filled with green and red depending on the percentage of failures in that square, and the opacity of the square being the percent of jobs in the entire column.  This heap map shows up right below the job bar and uses ~100 vertical pixels to capture a summary of the state of the filtered jobs.

![image](https://www.dropbox.com/s/80n5fahrpvflquj/Screenshot%202019-02-26%2023.57.46.png?raw=1)

The end goal is to make time-correlated failures across multiple jobs more obvious. For instance, looking at a PR job shows a vertical line as all the jobs kick off, while looking at a single job across many PRs can show the exact time when test started regressing, and the user can then scan into
deeper detail.  In the example above you can see outlier builds along the top, indicating there may be a specific failure mode that takes much longer than the others.  You can also assess the percentage of success at any time visually.

Displays the left and right times, then hovering over a cell lets you click to jump straight to that build with a subtle hover effect to suggest interactivity.