### PR TITLE
Fix firefox/safari log height calculation

### DIFF
--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -45,6 +45,7 @@ html {
 .linetext {
     width: calc(100% - 55px);
     margin-left: 55px;
+    min-height: 20px;
 }
 
 /* ansi colors from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors */


### PR DESCRIPTION
This fixes an issue where, if the last line of the log is blank (which it probably is because lines end in newlines), Safari and Firefox will omit it when calculating the height of the logs and consequently cut off half the last line. In the case of Safari (but not Firefox), this also breaks trackpad scrolling when the mouse is over the logs.

Chrome did this right before and this does not change its behaviour.