### PR TITLE
Borrow a fixed project for GCP Windows POC e2e test job.

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -317,7 +317,6 @@ resources:
   - k8s-boskos-gce-project-17
   - k8s-boskos-gce-project-18
   - k8s-boskos-gce-project-19
-  - k8s-boskos-gce-project-20
   - k8s-docker-validation-gci
   - k8s-e2e-gce-alpha1-5
   - k8s-e2e-gce-f8n-1-5

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
@@ -31,6 +31,7 @@ periodics:
       - --build=bazel
       - --stage=gs://kubernetes-release-dev/ci/ci-kubernetes-e2e-windows-gce-poc
       - --extract=local
+      - --gcp-project=k8s-boskos-gce-project-20
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce


### PR DESCRIPTION
For this test job we need to store some files in GCS where our Windows
K8s nodes can access them. Using a fixed project for the job will let us
stash these files without making them publicly available.

We expect to revert this change after we've sufficiently investigated
kubernetes/kubernetes#75148 (hopefully just a few days).