### PR TITLE
Minor - Fix broken kubetest reference

### DIFF
--- a/kubetest2/README.md
+++ b/kubetest2/README.md
@@ -7,5 +7,5 @@ This project is a stub currently, this doc will contain more details in the futu
 See also [the initial design doc] shared with kubernetes-sig-testing@googlegroups.com
 and kubernetes-dev@googlegroups.com
 
-[kubetest]: https://github.com/kubernetes/test-infra/tree/master/kubtest
+[kubetest]: https://github.com/kubernetes/test-infra/tree/master/kubetest
 [the initial design doc]: https://docs.google.com/document/d/1Dc7xg9lq4cxdDuz20YZjunuL5eju2WIXwO32praC5hs/

--- a/kubetest2/pkg/app/app.go
+++ b/kubetest2/pkg/app/app.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/test-infra/kubetest2/pkg/types"
 )
 
-// Main implements the kubtest2 deployer binary entrypoint
+// Main implements the kubetest2 deployer binary entrypoint
 // Each deployer binary should invoke this, in addition to loading deployers
 func Main(deployerName string, newDeployer types.NewDeployer) {
 	// see cmd.go for the rest of the CLI boilerplate

--- a/kubetest2/pkg/app/shim/shim.go
+++ b/kubetest2/pkg/app/shim/shim.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/test-infra/kubetest2/pkg/process"
 )
 
-// Main implements the kubtest2 root binary entrypoint
+// Main implements the kubetest2 root binary entrypoint
 func Main() {
 	if err := Run(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Just fixed three misspellings of kubetest, one of which was linking to a dead-end.

/area kubetest

/assign @BenTheElder 