### PR TITLE
Slack event log tool

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -56,6 +56,7 @@ filegroup(
         "//experiment/coverage:all-srcs",
         "//experiment/manual-trigger:all-srcs",
         "//experiment/resultstore:all-srcs",
+        "//experiment/slack-event-log:all-srcs",
         "//experiment/slack-oncall-updater:all-srcs",
         "//experiment/tracer:all-srcs",
     ],

--- a/experiment/slack-event-log/.gcloudignore
+++ b/experiment/slack-event-log/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/experiment/slack-event-log/.gitignore
+++ b/experiment/slack-event-log/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/experiment/slack-event-log/BUILD.bazel
+++ b/experiment/slack-event-log/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/slack-event-log",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//experiment/slack-event-log/handlers:go_default_library",
+        "//experiment/slack-event-log/slack:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "slack-event-log",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//experiment/slack-event-log/handlers:all-srcs",
+        "//experiment/slack-event-log/slack:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/slack-event-log/OWNERS
+++ b/experiment/slack-event-log/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- Katharine

--- a/experiment/slack-event-log/README.md
+++ b/experiment/slack-event-log/README.md
@@ -1,0 +1,10 @@
+# slack-event-log
+
+slack-event-log sends a log of interesting Slack events to a Slack channel (and stdout) to make it
+clearer to moderators when interesting things are happening. It also doubles as an audit log.
+
+In the name of simplicity, slack-event-log currently only provides the information that can be
+directly extracted from the webhook.
+
+Currently runs on appengine, but can be trivially moved to a Kubernetes cluster given DNS and SSL
+is set up.

--- a/experiment/slack-event-log/app.yaml
+++ b/experiment/slack-event-log/app.yaml
@@ -1,0 +1,1 @@
+runtime: go111

--- a/experiment/slack-event-log/handlers/BUILD.bazel
+++ b/experiment/slack-event-log/handlers/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "channels.go",
+        "emoji.go",
+        "handlers.go",
+        "meta.go",
+        "subteams.go",
+        "team.go",
+        "users.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/slack-event-log/handlers",
+    visibility = ["//visibility:public"],
+    deps = ["//experiment/slack-event-log/slack:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/slack-event-log/handlers/channels.go
+++ b/experiment/slack-event-log/handlers/channels.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/test-infra/experiment/slack-event-log/slack"
+)
+
+func (h *Handler) handleChannelUnarchive(body []byte) ([]byte, error) {
+	unarchiveEvent := struct {
+		Event struct {
+			Channel string `json:"channel"`
+			User    string `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &unarchiveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	h.sendMessage("Channel <#%s> was *unarchived* by <@%s>", unarchiveEvent.Event.Channel, unarchiveEvent.Event.User)
+	return nil, nil
+}
+
+func (h *Handler) handleChannelRename(body []byte) ([]byte, error) {
+	renameEvent := struct {
+		Event struct {
+			Channel struct {
+				ID      string `json:"id"`
+				Name    string `json:"name"`
+				Created int    `json:"created"`
+			} `json:"channel"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &renameEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	channel := renameEvent.Event.Channel
+
+	h.sendMessage("Channel <#%s> was *renamed* to %q", channel.ID, slack.EscapeMessage(channel.Name))
+	return nil, nil
+}
+
+func (h *Handler) handleChannelDeleted(body []byte) ([]byte, error) {
+	unarchiveEvent := struct {
+		Event struct {
+			Channel string `json:"channel"`
+			User    string `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &unarchiveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	h.sendMessage("Channel <#%s> was *deleted*", unarchiveEvent.Event.Channel)
+	return nil, nil
+}
+
+func (h *Handler) handleChannelCreated(body []byte) ([]byte, error) {
+	createEvent := struct {
+		Event struct {
+			Channel struct {
+				ID      string `json:"id"`
+				Name    string `json:"name"`
+				Created int    `json:"created"`
+				Creator string `json:"creator"`
+			} `json:"channel"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &createEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	channel := createEvent.Event.Channel
+
+	h.sendMessage("Channel <#%s|%s> was *created* by <@%s>", channel.ID, channel.Name, channel.Creator)
+	return nil, nil
+}
+
+func (h *Handler) handleChannelArchive(body []byte) ([]byte, error) {
+	archiveEvent := struct {
+		Event struct {
+			Channel string `json:"channel"`
+			User    string `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &archiveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	h.sendMessage("Channel <#%s> was *archived* by <@%s>", archiveEvent.Event.Channel, archiveEvent.Event.User)
+	return nil, nil
+}

--- a/experiment/slack-event-log/handlers/emoji.go
+++ b/experiment/slack-event-log/handlers/emoji.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func (h *Handler) handleEmojiChanged(body []byte) ([]byte, error) {
+	emojiEvent := struct {
+		Event struct {
+			Subtype string   `json:"subtype"`
+			Name    string   `json:"name,omitempty"`
+			Names   []string `json:"names,omitempty"`
+			Value   string   `json:"value,omitempty"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &emojiEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+	emoji := emojiEvent.Event
+	if emoji.Subtype == "add" {
+		if strings.HasPrefix(emoji.Value, "alias:") {
+			h.sendMessage("A *new emoji alias was added*: `:%s:`. It's an alias for `:%s:`. :%s:", emoji.Name, strings.TrimPrefix(emoji.Value, "alias:"), emoji.Name)
+		} else {
+			h.sendMessage("A *new emoji was added*: `:%s:` :%s:", emoji.Name, emoji.Name)
+		}
+	} else if emoji.Subtype == "remove" {
+		if len(emoji.Names) == 1 {
+			h.sendMessage("An *emoji was deleted*: `:%s:`", emoji.Names[0])
+		} else {
+			var aliases []string
+			for _, a := range emoji.Names {
+				aliases = append(aliases, "`:"+a+":`")
+			}
+			h.sendMessage("An *emoji was deleted*. It had several names: %s", strings.Join(aliases, ", "))
+		}
+	}
+	return nil, nil
+}

--- a/experiment/slack-event-log/handlers/handlers.go
+++ b/experiment/slack-event-log/handlers/handlers.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package handlers contains handlers for all Slack events.
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"k8s.io/test-infra/experiment/slack-event-log/slack"
+)
+
+type handlerFunc func(body []byte) ([]byte, error)
+
+// Handler handles Slack events.
+type Handler struct {
+	slack *slack.Slack
+}
+
+// New returns a new Handler.
+func New(slack *slack.Slack) *Handler {
+	return &Handler{slack: slack}
+}
+
+// HandleWebhook can be passed to http.HandlerFunc and will perform all processing associated with
+// Slack webhooks.
+func (h *Handler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf(fmt.Sprintf("failed to read body: %v", err))
+		http.Error(w, fmt.Sprintf("failed to read body: %v", err), 500)
+		return
+	}
+	log.Printf("%#v", r.Header)
+	log.Printf(string(body))
+	if err := h.slack.VerifySignature(body, r.Header); err != nil {
+		log.Printf(fmt.Sprintf("signature verification failed: %v", err))
+		http.Error(w, fmt.Sprintf("signature verification failed: %v", err), 403)
+		return
+	}
+
+	response, err := h.HandleMessage(body)
+
+	if err != nil {
+		log.Printf("Handling message failed: %v", err)
+	}
+
+	if response != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(response)
+	}
+}
+
+// HandleMessage handles a Slack webhook that has already been validated.
+func (h *Handler) HandleMessage(body []byte) ([]byte, error) {
+	t := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, err
+	}
+
+	messageMapping := map[string]handlerFunc{
+		"url_verification": h.handleURLVerification,
+		"event_callback":   h.handleEvent,
+	}
+
+	fn, ok := messageMapping[t.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown event type %q", t.Type)
+	}
+	output, err := fn(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", t.Type, err)
+	}
+	return output, nil
+}
+
+func (h *Handler) sendMessage(message string, args ...interface{}) {
+	s := fmt.Sprintf(message, args...)
+	log.Printf("Sending message: %q", s)
+	if err := h.slack.SendMessage(s); err != nil {
+		log.Printf("Sending message failed: %v", err)
+	}
+}
+
+func (h *Handler) handleEvent(body []byte) ([]byte, error) {
+	event := struct {
+		Event struct {
+			Type string `json:"type"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return nil, fmt.Errorf("error unmarshalling event type: %v", err)
+	}
+	t := event.Event.Type
+
+	eventMapping := map[string]handlerFunc{
+		"emoji_changed":      h.handleEmojiChanged,
+		"team_join":          h.handleTeamJoin,
+		"user_change":        h.handleUserChange,
+		"team_rename":        h.handleTeamRename,
+		"team_domain_change": h.handleTeamDomainChange,
+		"subteam_updated":    h.handleSubteamUpdated,
+		"subteam_created":    h.handleSubteamCreated,
+		"channel_unarchive":  h.handleChannelUnarchive,
+		"channel_rename":     h.handleChannelRename,
+		"channel_deleted":    h.handleChannelDeleted,
+		"channel_created":    h.handleChannelCreated,
+		"channel_archive":    h.handleChannelArchive,
+	}
+
+	fn, ok := eventMapping[t]
+	if !ok {
+		return nil, fmt.Errorf("unknown event type %q", t)
+	}
+	response, err := fn(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", t, err)
+	}
+	return response, nil
+}

--- a/experiment/slack-event-log/handlers/meta.go
+++ b/experiment/slack-event-log/handlers/meta.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (h *Handler) handleURLVerification(body []byte) ([]byte, error) {
+	request := struct {
+		Challenge string `json:"challenge"`
+	}{}
+	if err := json.Unmarshal(body, request); err != nil {
+		return nil, fmt.Errorf("error parsing request: %v", err)
+	}
+	response := map[string]string{"challenge": request.Challenge}
+	return json.Marshal(response)
+}

--- a/experiment/slack-event-log/handlers/subteams.go
+++ b/experiment/slack-event-log/handlers/subteams.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/test-infra/experiment/slack-event-log/slack"
+)
+
+func (h *Handler) handleSubteamUpdated(body []byte) ([]byte, error) {
+	moveEvent := struct {
+		Event struct {
+			Subteam slack.Subteam `json:"subteam"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &moveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	subteam := moveEvent.Event.Subteam
+
+	if !subteam.IsUsergroup {
+		return nil, nil
+	}
+
+	if subteam.DeleteTime != 0 {
+		h.sendMessage("Usergroup %s (%q) was *deleted* by <@%s>", subteam.Handle, slack.EscapeMessage(subteam.Name), subteam.DeletedBy)
+		return nil, nil
+	}
+
+	h.sendMessage("Usergroup <@%s> (%q) was *updated* by <@%s>", subteam.ID, slack.EscapeMessage(subteam.Name), subteam.UpdatedBy)
+	return nil, nil
+}
+
+func (h *Handler) handleSubteamCreated(body []byte) ([]byte, error) {
+	moveEvent := struct {
+		Event struct {
+			Subteam slack.Subteam `json:"subteam"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &moveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	subteam := moveEvent.Event.Subteam
+
+	if !subteam.IsUsergroup {
+		return nil, nil
+	}
+
+	h.sendMessage("Usergroup <@%s> (%q) was *created* by <@%s>", subteam.ID, slack.EscapeMessage(subteam.Name), subteam.CreatedBy)
+	return nil, nil
+}

--- a/experiment/slack-event-log/handlers/team.go
+++ b/experiment/slack-event-log/handlers/team.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (h *Handler) handleTeamRename(body []byte) ([]byte, error) {
+	renameEvent := struct {
+		Event struct {
+			Name string `json:"name"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &renameEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+	h.sendMessage("The *Slack team was renamed* to %q", renameEvent.Event.Name)
+	return nil, nil
+}
+
+func (h *Handler) handleTeamDomainChange(body []byte) ([]byte, error) {
+	moveEvent := struct {
+		Event struct {
+			URL string `json:"url"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &moveEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+	h.sendMessage("The *Slack team moved* to %s", moveEvent.Event.URL)
+	return nil, nil
+}

--- a/experiment/slack-event-log/handlers/users.go
+++ b/experiment/slack-event-log/handlers/users.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/test-infra/experiment/slack-event-log/slack"
+)
+
+func (h *Handler) handleTeamJoin(body []byte) ([]byte, error) {
+	userEvent := struct {
+		Event struct {
+			User slack.User `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &userEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	user := userEvent.Event.User
+	displayName := slack.EscapeMessage(user.Profile.DisplayName)
+	if displayName == "" {
+		displayName = "_none_"
+	}
+	h.sendMessage(fmt.Sprintf("A *new user joined*: <@%s> (display name: %s, real name: %s)", user.ID, displayName, slack.EscapeMessage(user.Profile.RealName)))
+	return nil, nil
+}
+
+func (h *Handler) handleUserChange(body []byte) ([]byte, error) {
+	userEvent := struct {
+		Event struct {
+			User slack.User `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &userEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	user := userEvent.Event.User
+	if user.Deleted {
+		h.sendMessage("A *user was deactivated*: <@%s> (this is heuristic: they are definitely deactivated now, but may also have been before)", user.ID)
+	}
+	return nil, nil
+}

--- a/experiment/slack-event-log/main.go
+++ b/experiment/slack-event-log/main.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"k8s.io/test-infra/experiment/slack-event-log/handlers"
+	"k8s.io/test-infra/experiment/slack-event-log/slack"
+)
+
+type options struct {
+	configPath string
+}
+
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.configPath, "config-path", "config.json", "Path to a file containing the slack config")
+	flag.Parse()
+	return o
+}
+
+func runServer(sl *slack.Slack) {
+	h := handlers.New(sl)
+
+	http.HandleFunc("/webhook", h.HandleWebhook)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+
+	log.Printf("Listening on port %s", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+}
+
+func main() {
+	o := parseFlags()
+	c, err := slack.LoadConfig(o.configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config from %s: %v", o.configPath, err)
+	}
+	s := slack.New(c)
+	runServer(s)
+}

--- a/experiment/slack-event-log/slack/BUILD.bazel
+++ b/experiment/slack-event-log/slack/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "slack.go",
+        "types.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/slack-event-log/slack",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/slack-event-log/slack/config.go
+++ b/experiment/slack-event-log/slack/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// Config is the information needed to communicate with Slack.
+type Config struct {
+	SigningSecret string `json:"signingSecret"`
+	WebhookURL    string `json:"webhook"`
+	AccessToken   string `json:"accessToken"`
+}
+
+// LoadConfig loads a Config from a JSON file.
+func LoadConfig(path string) (Config, error) {
+	config := Config{}
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return config, fmt.Errorf("couldn't open file: %v", err)
+	}
+	if err := json.Unmarshal(content, &config); err != nil {
+		return config, fmt.Errorf("couldn't parse config: %v", err)
+	}
+	return config, nil
+}

--- a/experiment/slack-event-log/slack/slack.go
+++ b/experiment/slack-event-log/slack/slack.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slack is used for basic interaction with Slack.
+package slack
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Slack has methods for interacting with Slack.
+type Slack struct {
+	Config Config
+}
+
+// New returns a new Slack.
+func New(config Config) *Slack {
+	return &Slack{Config: config}
+}
+
+// SendMessage sends a simple message to Slack.
+func (slack *Slack) SendMessage(message string) error {
+	toSend := struct {
+		Text string `json:"text"`
+	}{message}
+	marshalled, err := json.Marshal(toSend)
+	if err != nil {
+		return fmt.Errorf("failed to marshall slack message: %v", err)
+	}
+	b := bytes.NewBuffer(marshalled)
+	response, err := http.Post(slack.Config.WebhookURL, "application/json", b)
+	if err != nil {
+		return fmt.Errorf("failed to POST message to Slack: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("sending message to Slack failed")
+	}
+	return nil
+}
+
+// VerifySignature verifies the signature on a message from Slack to ensure it is real.
+func (slack *Slack) VerifySignature(body []byte, headers http.Header) error {
+	// Algorithm from https://api.slack.com/docs/verifying-requests-from-slack
+
+	expectedSignature := headers.Get("X-Slack-Signature")
+	if expectedSignature == "" {
+		return fmt.Errorf("X-Slack-Signature missing")
+	}
+	expectedSignatureBytes, err := hex.DecodeString(strings.TrimPrefix(expectedSignature, "v0="))
+	if err != nil {
+		return fmt.Errorf("X-Slack-Signature is not a valid hex string")
+	}
+
+	// Step 2
+	tsHeader := headers.Get("X-Slack-Request-Timestamp")
+	if tsHeader == "" {
+		return fmt.Errorf("X-Slack-Request-Timestamp header missing")
+	}
+	tsInt, err := strconv.ParseInt(tsHeader, 10, 64)
+	if tsHeader == "" {
+		return fmt.Errorf("couldn't parse timestamp %q: %v", tsHeader, err)
+	}
+	ts := time.Unix(tsInt, 0)
+	now := time.Now()
+	diff := now.Sub(ts)
+	if math.Abs(diff.Minutes()) > 5 {
+		return fmt.Errorf("clock difference %s too high", diff)
+	}
+
+	// Step 3
+	sigBase := append([]byte("v0:"+tsHeader+":"), body...)
+	h := hmac.New(sha256.New, []byte(slack.Config.SigningSecret))
+	_, _ = h.Write(sigBase)
+	ourSignature := h.Sum(nil)
+	if !hmac.Equal(ourSignature, expectedSignatureBytes) {
+		return fmt.Errorf("signature mismatch")
+	}
+	return nil
+}
+
+// EscapeMessage escapes special characters in Slack messages.
+func EscapeMessage(s string) string {
+	return strings.NewReplacer("<", "&lt;", ">", "&gt;", "&", "&amp;").Replace(s)
+}

--- a/experiment/slack-event-log/slack/types.go
+++ b/experiment/slack-event-log/slack/types.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slack
+
+// User represents a slack User object.
+type User struct {
+	ID             string `json:"id"`
+	TeamID         string `json:"team_id"`
+	Deleted        bool   `json:"deleted"`
+	Color          string `json:"color"`
+	TimeZone       string `json:"tz"`
+	TimeZoneLabel  string `json:"tz_label"`
+	TimeZoneOffset int    `json:"tz_offset"`
+	Profile        struct {
+		AvatarHash       string `json:"avatar_hash"`
+		StatusText       string `json:"status_text"`
+		StatusEmoji      string `json:"status_emoji"`
+		StatusExpiration int    `json:"status_expiration"`
+		RealName         string `json:"real_name"`
+		DisplayName      string `json:"display_name"`
+		Email            string `json:"email,omitempty"`
+		ImageOriginal    string `json:"image_original"`
+		Image24          string `json:"image_24"`
+		Image32          string `json:"image_32"`
+		Image48          string `json:"image_48"`
+		Image72          string `json:"image_72"`
+		Image192         string `json:"image_192"`
+		Image512         string `json:"image_512"`
+		Team             string `json:"team"`
+	} `json:"profile"`
+	IsAdmin           bool   `json:"is_admin"`
+	IsOwner           bool   `json:"is_owner"`
+	IsPrimaryOwner    bool   `json:"is_primary_owner"`
+	IsRestricted      bool   `json:"is_restricted"`
+	IsUltraRestricted bool   `json:"is_ultra_restricted"`
+	IsBot             bool   `json:"is_bot"`
+	IsStranger        bool   `json:"is_stranger"`
+	IsAppUser         bool   `json:"is_app_user"`
+	Has2FA            bool   `json:"has_2fa"`
+	Locale            string `json:"locale"`
+}
+
+// Subteam represents a slack Subteam object.
+type Subteam struct {
+	ID          string `json:"id"`
+	IsUsergroup bool   `json:"is_usergroup"`
+	Name        string `json:"name"`
+	Handle      string `json:"handle"`
+	UserCount   int    `json:"user_count"`
+	UpdatedBy   string `json:"updated_by"`
+	CreatedBy   string `json:"created_by"`
+	DeletedBy   string `json:"deleted_by"`
+	CreateTime  int    `json:"date_create"`
+	UpdateTime  int    `json:"date_update"`
+	DeleteTime  int    `json:"date_delete"`
+}


### PR DESCRIPTION
Simple tool that echoes interesting Slack events to a Slack channel, so that admins can be immediately aware of what is going on.

/cc @BenTheElder 