### PR TITLE
Enable Prometheus stack in node-killer test.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -35,6 +35,8 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
       - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
+      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Set everywhere if it works
+      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/74213

Now the https://github.com/kubernetes/perf-tests/pull/429 is merged we can enable the prometheus server back.

