### PR TITLE
switch kubernetes-incubator/service-catalog job images to master

### DIFF
--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.13
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
         args:
         - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
         - "--timeout=45"
@@ -42,7 +42,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.13
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
         args:
         - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
         - "--timeout=60"


### PR DESCRIPTION
Talked about this in our SIG meeting today, think we're going to try pegging this to master so we don't have to update it manually.

/assign @BenTheElder could you take a look at this when you have a second?