### PR TITLE
Enable prometheus in kubemark-100 for test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -290,6 +290,8 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
+      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Confirm it works and set everywhere
+      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=240m
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
This is to verify that it works in kubemark.
If everything is fine we will enable it everywhere.

Ref. https://github.com/kubernetes/kubernetes/issues/74213