### PR TITLE
update cluster-api ci image version (consistently failing at testgrid)

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -5,7 +5,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
+    - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
       args:
       - "--repo=sigs.k8s.io/cluster-api"
       - "--root=/go/src"
@@ -19,7 +19,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/cluster-api:v20180720-d52d72975
+    - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
       args:
       - "--repo=sigs.k8s.io/cluster-api"
       - "--root=/go/src"


### PR DESCRIPTION
the current periodic job is failing consistently, the only difference between pull-cluster-api-test and ci-cluster-api-test is the container version.

the error is about kube-builder: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cluster-api-test/7439/build-log.txt
```
I0225 23:26:40.121] go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
W0225 23:26:42.083] # sigs.k8s.io/cluster-api/vendor/sigs.k8s.io/yaml
W0225 23:26:42.084] vendor/sigs.k8s.io/yaml/yaml.go:42:48: undefined: DisallowUnknownFields
W0225 23:26:44.802] # sigs.k8s.io/cluster-api/vendor/k8s.io/client-go/transport
W0225 23:26:44.803] vendor/k8s.io/client-go/transport/round_trippers.go:470:9: undefined: strings.Builder
W0225 23:26:49.850] # sigs.k8s.io/cluster-api/vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse
W0225 23:26:49.850] vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse/util.go:339:11: undefined: strings.Builder
I0225 23:26:56.494] Makefile:65: recipe for target 'manifests' failed
```

the new version of cluster-api image should has the kube-builder required.


cc @BenTheElder @vincepri @detiber 