### PR TITLE
Configure our Tide instance to persist action history to GCS.

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -37,6 +37,8 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --job-config-path=/etc/job-config
+        - --gcs-credentials-file=/etc/service-account/service-account.json
+        - --history-uri=gs://k8s-prow/tide-history.json
         ports:
           - name: http
             containerPort: 8888
@@ -50,6 +52,9 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: service-account
+          mountPath: /etc/service-account
+          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -60,3 +65,6 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: service-account
+        secret:
+          secretName: tide-history-service-account


### PR DESCRIPTION
To support this PR I also created:
- The `k8s-prow` GCS bucket for storing Prow specific data for the prow.k8s.io instance.
- The GCP service account `tide-history@k8s-prow.iam.gserviceaccount.com` which has Storage Object Admin access to the `k8s-prow` bucket.
- The `tide-history-service-account` Kubernetes secret which contains the service account credentials file stored under the `service-account.json` key.

I think these are all the steps needed to configure access to the GCS object, but please sanity check.
This will take effect immediately after merging so I'll need to be monitoring when that happens.
/hold

/assign @fejta @stevekuznetsov 
ref #10646 