### PR TITLE
Add quotes to NPD node e2e jobs

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -82,8 +82,8 @@ periodics:
         --gcp-zone=us-west1-b
         --node-tests=true
         --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
-        --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-        --test_args="--nodes=8 --focus=NodeProblemDetector"
+        --node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"
+        --test_args=\"--nodes=8 --focus=NodeProblemDetector\"
         --timeout=60m
 
 - name: ci-npd-e2e-kubernetes-gce-gci

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -82,8 +82,8 @@ presubmits:
           --gcp-zone=us-west1-b
           --node-tests=true
           --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
-          --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-          --test_args="--nodes=8 --focus=NodeProblemDetector"
+          --node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"
+          --test_args=\"--nodes=8 --focus=NodeProblemDetector\"
           --timeout=60m
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
The [failed run](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/node-problem-detector/261/pull-npd-e2e-node/12) shows error `unknown flag: --cgroup-root`. This is probably due to problems on quotes of the flags. This PR tries out adding backslash to the quotes.