### PR TITLE
Restrict Prow approvers to those specified in OWNERS files under 'prow/'.

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -931,6 +931,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to prow's plugins
+        name: area/prow/plugins
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to prow's pubsub reporter component
         name: area/prow/pubsub
         target: both

--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
 
 filters:
   ".*":

--- a/prow/clonerefs/OWNERS
+++ b/prow/clonerefs/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/clonerefs

--- a/prow/cmd/branchprotector/OWNERS
+++ b/prow/cmd/branchprotector/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- fejta
+
 labels:
  - area/prow/branchprotector

--- a/prow/cmd/clonerefs/OWNERS
+++ b/prow/cmd/clonerefs/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/clonerefs

--- a/prow/cmd/deck/OWNERS
+++ b/prow/cmd/deck/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+ - cjwagner
  - Katharine
+ - stevekuznetsov
 labels:
  - area/prow/deck

--- a/prow/cmd/entrypoint/OWNERS
+++ b/prow/cmd/entrypoint/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/entrypoint

--- a/prow/cmd/grandmatriarch/OWNERS
+++ b/prow/cmd/grandmatriarch/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- krzyzacy
-
-labels:
- - area/prow/gerrit
+- fejta

--- a/prow/cmd/horologium/OWNERS
+++ b/prow/cmd/horologium/OWNERS
@@ -1,4 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- cjwagner
+- krzyzacy
+- stevekuznetsov
+
 labels:
  - area/prow/horologium

--- a/prow/cmd/initupload/OWNERS
+++ b/prow/cmd/initupload/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/initupload

--- a/prow/cmd/jenkins-operator/OWNERS
+++ b/prow/cmd/jenkins-operator/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- stevekuznetsov
+
 labels:
  - area/prow/jenkins-operator

--- a/prow/cmd/mkbuild-cluster/OWNERS
+++ b/prow/cmd/mkbuild-cluster/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- fejta
 labels:
  - area/prow/mkbuild-cluster

--- a/prow/cmd/peribolos/OWNERS
+++ b/prow/cmd/peribolos/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+ - fejta
 labels:
  - area/prow/peribolos

--- a/prow/cmd/sidecar/OWNERS
+++ b/prow/cmd/sidecar/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/sidecar

--- a/prow/cmd/sub/OWNERS
+++ b/prow/cmd/sub/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- krzyzacy
-
+  - sebastienvas
 labels:
- - area/prow/gerrit
+ - area/prow/pubsub

--- a/prow/cmd/tackle/OWNERS
+++ b/prow/cmd/tackle/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- krzyzacy
-
-labels:
- - area/prow/gerrit
+  - fejta

--- a/prow/cmd/tide/OWNERS
+++ b/prow/cmd/tide/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+ - cjwagner
+ - stevekuznetsov
 labels:
  - area/prow/tide

--- a/prow/entrypoint/OWNERS
+++ b/prow/entrypoint/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/entrypoint

--- a/prow/initupload/OWNERS
+++ b/prow/initupload/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/initupload

--- a/prow/jenkins/OWNERS
+++ b/prow/jenkins/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- stevekuznetsov
 labels:
  - area/prow/jenkins-operator

--- a/prow/pluginhelp/OWNERS
+++ b/prow/pluginhelp/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- krzyzacy
-
-labels:
- - area/prow/gerrit
+- cjwagner

--- a/prow/plugins/OWNERS
+++ b/prow/plugins/OWNERS
@@ -1,7 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
-- krzyzacy
-
 labels:
- - area/prow/gerrit
+ - area/prow/plugins

--- a/prow/sidecar/OWNERS
+++ b/prow/sidecar/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cjwagner
 - stevekuznetsov
 labels:
  - area/prow/sidecar

--- a/prow/tide/OWNERS
+++ b/prow/tide/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- cjwagner
+- stevekuznetsov
 labels:
  - area/prow/tide


### PR DESCRIPTION
This PR enables the `no_parent_owners` option in the `prow/OWNERS` OWNERS file which will prevent approvers in the root OWNERS file from being considered approvers of files under `prow/`. This will primarily have the effect of restricting oncall rotation members' approval permissions for files under `prow/`. Oncall members are still approvers of the `prow/cluster` directory so this will not impact their ability to approve version bumps to Prow and individual members have been made approvers of their respective focus areas under `prow/` so this shouldn't introduce a barrier to development.

The motivation for this is not to require a thorough code review from an OWNER on every PR. Rather, the motivation is to ensure that Prow code owners get a chance to approve the direction of changes before they are merged.
I don't think that PR approvals will become a bottleneck for dev velocity, but if this negatively impacts productivity we can easily tweak things or revert this entirely.

/cc @BenTheElder @amwat @Katharine @krzyzacy @spiffxp 
/assign @fejta @stevekuznetsov 

I also added an `area/prow/plugins` label while I was updating the OWNERS files.
