### PR TITLE
testgrid: move kubernetes-anywhere jobs outside of release blocking

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4664,10 +4664,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
   - name: gce-cos-master-reboot
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-  - name: kubeadm-gce-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
-  - name: kubeadm-gce-stable-on-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
 
 - name: sig-release-master-informing
   dashboard_tab:
@@ -4689,6 +4685,12 @@ dashboards:
   - name: gce-master-scale-performance
     description: 5000-node performance test, runs once a day on weekdays
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
+  - name: kubeadm-gce-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-master
+  - name: kubeadm-gce-stable-on-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
+  - name: kubeadm-kind-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
 
 - name: sig-release-1.14-all
   dashboard_tab:
@@ -4795,6 +4797,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-14
   - name: kubeadm-gce-upgrade-1.13-1.14
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-13-1-14
+  - name: kubeadm-kind-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
 
 - name: sig-release-1.14-blocking
   dashboard_tab:
@@ -4836,10 +4840,6 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-build-1-14
   - name: periodic-bazel-test-1.14
     test_group_name: periodic-kubernetes-bazel-test-1-14
-  - name: kubeadm-gce-1.13-on-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13-on-1-14
-  - name: kubeadm-gce-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-14
 
 - name: sig-release-1.13-all
   dashboard_tab:
@@ -4936,6 +4936,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   - name: gke-device-plugin-gpu-p100-1.13
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable1
+  - name: kubeadm-kind-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
 
 - name: sig-release-1.13-blocking
   dashboard_tab:
@@ -4956,10 +4958,6 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-build-1-13
   - name: periodic-bazel-test-1.13
     test_group_name: periodic-kubernetes-bazel-test-1-13
-  - name: kubeadm-gce-1.12-on-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-12-on-1-13
-  - name: kubeadm-gce-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13
   - name: gce-cos-1.13-default
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable1-default
   - name: gce-cos-1.13-slow
@@ -5111,6 +5109,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
   - name: gke-device-plugin-gpu-p100-1.12
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2
+  - name: kubeadm-kind-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
 
 # These are the release *blocking* tests.  These provide a valid binary signal
 # to gate releases (alpha, beta, official).
@@ -5128,8 +5128,6 @@ dashboards:
   - name: gce-conformance-latest-1.12
     description: Runs conformance tests using kubetest against kubernetes release 1.12 branch on GCE
     test_group_name: ci-kubernetes-gce-conformance-latest-1-12
-  - name: kubeadm-gce-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-12
   - name: node-kubelet-1.12
     test_group_name: ci-kubernetes-node-kubelet-stable2
   - name: gce-cos-1.12-default


### PR DESCRIPTION
- move release-master-blocking/kubeadm-gce-master to
release-master-informing
- move release-master-blocking/kubeadm-gce-stable-on-master
to release-master-informing
- for release-1.y-blocking variants, move to release-1.y-all
(if they aren't already there)
- add kubeadm-kind-master to release-master-informing
- add kubeadm-kind-1.y to release-1.y-all

xref / discussed here:
https://github.com/kubernetes/sig-release/issues/518

/assign @krzyzacy @spiffxp 
@kubernetes/sig-release 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
