### PR TITLE
Set LOGROTATE_FILES_MAX_COUNT=1000 in scalability tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -118,6 +118,9 @@ presets:
   # Dump full systemd journal on master and nodes.
   - name: LOG_DUMP_SYSTEMD_JOURNAL
     value: "true"
+  # Keep all logrotated files (not just 5 latest which is a default)
+  - name: LOGROTATE_FILES_MAX_COUNT
+    value: 1000
 
 ###### Scalability Envs
 ### Common env variables for all scalability-related suites.


### PR DESCRIPTION
The default is 5, which makes that we are dropping some logs (mostly -audit ones right now).

/assign @wojtek-t 