### PR TITLE
Upload new image for prow jobs with bazel 0.23.2

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/rules-k8s/gcloud-bazel:v20190222-v0.1-11-g87de67e
+      - image: gcr.io/rules-k8s/gcloud-bazel:v20190313-v0.1-24-g7e16d1f
         args:
         - bash
         - -c


### PR DESCRIPTION
Blocking https://github.com/bazelbuild/rules_k8s/pull/289 and
https://github.com/bazelbuild/rules_k8s/pull/280 which need newer Bazel
version. Currently the image used by prow has Bazel 0.22.0