### PR TITLE
Ignore draft PRs in tide and pr status dashboard

### DIFF
--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -134,7 +134,7 @@ function getPRQuery(q: string): string {
             || tkn === "type:pr");
     }).join(" ");
     // Returns the query with is:pr to the start of the query
-    result = "is:pr " + result;
+    result = "is:pr -is:draft" + result;
     return result;
 }
 
@@ -253,7 +253,7 @@ window.onload = () => {
     // ?is:pr state:open query="author:<user_login>"
     if (window.location.search === "") {
         const login = getCookieByName("github_login");
-        const searchQuery = "is:pr state:open author:" + login;
+        const searchQuery = "is:pr state:open -is:draft author:" + login;
         window.location.search = "?query=" + encodeURIComponent(searchQuery);
     }
     const request = createXMLHTTPRequest((r) => {
@@ -304,7 +304,7 @@ function createSearchCard(): HTMLElement {
     const userBtn = createIcon("person", "Show my open pull requests", ["search-button"], true);
     userBtn.addEventListener("click", () => {
         const login = getCookieByName("github_login");
-        const searchQuery = "is:pr state:open author:" + login;
+        const searchQuery = "is:pr state:open -is:draft author:" + login;
         window.location.search = "?query=" + encodeURIComponent(searchQuery);
     });
 

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -150,7 +150,7 @@ type TideQuery struct {
 
 // Query returns the corresponding github search string for the tide query.
 func (tq *TideQuery) Query() string {
-	toks := []string{"is:pr", "state:open"}
+	toks := []string{"is:pr", "state:open", "-is:draft"}
 	for _, o := range tq.Orgs {
 		toks = append(toks, fmt.Sprintf("org:\"%s\"", o))
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -46,6 +46,7 @@ func TestTideQuery(t *testing.T) {
 
 	checkTok("is:pr")
 	checkTok("state:open")
+	checkTok("-is:draft")
 	checkTok("org:\"org\"")
 	checkTok("repo:\"k/k\"")
 	checkTok("repo:\"k/t-i\"")

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -343,7 +343,7 @@ func (da *DashboardAgent) GetHeadContexts(ghc githubClient, pr PullRequest) ([]C
 // by the user passed. The search is scoped to repositories that are configured with either Prow or
 // Tide.
 func (da *DashboardAgent) ConstructSearchQuery(login string) string {
-	tokens := []string{"is:pr", "state:open", "author:" + login}
+	tokens := []string{"is:pr", "state:open", "-is:draft", "author:" + login}
 	for i := range da.repos {
 		tokens = append(tokens, fmt.Sprintf("repo:\"%s\"", da.repos[i]))
 	}


### PR DESCRIPTION
The `-is:draft` token currently is not functional in the GitHub search
API but that is a bug. Once that is fixed, this commit will keep tide
from trying to merge unmerge-able draft PRs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 