### PR TITLE
Make spyglass resolve gcs "symlinks"

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -568,6 +568,14 @@ func handleRequestJobViews(sg *spyglass.Spyglass, cfg config.Getter, o options) 
 // renderSpyglass returns a pre-rendered Spyglass page from the given source string
 func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o options) (string, error) {
 	renderStart := time.Now()
+
+	src = strings.TrimSuffix(src, "/")
+	realPath, err := sg.ResolveSymlink(src)
+	if err != nil {
+		return "", fmt.Errorf("error when resolving real path: %v", err)
+	}
+	src = realPath
+
 	artifactNames, err := sg.ListArtifacts(src)
 	if err != nil {
 		return "", fmt.Errorf("error listing artifacts: %v", err)


### PR DESCRIPTION
Apparently testgrid links to GCS "symlinks" for PRs instead of to the actual artifact directory. Gubernator resolved these, but spyglass just panics.

Fixing the panic and instead returning an error will happen in another PR, but this one adds the missing functionality.

I have endeavoured to do this without URL parsing, which incurs an unnecessary but probably negligible penalty on non-symlink pages.