### PR TITLE
Enable Prometheus in all Kubemark tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -290,8 +290,6 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
-      # TODO(https://github.com/kubernetes/kubernetes/issues/74213): Confirm it works and set everywhere
-      - --test-cmd-args=--enable-prometheus-server
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=240m
       # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -40,6 +40,8 @@ presets:
   # Allow one node to not be ready after cluster creation.
   - name: ALLOWED_NOTREADY_NODES
     value: 1
+  - name: ENABLE_PROMETHEUS_SERVER
+    value: "true"
 ### kubemark-gce-big
 - labels:
     preset-e2e-kubemark-gce-big: "true"


### PR DESCRIPTION
After fixing the KUBEMARK_ROOT_KUBECONFIG env variable issue, the kubemark-100 has been passing with the prometheus stack enabled.
![CRt6NDVFyBC](https://user-images.githubusercontent.com/2604887/54420951-a29e3380-470b-11e9-83de-828424f25ff1.png)


We're good to enable it in all kubemark tests.

Ref. https://github.com/kubernetes/kubernetes/issues/74213