### PR TITLE
Ignore results without a started.json

### DIFF
--- a/experiment/resultstore/main.go
+++ b/experiment/resultstore/main.go
@@ -440,7 +440,7 @@ func transferBuild(ctx context.Context, storageClient *storage.Client, rsClient 
 		return nil
 	}
 
-	if result.finished.Running && !includePending {
+	if (result.started.Pending || result.finished.Running) && !includePending {
 		log.Debug("Skip pending result")
 		return nil
 	}

--- a/experiment/resultstore/main_test.go
+++ b/experiment/resultstore/main_test.go
@@ -132,7 +132,9 @@ func TestInsertLink(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			changed, err := insertLink(&gcs.Started{Metadata: tc.input}, viewURL)
+			var start gcs.Started
+			start.Metadata = tc.input
+			changed, err := insertLink(&start, viewURL)
 			switch {
 			case err != nil:
 				if !tc.err {


### PR DESCRIPTION
/assign @Katharine @michelle192837 

We are getting a lot of errors like `gs://kubernetes-jenkins/logs/istio-periodic-e2e-gke-addon/4813/: download: started: read logs/istio-periodic-e2e-gke-addon/4813/started.json: storage: object doesn't exist` - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-resultstore-upload/124