### PR TITLE
Make Tide trigger batches before triggering serial tests.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -966,12 +966,6 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, n
 	if len(sp.presubmits) == 0 {
 		return Wait, nil, nil
 	}
-	// If we have no serial jobs pending or successful, trigger one.
-	if len(nones) > 0 && len(pendings) == 0 && len(successes) == 0 {
-		if ok, pr := pickSmallestPassingNumber(sp.log, c.ghc, nones, sp.cc); ok {
-			return Trigger, []PullRequest{pr}, c.trigger(sp, sp.presubmits, []PullRequest{pr})
-		}
-	}
 	// If we have no batch, trigger one.
 	if len(sp.prs) > 1 && len(batchPending) == 0 {
 		batch, err := c.pickBatch(sp, sp.cc)
@@ -980,6 +974,12 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, n
 		}
 		if len(batch) > 1 {
 			return TriggerBatch, batch, c.trigger(sp, sp.presubmits, batch)
+		}
+	}
+	// If we have no serial jobs pending or successful, trigger one.
+	if len(nones) > 0 && len(pendings) == 0 && len(successes) == 0 {
+		if ok, pr := pickSmallestPassingNumber(sp.log, c.ghc, nones, sp.cc); ok {
+			return Trigger, []PullRequest{pr}, c.trigger(sp, sp.presubmits, []PullRequest{pr})
 		}
 	}
 	return Wait, nil, nil

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1035,6 +1035,43 @@ func TestTakeAction(t *testing.T) {
 			triggered: 0,
 			action:    Wait,
 		},
+		{
+			name: "no pending serial or batch, should trigger batch",
+
+			batchPending: false,
+			successes:    []int{},
+			pendings:     []int{},
+			nones:        []int{1, 2, 3},
+			batchMerges:  []int{},
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
+			merged:           0,
+			triggered:        1,
+			triggeredBatches: 1,
+			action:           TriggerBatch,
+		},
+		{
+			name: "pending batch, no serial, should trigger serial",
+
+			batchPending: true,
+			successes:    []int{},
+			pendings:     []int{},
+			nones:        []int{1, 2, 3},
+			batchMerges:  []int{},
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
+			merged:    0,
+			triggered: 1,
+			action:    Trigger,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
This is important in order to ensure that the serially tested PR is a
member of the batch. This does not occur if we trigger the serial tests
first because that makes the PR pending and prevents it from being
included in the batch when we pick the batch members next sync loop.

I believe this is the cause of triggering multiple of the same batch: https://prow.k8s.io/tide-history?repo=kubernetes%2Fkubernetes
Note that we only appear to trigger the same exact batch twice if the serially tested PR is not a member of the batch.

/assign @stevekuznetsov  @amwat 
/cc @fejta 