### PR TITLE
Add k8s 1.13.4 GCE PD CSI Driver test SKU

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable
+- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-master
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -16,6 +16,32 @@ periodics:
       - "--scenario=execute"
       - "--" # end bootstrap args, scenario args below
       - "test/run-k8s-integration.sh"
+      env:
+      - name: GCE_PD_OVERLAY_NAME
+        value: "stable"
+      - name: GCE_PD_DO_DRIVER_BUILD
+        value: "false"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-1-13-4
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
+      args:
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--clean"
+      - "--timeout=60" # Minutes
+      - "--scenario=execute"
+      - "--" # end bootstrap args, scenario args below
+      - "test/run-k8s-integration.sh"
+      - "--kube-version=1.13.4"
       env:
       - name: GCE_PD_OVERLAY_NAME
         value: "stable"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3373,8 +3373,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-structured-merge-diff-test
 
 # GCP Compute Persistent Disk CSI Driver Test Groups
-- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable
-  gcs_prefix: kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable
+- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-master
+- name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-1-13-4
+  gcs_prefix: kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-1-13-4
 
 # AWS Test Groups
 - name: pull-aws-alb-ingress-controller-lint
@@ -6077,8 +6079,11 @@ dashboards:
 - name: sig-gcp-compute-persistent-disk-csi-driver
   dashboard_tab:
   - name: Kubernetes Master Driver Stable
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable
+    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-master
     description: Kubernetes Integration tests for Kubernetes Master branch and Driver Stable
+  - name: Kubernetes v1.13.4 Driver Stable
+    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-k8s-integration-stable-1-13-4
+    description: Kubernetes Integration tests for Kubernetes 1.13.4 and Driver Stable
 
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
   dashboard_tab:


### PR DESCRIPTION
We don't yet have infrastructure to support getting a k8s version `1.13.x` so we have to specify the patch version. I have opened an issue on the driver to support this:
https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/239

/assign @msau42 