### PR TITLE
deck: fix comment for PR history URL

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -596,7 +596,7 @@ func handleJobHistory(o options, cfg config.Getter, gcsClient *storage.Client) h
 // handlePRHistory handles requests to get the test history if a given PR
 // The url must look like this:
 //
-// /pr-history/<org>/<repo>/<pr number>
+// /pr-history?org=<org>&repo=<repo>&pr=<pr number>
 func handlePRHistory(o options, cfg config.Getter, gcsClient *storage.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setHeadersNoCaching(w)


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/blob/d43c282ebd76c8b1047e20af5e07d263faec2dda/prow/cmd/deck/pr_history.go#L185

Got confused by the comment while debugging something :S 

/assign @Katharine 
/shrug