### PR TITLE
Switch approve plugin config defaults.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -37,10 +37,6 @@ owners:
   - kubernetes-sigs/contributor-playground
   - helm/charts
 
-# TODO(fejta): delete these in before April
-use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019: true
-use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019: true
-
 approve:
 - repos:
   - kubernetes/cloud-provider-aws
@@ -73,6 +69,7 @@ approve:
   - kubernetes-incubator/ip-masq-agent
   require_self_approval: false
   lgtm_acts_as_approve: true
+  ignore_review_state: true
 - repos:
   - kubernetes/kops
   - kubernetes/kubernetes
@@ -81,6 +78,7 @@ approve:
   - kubernetes-sigs
   - client-go/unofficial-docs
   require_self_approval: false
+  ignore_review_state: true
 - repos:
   - bazelbuild
   - kubernetes/community
@@ -92,6 +90,7 @@ approve:
   - helm/charts
   require_self_approval: false
   lgtm_acts_as_approve: true
+  ignore_review_state: true
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:


### PR DESCRIPTION
These are producing lots of deprecation warnings that I'd like to get rid of. Lets update to get rid of them and use the new defaults for repos that don't explicitly specify a config. I have updated existing approve plugin configs so that this is a no-op for repos that do explicitly specify config.
Repos that don't specify a config will now default to having implicit self approval from PR authors and GH reviews will influence approval state just as `/approve` and `/approve cancel` would. 

Hold for contribex approval. I'll send out a notice to k-dev about this before it merges.
/hold
/assign @fejta @cblecker @spiffxp 
@kubernetes/sig-contributor-experience-pr-reviews 