### PR TITLE
Use https for gcsweb links

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -244,7 +244,7 @@ def do_tg_url(testgrid_query, test_name=''):
 def do_gcs_browse_url(gcs_path):
     if not gcs_path.endswith('/'):
         gcs_path += '/'
-    return 'http://gcsweb.k8s.io/gcs' + gcs_path
+    return 'https://gcsweb.k8s.io/gcs' + gcs_path
 
 
 static_hashes = {}

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -150,10 +150,10 @@ class HelperTest(unittest.TestCase):
     def test_gcs_browse_url(self):
         self.assertEqual(
             filters.do_gcs_browse_url('/k8s/foo'),
-            'http://gcsweb.k8s.io/gcs/k8s/foo/')
+            'https://gcsweb.k8s.io/gcs/k8s/foo/')
         self.assertEqual(
             filters.do_gcs_browse_url('/k8s/bar/'),
-            'http://gcsweb.k8s.io/gcs/k8s/bar/')
+            'https://gcsweb.k8s.io/gcs/k8s/bar/')
 
     def test_pod_name(self):
         self.assertEqual(filters.do_parse_pod_name("start pod 'client-c6671' to"), 'client-c6671')

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,7 +26,7 @@ sinker:
 deck:
   spyglass:
     size_limit: 500000000 # 500MB
-    gcs_browser_prefix: http://gcsweb.k8s.io/gcs/
+    gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
     testgrid_config: gs://k8s-testgrid/config
     testgrid_root: https://testgrid.k8s.io/
     viewers:


### PR DESCRIPTION
gcsweb.k8s.io now runs behind https. It upgrades http->https, but we may as well link directly to https as well.

/assign @Katharine 