### PR TITLE
Add a Slack welcome bot

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -60,6 +60,7 @@ filegroup(
         "//experiment/slack/slack:all-srcs",
         "//experiment/slack/slack-event-log:all-srcs",
         "//experiment/slack/slack-report-message:all-srcs",
+        "//experiment/slack/slack-welcomer:all-srcs",
         "//experiment/tracer:all-srcs",
     ],
     tags = ["automanaged"],

--- a/experiment/slack/slack-report-message/handler.go
+++ b/experiment/slack/slack-report-message/handler.go
@@ -117,7 +117,7 @@ func (h *handler) handleReportMessage(interaction slackInteraction, rw http.Resp
 			State:          string(state),
 		},
 	}
-	if err := h.client.CallMethod("dialog.open", dialog); err != nil {
+	if err := h.client.CallMethod("dialog.open", dialog, nil); err != nil {
 		logError(rw, "Failed to call dialog.open: %v", err)
 		return
 	}
@@ -193,7 +193,7 @@ func (h *handler) handleReportSubmission(interaction slackInteraction, rw http.R
 			},
 		},
 	}
-	if err := h.client.CallMethod(h.client.Config.WebhookURL, report); err != nil {
+	if err := h.client.CallMethod(h.client.Config.WebhookURL, report, nil); err != nil {
 		logError(rw, "Failed to send report: %v.", err)
 		return
 	}
@@ -204,7 +204,7 @@ func (h *handler) handleReportSubmission(interaction slackInteraction, rw http.R
 		"replace_original": false,
 	}
 
-	if h.client.CallMethod(interaction.ResponseURL, response) != nil {
+	if h.client.CallMethod(interaction.ResponseURL, response, nil) != nil {
 		logError(rw, "Failed to send response: %v.", err)
 		return
 	}

--- a/experiment/slack/slack-welcomer/.gcloudignore
+++ b/experiment/slack/slack-welcomer/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/experiment/slack/slack-welcomer/.gitignore
+++ b/experiment/slack/slack-welcomer/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/experiment/slack/slack-welcomer/BUILD.bazel
+++ b/experiment/slack/slack-welcomer/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "handler.go",
+        "main.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/slack/slack-welcomer",
+    visibility = ["//visibility:private"],
+    deps = ["//experiment/slack/slack:go_default_library"],
+)
+
+go_binary(
+    name = "slack-welcomer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/slack/slack-welcomer/app.yaml
+++ b/experiment/slack/slack-welcomer/app.yaml
@@ -1,0 +1,1 @@
+runtime: go111

--- a/experiment/slack/slack-welcomer/handler.go
+++ b/experiment/slack/slack-welcomer/handler.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"k8s.io/test-infra/experiment/slack/slack"
+	"log"
+	"net/http"
+)
+
+type handler struct {
+	client      *slack.Client
+	messagePath string
+}
+
+func logError(rw http.ResponseWriter, format string, args ...interface{}) {
+	s := fmt.Sprintf(format, args...)
+	log.Println(s)
+	http.Error(rw, s, 500)
+}
+
+type handlerFunc func(body []byte) ([]byte, error)
+
+// ServeHTTP handles Slack webhook requests.
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logError(rw, "Failed to read incoming request body: %v", err)
+		return
+	}
+	if err := h.client.VerifySignature(body, r.Header); err != nil {
+		logError(rw, "Failed validation: %v", err)
+		return
+	}
+	response, err := h.handleMessage(body)
+	if err != nil {
+		logError(rw, "Failed to handle message: %v", err)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	_, _ = rw.Write(response)
+}
+
+func (h *handler) handleMessage(body []byte) ([]byte, error) {
+	t := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, err
+	}
+
+	messageMapping := map[string]handlerFunc{
+		"url_verification": h.handleURLVerification,
+		"event_callback":   h.handleEvent,
+	}
+
+	fn, ok := messageMapping[t.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown event type %q", t.Type)
+	}
+	output, err := fn(body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", t.Type, err)
+	}
+	return output, nil
+}
+
+func (h *handler) handleURLVerification(body []byte) ([]byte, error) {
+	request := struct {
+		Challenge string `json:"challenge"`
+	}{}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, fmt.Errorf("error parsing request: %v", err)
+	}
+	response := map[string]string{"challenge": request.Challenge}
+	return json.Marshal(response)
+}
+
+func (h *handler) handleEvent(body []byte) ([]byte, error) {
+	event := struct {
+		Event struct {
+			Type string     `json:"type"`
+			User slack.User `json:"user"`
+		} `json:"event"`
+	}{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	// We should only be getting team_join events, but be sure to filter out anything else.
+	// We don't consider this an error, because Slack might get upset if we did.
+	if event.Event.Type != "team_join" {
+		return []byte{}, nil
+	}
+
+	if err := h.sendWelcome(event.Event.User.ID); err != nil {
+		return nil, fmt.Errorf("failed to send welcome: %v", err)
+	}
+	return []byte{}, nil
+}
+
+func (h *handler) sendWelcome(uid string) error {
+	welcome, err := h.getWelcome()
+	if err != nil {
+		return fmt.Errorf("couldn't get welcome: %v", err)
+	}
+
+	// Slack requires that we first open an "IM channel" that we can then use to actually send messages.
+	response := struct {
+		Channel struct {
+			ID string `json:"id"`
+		} `json:"channel"`
+	}{}
+	if err := h.client.CallMethod("im.open", map[string]string{"user": uid}, &response); err != nil {
+		return fmt.Errorf("couldn't open IM channel: %v", err)
+	}
+	channel := response.Channel.ID
+
+	message := struct {
+		Channel   string `json:"channel"`
+		Text      string `json:"text"`
+		AsUser    bool   `json:"as_user"`
+		LinkNames bool   `json:"link_names"`
+	}{
+		Channel:   channel,
+		Text:      welcome,
+		AsUser:    true, // Send messages as the bot user, rather than as the app (a very subtle distinction)
+		LinkNames: true, // Parse @names and #names in the welcome message but still allow other fancy formatting.
+	}
+	if err := h.client.CallMethod("chat.postMessage", message, nil); err != nil {
+		return fmt.Errorf("failed to send message: %v", err)
+	}
+	return nil
+}
+
+func (h *handler) getWelcome() (string, error) {
+	message, err := ioutil.ReadFile(h.messagePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %v", h.messagePath, err)
+	}
+	return string(message), nil
+}

--- a/experiment/slack/slack-welcomer/main.go
+++ b/experiment/slack/slack-welcomer/main.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"k8s.io/test-infra/experiment/slack/slack"
+)
+
+type options struct {
+	configPath  string
+	messagePath string
+}
+
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.configPath, "config-path", "config.json", "Path to a file containing the slack config")
+	flag.StringVar(&o.messagePath, "message-path", "welcome.md", "Path to a file containing the welcome message")
+	flag.Parse()
+	return o
+}
+
+func runServer(sl *slack.Client, o options) {
+	h := &handler{client: sl, messagePath: o.messagePath}
+
+	http.Handle("/webhook", h)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+
+	log.Printf("Listening on port %s", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+}
+
+func main() {
+	o := parseFlags()
+	c, err := slack.LoadConfig(o.configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config from %s: %v", o.configPath, err)
+	}
+	s := slack.New(c)
+	runServer(s, o)
+}

--- a/experiment/slack/slack-welcomer/welcome.md
+++ b/experiment/slack/slack-welcomer/welcome.md
@@ -1,0 +1,10 @@
+Welcome to Slack!
+
+This is a _welcome message_. It is formatted using `mrkdwn`, which is like Markdown but not.
+
+You can references users and channels and they should be linkified: #testing-things
+
+You can read the <https://github.com/cncf/foundation/blob/master/code-of-conduct.md|Code of Conduct>.
+That wasn't very markdown but oh well.
+
+Obviously, this is placeholder text.


### PR DESCRIPTION
This bot sends a message (defined by `welcome.md`, currently just a placeholder) to new users when they join Slack.

/cc @BenTheElder 