### PR TITLE
Allow configure plank to not restart missing pods

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -198,6 +198,8 @@ type Plank struct {
 	// JobURLPrefixConfig is the host and path prefix under which job details
 	// will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
 	JobURLPrefixConfig map[string]string `json:"job_url_prefix_config,omitempty"`
+	// SkipRestartMissingPod will mark prowjob as error when associated pod is missing
+	SkipRestartMissingPod bool `json:"skip_restart_missing_pod,omitempty"`
 }
 
 func (p Plank) GetJobURLPrefix(refs *prowapi.Refs) string {


### PR DESCRIPTION
If k8s decide to reschedule the pods, that's fine, let k8s handle that, technically I don't see a scenario that we want to restart a missing pods from plank. Thoughts?

/assign @stevekuznetsov @fejta @cjwagner 
ref https://github.com/kubernetes/test-infra/issues/11594
cc @mm4tt 