### PR TITLE
Use nogo for code analysis instead of go vet

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,10 +4,43 @@
 
 load("@io_kubernetes_build//defs:run_in_workspace.bzl", "workspace_binary")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
 
 workspace_binary(
     name = "go",
     cmd = "@go_sdk//:bin/go",
+)
+
+nogo(
+    name = "nogo_vet",
+    config = "nogo_config.json",
+    visibility = ["//visibility:public"],
+    # These deps enable the analyses equivalent to running `go vet`.
+    # Passing vet = True enables only a tiny subset of these (the ones
+    # that are always correct).
+    # You can see the what `go vet` does by running `go doc cmd/vet`.
+    deps = [
+        "@org_golang_x_tools//go/analysis/passes/asmdecl:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/assign:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/atomic:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/bools:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/buildtag:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/cgocall:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/composite:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/copylock:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/httpresponse:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/loopclosure:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/lostcancel:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/nilfunc:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/printf:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/shift:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/stdmethods:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/structtag:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/tests:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unreachable:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
+    ],
 )
 
 workspace_binary(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,10 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/atomic:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/bools:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/buildtag:go_tool_library",
-        "@org_golang_x_tools//go/analysis/passes/cgocall:go_tool_library",
+        # cgocall appears to be confused by github.com/mattn/go-sqlite3 and fails
+        # even when configured not to run. Given we don't use cgocall much, skip
+        # it for now.
+        # "@org_golang_x_tools//go/analysis/passes/cgocall:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/composite:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/copylock:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/httpresponse:go_tool_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -67,12 +67,6 @@ workspace_binary(
 )
 
 workspace_binary(
-    name = "govet",
-    args = ["vet"],
-    cmd = "@go_sdk//:bin/go",
-)
-
-workspace_binary(
     name = "golint",
     cmd = "@com_github_golang_lint//golint",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,10 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.11.5")
+go_register_toolchains(
+    go_version = "1.11.5",
+    nogo = "@//:nogo_vet",
+)
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,8 +15,8 @@ versions.check(minimum_bazel_version = "0.18.0")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "492c3ac68ed9dcf527a07e6a1b2dcbf199c6bf8b35517951467ac32e421c06c1",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.17.0/rules_go-0.17.0.tar.gz"],
+    sha256 = "6776d68ebb897625dead17ae510eac3d5f6342367327875210df44dbe2aeeb19",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.17.1/rules_go-0.17.1.tar.gz",
 )
 
 http_archive(

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -218,22 +218,6 @@ presubmits:
         command:
         - ./hack/verify-gofmt.sh
 
-  - name: pull-test-infra-verify-govet
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    path_alias: k8s.io/test-infra
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-experimental
-        command:
-        - runner.sh
-        args:
-        - ./hack/verify-govet.sh
-
   - name: pull-test-infra-verify-labels
     branches:
     - master

--- a/experiment/resultstore/main_test.go
+++ b/experiment/resultstore/main_test.go
@@ -141,7 +141,7 @@ func TestInsertLink(t *testing.T) {
 			case tc.err:
 				t.Error("failed to received an error")
 			case changed != tc.changed:
-				t.Error("changed %t != expected %t", changed, tc.changed)
+				t.Errorf("changed %t != expected %t", changed, tc.changed)
 			case !reflect.DeepEqual(tc.expected, tc.input):
 				t.Errorf("metadata %#v != expected %#v", tc.input, tc.expected)
 			}

--- a/hack/check-pr.sh
+++ b/hack/check-pr.sh
@@ -63,7 +63,6 @@ step hack/verify-bazel.sh hack/verify-bazel.sh || failing+=("bazel")
 step hack/verify-gofmt.sh hack/verify-gofmt.sh || failing+=("gofmt")
 step hack/verify-tslint.sh hack/verify-tslint.sh || failing+=("tslint")
 step //:golint bazel run //:golint -- "${dirs[@]}" || failing+=("golint")
-step //:govet bazel run //:govet -- "${dirs[@]}" || failing+=("govet")
 step "bazel test" bazel test --build_tests_only "${tests[@]}" || failing+=("bazel test")
 step hack/verify_boilerplate.py hack/verify_boilerplate.py || failing+=("boilerplate")
 

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -18,6 +18,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# TODO(fejta): check in testgrid pb.go files
-# TODO(Katharine): get spyglass and deck out of the skip list
-bazel run //:govet -- $(bazel run //:go -- list ./... | grep -v -E 'k8s.io/test-infra/(testgrid|experiment/resultstore|prow/spyglass|prow/cmd/deck)')
+echo "Calling verify-govet.sh is no longer necessary: vetting is run automatically as part of all builds."
+echo "Building everything to verify that we pass vetting."
+bazel build //...

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -1,0 +1,123 @@
+{
+  "structtag": {
+    "exclude_files": {
+      "prow/github/client.go": "intentional violation",
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "asmdecl": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "assign": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "atomic": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "bools": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "buildtag": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "cgocall": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "composites": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "copylocks": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "httpresponse": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "loopclosure": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "lostcancel": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "nilfunc": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "printf": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "shift": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "stdmethods": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "tests": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "unreachable": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "unsafeptr": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  },
+  "unusedresult": {
+    "exclude_files": {
+      "external/": "external tools don't pass vet",
+      "vendor/": "vendor doesn't pass vet"
+    }
+  }
+}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2701,9 +2701,6 @@ test_groups:
 - name: pull-test-infra-verify-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-bazel
   num_columns_recent: 20
-- name: pull-test-infra-verify-govet
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-govet
-  num_columns_recent: 20
 - name: pull-test-infra-verify-gofmt
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-gofmt
   num_columns_recent: 20
@@ -7241,9 +7238,6 @@ dashboards:
     base_options: width=10
   - name: verify-bazel
     test_group_name: pull-test-infra-verify-bazel
-    base_options: width=10
-  - name: verify-govet
-    test_group_name: pull-test-infra-verify-govet
     base_options: width=10
   - name: verify-gofmt
     test_group_name: pull-test-infra-verify-gofmt


### PR DESCRIPTION
Currently we run a `go vet` presubmit, but need to have a [skip list](https://github.com/kubernetes/test-infra/blob/e223f27b7c7170b2014b901a3170939470f740ab/hack/verify-govet.sh#L23) because anything with a transitive dependency on generated code fails. Currently that is anything testgrid, anything resultstore, and also both deck and spyglass.

This change moves to using rules_go's [`nogo`](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst) to always perform the analysis at build time, ensuring that whatever needs to be analysed is analysed and has its dependencies at the time.

I've enabled the same set of analyses that `go vet` would run, which is much more than `nogo`'s `vet = True` option (which only includes analyses that never produce a false positive). I've explicitly exempted `vendor/*` from vetting because several dependencies don't pass, and `external/*` from vetting because Gazelle doesn't pass. This could be tightened to only exclude specific dependencies from specific checks, though.

An interesting side effect of this is that instead of our analyses being dependent on the go version we're using, they're instead dependent on the version of golang.org/x/tools we're pulling in. Currently that's [`6cd1fcedba52`](https://github.com/golang/tools/tree/6cd1fcedba52a3e8045a1c96970cec308e4a632c), which is more recent than go1.11.5, and so we pick up a new failure in our own code:

`.../prow/github/client.go:2042:3: struct field ParentTeamID repeats json tag "parent_team_id" also at types.go:707`

For now I've exempted that one too, because it appears to be intentional. I've also verified that we really are still building with 1.11.5 despite picking up a more recent vet failure.

(I expect it's going to fail `pull-test-infra-verify-govet` because the script it's running no longer exists)