### PR TITLE
Add --status-path to save/load status state

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -159,6 +159,7 @@ filegroup(
         "//metrics:all-srcs",
         "//pkg/flagutil:all-srcs",
         "//pkg/ghclient:all-srcs",
+        "//pkg/io:all-srcs",
         "//prow:all-srcs",
         "//robots/commenter:all-srcs",
         "//robots/coverage:all-srcs",

--- a/pkg/io/BUILD.bazel
+++ b/pkg/io/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["opener.go"],
+    importpath = "k8s.io/test-infra/pkg/io",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//testgrid/util/gcs:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/io/opener.go
+++ b/pkg/io/opener.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
+
+	"k8s.io/test-infra/testgrid/util/gcs" // TODO(fejta): move this logic here
+)
+
+type storageClient interface {
+	Bucket(name string) *storage.BucketHandle
+}
+
+// Aliases to types in the standard library
+type (
+	ReadCloser  = io.ReadCloser
+	WriteCloser = io.WriteCloser
+)
+
+// Opener has methods to read and write paths
+type Opener interface {
+	Reader(ctx context.Context, path string) (ReadCloser, error)
+	Writer(ctx context.Context, path string) (WriteCloser, error)
+}
+
+type opener struct {
+	gcs storageClient
+}
+
+// NewOpener returns an opener that can read GCS and local paths.
+func NewOpener(ctx context.Context, creds string) (Opener, error) {
+	var options []option.ClientOption
+	if creds != "" {
+		options = append(options, option.WithCredentialsFile(creds))
+	}
+	client, err := storage.NewClient(ctx, options...)
+	if err != nil {
+		if creds != "" {
+			return nil, err
+		}
+		logrus.WithError(err).Debug("Cannot load application default gcp credentials")
+		client = nil
+	}
+	return opener{gcs: client}, nil
+}
+
+// IsNotExist will return true if the error is because the object does not exist.
+func IsNotExist(err error) bool {
+	return os.IsNotExist(err) || err == storage.ErrObjectNotExist
+}
+
+// LogClose will attempt a close an log any error
+func LogClose(c io.Closer) {
+	if err := c.Close(); err != nil {
+		logrus.WithError(err).Error("Failed to close")
+	}
+}
+
+func (o opener) openGCS(path string) (*storage.ObjectHandle, error) {
+	if !strings.HasPrefix(path, "gs://") {
+		return nil, nil
+	}
+	if o.gcs == nil {
+		return nil, errors.New("no gcs client configured")
+	}
+	var p gcs.Path
+	if err := p.Set(path); err != nil {
+		return nil, err
+	}
+	if p.Object() == "" {
+		return nil, errors.New("object name is empty")
+	}
+	return o.gcs.Bucket(p.Bucket()).Object(p.Object()), nil
+}
+
+// Reader will open the path for reading, returning an IsNotExist() error when missing
+func (o opener) Reader(ctx context.Context, path string) (io.ReadCloser, error) {
+	g, err := o.openGCS(path)
+	if err != nil {
+		return nil, fmt.Errorf("bad gcs path: %v", err)
+	}
+	if g == nil {
+		return os.Open(path)
+	}
+	return g.NewReader(ctx)
+}
+
+// Writer returns a writer that overwrites the path.
+func (o opener) Writer(ctx context.Context, path string) (io.WriteCloser, error) {
+	g, err := o.openGCS(path)
+	if err != nil {
+		return nil, fmt.Errorf("bad gcs path: %v", err)
+	}
+	if g == nil {
+		return os.Create(path)
+	}
+	return g.NewWriter(ctx), nil
+}

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//pkg/io:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
@@ -21,10 +22,7 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/tide:go_default_library",
-        "//testgrid/util/gcs:go_default_library",
-        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/tide",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
@@ -19,13 +20,13 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
-        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/prow/tide/history/BUILD.bazel
+++ b/prow/tide/history/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "k8s.io/test-infra/prow/tide/history",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1252,7 +1252,7 @@ func TestServeHTTP(t *testing.T) {
 		Context:     githubql.String("coverage/coveralls"),
 		Description: githubql.String("Coverage increased (+0.1%) to 27.599%"),
 	}}
-	hist, err := history.New(100, nil)
+	hist, err := history.New(100, nil, "")
 	if err != nil {
 		t.Fatalf("Failed to create history client: %v", err)
 	}
@@ -1478,7 +1478,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 		})
-		hist, err := history.New(100, nil)
+		hist, err := history.New(100, nil, "")
 		if err != nil {
 			t.Fatalf("Failed to create history client: %v", err)
 		}

--- a/testgrid/util/gcs/BUILD.bazel
+++ b/testgrid/util/gcs/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/test-infra/testgrid/util/gcs",
     visibility = [
         "//experiment/resultstore:__subpackages__",
+        "//pkg/io:__subpackages__",
         "//prow/cmd/tide:__subpackages__",
         "//prow/gcsupload:__subpackages__",
         "//prow/spyglass:__subpackages__",


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov 

Add a `--status-path` flag to tide, and save this value once an hour. This value can be either a `/local/path` to something like a PV or else a `gs://bucket/obj` path (when `--gcs-credentials-file` is set).

When set it will allow tide to restart without needing to check the status on all open PRs. Just the ones updated since the last save.
* Recheck all PRs if the query changed
* Problems loading the state are logged, continuing as if no state is known.

Tide's action history can now use either gcs or a PV as well

ref #11679 