### PR TITLE
Enable Tide for k/security repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -393,6 +393,7 @@ tide:
     - kubernetes/publishing-bot
     - kubernetes/release
     - kubernetes/repo-infra
+    - kubernetes/security
     - kubernetes/sig-release
     - kubernetes/steering
     - kubernetes/test-infra


### PR DESCRIPTION
Required to merge https://github.com/kubernetes/security/pull/1.

/assign @cblecker 