### PR TITLE
enable cluster-api integration test job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -93,9 +93,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-service-account: "true"
       preset-kind-volume-mounts: "true"
-    always_run: false
-    optional: true
-    skip_report: true
+    always_run: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     spec:


### PR DESCRIPTION
tested with two pull requests, they are passing, https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-cluster-api#pr-integration

i don't see a big risk to enable it, @detiber  any suggestion?

cc @vincepri 


