### PR TITLE
kubetest2: implement a kind deployer

### DIFF
--- a/kubetest2/BUILD.bazel
+++ b/kubetest2/BUILD.bazel
@@ -27,6 +27,7 @@ filegroup(
         ":package-srcs",
         "//kubetest2/kubetest2-kind:all-srcs",
         "//kubetest2/pkg/app:all-srcs",
+        "//kubetest2/pkg/exec:all-srcs",
         "//kubetest2/pkg/metadata:all-srcs",
         "//kubetest2/pkg/process:all-srcs",
         "//kubetest2/pkg/types:all-srcs",

--- a/kubetest2/kubetest2-kind/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-kind/deployer/BUILD.bazel
@@ -5,7 +5,13 @@ go_library(
     srcs = ["deployer.go"],
     importpath = "k8s.io/test-infra/kubetest2/kubetest2-kind/deployer",
     visibility = ["//visibility:public"],
-    deps = ["//kubetest2/pkg/types:go_default_library"],
+    deps = [
+        "//kubetest2/pkg/exec:go_default_library",
+        "//kubetest2/pkg/metadata:go_default_library",
+        "//kubetest2/pkg/process:go_default_library",
+        "//kubetest2/pkg/types:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
 )
 
 filegroup(

--- a/kubetest2/kubetest2-kind/main.go
+++ b/kubetest2/kubetest2-kind/main.go
@@ -25,5 +25,5 @@ import (
 )
 
 func main() {
-	app.Main(deployer.Name, deployer.Usage(), deployer.New)
+	app.Main(deployer.Name, deployer.New)
 }

--- a/kubetest2/pkg/app/app.go
+++ b/kubetest2/pkg/app/app.go
@@ -29,9 +29,9 @@ import (
 
 // Main implements the kubetest2 deployer binary entrypoint
 // Each deployer binary should invoke this, in addition to loading deployers
-func Main(deployerName, deployerUsage string, newDeployer types.NewDeployer) {
+func Main(deployerName string, newDeployer types.NewDeployer) {
 	// see cmd.go for the rest of the CLI boilerplate
-	if err := Run(deployerName, deployerUsage, newDeployer); err != nil {
+	if err := Run(deployerName, newDeployer); err != nil {
 		// only print the error if it's not an IncorrectUsage (which we've)
 		// already output along with usage
 		if _, isUsage := err.(types.IncorrectUsage); !isUsage {

--- a/kubetest2/pkg/app/cmd.go
+++ b/kubetest2/pkg/app/cmd.go
@@ -138,7 +138,14 @@ func runE(
 		}
 	}
 
-	// if we encountered any errors with the user input, show help and return
+	// print usage and return if explicitly requested
+	if opts.HelpRequested() {
+		cmd.Print(usage.String())
+		return nil
+	}
+
+	// otherwise if we encountered any errors with the user input
+	// show the error / help, usage and then return
 	if parseError != nil {
 		// ensure this is an incorrect usage error so the top level
 		// app logic will not print the error again, see Main()
@@ -155,12 +162,6 @@ func runE(
 		cmd.Print("\n\n")
 		cmd.Print(usage.String())
 		return parseError
-	}
-
-	// print usage and return if explicitly requested
-	if opts.HelpRequested() {
-		cmd.Print(usage.String())
-		return nil
 	}
 
 	// run RealMain, which contains all of the logic beyond the CLI boilerplate
@@ -269,11 +270,11 @@ func (u *usage) String() string {
 	s := fmt.Sprintf(
 		strings.TrimPrefix(`
 Usage:
-  kubetest2 %s [Flags] [DeployerArgs] -- [TesterArgs]
+  kubetest2 %s [Flags] [DeployerFlags] -- [TesterArgs]
 
 Flags:
 %s
-DeployerArgs(%s):
+DeployerFlags(%s):
 %s
 `, "\n"),
 		u.deployerName,

--- a/kubetest2/pkg/exec/BUILD.bazel
+++ b/kubetest2/pkg/exec/BUILD.bazel
@@ -3,12 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "helpers.go",
-        "types.go",
+        "doc.go",
+        "exec.go",
+        "local.go",
     ],
-    importpath = "k8s.io/test-infra/kubetest2/pkg/types",
+    importpath = "k8s.io/test-infra/kubetest2/pkg/exec",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )
 
 filegroup(

--- a/kubetest2/pkg/exec/doc.go
+++ b/kubetest2/pkg/exec/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec contains an interface for executing commands, along with helpers
+// TODO(bentheelder): add standardized timeout functionality & a default timeout
+// so that commands cannot hang indefinitely (!)
+package exec

--- a/kubetest2/pkg/exec/exec.go
+++ b/kubetest2/pkg/exec/exec.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+)
+
+// Cmd abstracts over running a command somewhere, this is useful for testing
+type Cmd interface {
+	Run() error
+	// Each entry should be of the form "key=value"
+	SetEnv(...string) Cmd
+	SetStdin(io.Reader) Cmd
+	SetStdout(io.Writer) Cmd
+	SetStderr(io.Writer) Cmd
+}
+
+// Cmder abstracts over creating commands
+type Cmder interface {
+	// command, args..., just like os/exec.Cmd
+	Command(string, ...string) Cmd
+}
+
+// DefaultCmder is a LocalCmder instance used for convienience, packages
+// originally using os/exec.Command can instead use pkg/kind/exec.Command
+// which forwards to this instance
+// TODO(bentheelder): swap this for testing
+// TODO(bentheelder): consider not using a global for this :^)
+var DefaultCmder = &LocalCmder{}
+
+// Command is a convience wrapper over DefaultCmder.Command
+func Command(command string, args ...string) Cmd {
+	return DefaultCmder.Command(command, args...)
+}
+
+// CombinedOutputLines is like os/exec's cmd.CombinedOutput(),
+// but over our Cmd interface, and instead of returning the byte buffer of
+// stderr + stdout, it scans these for lines and returns a slice of output lines
+func CombinedOutputLines(cmd Cmd) (lines []string, err error) {
+	var buff bytes.Buffer
+	cmd.SetStdout(&buff)
+	cmd.SetStderr(&buff)
+	err = cmd.Run()
+	scanner := bufio.NewScanner(&buff)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, err
+}
+
+// InheritOutput sets cmd's output to write to the current process's stdout and stderr
+func InheritOutput(cmd Cmd) {
+	cmd.SetStderr(os.Stderr)
+	cmd.SetStdout(os.Stdout)
+}

--- a/kubetest2/pkg/exec/local.go
+++ b/kubetest2/pkg/exec/local.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"io"
+	osexec "os/exec"
+)
+
+// LocalCmd wraps os/exec.Cmd, implementing the exec.Cmd interface
+type LocalCmd struct {
+	*osexec.Cmd
+}
+
+var _ Cmd = &LocalCmd{}
+
+// LocalCmder is a factory for LocalCmd, implementing Cmder
+type LocalCmder struct{}
+
+var _ Cmder = &LocalCmder{}
+
+// Command returns a new exec.Cmd backed by Cmd
+func (c *LocalCmder) Command(name string, arg ...string) Cmd {
+	return &LocalCmd{
+		Cmd: osexec.Command(name, arg...),
+	}
+}
+
+// SetEnv sets env
+func (cmd *LocalCmd) SetEnv(env ...string) Cmd {
+	cmd.Env = env
+	return cmd
+}
+
+// SetStdin sets stdin
+func (cmd *LocalCmd) SetStdin(r io.Reader) Cmd {
+	cmd.Stdin = r
+	return cmd
+}
+
+// SetStdout set stdout
+func (cmd *LocalCmd) SetStdout(w io.Writer) Cmd {
+	cmd.Stdout = w
+	return cmd
+}
+
+// SetStderr sets stderr
+func (cmd *LocalCmd) SetStderr(w io.Writer) Cmd {
+	cmd.Stderr = w
+	return cmd
+}
+
+// Run runs
+func (cmd *LocalCmd) Run() error {
+	return cmd.Cmd.Run()
+}

--- a/kubetest2/pkg/metadata/junit.go
+++ b/kubetest2/pkg/metadata/junit.go
@@ -31,6 +31,26 @@ type JUnitError interface {
 	SystemOut() string
 }
 
+type simpleJUnitError struct {
+	error
+	systemOut string
+}
+
+// ensure simpleJUnitError implements JUnitError
+var _ JUnitError = &simpleJUnitError{}
+
+func (s *simpleJUnitError) SystemOut() string {
+	return s.systemOut
+}
+
+// NewJUnitError returns a simple instance of JUnitError wrapping systemOut
+func NewJUnitError(inner error, systemOut string) error {
+	return &simpleJUnitError{
+		error:     inner,
+		systemOut: systemOut,
+	}
+}
+
 // testSuite holds a slice of TestCase and other summary metadata.
 //
 // A build (column in testgrid) is composed of one or more TestSuites.

--- a/kubetest2/pkg/process/doc.go
+++ b/kubetest2/pkg/process/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package process contains helpers for executing processes
+// Package process contains helpers for executing processes in ways that behave
+// similarly to syscall.Exec, but using child processes instead
 package process

--- a/kubetest2/pkg/process/exec.go
+++ b/kubetest2/pkg/process/exec.go
@@ -42,7 +42,7 @@ func execCmdWithSignals(cmd *exec.Cmd) error {
 	// TODO(bentheelder): what should this buffer size be?
 	signals := make(chan os.Signal, 5)
 	signal.Notify(signals)
-	defer close(signals)
+	defer signal.Stop(signals)
 
 	// start the process
 	if err := cmd.Start(); err != nil {

--- a/kubetest2/pkg/process/exec.go
+++ b/kubetest2/pkg/process/exec.go
@@ -29,11 +29,15 @@ func Exec(argv0 string, args []string, env []string) error {
 	cmd := exec.Command(argv0, args...)
 	cmd.Env = env
 
-	// inherit all standard file descriptors, as if `syscall.Exec`ed
+	// inherit some standard file descriptors, as if `syscall.Exec`ed
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
+	return execCmdWithSignals(cmd)
+}
+
+func execCmdWithSignals(cmd *exec.Cmd) error {
 	// setup listener to forward all signals
 	// TODO(bentheelder): what should this buffer size be?
 	signals := make(chan os.Signal, 5)

--- a/kubetest2/pkg/process/junitexec.go
+++ b/kubetest2/pkg/process/junitexec.go
@@ -36,7 +36,7 @@ func (e *execJunitError) SystemOut() string {
 
 var _ metadata.JUnitError = &execJunitError{}
 
-// ExecJUnit is like exec, except that it tees the output and captures it
+// ExecJUnit is like Exec, except that it tees the output and captures it
 // for returning a metadata.JUnitError if the process does not exit success
 func ExecJUnit(argv0 string, args []string, env []string) error {
 	// construct command from inputs

--- a/kubetest2/pkg/types/types.go
+++ b/kubetest2/pkg/types/types.go
@@ -18,6 +18,10 @@ limitations under the License.
 // and tester implementations
 package types
 
+import (
+	"github.com/spf13/pflag"
+)
+
 // IncorrectUsage is an error with an addition HelpText() method
 // NewDeployer and NewTester implementations should return a type meeting this
 // interface if they want to display usage to the user when incorrect arguments
@@ -29,12 +33,19 @@ type IncorrectUsage interface {
 
 // NewDeployer should process & store deployerArgs and the common Options
 // kubetest2 will call this once at startup
-// common will provide access to options defined by common flags and kubetest2
-// logic, while deployerArgs provides all unknown arguments passed to kubetest2
-// before the first bare `--` if any.
+//
+// opts will provide access to options defined by common flags and kubetest2 logic
+//
+// hiddenKubetest2Flags contains all top level kubetest2 flags, marked as hidden
+// so they may be included when parsing deployer flags but will not show up
+// when returning deployer flag usage
+//
+// args provides all arguments passed to kubetest2 before the first bare `--`,
+// if any. (args after the `--` are Tester args)
+//
 // When incorrect arguments or flags are supplied, the IncorrectUsage superset
 // of error can be returned. kubetest2 will display the HelpText() output
-type NewDeployer func(common Options, deployerArgs []string) (Deployer, error)
+type NewDeployer func(opts Options, hiddenKubetest2Flags *pflag.FlagSet, args []string) (Deployer, error)
 
 // Options is an interface to get common options supplied by kubetest2
 // to all implementations

--- a/kubetest2/pkg/types/types.go
+++ b/kubetest2/pkg/types/types.go
@@ -31,21 +31,13 @@ type IncorrectUsage interface {
 	HelpText() string
 }
 
-// NewDeployer should process & store deployerArgs and the common Options
-// kubetest2 will call this once at startup
+// NewDeployer should return a new instance of a Deployer along with a flagset
+// bound to the deployer with any additional Deployer specific CLI flags
+//
+// kubetest2 will call this once at startup for the injected deployer
 //
 // opts will provide access to options defined by common flags and kubetest2 logic
-//
-// hiddenKubetest2Flags contains all top level kubetest2 flags, marked as hidden
-// so they may be included when parsing deployer flags but will not show up
-// when returning deployer flag usage
-//
-// args provides all arguments passed to kubetest2 before the first bare `--`,
-// if any. (args after the `--` are Tester args)
-//
-// When incorrect arguments or flags are supplied, the IncorrectUsage superset
-// of error can be returned. kubetest2 will display the HelpText() output
-type NewDeployer func(opts Options, hiddenKubetest2Flags *pflag.FlagSet, args []string) (Deployer, error)
+type NewDeployer func(opts Options) (deployer Deployer, flags *pflag.FlagSet)
 
 // Options is an interface to get common options supplied by kubetest2
 // to all implementations


### PR DESCRIPTION
- cleaned up the process package
- added a simple helper for junit errors
- fixed a bug in the process package with cancelling signals and clarified the purpose
- added a cleaned up fork of kind's exec package (for subprocess execution with an interface that can be mocked or implemented against remotes etc.) for use in kubetest2
- implemented the kind deployer and refactored cmd a bit
  - split up usage and options
   - NewDeployer now returns a `*pflag.FlagSet` instead of receiving args, this flagset should be bound to the deployer and parsing on it will be called by the kubetest2 app with the appropriate args
 - help / usage is now deffered to just before the actual kubetest2 main logic would be called

TODO (in follow up PRs): 
- auto-manage the kind binary instead of assuming one is available on the host / created a helper package for this
- still need to document
- add a `none` deployer for purely testing with no deployer assumptions
- implement a ginkgo e2e tester
- implement more deployers ...

/assign @neolit123 @krzyzacy @amwat 
