### PR TITLE
kubernetes-csi: enable Docker

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path.yaml
@@ -6,11 +6,19 @@ presubmits:
     skip_report: false
     labels:
       preset-service-account: "true"
-      preset-cadvisor-docker-credential: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
       # We need this image because it has Docker and kind.
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
         command:
+        - runner.sh
+        args:
         - ./.prow.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        # Copied from config/jobs/kubernetes/sig-testing/verify.yaml.
+        resources:
+          requests:
+            cpu: 4


### PR DESCRIPTION
We must explicitly call runner.sh and that in turn needs a privileged
security context.

The resource allocation is the same as in
config/jobs/kubernetes/sig-testing/verify.yaml, which served as
example for a job using Docker.

preset-cadvisor-docker-credential isn't needed, that was a
cut-and-paste error when setting up the job.