### PR TITLE
Delete pods that run into Pod pending timeout

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -420,6 +420,13 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			pj.SetComplete()
 			pj.Status.State = prowapi.ErrorState
 			pj.Status.Description = "Pod pending timeout."
+			client, ok := c.pkcs[pj.ClusterAlias()]
+			if !ok {
+				return fmt.Errorf("unknown cluster alias %q", pj.ClusterAlias())
+			}
+			if err := client.DeletePod(pod.ObjectMeta.Name); err != nil {
+				return fmt.Errorf("failed to delete pod %s that was in pending timeout: %v", pod.Name, err)
+			}
 
 		default:
 			// Pod is running. Do nothing.

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1096,7 +1096,7 @@ func TestSyncPendingJob(t *testing.T) {
 				},
 			},
 			expectedState:    prowapi.ErrorState,
-			expectedNumPods:  1,
+			expectedNumPods:  0,
 			expectedComplete: true,
 			expectedReport:   true,
 			expectedURL:      "nightmare/error",


### PR DESCRIPTION
Background: We've had some jobs that had very high requests. Today was a busy day for the Repo that holds those jobs, so we piled up pods that were in Pending because the build clusters capacity was exhausted. The jobs failed, the Pods still stayed, preventing new Jobs from getting scheduled.

IMHO there is no point at all in having a Pod for a job that has already been marked as failed.