### PR TITLE
Update sig-windows-config.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -116,7 +116,7 @@ periodics:
       securityContext:
         privileged: true
 
-- interval: 6h
+- interval: 3h
   name: ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
   labels:
     preset-service-account: "true"
@@ -151,7 +151,7 @@ periodics:
       - "--acsengine-win-binaries"
       - "--acsengine-hyperkube"
       - "--acsengine-agentpoolcount=2"
-      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[k8s.io\\].Pods.*should.cap.back-off.at.MaxContainerBackOff.\\[Slow\\]\\[NodeConformance\\]|\\[sig-network\\].DNS.should.provide.DNS.for.services..\\[Conformance\\]|\\[sig-storage\\].Secrets.should.be.consumable.from.pods.in.volume.\\[NodeConformance\\].\\[Conformance\\]|\\[k8s.io\\].Kubelet.when.scheduling.a.busybox.command.in.a.pod.should.print.the.output.to.logs.\\[NodeConformance\\].\\[Conformance\\]|\\[k8s.io\\].Kubelet.when.scheduling.a.busybox.command.that.always.fails.in.a.pod.should.be.possible.to.delete.\\[NodeConformance\\].\\[Conformance\\]"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[k8s.io\\].Pods.*should.cap.back-off.at.MaxContainerBackOff.\\[Slow\\]\\[NodeConformance\\]|\\[sig-network\\].DNS.should.provide.DNS.for.services..\\[Conformance\\]|\\[sig-storage\\].Secrets.should.be.consumable.from.pods.in.volume.\\[NodeConformance\\].\\[Conformance\\]|\\[k8s.io\\].Kubelet.when.scheduling.a.busybox.command.in.a.pod.should.print.the.output.to.logs.\\[NodeConformance\\].\\[Conformance\\]|\\[k8s.io\\].Kubelet.when.scheduling.a.busybox.command.that.always.fails.in.a.pod.should.be.possible.to.delete.\\[NodeConformance\\].\\[Conformance\\]|\\[k8s.io\\].Pods.*should.have.their.auto-restart.back-off.timer.reset.on.image.update.\\[Slow\\]\\[NodeConformance\\]"
       - "--timeout=450m"
       securityContext:
         privileged: true


### PR DESCRIPTION
Increases staging job frequency to 3h. 

With the merging of: https://github.com/kubernetes/kubernetes/pull/71950 the two tests mentioned here: https://github.com/kubernetes/kubernetes/issues/71949 should be ok. Added both of them to the inclusion list of the staging job. Once we have a couple of successful runs, we move them to the main job and 1.14 job.