### PR TITLE
Trigger postsubmits for branch names with a slash

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -545,8 +545,9 @@ type PushEvent struct {
 
 // Branch returns the name of the branch to which the user pushed.
 func (pe PushEvent) Branch() string {
-	refs := strings.Split(pe.Ref, "/")
-	return refs[len(refs)-1]
+	ref := strings.TrimPrefix(pe.Ref, "refs/heads/") // if Ref is a branch
+	ref = strings.TrimPrefix(ref, "refs/tags/")      // if Ref is a tag
+	return ref
 }
 
 // Commit represents general info about a commit.

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -82,25 +82,25 @@ func TestPush(t *testing.T) {
 	pushEvManual.Pusher.Name = "Jester Tester"
 	pushEvManual.Pusher.Email = "tester@users.noreply.github.com"
 	pushEvManual.Sender.Login = "tester"
-	pushEvManual.Ref = "refs/head/master"
+	pushEvManual.Ref = "refs/heads/master"
 
 	pushEvManualBranchWhiteListed := pushEv
 	pushEvManualBranchWhiteListed.Pusher.Name = "Warren Teened"
 	pushEvManualBranchWhiteListed.Pusher.Email = "wteened@users.noreply.github.com"
 	pushEvManualBranchWhiteListed.Sender.Login = "wteened"
-	pushEvManualBranchWhiteListed.Ref = "refs/head/warrens-branch"
+	pushEvManualBranchWhiteListed.Ref = "refs/heads/warrens-branch"
 
 	pushEvManualNotBranchWhiteListed := pushEvManualBranchWhiteListed
-	pushEvManualNotBranchWhiteListed.Ref = "refs/head/master"
+	pushEvManualNotBranchWhiteListed.Ref = "refs/heads/master"
 
 	pushEvManualCreated := pushEvManual
 	pushEvManualCreated.Created = true
-	pushEvManualCreated.Ref = "refs/head/release-1.99"
+	pushEvManualCreated.Ref = "refs/heads/release-1.99"
 	pushEvManualCreated.Compare = "https://github.com/kubernetes/kubernetes/compare/045a6dca0784"
 
 	pushEvManualDeleted := pushEvManual
 	pushEvManualDeleted.Deleted = true
-	pushEvManualDeleted.Ref = "refs/head/release-1.99"
+	pushEvManualDeleted.Ref = "refs/heads/release-1.99"
 	pushEvManualDeleted.Compare = "https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"
 
 	pushEvManualForced := pushEvManual

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestCreateRefs(t *testing.T) {
 	pe := github.PushEvent{
-		Ref: "master",
+		Ref: "refs/heads/master",
 		Repo: github.Repo{
 			Owner: github.User{
 				Name: "kubernetes",
@@ -66,7 +66,7 @@ func TestHandlePE(t *testing.T) {
 		{
 			name: "branch deleted",
 			pe: github.PushEvent{
-				Ref: "master",
+				Ref: "refs/heads/master",
 				Repo: github.Repo{
 					FullName: "org/repo",
 				},
@@ -77,7 +77,7 @@ func TestHandlePE(t *testing.T) {
 		{
 			name: "no matching files",
 			pe: github.PushEvent{
-				Ref: "master",
+				Ref: "refs/heads/master",
 				Commits: []github.Commit{
 					{
 						Added: []string{"example.txt"},
@@ -91,7 +91,7 @@ func TestHandlePE(t *testing.T) {
 		{
 			name: "one matching file",
 			pe: github.PushEvent{
-				Ref: "master",
+				Ref: "refs/heads/master",
 				Commits: []github.Commit{
 					{
 						Added:    []string{"example.txt"},
@@ -107,7 +107,7 @@ func TestHandlePE(t *testing.T) {
 		{
 			name: "no change matcher",
 			pe: github.PushEvent{
-				Ref: "master",
+				Ref: "refs/heads/master",
 				Commits: []github.Commit{
 					{
 						Added: []string{"example.txt"},
@@ -115,6 +115,21 @@ func TestHandlePE(t *testing.T) {
 				},
 				Repo: github.Repo{
 					FullName: "org2/repo2",
+				},
+			},
+			jobsToRun: 1,
+		},
+		{
+			name: "branch name with a slash",
+			pe: github.PushEvent{
+				Ref: "refs/heads/release/v1.14",
+				Commits: []github.Commit{
+					{
+						Added: []string{"hack.sh"},
+					},
+				},
+				Repo: github.Repo{
+					FullName: "org3/repo3",
 				},
 			},
 			jobsToRun: 1,
@@ -144,6 +159,16 @@ func TestHandlePE(t *testing.T) {
 				{
 					JobBase: config.JobBase{
 						Name: "pass-salt",
+					},
+				},
+			},
+			"org3/repo3": {
+				{
+					JobBase: config.JobBase{
+						Name: "pass-pepper",
+					},
+					Brancher: config.Brancher{
+						Branches: []string{"release/v1.14"},
 					},
 				},
 			},


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/blob/3931105de5389088029a7a2665172de4fc6410e1/prow/github/types.go#L546-L550

If the branch name contains a slash (`/`), this will not return the correct branch name.

Instead, we can trim `refs/heads/` to get the complete branch name irrespective of the characters in the name. Since this method is also used for triggering on tags, we trim `refs/tags/` too.
(ref https://developer.github.com/v3/activity/events/types/#pushevent)

For context, slack discussion - https://kubernetes.slack.com/archives/CDECRSC5U/p1553011053304900

/kind bug
/assign @cjwagner @stevekuznetsov 