### PR TITLE
Remove jobs for Ingress-GCE upgrade + downgrade tests

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -46,30 +46,6 @@ postsubmits:
           privileged: true
 
 periodics:
-- name: ci-ingress-gce-downgrade-e2e
-  interval: 60m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
-      args:
-      - --timeout=340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:master
-      - --extract=ci/latest
-      - --gcp-project-type=ingress-project
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:IngressDowngrade\]
-      - --timeout=320m
-
 - name: ci-ingress-gce-e2e
   interval: 60m
   labels:
@@ -214,28 +190,4 @@ periodics:
       - --ginkgo-parallel=1
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:IngressScale\]
-      - --timeout=320m
-
-- name: ci-ingress-gce-upgrade-e2e
-  interval: 60m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
-      args:
-      - --timeout=340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --env=GCE_GLBC_IMAGE=k8s.gcr.io/ingress-gce-glbc-amd64:v1.4.3
-      - --extract=ci/latest
-      - --gcp-project-type=ingress-project
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:IngressUpgrade\]
       - --timeout=320m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -248,10 +248,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-4
 - name: ci-ingress-gce-e2e-scale
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-scale
-- name: ci-ingress-gce-upgrade-e2e
-  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-upgrade-e2e
-- name: ci-ingress-gce-downgrade-e2e
-  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-downgrade-e2e
 - name: ci-cluster-api-build
   gcs_prefix: kubernetes-jenkins/logs/ci-cluster-api-build
 - name: ci-cluster-api-test
@@ -6296,14 +6292,6 @@ dashboards:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: ingress-gce-image-push
     test_group_name: ci-ingress-gce-image-push
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-upgrade-e2e
-    test_group_name: ci-ingress-gce-upgrade-e2e
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-downgrade-e2e
-    test_group_name: ci-ingress-gce-downgrade-e2e
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 


### PR DESCRIPTION
We have similar tests now in k/ingress-gce that we use to block releases so there is no reason for these to hang around. 

/assign @krzyzacy 