### PR TITLE
Apparently conformance tests have to run serially

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3046,9 +3046,6 @@ presubmits:
         - --
         - -c
         - cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh
-        env:
-        - name: PARALLEL
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -19,10 +19,6 @@ presubmits:
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
-          env:
-            # skip serial tests and run with --ginkgo-parallel
-            - name: "PARALLEL"
-              value: "true"
           args:
             - "--job=$(JOB_NAME)"
             - "--root=/go/src"


### PR DESCRIPTION
There are 10+ conformance tests marked [Serial], So we cannot run them
in parallel.

Change-Id: Iec1c9a499a24ab58092e8630451caeabbf40b5c0