### PR TITLE
mkpj: validate github options

### DIFF
--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -135,6 +135,10 @@ func (o *options) Validate() error {
 		return errors.New("required flag --config-path was unset")
 	}
 
+	if err := o.github.Validate(false); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This was never called:

https://github.com/kubernetes/test-infra/blob/fa93478401aca5d9b5302a60012c7c0aac9c1172/prow/flagutil/github.go#L62-L79

which meant that using `--github-token-file` silently failed. 

/cc @alvaroaleman @stevekuznetsov 