### PR TITLE
gcsweb links should end in slashes

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -612,6 +612,10 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		runPath, err := sg.RunPath(src)
 		if err == nil {
 			artifactsLink = gcswebPrefix + runPath
+			// gcsweb wants us to end URLs with a trailing slash
+			if !strings.HasSuffix(artifactsLink, "/") {
+				artifactsLink += "/"
+			}
 		}
 	}
 


### PR DESCRIPTION
GCSWeb has two modes of operation, depending on the requested bucket: it can actually display things, or it can just redirect you to the Google Cloud Console's GCS browser. 

In the former case, trailing slashes are optional, but in the latter case they are mandatory. Change spyglass to always add a trailing slash.