### PR TITLE
Add a e2e test using conformance image + kind

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3016,6 +3016,71 @@ presubmits:
   - agent: kubernetes
     always_run: false
     cluster: security
+    context: pull-security-kubernetes-conformance-image-test
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-conformance-image-test
+    optional: true
+    rerun_command: /test pull-security-kubernetes-conformance-image-test
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --job=$(JOB_NAME)
+        - --root=/go/src
+        - --repo=k8s.io/test-infra=master
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=sigs.k8s.io/kind=master
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --scenario=execute
+        - --
+        - bash
+        - --
+        - -c
+        - cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh
+        env:
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-conformance-image-test,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    cluster: security
     context: pull-security-kubernetes-godeps
     decorate: true
     labels:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -1,0 +1,67 @@
+presubmits:
+  kubernetes/kubernetes:
+  # conformance test against kubernetes master branch with `kind`, skipping
+  # serial tests so it runs in ~20m
+  - name: pull-kubernetes-conformance-image-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    always_run: false
+    optional: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
+          env:
+            # skip serial tests and run with --ginkgo-parallel
+            - name: "PARALLEL"
+              value: "true"
+          args:
+            - "--job=$(JOB_NAME)"
+            - "--root=/go/src"
+            - "--repo=k8s.io/test-infra=master"
+            - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+            - "--repo=sigs.k8s.io/kind=master"
+            - "--service-account=/etc/service-account/service-account.json"
+            - "--upload=gs://kubernetes-jenkins/pr-logs"
+            - "--scenario=execute"
+            - "--"
+            # the script must run from kubernetes, but we're checking out kind
+            - "bash"
+            - "--"
+            - "-c"
+            - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          # kind needs /lib/modules and cgroups from the host
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+      # trialing this on kind jobs, we are using FQDN for in-cluster services, now
+      # so use ndots 1 to improve dns performance
+      # TODO(bentheelder): consider setting this at the cluster level instead
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/experiment/kind-conformance-e2e.sh
+++ b/experiment/kind-conformance-e2e.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+source $(dirname "${BASH_SOURCE[0]}")/kind-e2e.sh
+
+run_tests() {
+  # binaries needed by the conformance image
+  rm -rf _output/bin
+  make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
+
+  # grab the version number for kubernetes
+  export KUBE_ROOT=${PWD}
+  source ${KUBE_ROOT}/hack/lib/version.sh
+  kube::version::get_version_vars
+
+  export VERSION=$(echo -n "${KUBE_GIT_VERSION}" | cut -f 1 -d '+')
+  export KUBECONFIG=$(kind get kubeconfig-path)
+
+  pushd ${PWD}/cluster/images/conformance
+
+  # build and load the conformance image into the kind nodes
+  make build ARCH=amd64
+  kind load docker-image k8s.gcr.io/conformance-amd64:${VERSION}
+
+  # patch the image in manifest
+  sed -i "s|conformance-amd64:.*|conformance-amd64:${VERSION}|g" conformance-e2e.yaml
+  ./conformance-e2e.sh
+
+  popd
+
+  # extract the test results
+  NODE_NAME=$(kubectl get po -n conformance e2e-conformance-test -o 'jsonpath={.spec.nodeName}')
+  docker exec ${NODE_NAME} tar cvf - /tmp/results | tar -C ${ARTIFACTS} --strip-components 2 -xf -
+}
+
+main

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -21,13 +21,15 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
+set -o xtrace
 
 # our exit handler (trap)
 cleanup() {
+    # always attempt to dump logs
+    kind "export" logs "${ARTIFACTS}/logs" || true
     # KIND_IS_UP is true once we: kind create
     if [[ "${KIND_IS_UP:-}" = true ]]; then
-        kind delete || true
+        kind delete cluster || true
     fi
     # clean up e2e.test symlink
     rm -f _output/bin/e2e.test
@@ -38,7 +40,7 @@ cleanup() {
     fi
 }
 
-# install kind to a tempdir GOPATH from this script's test-infra checkout
+# install kind to a tempdir GOPATH from this script's kind checkout
 install_kind() {
     # install `kind` to tempdir
     TMP_DIR=$(mktemp -d)
@@ -48,7 +50,7 @@ install_kind() {
     if [[ $(go list sigs.k8s.io/kind) = "sigs.k8s.io/kind" ]]; then
         env "GOBIN=${TMP_DIR}/bin" go install sigs.k8s.io/kind
     else
-        env "GOPATH=${TMP_DIR}" go get sigs.k8s.io/kind
+        env "GOPATH=${TMP_DIR}" go get -u sigs.k8s.io/kind
     fi
     PATH="${TMP_DIR}/bin:${PATH}"
     export PATH
@@ -56,10 +58,6 @@ install_kind() {
 
 # build kubernetes / node image, e2e binaries
 build() {
-    # build the base image
-    # TODO(bentheelder): eliminate this once we publish this image
-    kind build base
-
     # possibly enable bazel build caching before building kubernetes
     BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
     if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
@@ -68,7 +66,7 @@ build() {
     fi
 
     # build the node image w/ kubernetes
-    kind build node --type=bazel
+    kind build node-image --type=bazel
 
     # make sure we have e2e requirements
     #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"
@@ -89,19 +87,49 @@ build() {
 
 # up a cluster with kind
 create_cluster() {
+    # create the config file
+    cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
+# config for 1 control plane node and 2 workers
+# necessary for conformance
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+# the control plane node
+- role: control-plane
+- role: worker
+  replicas: 2
+EOF
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it
     KIND_IS_UP=true
-    kind create
+    # actually create, with:
+    # - do not delete created nodes from a failed cluster create (for debugging)
+    # - wait up to one minute for the nodes to be "READY"
+    # - set log leve to debug
+    # - use our multi node config
+    kind create cluster \
+        --image=kindest/node:latest \
+        --retain \
+        --wait=1m \
+        --loglevel=debug \
+        "--config=${ARTIFACTS}/kind-config.yaml"
 }
 
 # run e2es with kubetest
 run_tests() {
-    # default WORKSPACE if not in CI
-    WORKSPACE="${WORKSPACE:-${PWD}}"
+    # export the KUBECONFIG
+    KUBECONFIG="$(kind get kubeconfig-path)"
+    export KUBECONFIG
 
     # base kubetest args
     KUBETEST_ARGS="--provider=skeleton --test --check-version-skew=false"
+
+    # get the number of worker nodes
+    # TODO(bentheelder): this is kinda gross
+    NUM_NODES="$(kubectl get nodes \
+        -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.taints}{"\n"}{end}' \
+        | grep -cv "node-role.kubernetes.io/master" \
+    )"
 
     # ginkgo regexes
     SKIP="${SKIP:-"Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]"}"
@@ -114,11 +142,7 @@ run_tests() {
     fi
 
     # add ginkgo args
-    KUBETEST_ARGS="${KUBETEST_ARGS} --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${WORKSPACE}/_artifacts --disable-log-dump=true\""
-
-    # export the KUBECONFIG
-    # TODO(bentheelder): provide a `kind` command that can be eval'ed instead
-    export KUBECONFIG="${HOME}/.kube/kind-config-1"
+    KUBETEST_ARGS="${KUBETEST_ARGS} --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${ARTIFACTS} --disable-log-dump=true --num-nodes=${NUM_NODES}\""
 
     # setting this env prevents ginkg e2e from trying to run provider setup
     export KUBERNETES_CONFORMANCE_TEST="y"
@@ -129,6 +153,11 @@ run_tests() {
 
 # setup kind, build kubernetes, create a cluster, run the e2es
 main() {
+    # ensure artifacts exists when not in CI
+    ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+    mkdir -p "${ARTIFACTS}"
+    export ARTIFACTS
+    # now build an run the cluster and tests
     trap cleanup EXIT
     install_kind
     build
@@ -136,4 +165,6 @@ main() {
     run_tests
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2625,6 +2625,9 @@ test_groups:
 - name: pull-kubernetes-local-e2e
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-local-e2e
   num_columns_recent: 20
+- name: pull-kubernetes-conformance-image-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-conformance-image-test
+  num_columns_recent: 20
 - name: pull-kubernetes-e2e-containerd-gce
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-containerd-gce
   num_columns_recent: 20
@@ -6790,6 +6793,11 @@ dashboards:
   - name: pull-kubernetes-local-e2e
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: pull-kubernetes-local-e2e
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: pull-kubernetes-conformance-image-test
+    description: Runs conformance tests using kind and the conformance image
+    test_group_name: pull-kubernetes-conformance-image-test
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 


### PR DESCRIPTION
We have conformance image in k/k that we want to test using kind

- Add optional presubmit test that can be kicked off when needed in k/k repo PRs
- update the experiment/kind-e2e.sh with latest script from kubernetes-sigs/kind repo
- Add a condition to skip running the `main` method when the file is sourced 
- Add another script experiment/kind-conformance-e2e.sh that re-uses most of the kind-e2e.sh except for the tests themselves (which is delegated to the conformance image)

Related to https://github.com/kubernetes/kubernetes/issues/69777

Change-Id: I18469a4d4c6b45fb525bc3f6f29cae8ded519ccc