### PR TITLE
Increase Tide sync period to 2m.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -319,6 +319,7 @@ branch-protection:
             - continuous-integration/travis-ci
 
 tide:
+  sync_period: 2m
   queries:
   - orgs:
     - kubeflow


### PR DESCRIPTION
This should mitigate Tide throttling [problems](http://velodrome.k8s.io/dashboard/db/monitoring?panelId=9&fullscreen&orgId=1&from=1551701983819&to=1551745183819). We really should have already had this set so something above 90 seconds anyways since that appears to be the steady state period when everything is healthy.
http://velodrome.k8s.io/dashboard/db/monitoring?panelId=9&fullscreen&orgId=1&from=now-7d&to=now
/assign @amwat @stevekuznetsov 