### PR TITLE
Allow config-updater plugin to look for Prow config under config/

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -259,9 +259,9 @@ config_updater:
   maps:
     label_sync/labels.yaml:
       name: label-config
-    prow/config.yaml:
+    config/config.yaml:
       name: config
-    prow/plugins.yaml:
+    config/plugins.yaml:
       name: plugins
     config/jobs/**/*.yaml:
       name: job-config


### PR DESCRIPTION
In order to move the plugins.yaml and config.yaml to the config/
directory alongside the job configuration in a seamless manner, the
plugin must fist be configured to search for the new locations of the
files. The plugin will then continue to update from the current location
until the files are moved, then only update from the new location and we
will be free to remove the current config updating lines.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta @spiffxp 

