### PR TITLE
Add run_if_changed to boskos/testgrid config upload job, and decorate them

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -18,6 +18,7 @@ postsubmits:
   - name: ci-test-infra-bazel
     branches:
     - master
+    decorate: true
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -25,13 +26,10 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-experimental
+        command:
+        - runner.sh
+        - ./scenarios/kubernetes_bazel.py
         args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-jenkins/logs
-        - --scenario=kubernetes_bazel
-        - -- # end bootstrap args, scenario args below
         - --build=//...
         - --install=gubernator/test_requirements.txt
         - --test=//...
@@ -48,16 +46,14 @@ postsubmits:
     - master
     labels:
       preset-service-account: "true"
+    run_if_changed: '^boskos/.*$'
+    decorate: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-experimental
+        command:
+        - runner.sh
         args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-jenkins/logs
-        - --scenario=execute
-        - --
         - ./boskos/update_prow_config.sh
         env:
         - name: PROW_SERVICE_ACCOUNT
@@ -77,16 +73,14 @@ postsubmits:
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
+    run_if_changed: '^testgrid/.*$'
+    decorate: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-experimental
+        command:
+        - runner.sh
         args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - --service-account=/etc/service-account/service-account.json
-        - --upload=gs://kubernetes-jenkins/logs
-        - --scenario=execute
-        - --
         - ./testgrid/config-upload.sh
         resources:
           requests:


### PR DESCRIPTION
These are running against every commit now which is not necessary (checking from https://github.com/kubernetes/test-infra/commits/master)

Also we probably don't have to push/deploy prow when there's no prow changes? (didn't touch that yet, and you can see the red cross-marks of failing prow-push jobs :man_shrugging: )

/assign @cjwagner @amwat 
cc @michelle192837 