### PR TITLE
kubernetes-csi: initial presubmit job with E2E testing

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path.yaml
@@ -1,0 +1,16 @@
+presubmits:
+  kubernetes-csi/csi-driver-host-path:
+  - name: pull-sig-storage-csi-driver-host-path
+    always_run: false
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-cadvisor-docker-credential: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      # We need this image because it has Docker and kind.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
+        command:
+        - ./.prow.sh


### PR DESCRIPTION
This job is part of the plan for switching the kubernetes-csi release
process from Travis CI to Prow.

xref: https://github.com/kubernetes/enhancements/pull/807
xref: https://github.com/kubernetes-csi/csi-driver-host-path/pull/16