### PR TITLE
Set the default config context to be the default cluster alias instead of an empty string

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -41,8 +41,11 @@ func LoadClusterConfigs(kubeconfig, buildCluster string) (configurations map[str
 		logrus.Warnf("Failed to create in-cluster config: %v", err)
 	} else {
 		defCtx = new(string)
+		// TODO convert the default cluster alias into a default in-cluster context
+		*defCtx = DefaultClusterAlias
 		logrus.Info("* in-cluster")
 		configs[*defCtx] = *localCfg
+		configs[""] = *localCfg
 	}
 
 	// Attempt to load external clusters too


### PR DESCRIPTION
This default config context is used by the build controller to load the cluster configuration, 
but tide creates prow jobs with the default cluster alias as a value in the spec.Cluster instead of an empty string.
The value from spec.Cluster is used by build controller as a cluster context when reconciling the builds.

See where the default cluster value is set: https://github.com/kubernetes/test-infra/blob/9c83e851fd7bae91648585b3a7d6897d67cf08b5/prow/config/config.go#L1173
The build controller used as the default context an empty string when loading the cluster config:
https://github.com/kubernetes/test-infra/blob/9c83e851fd7bae91648585b3a7d6897d67cf08b5/prow/cmd/build/main.go#L143
but the context used to lookup the config is read from prow job spec.Cluster which is not an empty string but "default"
https://github.com/kubernetes/test-infra/blob/9c83e851fd7bae91648585b3a7d6897d67cf08b5/prow/cmd/build/controller.go#L147