### PR TITLE
plugins.yaml: enable /test for all kubernetes-csi repos

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -499,15 +499,10 @@ plugins:
   - shrug
   - size
   - skip
+  - trigger
   - verify-owners
   - wip
   - yuks
-
-  kubernetes-csi/csi-lib-utils:
-  - trigger
-
-  kubernetes-csi/csi-driver-host-path:
-  - trigger
 
   kubernetes-incubator:
   - approve


### PR DESCRIPTION
We are in the process of enabling Prow testing for several repos in
the kubernetes-csi
organization (https://github.com/kubernetes/enhancements/pull/807,
https://github.com/kubernetes/test-infra/pull/11715).

Instead of enabling the /test trigger individually for just the repos
where it works and then remember to update it when adding new ones, it
is simpler to just enable it for the entire org.