### PR TITLE
spyglass: Include both started and finished metadata

### DIFF
--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
+        "//testgrid/metadata:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 	"k8s.io/test-infra/prow/spyglass/lenses"
+	"k8s.io/test-infra/testgrid/metadata"
 )
 
 const (
@@ -116,9 +117,13 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 	}
 
 	metadataViewData.Metadata = map[string]string{"node": started.Node}
-	for k, v := range finished.Metadata {
-		if s, ok := v.(string); ok && v != "" {
-			metadataViewData.Metadata[k] = s
+
+	metadatas := []metadata.Metadata{started.Metadata, finished.Metadata}
+	for _, m := range metadatas {
+		for k, v := range m {
+			if s, ok := v.(string); ok && v != "" {
+				metadataViewData.Metadata[k] = s
+			}
 		}
 	}
 


### PR DESCRIPTION
Include metadata from both `started.json` and `finished.json`. If there are duplicate keys, `finished.json` wins.

This was easier than perf.

/cc @fejta 