### PR TITLE
Removing logexporter from kubemark-5000

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -388,7 +388,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1080m
-      - --use-logexporter
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Removing logexporter from ci-kubernetes-kubemark-gce-scale ci job.

Logexporter is treating hollow nodes logs as normal nodes logs, therefore exporting them instead of root cluster ones. Logexporter shouldn't be use to export kubemark logs.