### PR TITLE
Search sequentially

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -178,6 +178,8 @@ func (t *throttler) Do(req *http.Request) (*http.Response, error) {
 
 func (t *throttler) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
 	t.Wait()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	return t.graph.Query(ctx, q, vars)
 }
 


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov 

This restricts throttled clients to a single concurrent query. 

This should have minimal impact on total latency, as the duration of the serialized critical path should be small. In exchange this smooth load to github on startup, avoiding a short burst of activity.

