### PR TITLE
Don't panic when RunToPR gets a non-numeric PR number

### DIFF
--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -251,9 +251,10 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 			if len(split) < 3 {
 				return "", "", 0, fmt.Errorf("malformed %s key %q should have at least three components", gcs.PRLogs, key)
 			}
-			prNum, err := strconv.Atoi(split[len(split)-3])
+			prNumStr := split[len(split)-3]
+			prNum, err := strconv.Atoi(prNumStr)
 			if err != nil {
-				return "", "", 0, fmt.Errorf("couldn't parse PR number %q in %q: %v", split[len(split)-3], key, err)
+				return "", "", 0, fmt.Errorf("couldn't parse PR number %q in %q: %v", prNumStr, key, err)
 			}
 			// We don't actually attempt to look up the job's own configuration.
 			// In practice, this shouldn't matter: we only want to read DefaultOrg and DefaultRepo, and overriding those

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -248,6 +248,9 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 		if logType == gcs.NonPRLogs {
 			return "", "", 0, fmt.Errorf("not a PR URL: %q", key)
 		} else if logType == gcs.PRLogs {
+			if len(split) < 3 {
+				return "", "", 0, fmt.Errorf("malformed %s key %q should have at least three components", gcs.PRLogs, key)
+			}
 			prNum, err := strconv.Atoi(split[len(split)-3])
 			if err != nil {
 				return "", "", 0, fmt.Errorf("couldn't parse PR number %q in %q: %v", split[len(split)-3], key, err)

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -250,7 +250,7 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 		} else if logType == gcs.PRLogs {
 			prNum, err := strconv.Atoi(split[len(split)-3])
 			if err != nil {
-				return "", "", 0, fmt.Errorf("couldn't parse PR number %q in %q: %v", split[5], key, err)
+				return "", "", 0, fmt.Errorf("couldn't parse PR number %q in %q: %v", split[len(split)-3], key, err)
 			}
 			// We don't actually attempt to look up the job's own configuration.
 			// In practice, this shouldn't matter: we only want to read DefaultOrg and DefaultRepo, and overriding those

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -709,6 +709,11 @@ func TestRunToPR(t *testing.T) {
 			expError: true,
 		},
 		{
+			name:     "Longer bad GCS key errors",
+			src:      "gcs/kubernetes-jenkins/pr-logs",
+			expError: true,
+		},
+		{
 			name:     "Nonsense string errors",
 			src:      "friendship is magic",
 			expError: true,

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -699,6 +699,11 @@ func TestRunToPR(t *testing.T) {
 			expError: true,
 		},
 		{
+			name:     "GCS PR job in directory errors",
+			src:      "gcs/kubernetes-jenkins/pr-logs/directory/example-job-name/314159",
+			expError: true,
+		},
+		{
 			name:     "Bad GCS key errors",
 			src:      "gcs/this is just nonsense",
 			expError: true,


### PR DESCRIPTION
This fixes the issue that led to spyglass not having symlink resolution leading to a panic instead of an error.

The panic is gone now because #11614 implemented symlink resolution, but this PR fixes the panic. Amusingly, the error was already handled, but creating the error caused a panic.

Also fix a similar bug I noticed while working on this.