### PR TITLE
Add flannel l2bridge tests for Windows

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3308,6 +3308,10 @@ test_groups:
 # Cloud-provider-azure e2e tests
 - name: ci-cloud-provider-azure-master
   gcs_prefix: kubernetes-jenkins/logs/ci-cloud-provider-azure-master
+  
+# Flannel CNI on Windows test groups
+- name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
+  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-l2bridge-master-windows
 
 # Add New Testgroups Here
 
@@ -7631,6 +7635,9 @@ dashboards:
   - name: cfcr-vsphere-windows-master
     description: Runs Windows verification tests on a master-branch Kubernetes cluster provided by CFCR (https://github.com/cloudfoundry-incubator/kubo-release) on vSphere"
     test_group_name: ci-kubernetes-e2e-windows-cfcr
+  - name: flannel-l2bridge-windows-master
+    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in l2bridge network mode.
+    test_group_name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
 
 # sig-azure dashboard
 - name: sig-azure-master


### PR DESCRIPTION
Adds test results for k8s clusters with Flannel CNI in l2bridge network mode.