### PR TITLE
Remove pull-cluster-api-bazel-verify job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -1,21 +1,5 @@
 presubmits:
   kubernetes-sigs/cluster-api:
-  - name: pull-cluster-api-bazel-verify
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    skip_branches:
-    - gh-pages
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20180927-f09bc3b1b
-        args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./hack/verify-bazel.sh"
   - name: pull-cluster-api-build
     always_run: true
     labels:
@@ -64,7 +48,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2460,9 +2460,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-org-verify-all
   num_columns_recent: 30
 #presubmits
-- name: pull-cluster-api-bazel-verify
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-bazel-verify
-  num_columns_recent: 20
 - name: pull-cluster-api-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-build
   num_columns_recent: 20
@@ -5924,8 +5921,6 @@ dashboards:
     test_group_name: ci-cluster-api-test
   - name: pr-build
     test_group_name: pull-cluster-api-build
-  - name: verify-bazel
-    test_group_name: pull-cluster-api-bazel-verify
   - name: pr-make
     test_group_name: pull-cluster-api-make
   - name: pr-test


### PR DESCRIPTION
1) remove job: pull-cluster-api-bazel-verify
   pull-cluster-api-bazel-verify is only calling ./hack/verify-bazel.sh which already covered
   by pull-cluster-api-test job (it actually calling verify-bazel.sh, verify_clientset.sh etc).

2) update job: pull-cluster-api-test with e2e image (bazel is needed)
otherwise, you will see log (`./hack/verify-bazel.sh
Bazel not available, skipping validation`) in current job, https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/sigs.k8s.io_cluster-api/805/pull-cluster-api-test/1724/build-log.txt




cc @BenTheElder @vincepri @detiber 