### PR TITLE
Use config file for release versions for manage_release_versions.py

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -15,6 +15,7 @@ py_binary(
         "//scenarios:kubernetes_verify.py",
         "//testgrid:config-yaml",
     ],
+    deps = ["@ruamel_yaml//ruamel/yaml:ruamel.yaml"],
 )
 
 py_binary(

--- a/experiment/releases.yaml
+++ b/experiment/releases.yaml
@@ -1,0 +1,8 @@
+# This file defines the list of versions that's used in
+# `experiment/manage_release_versions.py`
+
+current: "1.13"
+stable1: "1.12"
+stable2: "1.11"
+stable3: "1.10"
+deprecated: "1.9"


### PR DESCRIPTION
As part of #11730 remove hard coded versions from scripts and use config file
/cc @amwat @imkin @munnerz