### PR TITLE
Add website teams for /milestone

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -235,6 +235,10 @@ repo_milestone:
     maintainers_id: 3169231
     maintainers_team: community-milestone-maintainers
     maintainers_friendly_name: Community Milestone Maintainers
+  kubernetes/website:
+    maintainers_id: 3175912
+    maintainers_team: website-milestone-maintainers 
+    maintainers_friendly_name: Website milestone maintainers
 
 project_config:
   project_org_configs:
@@ -489,6 +493,9 @@ plugins:
 
   kubernetes/utils:
   - override
+  
+  kubernetes/website:
+  - milestone
 
   kubernetes-client:
   - approve


### PR DESCRIPTION
💚 OK to merge 💚  

**Update:** https://github.com/kubernetes/org/pull/644 has merged, so this PR is 🆗 to merge.

For https://github.com/kubernetes/test-infra/issues/11687#issuecomment-474388190.

This PR adds `/milestone` capability for localization subproject owners in k/website.