### PR TITLE
 Transfer completed jobs into resultstore every 5m

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -160,3 +160,26 @@ periodics:
     - name: slack
       secret:
         secretName: slack-usergroup-token
+- interval: 5m
+  name: ci-test-infra-resultstore-upload
+  cluster: test-infra-trusted
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/resultstore:latest
+      command:
+      - /app/experiment/resultstore/app.binary
+      args:
+      - --service-account=/etc/creds/service-account.json
+      - --upload=k8s-prow
+      - --deadline=10m
+      - --latest=5
+      - --gcs-auth
+      volumeMounts:
+      - name: creds
+        mountPath: /etc/creds
+        readOnly: true
+    volumes:
+    - name: creds
+      secret:
+        secretName: resultstore-service-account

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -166,7 +166,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/resultstore:latest
+    - image: gcr.io/k8s-testimages/resultstore:v20190305-6a087591f
       command:
       - /app/experiment/resultstore/app.binary
       args:

--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -1,4 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image", "prow_push")
+
+prow_image(name = "image")
+
+prow_push(
+    name = "push",
+    images = {
+        "{STABLE_DOCKER_REPO}/resultstore:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/resultstore:latest": ":image",
+        "{STABLE_DOCKER_REPO}/resultstore:latest-{BUILD_USER}": ":image",
+    },
+)
 
 go_library(
     name = "go_default_library",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -783,6 +783,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-build-smoke
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
+- name: ci-test-infra-resultstore-upload
+  gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-resultstore-upload
 # Ubuntu node e2e tests (contact: @kubernetes/ubuntu-image on github)
 - name: ci-kubernetes-e2enode-ubuntu1-k8sbeta-gkespec
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2enode-ubuntu1-k8sbeta-gkespec
@@ -6806,6 +6808,11 @@ dashboards:
   - name: post-build-smoke
     description: basic postsubmit to ensure build controller works correctly
     test_group_name: post-test-infra-build-smoke
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: resultstore-upload
+    description: transfer finished results into resultstore
+    test_group_name: ci-test-infra-resultstore-upload
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 


### PR DESCRIPTION
Using a periodic testgrid job - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-resultstore-upload/1

/assign @michelle192837 @Katharine 
