### PR TITLE
Fix NPD job command line breaking

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -41,7 +41,7 @@ periodics:
       args:
       - bash
       - -c
-      - |
+      - >
         ./test/build.sh install-lib &&
         make test
 
@@ -64,7 +64,7 @@ periodics:
       args:
       - bash
       - -c
-      - |
+      - >
         ./test/build.sh get-ci-env &&
         source ci.env &&
         /workspace/scenarios/kubernetes_e2e.py
@@ -97,7 +97,7 @@ periodics:
       args:
       - bash
       - -c
-      - |
+      - >
         ./test/build.sh get-ci-env &&
         source ci.env &&
         /workspace/scenarios/kubernetes_e2e.py
@@ -129,7 +129,7 @@ periodics:
       args:
       - bash
       - -c
-      - |
+      - >
         ./test/build.sh get-ci-env &&
         source ci.env &&
         /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         args:
         - bash
         - -c
-        - |
+        - >
           ./test/build.sh install-lib &&
           make build
         # docker-in-docker needs privileged mode
@@ -41,7 +41,7 @@ presubmits:
         args:
         - bash
         - -c
-        - |
+        - >
           ./test/build.sh install-lib &&
           make test
 
@@ -63,7 +63,7 @@ presubmits:
         args:
         - bash
         - -c
-        - |
+        - >
           ./test/build.sh pr $(PULL_REFS) &&
           source pr.env &&
           /workspace/scenarios/kubernetes_e2e.py
@@ -99,7 +99,7 @@ presubmits:
         args:
         - bash
         - -c
-        - |
+        - >
           ./test/build.sh pr $(PULL_REFS) &&
           source pr.env &&
           /workspace/scenarios/kubernetes_e2e.py
@@ -134,7 +134,7 @@ presubmits:
         args:
         - bash
         - -c
-        - |
+        - >
           ./test/build.sh pr $(PULL_REFS) &&
           source pr.env &&
           /workspace/scenarios/kubernetes_e2e.py


### PR DESCRIPTION
The commands currently use `|` for long bash command. It should be `>`, which treats single newline as space.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.