### PR TITLE
Added Config Parameter DefaultStatusErrorLink

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -111,6 +111,11 @@ type ProwConfig struct {
 
 	// GitHubOptions allows users to control how prow applications display GitHub website links.
 	GitHubOptions GitHubOptions `json:"github,omitempty"`
+
+	// StatusErrorLink is the url that will be used for jenkins prowJobs that can't be
+	// found, or have another generic issue. The default that will be used if this is not set
+	// is: https://github.com/kubernetes/test-infra/issues
+	StatusErrorLink string `json:"status_error_link,omitempty"`
 }
 
 // OwnersDirBlacklist is used to configure which directories to ignore when
@@ -1002,6 +1007,10 @@ func parseProwConfig(c *Config) error {
 		return fmt.Errorf("unable to parse github.link_url, might not be a valid url: %v", err)
 	}
 	c.GitHubOptions.LinkURL = linkURL
+
+	if c.StatusErrorLink == "" {
+		c.StatusErrorLink = "https://github.com/kubernetes/test-infra/issues"
+	}
 
 	if c.LogLevel == "" {
 		c.LogLevel = "info"

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -35,10 +35,6 @@ import (
 	"k8s.io/test-infra/prow/pjutil"
 )
 
-const (
-	testInfra = "https://github.com/kubernetes/test-infra/issues"
-)
-
 type prowJobClient interface {
 	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
 	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
@@ -345,7 +341,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, reports chan<- prowapi.P
 	if !jbExists {
 		pj.SetComplete()
 		pj.Status.State = prowapi.ErrorState
-		pj.Status.URL = testInfra
+		pj.Status.URL = c.cfg().StatusErrorLink
 		pj.Status.Description = "Error finding Jenkins job."
 	} else {
 		switch {
@@ -418,7 +414,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 			c.log.WithError(err).WithFields(pjutil.ProwJobFields(&pj)).Warn("Cannot start Jenkins build")
 			pj.SetComplete()
 			pj.Status.State = prowapi.ErrorState
-			pj.Status.URL = testInfra
+			pj.Status.URL = c.cfg().StatusErrorLink
 			pj.Status.Description = "Error starting Jenkins job."
 		} else {
 			pj.Status.State = prowapi.PendingState

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -81,6 +81,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, operators []config.Jen
 						},
 					},
 				},
+				StatusErrorLink: "https://github.com/kubernetes/test-infra/issues",
 			},
 			JobConfig: config.JobConfig{
 				Presubmits: presubmitMap,

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -36,10 +36,6 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/decorate"
 )
 
-const (
-	testInfra = "https://github.com/kubernetes/test-infra/issues"
-)
-
 type kubeClient interface {
 	CreateProwJob(prowapi.ProwJob) (prowapi.ProwJob, error)
 	GetProwJob(string) (prowapi.ProwJob, error)


### PR DESCRIPTION
Fixes: #11619 

This Pull Request adds a config parameter to the JenkinsOperator struct, that allows overriding the status link that will be used if the jenkins-operator is unable to determine the correct job link.

/kind area/prow/jenkins-operator