### PR TITLE
Update ubuntu image for 1.14 e2e node config

### DIFF
--- a/jobs/e2e_node/image-config-1-14.yaml
+++ b/jobs/e2e_node/image-config-1-14.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-beta:
     image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/74658

Setting up the 1.14 CI used the old Ubuntu version from 1.13: https://github.com/kubernetes/test-infra/pull/11370

/assign @krzyzacy 