### PR TITLE
Work around bizarre spyglass height bug

### DIFF
--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -55,8 +55,17 @@ class SpyglassImpl implements Spyglass {
     return result.data;
   }
   public contentUpdated(): void {
-    // .then() to suppress complaints about unhandled promises (we just don't care here).
-    this.postMessage({type: 'contentUpdated', height: document.body.offsetHeight}).then();
+    // Use .then() instead of await to avoid infecting our caller with our
+    // asynchronicity.
+    this.postMessage({type: 'contentUpdated', height: document.body.offsetHeight}).then(({data}) => {
+      // If before this call we were not actually visible, recalculate our height.
+      // This works around a bizarre issue where other elements on the parent page
+      // being resized can cause us to produce an incorrect height. Recalculating
+      // after we become visible ensures we produce the correct value.
+      if (data === 'madeVisible') {
+        this.contentUpdated();
+      }
+    });
   }
 
   private postMessage(message: Message): Promise<Response> {

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -47,12 +47,16 @@ window.addEventListener('message', async (e) => {
     switch (message.type) {
       case "contentUpdated":
         frame.style.height = `${message.height}px`;
-        frame.style.visibility = 'visible';
-        if (frame.dataset.hideTitle) {
-          frame.parentElement!.parentElement!.classList.add('hidden-title');
+        if (frame.style.visibility !== 'visible') {
+          frame.style.visibility = 'visible';
+          if (frame.dataset.hideTitle) {
+            frame.parentElement!.parentElement!.classList.add('hidden-title');
+          }
+          document.querySelector<HTMLElement>(`#${lens}-loading`)!.style.display = 'none';
+          respond('madeVisible');
+        } else {
+          respond('');
         }
-        document.querySelector<HTMLElement>(`#${lens}-loading`)!.style.display = 'none';
-        respond('');
         break;
       case "request": {
         const req = await fetch(urlForLensRequest(lens, 'callback'),


### PR DESCRIPTION
Apparently, when a lens frame is hidden (because it's loading), and another lens on the page changes its height, the lens can end up calculating a height that is too short (somehow). Once they become visible, the issue does not occur.

To work around this issue, lenses will now recalculate their height again when they first become visible.

This appears to fix the issue, but I am not confident in having correctly identified the root cause.