### PR TITLE
Add method to fetch release version with http client

### DIFF
--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -164,6 +164,20 @@ func TestExtractStrategies(t *testing.T) {
 		if !strings.HasPrefix(path.Dir(url), "gs:/") {
 			return []byte{}, fmt.Errorf("url %s must starts with gs:/", path.Dir(url))
 		}
+
+		return []byte("v1.2.3+abcde"), nil
+	}
+
+	oldHTTPCat := httpCat
+	defer func() { httpCat = oldHTTPCat }()
+	httpCat = func(url string) ([]byte, error) {
+		if path.Ext(url) != ".txt" {
+			return []byte{}, fmt.Errorf("url %s must end with .txt", url)
+		}
+		if !strings.HasPrefix(url, "https://") {
+			return []byte{}, fmt.Errorf("url %s must starts with https://", url)
+		}
+
 		return []byte("v1.2.3+abcde"), nil
 	}
 


### PR DESCRIPTION
This PR fixes: https://github.com/kubernetes/test-infra/issues/11694 and allows kubetest to be used without the need to install `gsutil` which makes it easier to use `kubtest` in an ci environment (or a Docker container).