### PR TITLE
Add CAPA e2e periodic and post-submit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,7 +1,7 @@
 periodics:  
-- interval: 4h
-  name: periodic-cluster-api-provider-aws-test-creds
+- name: periodic-cluster-api-provider-aws-test-creds
   decorate: true
+  interval: 4h
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16,3 +16,42 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.12
       command:
       - "./scripts/ci-aws-cred-test.sh"
+- name: periodic-cluster-api-provider-aws-bazel-e2e
+  decorate: true
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extxa_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.12
+      command:
+      - make
+      args:
+      - e2e
+      env:
+      - name: BOSKOS_HOST
+        value: "http://boskos.test-pods.svc.cluster.local."
+postsubmits:
+  kubernetes-sigs/cluster-api-provider-aws:
+  - name: pull-cluster-api-provider-aws-bazel-e2e
+    decorate: true
+    max_concurrency: 5
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.12
+        command:
+        - make
+        args:
+        - e2e
+        env:
+        - name: BOSKOS_HOST
+          value: "http://boskos.test-pods.svc.cluster.local."

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2480,6 +2480,9 @@ test_groups:
 - name: pull-cluster-api-integration
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-integration
   num_columns_recent: 20
+- name: periodic-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-bazel-e2e
+  num_columns_recent: 20
 - name: periodic-cluster-api-provider-aws-test-creds
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds
   num_columns_recent: 20
@@ -2494,6 +2497,9 @@ test_groups:
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-test
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-e2e
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-integration
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-integration
@@ -5896,10 +5902,14 @@ dashboards:
     test_group_name: pull-cluster-api-provider-aws-bazel-build
   - name: bazel-pr-test
     test_group_name: pull-cluster-api-provider-aws-bazel-test
+  - name: bazel-e2e
+    test_group_name: pull-cluster-api-provider-aws-bazel-e2e
   - name: bazel-pr-integration
     test_group_name: pull-cluster-api-provider-aws-bazel-integration
   - name: test-creds
     test_group_name: periodic-cluster-api-provider-aws-test-creds
+  - name: periodic-bazel-e2e
+    test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
 
 - name: sig-cluster-lifecycle-cluster-api-provider-azure
   dashboard_tab:


### PR DESCRIPTION
This patch adds CAPA e2e periodic and post-submit jobs.

Blocked by:
1. boskos: Deploying a new Boskos janitor for AWS (https://github.com/kubernetes/test-infra/pull/11511)
2. e2e tests (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/606)

/cc @krzyzacy @detiber @randomvariable @vincepri
/hold