### PR TITLE
Make Tide status page's history icon column have fixed width.

### DIFF
--- a/prow/cmd/deck/static/tide/tide.ts
+++ b/prow/cmd/deck/static/tide/tide.ts
@@ -230,6 +230,7 @@ function redrawPools(): void {
 
 function createHistoryCell(pool: TidePool): HTMLTableDataCellElement {
     const td = document.createElement("td");
+    td.classList.add("icon-cell");
     td.appendChild(tidehistory.poolIcon(pool.Org, pool.Repo, pool.Branch));
     return td;
 }


### PR DESCRIPTION
Currently the first column of the [Tide status page](https://prow.k8s.io/tide) (containing icons linking to the Tide history) does not have a fixed width. This PR fixes the width :upside_down_face: .

/cc @fejta @Katharine @michelle192837 