### PR TITLE
Add specific yaml's for each Ingress job + add a new job for release-1.5 branch

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -1,3 +1,140 @@
+presets:
+- labels:
+    preset-ingress-master-yaml: "true"
+  env:
+  - name: CUSTOM_INGRESS_YAML
+    # we want to keep extra spaces for the yaml file.
+    value: |2+
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: l7-lb-controller
+          namespace: kube-system
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+            seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+          labels:
+            k8s-app: gcp-lb-controller
+            kubernetes.io/name: "GLBC"
+        spec:
+          terminationGracePeriodSeconds: 600
+          hostNetwork: true
+          containers:
+            # HEAD is used unless otherwised specified by each individual job.
+          - image: k8s.gcr.io/ingress-gce-glbc-amd64:master
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8086
+                scheme: HTTP
+              initialDelaySeconds: 30
+              # healthz reaches out to GCE
+              periodSeconds: 30
+              timeoutSeconds: 15
+              successThreshold: 1
+              failureThreshold: 5
+            name: l7-lb-controller
+            volumeMounts:
+            - mountPath: /etc/gce.conf
+              name: cloudconfig
+              readOnly: true
+            - mountPath: /var/log/glbc.log
+              name: logfile
+              readOnly: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 50Mi
+            args:
+            - --v=3
+            - --logtostderr=false
+            - --log_file=/var/log/glbc.log
+            - --enable-finalizer-remove
+            - --apiserver-host=http://localhost:8080
+            - --default-backend-service=kube-system/default-http-backend
+            - --sync-period=600s
+            - --running-in-cluster=false
+            - --config-file-path=/etc/gce.conf
+            - --healthz-port=8086
+            - --gce-ratelimit=ga.Operations.Get,qps,10,100
+            - --gce-ratelimit=alpha.Operations.Get,qps,10,100
+            - --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1
+            - --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1
+            - --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1
+            - --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1
+            - --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1
+            - --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1
+            - --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1
+          volumes:
+          - hostPath:
+              path: /etc/gce.conf
+              type: FileOrCreate
+            name: cloudconfig
+          - hostPath:
+              path: /var/log/glbc.log
+              type: FileOrCreate
+            name: logfile
+
+- labels:
+    preset-ingress-v1.3-and-above-yaml: "true"
+  env:
+  - name: CUSTOM_INGRESS_YAML
+    # we want to keep extra spaces for the yaml file.
+    value: |2+
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: l7-lb-controller
+          namespace: kube-system
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+            seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+          labels:
+            k8s-app: gcp-lb-controller
+            kubernetes.io/name: "GLBC"
+        spec:
+          terminationGracePeriodSeconds: 600
+          hostNetwork: true
+          containers:
+            # HEAD is used unless otherwised specified by each individual job.
+          - image: k8s.gcr.io/ingress-gce-glbc-amd64:master
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8086
+                scheme: HTTP
+              initialDelaySeconds: 30
+              # healthz reaches out to GCE
+              periodSeconds: 30
+              timeoutSeconds: 15
+              successThreshold: 1
+              failureThreshold: 5
+            name: l7-lb-controller
+            volumeMounts:
+            - mountPath: /etc/gce.conf
+              name: cloudconfig
+              readOnly: true
+            - mountPath: /var/log/glbc.log
+              name: logfile
+              readOnly: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 50Mi
+            command:
+            - sh
+            - -c
+            - 'exec /glbc --enable-backend-config --gce-ratelimit=ga.Operations.Get,qps,10,100 --gce-ratelimit=alpha.Operations.Get,qps,10,100 --gce-ratelimit=beta.Operations.Get,qps,10,100 --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1 --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.Get,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.AttachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.DetachNetworkEndpoints,qps,1.8,1 --gce-ratelimit=beta.NetworkEndpointGroups.ListNetworkEndpoints,qps,1.8,1 --verbose--apiserver-host=http://localhost:8080 --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=false --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1'
+          volumes:
+          - hostPath:
+              path: /etc/gce.conf
+              type: FileOrCreate
+            name: cloudconfig
+          - hostPath:
+              path: /var/log/glbc.log
+              type: FileOrCreate
+            name: logfile
+
 presubmits:
   kubernetes/ingress-gce:
   - name: pull-ingress-gce-test
@@ -51,6 +188,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-ingress-master-yaml: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -77,6 +215,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-ingress-master-yaml: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -99,34 +238,12 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]
       - --timeout=320m
 
-- name: ci-ingress-gce-e2e-release-1-2
-  interval: 480m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
-      args:
-      - --timeout=340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:release-1.2
-      - --extract=ci/latest
-      - --gcp-project-type=ingress-project
-      - --ginkgo-parallel=1
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Ingress\]
-      - --timeout=320m
-
 - name: ci-ingress-gce-e2e-release-1-3
   interval: 240m
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-ingress-v1.3-and-above-yaml: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -150,6 +267,31 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-ingress-v1.3-and-above-yaml: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
+      args:
+      - --timeout=340
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:release-1.4
+      - --extract=ci/latest
+      - --gcp-project-type=ingress-project
+      - --ginkgo-parallel=1
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:Ingress\] 
+      - --timeout=320m
+
+- name: ci-ingress-gce-e2e-release-1-5
+  interval: 90m
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-ingress-v1.3-and-above-yaml: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -173,6 +315,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-ingress-master-yaml: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -240,12 +240,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e
 - name: ci-ingress-gce-e2e-multi-zone
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-multi-zone
-- name: ci-ingress-gce-e2e-release-1-2
-  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-2
 - name: ci-ingress-gce-e2e-release-1-3
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-3
 - name: ci-ingress-gce-e2e-release-1-4
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-4
+- name: ci-ingress-gce-e2e-release-1-5
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-release-1-5
 - name: ci-ingress-gce-e2e-scale
   gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e-scale
 - name: ci-cluster-api-build
@@ -6299,16 +6299,16 @@ dashboards:
     test_group_name: ci-ingress-gce-e2e-multi-zone
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-e2e-release-1.2
-    test_group_name: ci-ingress-gce-e2e-release-1-2
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: ingress-gce-e2e-release-1.3
     test_group_name: ci-ingress-gce-e2e-release-1-3
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: ingress-gce-e2e-release-1.4
     test_group_name: ci-ingress-gce-e2e-release-1-4
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
+  - name: ingress-gce-e2e-release-1.5
+    test_group_name: ci-ingress-gce-e2e-release-1-5
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: ingress-gce-e2e-scale


### PR DESCRIPTION
This PR does two things:

1. Add Ingress-GCE controller YAML's for each test job so that we don't use the YAML defined in k/k
2. Add a job for the 1.5 branch and delete the job for the 1.2 branch. 

/assign @krzyzacy 