### PR TITLE
add optional gzip support to configmap updater

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -421,6 +421,9 @@ type ConfigUpdater struct {
 	// github.com/kubernetes/test-infra/prow/plugins.yaml assuming the config-updater
 	// plugin is enabled for kubernetes/test-infra. Defaults to "prow/plugins.yaml".
 	PluginFile string `json:"plugin_file,omitempty"`
+	// If GZIP is true then files will be gzipped before insertion into
+	// their corresponding configmap
+	GZIP bool `json:"gzip"`
 }
 
 // MergeWarning is a config for the slackevents plugin's manual merge warnings.

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -674,7 +674,7 @@ func TestUpdateConfig(t *testing.T) {
 
 		m.SetDefaults()
 
-		if err := handle(fgc, fkc.CoreV1(), defaultNamespace, log, event, m.Maps); err != nil {
+		if err := handle(fgc, fkc.CoreV1(), defaultNamespace, log, event, &m); err != nil {
 			t.Errorf("%s: unexpected error handling: %s", tc.name, err)
 			continue
 		}


### PR DESCRIPTION
... and the config-bootstrapper

this is gated behind a plugin config flag and a CLI flag on the bootstrapper, the default is the existing non-gzipped behavior.

we can deploy this, flip it on in the config, and flip it back off / re-bootstrap the config if we observe issues for any reason.