### PR TITLE
Enable Prometheus in all non-kubemark tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -35,8 +35,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
       - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Set everywhere if it works
-      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -124,6 +124,8 @@ presets:
   # Experimentally use cos-69-10895-138-0 to test fs-related fixes there.
   - name: KUBE_GCE_MASTER_IMAGE
     value: cos-69-10895-138-0
+  - name: ENABLE_PROMETHEUS_SERVER
+    value: "true"
 
 ###### Scalability Envs
 ### Common env variables for all scalability-related suites.

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -68,8 +68,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
-      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Set everywhere if it works
-      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter


### PR DESCRIPTION
The last 3 runs of gce-scale-performance (with Prometheus stack enabled) have passed.
![1ms0lj4ndro](https://user-images.githubusercontent.com/2604887/54030028-a4677480-41aa-11e9-8a32-4708055fc550.png)

Ref https://github.com/kubernetes/kubernetes/issues/74213