### PR TITLE
trim trailing new line from revparse call

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -185,7 +185,7 @@ func (g *gitCtx) gitRevParse() (string, error) {
 		logrus.WithError(err).Error("git rev-parse HEAD failed!")
 		return "", err
 	}
-	return commit, nil
+	return strings.TrimSpace(commit), nil
 }
 
 // commandsForPullRefs returns the list of commands needed to fetch and


### PR DESCRIPTION
luckily testgrid was also stripping new lines already

/assign @cjwagner @stevekuznetsov 
cc @spiffxp who caught the bug

