### PR TITLE
Run the slack oncall updater at xx:30 instead of xx:05

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -133,7 +133,7 @@ periodics:
       secret:
         secretName: k8s-ci-robot-ssh-keys
         defaultMode: 0400
-- cron: "05 * * * *"  # Run at five minutes past the hour every day
+- cron: "30 * * * *"  # Run at half past the hour, every hour, every day
   name: ci-test-infra-update-slack-oncall
   cluster: test-infra-trusted
   decorate: true


### PR DESCRIPTION
Turns out that while our oncall technically hands off at noon (under usual circumstances), the world outside Google doesn't get to hear about it until xx:27.

Try moving the slack oncall updater to run shortly after that time.