### PR TITLE
aks-engine deployer: update agentPoolCount from CLI

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -245,6 +245,11 @@ func (c *Cluster) populateApiModelTemplate() error {
 			agentPool.VMSize = c.agentVMSize
 		}
 	}
+	if c.agentPoolCount != 0 {
+		for _, agentPool := range v.Properties.AgentPoolProfiles {
+			agentPool.Count = c.agentPoolCount
+		}
+	}
 	if c.adminUsername != "" {
 		v.Properties.LinuxProfile.AdminUsername = c.adminUsername
 		if v.Properties.WindowsProfile != nil {


### PR DESCRIPTION
Template should be updated with agentPoolCount from CLI, if passed.