### PR TITLE
Adding e2e test for fully automated storage version migration

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/presubmits.yaml
@@ -10,7 +10,34 @@ presubmits:
         - make
         - test
 
-  - name: pull-kube-storage-version-migrator-e2e
+  - name: pull-kube-storage-version-migrator-manually-launched-e2e
+    decorate: true
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-master-image=gci
+        - --gcp-node-image=gci
+        - --gcp-nodes=1
+        - --gcp-zone=us-central1-f
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../test/e2e/test-cmd.sh
+        - --timeout=50m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  - name: pull-kube-storage-version-migrator-fully-automated-e2e
     decorate: true
     always_run: true
     # TODO: remove this when the test is stable
@@ -34,7 +61,7 @@ presubmits:
         - --gcp-zone=us-central1-f
         - --provider=gce
         - --test=false
-        - --test-cmd=../test/e2e/test-cmd.sh
+        - --test-cmd=../test/e2e/test-fully-automated.sh
         - --timeout=50m
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
/assign @krzyzacy 

I added another test entry instead of running the new e2e test in serial with the old one because that would take too long.