### PR TITLE
boskos: Deploying a new Boskos janitor for AWS

### DIFF
--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -32,6 +32,9 @@ reaper:
 janitor:
 	go build -o janitor/janitor k8s.io/test-infra/boskos/janitor/
 
+janitor-aws:
+	$(MAKE) -C ../maintenance/aws-janitor/cmd/aws-janitor-boskos
+
 metrics:
 	go build -o metrics/metrics k8s.io/test-infra/boskos/metrics/
 
@@ -52,6 +55,12 @@ janitor-image:
 	docker build --no-cache -t "$(HUB)/janitor:$(TAG)" janitor
 	docker push "$(HUB)/janitor:$(TAG)"
 	rm janitor/janitor
+
+janitor-aws-image: export DOCKER_OPTS=--no-cache
+janitor-aws-image: export IMAGE=$(HUB)/janitor-aws
+janitor-aws-image:
+	$(MAKE) -C ../maintenance/aws-janitor/cmd/aws-janitor-boskos image push
+	$(MAKE) -C ../maintenance/aws-janitor/cmd/aws-janitor-boskos clean
 
 metrics-image:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o metrics/metrics k8s.io/test-infra/boskos/metrics/
@@ -81,4 +90,4 @@ update-config: get-cluster-credentials
 get-cluster-credentials:
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
-.PHONY: boskos client reaper janitor metrics server-image reaper-image janitor-image metrics-image server-deployment reaper-deployment janitor-deployment metrics-deployment service update-config get-cluster-credentials
+.PHONY: boskos client reaper janitor janitor-aws metrics server-image reaper-image janitor-image janitor-aws-image metrics-image server-deployment reaper-deployment janitor-deployment metrics-deployment service update-config get-cluster-credentials

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -79,6 +79,6 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-aws
-        image: akutz/boskos-janitor-aws:v20190226-99e2515db
+        image: akutz/boskos-janitor-aws:v20190226-f06ce8bad
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -61,4 +61,24 @@ spec:
       - name: service
         secret:
           secretName: service-account
-
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: boskos-janitor-aws
+  labels:
+    app: boskos-janitor-aws
+  namespace: test-pods
+spec:
+  replicas: 4  # 4 distributed janitor instances
+  template:
+    metadata:
+      labels:
+        app: boskos-janitor-aws
+    spec:
+      terminationGracePeriodSeconds: 300
+      containers:
+      - name: boskos-janitor-aws
+        image: akutz/boskos-janitor-aws:v20190226-99e2515db
+        args:
+        - --boskos-url=http://boskos.test-pods.svc.cluster.local.

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/.gitignore
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/.gitignore
@@ -1,0 +1,1 @@
+/aws-janitor-boskos

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/Dockerfile
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch-20190204-slim
+
+RUN apt-get -y update && \
+    apt-get -y install ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY aws-janitor-boskos /usr/local/bin/
+
+CMD ["aws-janitor-boskos"]
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/Makefile
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROGRAM ?= aws-janitor-boskos
+HUB ?= gcr.io/k8s-testimages
+IMAGE ?= $(HUB)/$(notdir $(PROGRAM))
+TAG ?= $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+build: $(PROGRAM)
+$(PROGRAM):
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o "$@"
+
+image:
+	GOOS=linux GOARCH=amd64 $(MAKE)
+	docker build $(DOCKER_OPTS) -t "$(IMAGE):$(TAG)" .
+
+push: image
+	docker push "$(IMAGE):$(TAG)"
+
+push-latest: push
+	docker tag "$(IMAGE):$(TAG)" "$(IMAGE):latest"
+	docker push "$(IMAGE):latest"
+
+clean:
+	rm -f $(PROGRAM)
+
+.PHONY: $(PROGRAM) build clean image push push-latest


### PR DESCRIPTION
This patch deploys a new Boskos janitor as a service in the same cluster running Prow. The new service is named `boskos-janitor-aws`.

Related to:
1. https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/272
2. https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/606

Blocked by:
1. https://github.com/kubernetes/test-infra/pull/11504

/area boskos
/assign @krzyzacy 
/cc @detiber @randomvariable @vincepri
/hold