### PR TITLE
Produce consistent search string

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1374,7 +1374,7 @@ func orgRepoQueryString(orgs, repos []string, orgExceptions map[string]sets.Stri
 	for _, o := range orgs {
 		toks = append(toks, fmt.Sprintf("org:\"%s\"", o))
 
-		for _, e := range orgExceptions[o].UnsortedList() {
+		for _, e := range orgExceptions[o].List() {
 			toks = append(toks, fmt.Sprintf("-repo:\"%s\"", e))
 		}
 	}


### PR DESCRIPTION
* Use `List()` rather than `UnsortedList()` in `openPRsQuery()` so that the query only changes when the inputs change
* Log whenever we detect a changed query (should be rare and interesting, so using info)
* Stop always logging the search duration and error

/assign @cjwagner @stevekuznetsov 

ref https://github.com/kubernetes/test-infra/issues/11679