### PR TITLE
Add pprof debug output to prow controllers

### DIFF
--- a/prow/cmd/build/main.go
+++ b/prow/cmd/build/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
 
 	buildset "github.com/knative/build/pkg/client/clientset/versioned"
 	buildinfo "github.com/knative/build/pkg/client/informers/externalversions"
@@ -131,6 +132,8 @@ func newBuildConfig(cfg rest.Config, stop chan struct{}) (*buildConfig, error) {
 func main() {
 	o := parseOptions()
 	logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "build"})
+
+	pjutil.ServePProf()
 
 	configAgent := &config.Agent{}
 	if o.config != "" {

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/github/reporter:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/pubsub/reporter:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/pjutil"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobinformer "k8s.io/test-infra/prow/client/informers/externalversions"
@@ -142,6 +143,8 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "crier"}),
 	)
+
+	pjutil.ServePProf()
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -27,7 +27,6 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
-	"net/http/pprof"
 	"net/url"
 	"os"
 	"path"
@@ -147,14 +146,7 @@ func main() {
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "deck"}),
 	)
 
-	// serve debug info
-	pprofMux := http.NewServeMux()
-	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
-	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	go func() { logrus.WithError(http.ListenAndServe(":8082", pprofMux)).Fatal("ListenAndServe returned.") }()
+	pjutil.ServePProf()
 
 	// setup config agent, pod log clients etc.
 	configAgent := &config.Agent{}

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/adapter"
@@ -77,6 +78,9 @@ func gatherOptions() options {
 
 func main() {
 	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "gerrit"}))
+
+	pjutil.ServePProf()
+
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -81,6 +81,9 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "horologium"}),
 	)
+
+	pjutil.ServePProf()
+
 	if !o.dryRun.Explicit {
 		logrus.Warning("Horologium requies --dry-run=false to function correctly in production.")
 		logrus.Warning("--dry-run will soon default to true. Set --dry-run=false by March 15.")

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//prow/jenkins:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//vendor/github.com/NYTimes/gziphandler:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -130,6 +131,8 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "jenkins-operator"}),
 	)
+
+	pjutil.ServePProf()
 
 	if _, err := labels.Parse(o.selector); err != nil {
 		logrus.WithError(err).Fatal("Error parsing label selector.")

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/plank:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -97,6 +98,8 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "plank"}),
 	)
+
+	pjutil.ServePProf()
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -19,9 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"time"
 
@@ -88,10 +85,7 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 
-	// for pprof endpoints
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
+	pjutil.ServePProf()
 
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "sinker"}),

--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/statusreconciler:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -82,6 +83,8 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "status-reconciler"}),
 	)
+
+	pjutil.ServePProf()
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/tide:go_default_library",
         "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -121,6 +122,8 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tide"}),
 	)
+
+	pjutil.ServePProf()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -277,6 +277,8 @@ func main() {
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "tot"}),
 	)
 
+	pjutil.ServePProf()
+
 	s, err := newStore(o.storagePath)
 	if err != nil {
 		logrus.WithError(err).Fatal("newStore failed")

--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "pjutil.go",
+        "pprof.go",
         "tot.go",
     ],
     importpath = "k8s.io/test-infra/prow/pjutil",

--- a/prow/pjutil/pprof.go
+++ b/prow/pjutil/pprof.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pjutil contains helpers for working with ProwJobs.
+package pjutil
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ServePProf sets up a handler for pprof debug endpoints and starts a server for them asynchronously.
+// The contents of this function are identical to what the `net/http/pprof` package does on import for
+// the simple case where the default mux is to be used, but with a custom mux to ensure we don't serve
+// this data from an exposed port.
+func ServePProf() {
+	pprofMux := http.NewServeMux()
+	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
+	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	go func() {
+		logrus.WithError(http.ListenAndServe(":6060", pprofMux)).Fatal("ListenAndServe returned while serving pprof data.")
+	}()
+}


### PR DESCRIPTION
Having debug output available over HTTP allows for an admin to use
`kubectl port-forward` to grab data from the process on-demand. This is
incredibly useful to debug errant behavior and will enable us to respond
to resource usage worries. Go authors declare that they run with these
endpoints on at all times in production without seeing overhead for the
profiling:

https://groups.google.com/d/msg/golang-nuts/e6lB8ENbIw8/azeTCGj7AgAJ

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @BenTheElder @krzyzacy 