### PR TITLE
Make Tide's mergePRs return an error if any merge fails.

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",


### PR DESCRIPTION
Currently mergePRs can fail to merge a PR in a batch and still return successfully. This is definitely wrong and prevents the tide-history from indicating an error when batches fail to merge in this way. This PR refactors the function to return an error if any member of the batch cannot be merged.
The diff looks bigger than it really is, most of it is just moving code or indenting it into a helper function.

/assign @stevekuznetsov