### PR TITLE
Slack oncall usergroup updater

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -133,3 +133,30 @@ periodics:
       secret:
         secretName: k8s-ci-robot-ssh-keys
         defaultMode: 0400
+- cron: "05 * * * *"  # Run at five minutes past the hour every day
+  name: ci-test-infra-update-slack-oncall
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+  spec:
+    containers:
+    - image: launcher.gcr.io/google/bazel
+      command:
+      - bazel
+      args:
+      - run
+      - //experiment/slack-oncall-updater
+      - --
+      - --token-path=/etc/slack-token/token
+      - --group-id=SGLF0GUQH
+      volumeMounts:
+      - name: slack
+        mountPath: /etc/slack-token
+        readOnly: true
+    volumes:
+    - name: slack
+      secret:
+        secretName: slack-usergroup-token

--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -56,6 +56,7 @@ filegroup(
         "//experiment/coverage:all-srcs",
         "//experiment/manual-trigger:all-srcs",
         "//experiment/resultstore:all-srcs",
+        "//experiment/slack-oncall-updater:all-srcs",
         "//experiment/tracer:all-srcs",
     ],
     tags = ["automanaged"],

--- a/experiment/slack-oncall-updater/BUILD.bazel
+++ b/experiment/slack-oncall-updater/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/slack-oncall-updater",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "slack-oncall-updater",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/slack-oncall-updater/OWNERS
+++ b/experiment/slack-oncall-updater/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- Katharine

--- a/experiment/slack-oncall-updater/main.go
+++ b/experiment/slack-oncall-updater/main.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func getJSON(url string, v interface{}) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to fetch %q: %v", url, err)
+	}
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(v)
+	if err != nil {
+		return fmt.Errorf("failed to decode json from %q: %v", url, err)
+	}
+	return nil
+}
+
+func getCurrentOncaller() (string, error) {
+	oncaller := struct {
+		OnCall struct {
+			TestInfra string `json:"testinfra"`
+		} `json:"Oncall"`
+	}{}
+
+	err := getJSON("https://storage.googleapis.com/kubernetes-jenkins/oncall.json", &oncaller)
+	if err != nil {
+		return "", err
+	}
+
+	return oncaller.OnCall.TestInfra, nil
+}
+
+func mapGitHubToSlack(github string) (string, error) {
+	// Maps (case-sensitive!) GitHub usernames to Slack user IDs.
+	// Add yourself when you join the oncall rotation.
+	// You can mostly easily find your user ID by visiting your Slack profile, clicking "...",
+	// and clicking "Copy user ID".
+	mapping := map[string]string{
+		"amwat":       "U9B1P2UGP",
+		"BenTheElder": "U1P7T516X",
+		"cjwagner":    "U4QFZFMCM",
+		"fejta":       "U0E2KHQ13",
+		"Katharine":   "UBTBNJ6GL",
+		"krzyzacy":    "U22Q65CTG",
+	}
+	id, ok := mapping[github]
+	if !ok {
+		return "", fmt.Errorf("couldn't find a Slack ID for GitHub user %q", github)
+	}
+	return id, nil
+}
+
+func updateGroupMembership(token, groupID, userID string) error {
+	result := struct {
+		Ok    bool   `json:"ok"`
+		Error string `json:"error,omitempty"`
+	}{}
+
+	err := getJSON("https://slack.com/api/usergroups.users.update?token="+token+"&users="+userID+"&usergroup="+groupID, &result)
+	if err != nil {
+		return fmt.Errorf("couldn't make membership request: %v", err)
+	}
+
+	if !result.Ok {
+		return fmt.Errorf("couldn't update membership: %s", result.Error)
+	}
+
+	return nil
+}
+
+func getTokenFromPath(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("couldn't open file: %v", err)
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+type options struct {
+	tokenPath string
+	groupID   string
+}
+
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.tokenPath, "token-path", "/etc/slack-token", "Path to a file containing the slack token")
+	flag.StringVar(&o.groupID, "group-id", "", "Slack group ID")
+	flag.Parse()
+	return o
+}
+
+func main() {
+	o := parseFlags()
+
+	token, err := getTokenFromPath(o.tokenPath)
+	if err != nil {
+		log.Fatalf("Failed to get Slack token: %v", err)
+	}
+
+	oncall, err := getCurrentOncaller()
+	if err != nil {
+		log.Fatalf("Failed to find current oncaller: %v", err)
+	}
+	log.Printf("Current oncaller: %s\n", oncall)
+
+	userID, err := mapGitHubToSlack(oncall)
+	if err != nil {
+		log.Fatalf("Failed to get Slack ID: %v", err)
+	}
+	log.Printf("%s's slack ID: %s\n", oncall, userID)
+
+	log.Printf("Adding slack user %s to slack usergroup %s", userID, o.groupID)
+	if err := updateGroupMembership(token, o.groupID, userID); err != nil {
+		log.Fatalf("Failed to update usergroup membership: %v", err)
+	}
+	log.Printf("Done!")
+}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2681,6 +2681,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-prow
 - name: ci-test-infra-autobump-prow
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-autobump-prow
+- name: ci-test-infra-update-slack-oncall
+  gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-update-slack-oncall
 - name: pull-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel
   num_columns_recent: 20
@@ -6800,6 +6802,13 @@ dashboards:
     test_group_name: pull-kubernetes-conformance-image-test
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: slack-oncall-updater
+    description: runs experiment/slack-oncall-updater to update the membership of the test-infra-oncall slack usergroup
+    test_group_name: ci-test-infra-update-slack-oncall
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+    alert_options:
+      alert_mail_to_addresses: ktbry@google.com
 
 - name: sig-testing-canaries
   dashboard_tab:


### PR DESCRIPTION
Add an hourly periodic to update a slack group based on the current oncaller.

This tool is very single-purpose, so the mapping is currently just hardcoded. We can't derive it from Slack (because a) then we'd need more permissions and also b) users don't really have great, trustworthy stable identifiers other than these ones), but we could probably put it in a JSON file or something if we really wanted the added complexity.

/hold
/cc @BenTheElder 
also cc anyone else interested