### PR TITLE
Enable trigger plugin for csi-driver-host-path

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -505,6 +505,9 @@ plugins:
   kubernetes-csi/csi-lib-utils:
   - trigger
 
+  kubernetes-csi/csi-driver-host-path:
+  - trigger
+
   kubernetes-incubator:
   - approve
   - assign


### PR DESCRIPTION
/assign @pohly 

This should make the `/test <..>` commands work for https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path.yaml.