### PR TITLE
Better handling of having only empty JUnit files

### DIFF
--- a/prow/spyglass/lenses/junit/junit.css
+++ b/prow/spyglass/lenses/junit/junit.css
@@ -1,3 +1,9 @@
+#empty-junit-container {
+  color: #e8e8e8;
+  text-align: center;
+  padding-bottom: 10px;
+}
+
 .hidden-tests {
   visibility: collapse;
   display: none;

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -158,9 +158,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		}
 	}
 
-	if jvd.NumTests = len(jvd.Passed) + len(jvd.Failed) + len(jvd.Skipped); jvd.NumTests == 0 {
-		return "Found no valid JUnit test results"
-	}
+	jvd.NumTests = len(jvd.Passed) + len(jvd.Failed) + len(jvd.Skipped)
 
 	junitTemplate, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -7,6 +7,11 @@
 {{$numF := len .Failed}}
 {{$numP := len .Passed}}
 {{$numS := len .Skipped}}
+{{if eq .NumTests 0}}
+  <div id="empty-junit-container">
+    No tests were recorded.
+  </div>
+{{else}}
 <div id="junit-container">
   <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
   {{if gt $numF 0}}
@@ -68,4 +73,5 @@
   {{end}}
   </table>
 </div>
+{{end}}
 {{end}}


### PR DESCRIPTION
Legible text in a reasonable place with reasonable padding, instead of black text stuck in the corner.

![image](https://user-images.githubusercontent.com/110792/54155527-89db0880-4401-11e9-83b1-a0e3787372e1.png)
