### PR TITLE
Add kubernetes repo for NPD node e2e tests

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -56,6 +56,10 @@ periodics:
     repo: node-problem-detector
     base_ref: master
     path_alias: k8s.io/node-problem-detector
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -67,8 +71,8 @@ periodics:
       - >-
         ./test/build.sh get-ci-env &&
         source ci.env &&
+        cd $(GOPATH)/src/k8s.io/kubernetes &&
         /workspace/scenarios/kubernetes_e2e.py
-        --extract=ci/latest
         --deployment=node
         --provider=gce
         --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -55,6 +55,11 @@ presubmits:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190301-76bc03340-master
@@ -66,8 +71,8 @@ presubmits:
         - >-
           ./test/build.sh pr $(PULL_REFS) &&
           source pr.env &&
+          cd $(GOPATH)/src/k8s.io/kubernetes &&
           /workspace/scenarios/kubernetes_e2e.py
-          --extract=ci/latest
           --deployment=node
           --provider=gce
           --gcp-zone=us-west1-b


### PR DESCRIPTION
Running node e2e tests need access to kubernetes code instead of release binary. This PR adds the extra kubernetes repo for NPD node e2e jobs.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.