### PR TITLE
Add periodic jobs for conformance-image

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3015,15 +3015,20 @@ presubmits:
     trigger: (?m)^/test( | .* )pull-security-kubernetes-bazel-test,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    branches:
+    - master
     cluster: security
     context: pull-security-kubernetes-conformance-image-test
     labels:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
       preset-service-account: "true"
+    max_concurrency: 8
     name: pull-security-kubernetes-conformance-image-test
     optional: true
     rerun_command: /test pull-security-kubernetes-conformance-image-test
+    run_if_changed: conformance
     spec:
       containers:
       - args:
@@ -3053,26 +3058,9 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
         - mountPath: /etc/ssh-security
           name: ssh-security
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - name: ssh-security
         secret:
           defaultMode: 256

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -3,13 +3,19 @@ presubmits:
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   - name: pull-kubernetes-conformance-image-test
+    branches:
+      - master
+    always_run: false
+    skip_report: false
+    max_concurrency: 8
+    optional: true
+    run_if_changed: 'conformance'
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
-    always_run: false
-    optional: true
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
@@ -35,13 +41,6 @@ presubmits:
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
-          # kind needs /lib/modules and cgroups from the host
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
           resources:
             requests:
               # these are both a bit below peak usage during build
@@ -49,19 +48,42 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
-      volumes:
-        - name: modules
-          hostPath:
-            path: /lib/modules
-            type: Directory
-        - name: cgroup
-          hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-      # trialing this on kind jobs, we are using FQDN for in-cluster services, now
-      # so use ndots 1 to improve dns performance
-      # TODO(bentheelder): consider setting this at the cluster level instead
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
+
+periodics:
+  # conformance test against kubernetes master branch with `kind`
+  - interval: 1h
+    name: ci-kubernetes-conformance-image-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
+          args:
+            - "--job=$(JOB_NAME)"
+            - "--root=/go/src"
+            - "--repo=k8s.io/test-infra=master"
+            - "--repo=k8s.io/kubernetes=master"
+            - "--repo=sigs.k8s.io/kind=master"
+            - "--service-account=/etc/service-account/service-account.json"
+            - "--upload=gs://kubernetes-jenkins/logs"
+            - "--scenario=execute"
+            - "--"
+            # the script must run from kubernetes, but we're checking out kind
+            - "bash"
+            - "--"
+            - "-c"
+            - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3176,6 +3176,9 @@ test_groups:
   num_columns_recent: 3
 - name: ci-kind-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kind-build
+- name: ci-kubernetes-conformance-image-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-conformance-image-test
+  num_columns_recent: 3
 
 # cloud-provider-openstack e2e conformance tests
 # name format: PR trigger ci-presubmit-${zuul-job-name}
@@ -3447,6 +3450,9 @@ dashboards:
   - name: kind, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance
+  - name: kind-image, master (dev)
+    description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
+    test_group_name: ci-kubernetes-conformance-image-test
   - name: kind, master (dev) [non-serial]
     description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
     test_group_name: ci-kubernetes-kind-conformance-parallel
@@ -3608,6 +3614,11 @@ dashboards:
     test_group_name: ci-kubernetes-kind-conformance-latest-1-11
     alert_options:
       alert_mail_to_addresses: bentheelder@google.com
+  - name: kind-image, master (dev)
+    description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
+    test_group_name: ci-kubernetes-conformance-image-test
+    alert_options:
+      alert_mail_to_addresses: davanum@gmail.com
 
 - name: conformance-hack-local-up-cluster
   dashboard_tab:
@@ -6886,6 +6897,9 @@ dashboards:
   - name: kind, v1.11 (dev)
     description: Runs conformance tests using kubetest against latest kubernetes relase-1.12 with a kubernetes-in-docker cluster
     test_group_name: ci-kubernetes-kind-conformance-latest-1-11
+  - name: conformance-image, master (dev)
+    description: Runs conformance test using connformance image against latest kubernetes master with a kubernetes-in-docker cluster
+    test_group_name: ci-kubernetes-conformance-image-test
 
 - name: sig-gcp-master
   dashboard_tab:


### PR DESCRIPTION
- add a CI job for conformance-image using kind
- use preset-kind-volume-mounts instead of the explicit mounts
- pull job should run on all conformance related changes

Change-Id: I58a432d16441a362a447c12126b755d290ad5119