### PR TITLE
spyglass: show metadata.links in the top bar

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -684,6 +684,12 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		tgLink = ""
 	}
 
+	extraLinks, err := sg.ExtraLinks(src)
+	if err != nil {
+		logrus.WithError(err).WithField("page", src).Warn("Failed to fetch extra links")
+		extraLinks = nil
+	}
+
 	var viewBuf bytes.Buffer
 	type lensesTemplate struct {
 		Lenses        []lenses.Lens
@@ -697,6 +703,7 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		TestgridLink  string
 		JobName       string
 		BuildID       string
+		ExtraLinks    []spyglass.ExtraLink
 	}
 	lTmpl := lensesTemplate{
 		Lenses:        ls,
@@ -710,6 +717,7 @@ func renderSpyglass(sg *spyglass.Spyglass, cfg config.Getter, src string, o opti
 		TestgridLink:  tgLink,
 		JobName:       jobName,
 		BuildID:       buildID,
+		ExtraLinks:    extraLinks,
 	}
 	t := template.New("spyglass.html")
 

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -18,12 +18,15 @@
 </div>
 {{end}}
 <div id="lens-container">
-  {{if or .JobHistLink .ArtifactsLink .PRHistLink .TestgridLink}}
+  {{if or .JobHistLink .ArtifactsLink .PRHistLink .TestgridLink .ExtraLinks}}
   <div id="links-card" class="mdl-card mdl-shadow--2dp lens-card">
     {{if .JobHistLink}}<a href="{{.JobHistLink}}">Job History</a>{{end}}
     {{if .PRHistLink}}<a href="{{.PRHistLink}}">PR History</a>{{end}}
     {{if .ArtifactsLink}}<a href="{{.ArtifactsLink}}">Artifacts</a>{{end}}
     {{if .TestgridLink}}<a href="{{.TestgridLink}}">Testgrid</a>{{end}}
+    {{range .ExtraLinks}}
+    <a href="{{.URL}}" title="{{.Description}}">{{.Name}}</a>
+    {{end}}
   </div>
   {{end}}
   {{range .Lenses}}

--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "//testgrid/config:go_default_library",
+        "//testgrid/metadata:go_default_library",
         "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -126,8 +126,6 @@ func (s *Spyglass) FetchArtifacts(src string, podName string, sizeLimit int64, a
 		if err != nil {
 			if name == "build-log.txt" {
 				podLogNeeded = true
-			} else {
-				logrus.Errorf("Failed to fetch artifact %s: %v", name, err)
 			}
 			continue
 		}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"os"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1290,5 +1292,95 @@ func TestResolveSymlink(t *testing.T) {
 			t.Errorf("test %q: expected %q, but got %q", tc.name, tc.result, result)
 			continue
 		}
+	}
+}
+
+func TestExtraLinks(t *testing.T) {
+	testCases := []struct {
+		name      string
+		content   string
+		links     []ExtraLink
+		expectErr bool
+	}{
+		{
+			name:  "does nothing without error given no started.json",
+			links: nil,
+		},
+		{
+			name:      "errors given a malformed started.json",
+			content:   "this isn't json",
+			expectErr: true,
+		},
+		{
+			name:    "does nothing given metadata with no links",
+			content: `{"metadata": {"somethingThatIsntLinks": 23}}`,
+			links:   nil,
+		},
+		{
+			name:    "returns well-formed links",
+			content: `{"metadata": {"links": {"ResultStore": {"url": "http://resultstore", "description": "The thing that isn't spyglass"}}}}`,
+			links:   []ExtraLink{{Name: "ResultStore", URL: "http://resultstore", Description: "The thing that isn't spyglass"}},
+		},
+		{
+			name:    "returns links without a description",
+			content: `{"metadata": {"links": {"ResultStore": {"url": "http://resultstore"}}}}`,
+			links:   []ExtraLink{{Name: "ResultStore", URL: "http://resultstore"}},
+		},
+		{
+			name:    "skips links without a URL",
+			content: `{"metadata": {"links": {"No Link": {"description": "bad link"}, "ResultStore": {"url": "http://resultstore"}}}}`,
+			links:   []ExtraLink{{Name: "ResultStore", URL: "http://resultstore"}},
+		},
+		{
+			name:    "skips links without a name",
+			content: `{"metadata": {"links": {"": {"url": "http://resultstore"}}}}`,
+			links:   []ExtraLink{},
+		},
+		{
+			name:    "returns no links when links is empty",
+			content: `{"metadata": {"links": {}}}`,
+			links:   []ExtraLink{},
+		},
+		{
+			name:    "returns multiple links",
+			content: `{"metadata": {"links": {"A": {"url": "http://a", "description": "A!"}, "B": {"url": "http://b"}}}}`,
+			links:   []ExtraLink{{Name: "A", URL: "http://a", Description: "A!"}, {Name: "B", URL: "http://b"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objects []fakestorage.Object
+			if tc.content != "" {
+				objects = []fakestorage.Object{
+					{
+						BucketName: "test-bucket",
+						Name:       "logs/some-job/42/started.json",
+						Content:    []byte(tc.content),
+					},
+				}
+			}
+			gcsServer := fakestorage.NewServer(objects)
+			defer gcsServer.Stop()
+
+			gcsClient := gcsServer.Client()
+			fakeConfigAgent := fca{}
+			fakeJa = jobs.NewJobAgent(fkc{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA")}, fakeConfigAgent.Config)
+			fakeJa.Start()
+			sg := New(fakeJa, fakeConfigAgent.Config, gcsClient, context.Background())
+
+			result, err := sg.ExtraLinks("gcs/test-bucket/logs/some-job/42")
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+			sort.Slice(tc.links, func(i, j int) bool { return tc.links[i].Name < tc.links[j].Name })
+			if !reflect.DeepEqual(result, tc.links) {
+				t.Fatalf("Expected links %#v, got %#v", tc.links, result)
+			}
+		})
 	}
 }

--- a/testgrid/metadata/job.go
+++ b/testgrid/metadata/job.go
@@ -69,7 +69,7 @@ type Finished struct {
 // Metadata values can either be string or string map of strings
 //
 // TODO(fejta): figure out which of these we want and document them
-// Special values: infra-commit, repos, repo, repo-commit, others
+// Special values: infra-commit, repos, repo, repo-commit, links, others
 type Metadata map[string]interface{}
 
 // String returns the name key if its value is a string, and true if the key is present.
@@ -94,6 +94,17 @@ func (m Metadata) Meta(name string) (*Metadata, bool) {
 		return &child, true
 	}
 	return nil, true
+}
+
+// Keys returns an array of the keys of all valid Metadata values.
+func (m Metadata) Keys() []string {
+	ka := make([]string, 0, len(m))
+	for k := range m {
+		if _, ok := m.Meta(k); ok {
+			ka = append(ka, k)
+		}
+	}
+	return ka
 }
 
 // Strings returns the submap of values in the map that are strings.


### PR DESCRIPTION
Makes the contents of `metadata.links` first-class in Spyglass. Looks like this (note "resultstore"):

![image](https://user-images.githubusercontent.com/110792/54146891-30b5a980-43ee-11e9-8742-475ada91a236.png)
