### PR TITLE
Try fixing spyglass height bug, again

### DIFF
--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -37,6 +37,7 @@ export interface Spyglass {
 class SpyglassImpl implements Spyglass {
   private pendingRequests = new Map<number, (v: Response) => void>();
   private messageId = 0;
+  private pendingUpdateTimer = 0;
 
   constructor() {
     window.addEventListener('message', (e) => this.handleMessage(e));
@@ -55,6 +56,13 @@ class SpyglassImpl implements Spyglass {
     return result.data;
   }
   public contentUpdated(): void {
+    this.updateHeight();
+    clearTimeout(this.pendingUpdateTimer);
+    // to be honest I have zero understanding of why this helps, but apparently it does.
+    this.pendingUpdateTimer = setTimeout(() => this.updateHeight(), 0);
+  }
+
+  private updateHeight(): void {
     // .then() to suppress complaints about unhandled promises (we just don't care here).
     this.postMessage({type: 'contentUpdated', height: document.body.offsetHeight}).then();
   }

--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -55,17 +55,8 @@ class SpyglassImpl implements Spyglass {
     return result.data;
   }
   public contentUpdated(): void {
-    // Use .then() instead of await to avoid infecting our caller with our
-    // asynchronicity.
-    this.postMessage({type: 'contentUpdated', height: document.body.offsetHeight}).then(({data}) => {
-      // If before this call we were not actually visible, recalculate our height.
-      // This works around a bizarre issue where other elements on the parent page
-      // being resized can cause us to produce an incorrect height. Recalculating
-      // after we become visible ensures we produce the correct value.
-      if (data === 'madeVisible') {
-        this.contentUpdated();
-      }
-    });
+    // .then() to suppress complaints about unhandled promises (we just don't care here).
+    this.postMessage({type: 'contentUpdated', height: document.body.offsetHeight}).then();
   }
 
   private postMessage(message: Message): Promise<Response> {

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -47,16 +47,12 @@ window.addEventListener('message', async (e) => {
     switch (message.type) {
       case "contentUpdated":
         frame.style.height = `${message.height}px`;
-        if (frame.style.visibility !== 'visible') {
-          frame.style.visibility = 'visible';
-          if (frame.dataset.hideTitle) {
-            frame.parentElement!.parentElement!.classList.add('hidden-title');
-          }
-          document.querySelector<HTMLElement>(`#${lens}-loading`)!.style.display = 'none';
-          respond('madeVisible');
-        } else {
-          respond('');
+        frame.style.visibility = 'visible';
+        if (frame.dataset.hideTitle) {
+          frame.parentElement!.parentElement!.classList.add('hidden-title');
         }
+        document.querySelector<HTMLElement>(`#${lens}-loading`)!.style.display = 'none';
+        respond('');
         break;
       case "request": {
         const req = await fetch(urlForLensRequest(lens, 'callback'),


### PR DESCRIPTION
Turns out my guess at a root cause for spyglass lenses sometimes being slightly too short in #11532 was wrong.

Revert that fix, try a simple but apparently more reliable fix. I don't really know why this helps, though I can speculate wildly.

For my future reference in case I end up here again looking for examples:

- #11532 fixed https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/70672/pull-kubernetes-e2e-gke/3870
- #11532 did _not_ fix https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/11602/pull-test-infra-verify-govet/20503, because the error appears after first visibility
- This fixes both