### PR TITLE
Add cluster-api presubmit integration job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -88,3 +88,22 @@ presubmits:
         - "--scenario=execute"
         - "--"
         - "./scripts/ci-is-vendor-in-sync.sh"
+  - name: pull-cluster-api-integration
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    always_run: false
+    optional: true
+    skip_report: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-integration.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2477,6 +2477,9 @@ test_groups:
 - name: pull-cluster-api-vendor-in-sync
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-vendor-in-sync
   num_columns_recent: 20
+- name: pull-cluster-api-integration
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-integration
+  num_columns_recent: 20
 - name: periodic-cluster-api-provider-aws-test-creds
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds
   num_columns_recent: 20
@@ -5898,6 +5901,8 @@ dashboards:
     test_group_name: pull-cluster-api-test
   - name: pr-vendor
     test_group_name: pull-cluster-api-vendor-in-sync
+  - name: pr-integration
+    test_group_name: pull-cluster-api-integration
 
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
   dashboard_tab:


### PR DESCRIPTION
this is for cluster-api main.

cc @BenTheElder @krzyzacy @vincepri @detiber @roberthbailey 

notes:
the `always_run` been set to `false`,  we want job manually triggered first, if it is passing consistently, i will set it to `true` later.
