### PR TITLE
Shorten spyglass page titles

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -621,6 +621,11 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		prHistLink = "/pr-history?org=" + org + "&repo=" + repo + "&pr=" + strconv.Itoa(number)
 	}
 
+	jobName, buildID, err := sg.KeyToJob(src)
+	if err != nil {
+		return "", fmt.Errorf("error determining jobName / buildID: %v", err)
+	}
+
 	announcement := ""
 	if cfg().Deck.Spyglass.Announcement != "" {
 		announcementTmpl, err := template.New("announcement").Parse(cfg().Deck.Spyglass.Announcement)
@@ -659,6 +664,8 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		PRHistLink    string
 		Announcement  template.HTML
 		TestgridLink  string
+		JobName       string
+		BuildID       string
 	}
 	lTmpl := lensesTemplate{
 		Lenses:        ls,
@@ -670,6 +677,8 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		PRHistLink:    prHistLink,
 		Announcement:  template.HTML(announcement),
 		TestgridLink:  tgLink,
+		JobName:       jobName,
+		BuildID:       buildID,
 	}
 	t := template.New("spyglass.html")
 

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -1,4 +1,4 @@
-{{define "title"}}Job View {{.Source}}{{end}}
+{{define "title"}}{{.JobName}} #{{.BuildID}}{{end}}
 
 {{define "scripts"}}
 <script type="text/javascript">


### PR DESCRIPTION
Give Spyglass pages titles like "ci-kubernetes-e2e-gci-gke #36989" instead of "Job View gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke/36989/"