### PR TITLE
prow: add transparent gzip reading to config loading

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,7 @@
 # Announcements
 
 New features added to each component:
+ - *March 9, 2019* prow components now support reading gzipped config files
  - *February 13, 2019* prow (both plank and crier) can set status on the commit
    for postsubmit jobs on github now! 
    Type of jobs can be reported to github is gated by a config field like


### PR DESCRIPTION
With this change Prow's `config.Load(...)` will auto-detect files with GZIP headers and decode them before Unmarshal using a drop in replacement / wrapper for `ioutil.ReadFile`.

The core function is only 12 lines (without comments / function header).

Once this is deployed the config agent can optionally start uploading config files gzipped. 
As @neolit123 [pointed out](https://github.com/kubernetes/test-infra/issues/11703#issuecomment-471129343) there's roughly a 14:1 ratio between the original job configs and the gzipped job configs, our yaml compresses _very_ well.