### PR TITLE
Add ability to give Prow private repository access for Github login.

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -315,10 +315,10 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 
 		mux.Handle("/pr-data.js", handleNotCached(
 			prStatusAgent.HandlePrStatus(prStatusAgent)))
-		
+
 		// The githibLoginOptionHandler requests the user to click a button whether or not they want to share
 		// private repositories with Prow or not.
-		githubLoginOptionHandler := gziphandler.GzipHandler(handleSimpleTemplate(o, cfg, "github-login-options.html", nil)).ServeHTTP
+		githubLoginOptionHandler := gziphandler.GzipHandler(handleSimpleTemplate(o, cfg, "github-login-option.html", nil)).ServeHTTP
 
 		// Handle login action, first we want to determine whether or not the user wants to Prow access to
 		// private repositories. If the user says "yes" then we add the "repo" scope to the requested scopes,

--- a/prow/cmd/deck/template/github-login-option.html
+++ b/prow/cmd/deck/template/github-login-option.html
@@ -1,0 +1,22 @@
+{{define "title"}}GitHub Login{{end}}
+
+{{define "content"}}
+<div class="mdl-card mdl-shadow--2dp">
+  <div class="mdl-card__title">
+    <h2 class="mdl-card__title-text">Github Login</h2>
+  </div>
+  <div class="mdl-card__supporting-text">
+    Would you like to give this Prow instance access to private repositories when logging in with GitHub?
+  </div>
+  <div class="mdl-card__actions mdl-card--border">
+    <a href="/github-login?private_repos=yes" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+      Yes, I want Prow to show my private repos
+    </a>
+    <a href="/github-login?private_repos=no" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+      No, just view public repos
+    </a>
+  </div>
+</div>
+{{end}}
+
+{{template "page" (settings mobileFriendly "pr" .)}}


### PR DESCRIPTION
Not able to test locally but instead of directing the user straight to Github with no scopes requested, we now ask the user if they'd like to give Prow access to their private repositories.

Once the user has confirmed yes or no we can get the right scopes for the token to give Prow permissions to the repositories the user intended.

Originally I was going to add it as a configuration option for config.yaml but @stevekuznetsov wanted a "checkbox" like functionality and I think this provides that with 2 buttons.