### PR TITLE
Make sinker delete pods that doesn't have associated prowjobs

### DIFF
--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
     ],
 )

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -160,6 +160,19 @@ func TestClean(t *testing.T) {
 		},
 		&corev1api.Pod{
 			ObjectMeta: metav1.ObjectMeta{
+				Name:      "new-running-no-pj",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw: "true",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodRunning,
+				StartTime: startTime(time.Now().Add(-10 * time.Second)),
+			},
+		},
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "old-running",
 				Namespace: "ns",
 				Labels: map[string]string{
@@ -196,9 +209,11 @@ func TestClean(t *testing.T) {
 		},
 	}
 	deletedPods := sets.NewString(
+		"new-running-no-pj",
 		"old-failed",
 		"old-succeeded",
 		"old-pending-abort",
+		"old-running",
 	)
 	setComplete := func(d time.Duration) *metav1.Time {
 		completed := metav1.NewTime(time.Now().Add(d))
@@ -293,6 +308,15 @@ func TestClean(t *testing.T) {
 			Status: prowv1.ProwJobStatus{
 				StartTime:      metav1.NewTime(time.Now().Add(-maxProwJobAge).Add(-time.Second)),
 				CompletionTime: setComplete(-time.Second),
+			},
+		},
+		&prowv1.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "new-failed",
+				Namespace: "ns",
+			},
+			Status: prowv1.ProwJobStatus{
+				StartTime: metav1.NewTime(time.Now().Add(-time.Minute)),
 			},
 		},
 		&prowv1.ProwJob{

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -427,6 +427,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			if err := client.DeletePod(pod.ObjectMeta.Name); err != nil {
 				return fmt.Errorf("failed to delete pod %s that was in pending timeout: %v", pod.Name, err)
 			}
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Deleted stale pending pod.")
 
 		default:
 			// Pod is running. Do nothing.


### PR DESCRIPTION
This should be a sane start point... we have jobs stuck in running for 40 days...

also added a logging when we successfully delete a pending pod.

/assign @stevekuznetsov @cjwagner 