### PR TITLE
Expose the Tide history page.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,8 @@
 # Announcements
 
 New features added to each component:
+ - *March 12, 2019* tide now records a history of its actions and exposes a
+   filterable view of these actions at the `/tide-history` deck path.
  - *March 9, 2019* prow components now support reading gzipped config files
  - *February 13, 2019* prow (both plank and crier) can set status on the commit
    for postsubmit jobs on github now! 

--- a/prow/cmd/README.md
+++ b/prow/cmd/README.md
@@ -10,7 +10,7 @@ Prow has a microservice architecture implemented as a collection of container im
 
 * [`hook`](/prow/cmd/hook) is the most important piece. It is a stateless server that listens for GitHub webhooks and dispatches them to the appropriate plugins. Hook's plugins are used to trigger jobs, implement 'slash' commands, post to Slack, and more. See the [`prow/plugins`](/prow/plugins/) directory for more information on plugins.
 * [`plank`](/prow/cmd/plank) is the controller that manages the job execution and lifecycle for jobs that run in k8s pods.
-* [`deck`](/prow/cmd/deck) presents a nice view of [recent jobs](https://prow.k8s.io/), [command](https://prow.k8s.io/command-help) and [plugin](https://prow.k8s.io/plugins) help information, the [status of merge automation](https://prow.k8s.io/tide), and a [dashboard for PR authors](https://prow.k8s.io/pr).
+* [`deck`](/prow/cmd/deck) presents a nice view of [recent jobs](https://prow.k8s.io/), [command](https://prow.k8s.io/command-help) and [plugin](https://prow.k8s.io/plugins) help information, the [current status](https://prow.k8s.io/tide) and (history)[https://prow.k8s.io/tide-history] of merge automation, and a [dashboard for PR authors](https://prow.k8s.io/pr).
 * [`horologium`](/prow/cmd/horologium) triggers periodic jobs when necessary.
 * [`sinker`](/prow/cmd/sinker) cleans up old jobs and pods.
 

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -89,6 +89,7 @@ ts_library(
     srcs = glob(["pr/*.ts"]),
     deps = [
         ":api",
+        ":common",
     ],
 )
 
@@ -98,6 +99,7 @@ rollup_bundle(
     deps = [
         ":pr",
         "@npm//dialog-polyfill",
+        "@npm//moment",
     ],
 )
 

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -166,3 +166,37 @@ export namespace tooltip {
     return tip;
   }
 }
+
+export namespace icon {
+  export function create(iconString: string, tip: string = ""): HTMLAnchorElement {
+    const i = document.createElement("i");
+    i.classList.add("icon-button", "material-icons");
+    i.innerHTML = iconString;
+    if (tip !== "") {
+       i.title = tip;
+    }
+
+    const container = document.createElement("a");
+    container.appendChild(i);
+    container.classList.add("mdl-button", "mdl-js-button", "mdl-button--icon");
+
+    return container;
+  }
+}
+
+export namespace tidehistory {
+  export function poolIcon(org: string, repo: string, branch: string): HTMLAnchorElement {
+    const link = icon.create("timeline", "Pool History");
+    const encodedRepo = encodeURIComponent(`${org}/${repo}`);
+    const encodedBranch = encodeURIComponent(branch);
+    link.href = `/tide-history?repo=${encodedRepo}&branch=${encodedBranch}`;
+    return link;
+  }
+
+  export function authorIcon(author: string): HTMLAnchorElement {
+    const link = icon.create("timeline", "Personal Tide History");
+    const encodedAuthor = encodeURIComponent(author);
+    link.href = `/tide-history?author=${encodedAuthor}`;
+    return link;
+  }
+}

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -4,6 +4,7 @@ import {Context} from '../api/github';
 import {Label, PullRequest, UserData} from '../api/pr';
 import {Job, JobState} from '../api/prow';
 import {Blocker, TideData, TidePool, TideQuery as ITideQuery} from '../api/tide';
+import {tidehistory} from '../common/common';
 
 declare const tideData: TideData;
 declare const allBuilds: Job[];
@@ -312,6 +313,7 @@ function createSearchCard(): HTMLElement {
     actionCtn.id = "search-action";
     actionCtn.appendChild(userBtn);
     actionCtn.appendChild(refBtn);
+    actionCtn.appendChild(tidehistory.authorIcon(getCookieByName("github_login")));
 
     const inputContainer = document.createElement("div");
     inputContainer.id = "search-input-ctn";
@@ -534,6 +536,8 @@ function createPRCardTitle(pr: PullRequest, tidePools: TidePool[], jobStatus: Va
     const prTitleText = document.createElement("div");
     prTitleText.appendChild(link);
     prTitleText.appendChild(subtitle);
+    prTitleText.appendChild(document.createTextNode("\u00A0"));
+    prTitleText.appendChild(tidehistory.poolIcon(pr.Repository.Owner.Login, pr.Repository.Name, pr.BaseRef.Name));
     prTitleText.classList.add("pr-title-text");
     prTitle.appendChild(prTitleText);
 

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 import {Job, JobState, JobType} from "../api/prow";
-import {cell} from "../common/common";
+import {cell, icon} from "../common/common";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';
 
@@ -514,11 +514,11 @@ function redraw(fz: FuzzySearch): void {
         const r = document.createElement("tr");
         r.appendChild(cell.state(build.state));
         if (build.pod_name) {
-            const icon = createIcon("description", "Build log");
-            icon.href = `log?job=${build.job}&id=${build.build_id}`;
+            const logIcon = icon.create("description", "Build log");
+            logIcon.href = `log?job=${build.job}&id=${build.build_id}`;
             const c = document.createElement("td");
             c.classList.add("icon-cell");
-            c.appendChild(icon);
+            c.appendChild(logIcon);
             r.appendChild(c);
         } else {
             r.appendChild(cell.text(""));
@@ -590,8 +590,8 @@ function redraw(fz: FuzzySearch): void {
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
     const url = `https://${window.location.hostname}/rerun?prowjob=${prowjob}`;
     const c = document.createElement("td");
-    const icon = createIcon("refresh", "Show instructions for rerunning this job");
-    icon.onclick = () => {
+    const i = icon.create("refresh", "Show instructions for rerunning this job");
+    i.onclick = () => {
         modal.style.display = "block";
         rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
         const copyButton = document.createElement('a');
@@ -600,7 +600,7 @@ function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob:
         copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
         rerunElement.appendChild(copyButton);
     };
-    c.appendChild(icon);
+    c.appendChild(i);
     c.classList.add("icon-cell");
     return c;
 }
@@ -827,25 +827,10 @@ function drawJobHistogram(total: number, jobHistogram: JobHistogram, start: numb
 }
 
 function createSpyglassCell(url: string): HTMLTableDataCellElement {
-    const icon = createIcon('visibility', 'View in Spyglass');
-    icon.href = url;
+    const i = icon.create('visibility', 'View in Spyglass');
+    i.href = url;
     const c = document.createElement('td');
     c.classList.add('icon-cell');
-    c.appendChild(icon);
+    c.appendChild(i);
     return c;
-}
-
-function createIcon(iconString: string, tooltip: string = ""): HTMLAnchorElement {
-    const icon = document.createElement("i");
-    icon.classList.add("icon-button", "material-icons");
-    icon.innerHTML = iconString;
-    if (tooltip !== "") {
-        icon.title = tooltip;
-    }
-
-    const container = document.createElement("a");
-    container.appendChild(icon);
-    container.classList.add("mdl-button", "mdl-js-button", "mdl-button--icon");
-
-    return container;
 }

--- a/prow/cmd/deck/static/tide/tide.ts
+++ b/prow/cmd/deck/static/tide/tide.ts
@@ -1,5 +1,5 @@
 import {PullRequest, TideData, TidePool} from '../api/tide';
-import {tooltip} from '../common/common';
+import {tidehistory, tooltip} from '../common/common';
 
 declare const tideData: TideData;
 
@@ -216,13 +216,8 @@ function redrawPools(): void {
     for (const pool of tideData.Pools) {
         const r = document.createElement("tr");
 
-        const deckLink = `/?repo=${pool.Org}%2F${pool.Repo}`;
-        const branchLink = `https://github.com/${pool.Org}/${pool.Repo}/tree/${pool.Branch}`;
-        const linksTD = document.createElement("td");
-        linksTD.appendChild(createLink(deckLink, `${pool.Org}/${pool.Repo}`));
-        linksTD.appendChild(document.createTextNode(" "));
-        linksTD.appendChild(createLink(branchLink, pool.Branch));
-        r.appendChild(linksTD);
+        r.appendChild(createHistoryCell(pool));
+        r.appendChild(createRepoCell(pool));
         r.appendChild(createActionCell(pool));
         r.appendChild(createBatchCell(pool));
         r.appendChild(createPRCell(pool, pool.SuccessPRs));
@@ -231,6 +226,22 @@ function redrawPools(): void {
 
         pools.appendChild(r);
     }
+}
+
+function createHistoryCell(pool: TidePool): HTMLTableDataCellElement {
+    const td = document.createElement("td");
+    td.appendChild(tidehistory.poolIcon(pool.Org, pool.Repo, pool.Branch));
+    return td;
+}
+
+function createRepoCell(pool: TidePool): HTMLTableDataCellElement {
+    const deckLink = `/?repo=` + encodeURIComponent(`${pool.Org}/${pool.Repo}`);
+    const branchLink = `https://github.com/${pool.Org}/${pool.Repo}/tree/${pool.Branch}`;
+    const linksTD = document.createElement("td");
+    linksTD.appendChild(createLink(deckLink, `${pool.Org}/${pool.Repo}`));
+    linksTD.appendChild(document.createTextNode(" "));
+    linksTD.appendChild(createLink(branchLink, pool.Branch));
+    return linksTD;
 }
 
 function createActionCell(pool: TidePool): HTMLTableDataCellElement {

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -36,6 +36,7 @@
       <a class="mdl-navigation__link{{if eq .PageName "command-help"}} mdl-navigation__link--current{{end}}" href="/command-help">Command Help</a>
       {{ if sections.Tide }}
         <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
+        <a class="mdl-navigation__link{{if eq .PageName "tide-history"}} mdl-navigation__link--current{{end}}" href="/tide-history">Tide History</a>
       {{ end }}
       <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
       <a class="mdl-navigation__link" href="https://github.com/kubernetes/test-infra/blob/master/prow/README.md" target="_blank">Documentation <span class="material-icons">open_in_new</span></a>

--- a/prow/cmd/deck/template/tide.html
+++ b/prow/cmd/deck/template/tide.html
@@ -23,12 +23,13 @@
   <div class="table-container">
     <table id="pools">
       <thead>
-      <th>Repo</th>
-      <th>State</th>
-      <th>Batch</th>
-      <th>Passing</th>
-      <th>Pending</th>
-      <th>Queued for Retest</th>
+        <th></th>
+        <th>Repo</th>
+        <th>State</th>
+        <th>Batch</th>
+        <th>Passing</th>
+        <th>Pending</th>
+        <th>Queued for Retest</th>
       </thead>
       <tbody>
       </tbody>

--- a/prow/cmd/tide/README.md
+++ b/prow/cmd/tide/README.md
@@ -20,7 +20,7 @@ them when they have up-to-date passing test results ("tide goes out").
 - Supports blocking merge to individual branches or whole repos using specifically labelled GitHub issues.
 - Exposes Prometheus metrics.
 - Supports repos that have 'optional' status contexts that shouldn't be required for merge.
-- Serves live data about current actions and pools which can be consumed by [Deck](/prow/cmd/deck) to populate the Tide dashboard and the PR dashboard.
+- Serves live data about current pools and a history of actions which can be consumed by [Deck](/prow/cmd/deck) to populate the [Tide dashboard](https://prow.k8s.io/tide), the [PR dashboard](https://prow.k8s.io/pr), and the [Tide history page](https://prow.k8s.io/tide-history).
 - Scales efficiently so that a single instance with a single bot token can provide merge automation to dozens of orgs and repos with unique merge criteria. Every distinct 'org/repo:branch' combination defines a disjoint merge pool so that merges only affect other PRs in the same branch.
 - Provides configurable merge modes ('merge', 'squash', or 'rebase').
 

--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -133,6 +133,23 @@ All PRs that conform to the criteria are processed and merged.
 The processing itself can include running jobs (e.g. tests) to verify the PRs are good to go.
 All commits in PRs from `github.com/kubeflow/community` repository are squashed before merging.
 
+### Persistent Storage of Action History
+
+Tide records a history of the actions it takes (namely triggering tests and merging).
+This history is stored in memory, but can be loaded from GCS and periodically flushed
+in order to persist across pod restarts. Persisting action history to GCS is strictly
+optional, but is nice to have if the Tide instance is restarted frequently or if
+users want to view older history.
+
+Both the `--history-uri` and `--gcs-credentials-file` flags must be specified to Tide
+to persist history to GCS. The GCS credentials file should be a [GCP service account
+key](https://cloud.google.com/iam/docs/service-accounts#service_account_keys) file
+for a service account that has permission to read and write the history GCS object.
+The history URI is the GCS object path at which the history data is stored. It should
+not be publicly readable if any repos are sensitive and must be a GCS URI like `gs://bucket/path/to/object`.
+
+[Example](https://github.com/kubernetes/test-infra/blob/b4089633afbe608271a6630bb66c6d74f29f78ef/prow/cluster/tide_deployment.yaml#L40-L41)
+
 # Configuring Presubmit Jobs
 
 Before a PR is merged, Tide ensures that all jobs configured as required in the `presubmits` part of the `config.yaml` file are passing against the latest base branch commit, rerunning the jobs if necessary. **No job is required to be configured** in which case it's enough if a PR meets all GitHub search criteria.


### PR DESCRIPTION
This PR addresses the remaining tasks in https://github.com/kubernetes/test-infra/issues/10646 except for sending an email to k-dev which I'll do once this merges.  Specifically it
- adds an entry for the Tide history page to Deck's navigation menu.
![historylinks-menu](https://user-images.githubusercontent.com/5334145/54245983-4c08dd80-44f0-11e9-9bf0-5b079eb240c6.png)
- makes the Tide dashboard link to the history page with the appropriate filters.
![historylinks-tidehighlighted](https://user-images.githubusercontent.com/5334145/54246010-6347cb00-44f0-11e9-900e-23b73032413c.png)
- makes the PR status page link to the history page with the appropriate filters (one link for the author's PRs and then a link next to each pool).
![historylinks-pr-highlighted](https://user-images.githubusercontent.com/5334145/54246021-68a51580-44f0-11e9-963a-bc492a95c4b8.png)
- updates the Tide docs to mention the history page.
- adds an announcement about the new page to ANNOUNCEMENTS.md


Each bullet point is in its own commit.
/assign @Katharine @stevekuznetsov 
/cc @fejta @spiffxp 