### PR TITLE
Add --dry-run flags to horologium and sinker

### DIFF
--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -35,6 +35,7 @@ spec:
         image: gcr.io/k8s-prow/horologium:v20190307-fd53164
         args:
         - --job-config-path=/etc/job-config
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,8 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20190307-fd53164 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/11660
+        - --dry-run=false
+        image: gcr.io/k8s-prow/sinker:v20190307-fd53164
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster


### PR DESCRIPTION
/assign @cjwagner @krzyzacy 


```yaml
jsonPayload: {
  component:  "horologium"   
  level:  "warning"   
  msg:  "Horologium requies --dry-run=false to function correctly in production."   
 }

jsonPayload: {
  component:  "sinker"   
  level:  "warning"   
  msg:  "Sinker requies --dry-run=false to function correctly in production."   
 }
```
