### PR TITLE
sig-gcp-release-1.12 should be grouped under sig-gcp

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -7845,6 +7845,7 @@ dashboard_groups:
   dashboard_names:
   - sig-gcp-master
   - sig-gcp-release-1.11
+  - sig-gcp-release-1.12
   - sig-gcp-compute-persistent-disk-csi-driver
 
 - name: sig-autoscaling


### PR DESCRIPTION
instead of being a top-level testgrid dashboard

/sig gcp
/sig release
/sig testing