### PR TITLE
Bump ghproxy, branchprotector, commenter, and label_sync with Prow.

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -5,9 +5,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       # pull requests against master branches in the kubernetes org labeled kind/api-change
       # exclude PRs that are in progress, held, or need rebase (typically aren't ready for API review).
@@ -47,9 +47,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubernetes
@@ -80,9 +80,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=is:pr
@@ -125,9 +125,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubernetes
@@ -161,9 +161,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubernetes
@@ -225,9 +225,9 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+    - image: gcr.io/k8s-prow/commenter:v20190322-1ad130161
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=repo:kubernetes/enhancements

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-testimages/label_sync:v20190126-6c4304780
+              image: gcr.io/k8s-prow/label_sync:v20190320-08fcf3e
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-testimages/label_sync:v20190126-6c4304780
+        image: gcr.io/k8s-prow/label_sync:v20190320-08fcf3e
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true


### PR DESCRIPTION
Steps: 
- [x] Switch `branchprotector` and `label_sync` from k8s cronjobs to Prow periodic jobs. (These are only cronjobs for legacy reasons AFAIK.) https://github.com/kubernetes/test-infra/pull/11841
- [x] Make Prow bump the image tags for `branchprotector`, `label_sync`, and `commenter` ProwJobs in the `config/` dir.

/assign @krzyzacy @stevekuznetsov 