### PR TITLE
remove the metadata bandaid hack

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3550,8 +3550,6 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        - name: METADATA_BANDAID
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
         imagePullPolicy: Always
         name: ""
@@ -3600,8 +3598,6 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        - name: METADATA_BANDAID
-          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-1.14
         imagePullPolicy: Always
         name: ""

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -33,10 +33,6 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        # TODO(bentheelder): remove bandaid once we have this metadata exposed
-        # properly, first-class
-        - name: METADATA_BANDAID
-          value: "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -71,10 +67,6 @@ presubmits:
               value: master
             - name: REPO_DIR
               value: /workspace/k8s.io/kubernetes
-            # TODO(bentheelder): remove bandaid once we have this metadata exposed
-            # properly, first-class
-            - name: METADATA_BANDAID
-              value: "true"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -142,10 +134,6 @@ periodics:
         value: master
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      # TODO(bentheelder): remove bandaid once we have this metadata exposed
-      # properly, first-class
-      - name: METADATA_BANDAID
-        value: "true"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -182,10 +170,6 @@ periodics:
             value: release-1.14
           - name: REPO_DIR
             value: /workspace/k8s.io/kubernetes
-          # TODO(bentheelder): remove bandaid once we have this metadata exposed
-          # properly, first-class
-          - name: METADATA_BANDAID
-            value: "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -95,13 +95,6 @@ fi
 SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
 export SOURCE_DATE_EPOCH
 
-# TODO(bentheelder): this is a band-aid! Delete this when we've exposed this data
-# in the pod-utils first-class.
-if [[ "${METADATA_BANDAID:-false}" == "true" ]]; then
-    mkdir -p "${ARTIFACTS}"
-    echo "{\"revision\": \"$(git rev-parse HEAD)\"}" >> "${ARTIFACTS}/metadata.json"
-fi
-
 # actually start bootstrap and the job
 set -o xtrace
 "$@"


### PR DESCRIPTION
we now record the SHA in started.json[RepoVersion] and can remove the bandaid hack

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-verify-master/27212/started.json

(also has https://github.com/kubernetes/test-infra/pull/11606 to remove the trailing \n but doesn't affect testgrid)

/assign @BenTheElder 