### PR TITLE
kubetest2: add support for writing junit_runner.xml

### DIFF
--- a/kubetest2/BUILD.bazel
+++ b/kubetest2/BUILD.bazel
@@ -27,6 +27,7 @@ filegroup(
         ":package-srcs",
         "//kubetest2/kubetest2-kind:all-srcs",
         "//kubetest2/pkg/app:all-srcs",
+        "//kubetest2/pkg/metadata:all-srcs",
         "//kubetest2/pkg/process:all-srcs",
         "//kubetest2/pkg/types:all-srcs",
     ],

--- a/kubetest2/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2/kubetest2-kind/deployer/deployer.go
@@ -59,6 +59,6 @@ func (d *deployer) DumpClusterLogs() error {
 	panic("unimplemented")
 }
 
-func (d *deployer) GetBuilder() types.Build {
+func (d *deployer) Build() error {
 	panic("unimplemented")
 }

--- a/kubetest2/pkg/app/BUILD.bazel
+++ b/kubetest2/pkg/app/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//kubetest2/pkg/app/shim:go_default_library",
         "//kubetest2/pkg/app/testers:go_default_library",
+        "//kubetest2/pkg/metadata:go_default_library",
         "//kubetest2/pkg/types:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/kubetest2/pkg/app/cmd.go
+++ b/kubetest2/pkg/app/cmd.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -125,6 +126,7 @@ func parseArgs(name string, opt *options, args []string) ([]string, []string, er
 	flags.BoolVar(&opt.up, "up", false, "provision the test cluster")
 	flags.BoolVar(&opt.down, "down", false, "tear down the test cluster")
 	flags.StringVar(&opt.test, "test", "", "test type to run, if unset no tests will run")
+	flags.StringVar(&opt.artifacts, "artifacts", os.Getenv("ARTIFACTS"), "directory to put artifacts, defaulting to ${ARTIFACTS}")
 
 	// finally, parse flags
 	if err := flags.Parse(args); err != nil {
@@ -135,11 +137,13 @@ func parseArgs(name string, opt *options, args []string) ([]string, []string, er
 
 // options holds flag values and implements deployer.Options
 type options struct {
-	help  bool
-	build bool
-	up    bool
-	down  bool
-	test  string
+	// options exposed via Options interface
+	help      bool
+	build     bool
+	up        bool
+	down      bool
+	test      string
+	artifacts string
 }
 
 // assert that options implements deployer options
@@ -163,4 +167,8 @@ func (o *options) ShouldDown() bool {
 
 func (o *options) ShouldTest() bool {
 	return o.test != ""
+}
+
+func (o *options) ArtifactsDir() string {
+	return o.artifacts
 }

--- a/kubetest2/pkg/metadata/BUILD.bazel
+++ b/kubetest2/pkg/metadata/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "junit.go",
+        "writer.go",
+    ],
+    importpath = "k8s.io/test-infra/kubetest2/pkg/metadata",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["writer_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/kubetest2/pkg/metadata/junit.go
+++ b/kubetest2/pkg/metadata/junit.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+// JUnitError represents an error with extra metadata suitable for structured
+// (JUnit.xml) output written by kubetest2
+// If this type is returned as an error by a Deployer, kubetest2 may write the
+// metadata to the output junit_runner.xml
+type JUnitError interface {
+	error
+	Stdout() string
+	Stderr() string
+}
+
+// testSuite holds a slice of TestCase and other summary metadata.
+//
+// A build (column in testgrid) is composed of one or more TestSuites.
+type testSuite struct {
+	XMLName  xml.Name `xml:"testsuite"`
+	Failures int      `xml:"failures,attr"`
+	Tests    int      `xml:"tests,attr"`
+	Time     float64  `xml:"time,attr"`
+	Cases    []testCase
+}
+
+func (t *testSuite) Write(writer io.Writer) error {
+	// write xml header
+	io.WriteString(writer, `<?xml version="1.0" encoding="UTF-8"?>`)
+	// write indented suite
+	e := xml.NewEncoder(writer)
+	e.Indent("", "    ")
+	return e.Encode(t)
+}
+
+func (t *testSuite) AddTestCase(tc testCase) {
+	t.Tests++
+	if tc.Failure != "" {
+		t.Failures++
+	}
+	t.Cases = append(t.Cases, tc)
+}
+
+// testCase holds the result of a test/step/command.
+//
+// This will become a row in testgrid.
+type testCase struct {
+	XMLName   xml.Name `xml:"testcase"`
+	Name      string   `xml:"name,attr"`
+	Time      float64  `xml:"time,attr"`
+	Failure   string   `xml:"failure,omitempty"`
+	Skipped   string   `xml:"skipped,omitempty"`
+	SystemOut string   `xml:"system-out,omitempty"`
+	SystemErr string   `xml:"system-err,omitempty"`
+}

--- a/kubetest2/pkg/metadata/writer.go
+++ b/kubetest2/pkg/metadata/writer.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"io"
+	"time"
+)
+
+// Writer manages writing out kubetest2 metadata, namely JUnit
+type Writer struct {
+	suite     testSuite
+	start     time.Time
+	runnerOut io.Writer
+	// for faking out time when testing
+	timeNow func() time.Time
+}
+
+// NewWriter constructs a new writer, the junit_runner.xml contents
+// will be written to runnerOut, with the top level kubetest2 stages as
+// metadata (Up, Down, etc.)
+func NewWriter(runnerOut io.Writer) *Writer {
+	suite := testSuite{}
+	return &Writer{
+		suite:     suite,
+		runnerOut: runnerOut,
+		start:     time.Now(),
+		timeNow:   time.Now,
+	}
+}
+
+// WrapStep executes doStep and captures the output to be written to the
+// kubetest2 runner metadta. if doStep returns a JUnitError this metadata
+// will be captured
+func (w *Writer) WrapStep(name string, doStep func() error) error {
+	start := w.timeNow()
+	err := doStep()
+	finish := w.timeNow()
+	tc := testCase{
+		Name: name,
+		Time: finish.Sub(start).Seconds(),
+	}
+	if err != nil {
+		tc.Failure = err.Error()
+	}
+	if v, ok := err.(JUnitError); ok {
+		tc.SystemOut = v.Stdout()
+		tc.SystemErr = v.Stderr()
+	}
+	w.suite.AddTestCase(tc)
+	return err
+}
+
+// Finish finalizes the metadata (time) and writes it out
+func (w *Writer) Finish() error {
+	w.suite.Time = w.timeNow().Sub(w.start).Seconds()
+	return w.suite.Write(w.runnerOut)
+}

--- a/kubetest2/pkg/metadata/writer_test.go
+++ b/kubetest2/pkg/metadata/writer_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fake time.Now that always increments by one second
+func makeFakeNow() func() time.Time {
+	var t time.Time
+	return func() time.Time {
+		t = t.Add(time.Second)
+		return t
+	}
+}
+
+// junitError impl for testing
+type junitError struct {
+	name   string
+	stderr string
+	stdout string
+}
+
+// assert that junitError is actually a JUnitError
+var _ JUnitError = &junitError{}
+
+func (j junitError) Error() string {
+	return j.name
+}
+
+func (j *junitError) Stderr() string {
+	return j.stderr
+}
+
+func (j *junitError) Stdout() string {
+	return j.stdout
+}
+
+func TestWriter(t *testing.T) {
+	type step = struct {
+		name        string
+		doStep      func() error
+		expectError bool
+	}
+
+	var testCases = []struct {
+		name           string
+		steps          []step
+		expectedOutput string
+	}{
+		{
+			name: "all passing",
+			steps: []step{
+				{
+					name:   "noop",
+					doStep: func() error { return nil },
+				},
+			},
+			expectedOutput: strings.TrimPrefix(
+				`
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" tests="1" time="3">
+    <testcase name="noop" time="1"></testcase>
+</testsuite>`,
+				"\n",
+			),
+		},
+		{
+			name: "one failed step",
+			steps: []step{
+				{
+					name:        "always fails",
+					doStep:      func() error { return errors.New("oh noes") },
+					expectError: true,
+				},
+			},
+			expectedOutput: strings.TrimPrefix(
+				`
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="1" time="3">
+    <testcase name="always fails" time="1">
+        <failure>oh noes</failure>
+    </testcase>
+</testsuite>`,
+				"\n",
+			),
+		},
+		{
+			name: "one failed step with junitError",
+			steps: []step{
+				{
+					name: "always fails (junitError)",
+					doStep: func() error {
+						return &junitError{
+							name:   "on noes",
+							stdout: "uh oh",
+							stderr: "whoops",
+						}
+					},
+					expectError: true,
+				},
+			},
+			expectedOutput: strings.TrimPrefix(
+				`
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="1" time="3">
+    <testcase name="always fails (junitError)" time="1">
+        <failure>on noes</failure>
+        <system-out>uh oh</system-out>
+        <system-err>whoops</system-err>
+    </testcase>
+</testsuite>`,
+				"\n",
+			),
+		},
+		{
+			name: "two passing steps and one failed step with junitError",
+			steps: []step{
+				{
+					name:   "noop",
+					doStep: func() error { return nil },
+				},
+				{
+					name:   "noop2",
+					doStep: func() error { return nil },
+				},
+				{
+					name: "always fails (junitError)",
+					doStep: func() error {
+						return &junitError{
+							name:   "on noes",
+							stdout: "uh oh",
+							stderr: "whoops",
+						}
+					},
+					expectError: true,
+				},
+			},
+			expectedOutput: strings.TrimPrefix(
+				`
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="3" time="7">
+    <testcase name="noop" time="1"></testcase>
+    <testcase name="noop2" time="1"></testcase>
+    <testcase name="always fails (junitError)" time="1">
+        <failure>on noes</failure>
+        <system-out>uh oh</system-out>
+        <system-err>whoops</system-err>
+    </testcase>
+</testsuite>`,
+				"\n",
+			),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc // capture range variable
+			// these are parallel safe, we faked out time etc.
+			t.Parallel()
+			// fake output io.WriteCloser
+			runnerOut := bytes.NewBuffer([]byte{})
+			// create a new writer and fake out the time
+			w := NewWriter(runnerOut)
+			w.timeNow = makeFakeNow()
+			w.start = w.timeNow()
+			// run all the steps
+			for _, step := range tc.steps {
+				err := w.WrapStep(step.name, step.doStep)
+				if err != nil && !step.expectError {
+					t.Errorf("got unexpected error for step %#v %v", step.name, err)
+				} else if err == nil && step.expectError {
+					t.Errorf("expected error for step: %#v and got none", step.name)
+				}
+			}
+			// finish writing the writer and check the output
+			err := w.Finish()
+			if err != nil {
+				t.Errorf("unexpected error for writer.Finish() %v", err)
+			}
+			output := runnerOut.String()
+			if output != tc.expectedOutput {
+				t.Errorf("runnerOut did not match expected \n%v\nVERSUS:\n %v", tc.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/kubetest2/pkg/types/types.go
+++ b/kubetest2/pkg/types/types.go
@@ -43,13 +43,24 @@ type Options interface {
 	// if this returns true, help text will be shown to the user after instancing
 	// the deployer and tester
 	HelpRequested() bool
+	// if this is true, kubetest2 will be calling deployer.Build
 	ShouldBuild() bool
+	// if this is true, kubetest2 will be calling deployer.Up
 	ShouldUp() bool
+	// if this is true, kubetest2 will be calling deployer.Down
 	ShouldDown() bool
+	// if this is true, kubetest2 will be calling tester.Test
 	ShouldTest() bool
+	// returns the path to the directory where artifacts should be written
+	// (including metadata files like junit_runner.xml)
+	ArtifactsDir() string
 }
 
 // Deployer defines the interface between kubetest and a deployer
+//
+// If any returned error meets the:
+// k8s.io/test-infra/kubetest2/pkg/metadata.JUnitError
+// interface, then this metadata will be pulled out when writing out the results
 type Deployer interface {
 	// Up should provision a new cluster for testing
 	Up() error
@@ -60,16 +71,10 @@ type Deployer interface {
 	// DumpClusterLogs should export logs from the cluster. It may be called
 	// multiple times. Options for this should come from New(...)
 	DumpClusterLogs() error
-	// GetBuilder should return a custom build instance for the implementation
-	// It may return a custom impelementation, a common implementation provided
-	// by the kubetest2 packages, or nil. If nil is returned a default builder
-	// will be used
-	GetBuilder() Build
+	// Build should build kubernetes and package it in whatever format
+	// the deployer consumes
+	Build() error
 }
-
-// Build should build kubernetes and package it in whatever format
-// the deployer consumes
-type Build func() error
 
 // NewTester should process & store deployerArgs and the common Options
 // kubetest2 will call this once at startup


### PR DESCRIPTION
- implement a `junit_runner.xml` metadata writer
  - add tests (100% coverage! 🙃)
- use this writer in kubestest2
- document how this integrates with the deployer interfaces
- minor cleanup, replace `GetBuilder` with just `Build` on the deployer interface ... deployers can just wrap a library provided default builder instead

Next steps:
- signal handling in the deployer binaries to interrupt cleanly on `SIGINT` etc.
- actually implement the kubetest2-kind/deployer
- document the app logic, how to write another deployer
- write utility packages for EG downloading kubernetes tarballs