### PR TITLE
Enable Tide status checkpoint.

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --gcs-credentials-file=/etc/service-account/service-account.json
         - --history-uri=gs://k8s-prow/tide-history.json
+        - --status-path=gs://k8s-prow/tide-status-checkpoint.yaml
         ports:
           - name: http
             containerPort: 8888


### PR DESCRIPTION
Enables the feature @fejta added to make Tide store and load its status checkpoint information from GCS so to minimize or prevent Tide status update brownouts on restart.

/cc @fejta 
/assign @stevekuznetsov 