### PR TITLE
Increase Tide's delay between merging PRs during a batch merge to reduce errors from GH.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -887,7 +887,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 				// If we have more PRs to merge, sleep to give Github time to recalculate
 				// mergeability.
 				if i+1 < len(prs) {
-					time.Sleep(time.Second * 3)
+					time.Sleep(time.Second * 5)
 				}
 				break
 			}


### PR DESCRIPTION
Our Tide logs indicate that we fail to merge batch PRs (besides the first PR in the batch) on the first attempt, but almost always succeed on the second attempt. Since we somewhat reliably fail after waiting only 3 seconds and succeed after waiting 7, this splits the difference by increasing the inter-merge delay to 5 seconds.
We can increase further if needed, but I am curious to see if this change has an effect first since it is also possible that we need to fail the first merge attempt in order to trigger a mergeability evaluation.

/assign @stevekuznetsov 