### PR TITLE
Add extra envs for NPD node e2e jobs

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -81,7 +81,7 @@ periodics:
         --provider=gce
         --gcp-zone=us-west1-b
         --node-tests=true
-        --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
+        '--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=$EXTRA_ENVS'
         '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
         '--test_args=--nodes=8 --focus=NodeProblemDetector'
         --timeout=60m

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
           --provider=gce
           --gcp-zone=us-west1-b
           --node-tests=true
-          --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
+          '--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=$EXTRA_ENVS'
           '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
           '--test_args=--nodes=8 --focus=NodeProblemDetector'
           --timeout=60m


### PR DESCRIPTION
NPD node e2e tests need the extra envs to use the newly built NPD docker image, otherwise, the default version is used.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.