### PR TITLE
Copy test-infra files into tmpdir, not tmpdir/test-infra

### DIFF
--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -27,7 +27,7 @@ _tmpdir="$(pwd)"
 
 trap "rm -rf ${_tmpdir}" EXIT
 
-cp -a "${TESTINFRA_ROOT}/" "${_tmpdir}"
+cp -a "${TESTINFRA_ROOT}/." "${_tmpdir}"
 ./hack/update-deps.sh
 
 diff=$(diff -Nupr \


### PR DESCRIPTION
/assign @BenTheElder @krzyzacy @munnerz 

I know this will shock you, but apparently mac and linux have different cp behavior.

This pattern appears to work in both locations, per https://askubuntu.com/questions/86822/how-can-i-copy-the-contents-of-a-folder-to-another-folder-in-a-different-directo


Mac says:
```man
     -R    If source_file designates a directory, cp copies the directory and the entire subtree connected at that point.  If the source_file
           ends in a /, the contents of the directory are copied rather than the directory itself.
```

Linux might have -T to do this, but it looks like `foo/.` works as intended in bot platforms.

Looks like https://github.com/kubernetes/test-infra/pull/11645 made it so verify-deps.sh only works on mac:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/11771/pull-test-infra-verify-deps/675