### PR TITLE
[WIP] Refactor 1.14 testgrid dashboards to match master

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4827,8 +4827,6 @@ dashboards:
 #TODO remove
 - name: sig-release-1.14-all
   dashboard_tab:
-  - name: soak-gci-gce-1.14
-    test_group_name: ci-kubernetes-soak-gci-gce-beta
   - name: gce-1.14-1.13-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   - name: gce-1.14-1.13-gci-kubectl-skew-serial
@@ -4897,6 +4895,8 @@ dashboards:
 
 - name: sig-release-1.14-informing
   dashboard_tab:
+  - name: soak-gci-gce-1.14
+    test_group_name: ci-kubernetes-soak-gci-gce-beta
   - name: gke-cos-1.14-default
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-default
   - name: gke-cos-1.14-reboot

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4824,6 +4824,7 @@ dashboards:
   - name: kubeadm-kind-master
     test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
 
+#TODO remove
 - name: sig-release-1.14-all
   dashboard_tab:
   - name: build-1.14
@@ -4976,6 +4977,18 @@ dashboards:
     test_group_name: periodic-kubernetes-bazel-build-1-14
   - name: periodic-bazel-test-1.14
     test_group_name: periodic-kubernetes-bazel-test-1-14
+
+- name: sig-release-1.14-informing
+  dashboard_tab:
+  - name: TODO
+    test_group_name: TODO
+
+- name: sig-release-1.14-upgrade
+  dashboard_tab:
+  - name: TODO
+    test_group_name: TODO
+
+
 
 - name: sig-release-1.13-all
   dashboard_tab:
@@ -7956,8 +7969,9 @@ dashboard_groups:
   - sig-release-master-blocking
   - sig-release-master-informing
   - sig-release-master-upgrade
-  - sig-release-1.14-all
   - sig-release-1.14-blocking
+  - sig-release-1.14-informing
+  - sig-release-1.14-upgrade
   - sig-release-1.13-all
   - sig-release-1.13-blocking
   - sig-release-1.12-all

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4837,10 +4837,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-13-1-14
   - name: kubeadm-kind-1.14
     test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
-  - name: aks-engine-azure-1-14-windows-release
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
-  - name: gce-windows-1.14
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sbeta
 
 - name: sig-release-1.14-blocking
   dashboard_tab:
@@ -4919,6 +4915,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   - name: kops-aws-1.14
     test_group_name: ci-kubernetes-e2e-kops-aws-beta
+  - name: aks-engine-azure-1-14-windows-release
+    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
+  - name: gce-windows-1.14
+    test_group_name: ci-kubernetes-e2e-windows-gce-k8sbeta
 
 - name: sig-release-1.14-upgrade
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4826,9 +4826,7 @@ dashboards:
 
 #TODO remove
 - name: sig-release-1.14-all
-  dashboard_tab:
-  - name: node-kubelet-1.14-features
-    test_group_name: ci-kubernetes-node-kubelet-beta-features
+  dashboard_tab: []
 
 - name: sig-release-1.14-blocking
   dashboard_tab:
@@ -4907,6 +4905,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   - name: kops-aws-1.14
     test_group_name: ci-kubernetes-e2e-kops-aws-beta
+  - name: node-kubelet-1.14-features
+    test_group_name: ci-kubernetes-node-kubelet-beta-features
   - name: kubeadm-gce-1.13-on-1.14
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13-on-1-14
   - name: kubeadm-gce-1.14

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4829,14 +4829,6 @@ dashboards:
   dashboard_tab:
   - name: node-kubelet-1.14-features
     test_group_name: ci-kubernetes-node-kubelet-beta-features
-  - name: kubeadm-gce-1.13-on-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13-on-1-14
-  - name: kubeadm-gce-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-14
-  - name: kubeadm-gce-upgrade-1.13-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-13-1-14
-  - name: kubeadm-kind-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
 
 - name: sig-release-1.14-blocking
   dashboard_tab:
@@ -4915,6 +4907,14 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   - name: kops-aws-1.14
     test_group_name: ci-kubernetes-e2e-kops-aws-beta
+  - name: kubeadm-gce-1.13-on-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13-on-1-14
+  - name: kubeadm-gce-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-14
+  - name: kubeadm-gce-upgrade-1.13-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-13-1-14
+  - name: kubeadm-kind-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
   - name: aks-engine-azure-1-14-windows-release
     test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   - name: gce-windows-1.14

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4827,16 +4827,6 @@ dashboards:
 #TODO remove
 - name: sig-release-1.14-all
   dashboard_tab:
-  - name: gce-1.14-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
-  - name: gce-1.14-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
-  - name: gce-1.13-1.14-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
-  - name: gce-1.13-1.14-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
-  - name: gke-1.14-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
   - name: node-kubelet-1.14-features
     test_group_name: ci-kubernetes-node-kubelet-beta-features
   - name: kubeadm-gce-1.13-on-1.14
@@ -4897,6 +4887,16 @@ dashboards:
   dashboard_tab:
   - name: soak-gci-gce-1.14
     test_group_name: ci-kubernetes-soak-gci-gce-beta
+  - name: gce-1.14-1.13-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
+  - name: gce-1.14-1.13-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
+  - name: gce-1.13-1.14-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
+  - name: gce-1.13-1.14-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
+  - name: gke-1.14-1.13-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
   - name: gke-cos-1.14-default
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-default
   - name: gke-cos-1.14-reboot

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4827,18 +4827,8 @@ dashboards:
 #TODO remove
 - name: sig-release-1.14-all
   dashboard_tab:
-  - name: gke-cos-1.14-default
-    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-default
-  - name: gke-cos-1.14-reboot
-    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-reboot
   - name: soak-gci-gce-1.14
     test_group_name: ci-kubernetes-soak-gci-gce-beta
-  - name: gke-cos-1.14-serial
-    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-serial
-  - name: gke-cos-1.14-slow
-    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-slow
-  - name: gke-cos-1.14-ingress
-    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-ingress
   - name: gce-1.14-1.13-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   - name: gce-1.14-1.13-gci-kubectl-skew-serial
@@ -4849,18 +4839,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
   - name: gke-1.14-1.13-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
-  - name: gke-1.14-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
-  - name: gke-1.13-1.14-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
-  - name: gke-1.13-1.14-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
-  - name: gke-device-plugin-gpu-1.14
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
-  - name: gke-device-plugin-gpu-p100-1.14
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
-  - name: kops-aws-1.14
-    test_group_name: ci-kubernetes-e2e-kops-aws-beta
   - name: node-kubelet-1.14-features
     test_group_name: ci-kubernetes-node-kubelet-beta-features
   - name: kubeadm-gce-1.13-on-1.14
@@ -4919,8 +4897,28 @@ dashboards:
 
 - name: sig-release-1.14-informing
   dashboard_tab:
-  - name: TODO
-    test_group_name: TODO
+  - name: gke-cos-1.14-default
+    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-default
+  - name: gke-cos-1.14-reboot
+    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-reboot
+  - name: gke-cos-1.14-serial
+    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-serial
+  - name: gke-cos-1.14-slow
+    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-slow
+  - name: gke-cos-1.14-ingress
+    test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-ingress
+  - name: gke-1.14-1.13-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
+  - name: gke-1.13-1.14-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
+  - name: gke-1.13-1.14-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
+  - name: gke-device-plugin-gpu-1.14
+    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
+  - name: gke-device-plugin-gpu-p100-1.14
+    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
+  - name: kops-aws-1.14
+    test_group_name: ci-kubernetes-e2e-kops-aws-beta
 
 - name: sig-release-1.14-upgrade
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4824,10 +4824,6 @@ dashboards:
   - name: kubeadm-kind-master
     test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
 
-#TODO remove
-- name: sig-release-1.14-all
-  dashboard_tab: []
-
 - name: sig-release-1.14-blocking
   dashboard_tab:
   - name: build-1.14

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4889,6 +4889,14 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-slow
   - name: gke-cos-1.14-ingress
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-ingress
+  - name: gke-1.14-1.13-downgrade-cluster-parallel
+    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
+  - name: gke-1.13-1.14-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
+  - name: gke-1.13-1.14-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
+  - name: gke-1.13-1.14-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
   - name: gke-1.14-1.13-gci-kubectl-skew-serial
     test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
   - name: gke-1.13-1.14-gci-kubectl-skew
@@ -4936,14 +4944,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
   - name: gke-1.14-1.13-downgrade-cluster
     test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
-  - name: gke-1.14-1.13-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
-  - name: gke-1.13-1.14-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
-  - name: gke-1.13-1.14-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
-  - name: gke-1.13-1.14-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
 
 - name: sig-release-1.13-all
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4827,27 +4827,6 @@ dashboards:
 #TODO remove
 - name: sig-release-1.14-all
   dashboard_tab:
-  - name: build-1.14
-    test_group_name: ci-kubernetes-build-beta
-  - name: verify-1.14
-    test_group_name: ci-kubernetes-verify-beta
-  - name: integration-1.14
-    test_group_name: ci-kubernetes-integration-beta
-  - name: gce-conformance-latest-1.14
-    description: Runs conformance tests using kubetest against kubernetes release 1.14 branch on GCE
-    test_group_name: ci-kubernetes-gce-conformance-latest-1-14
-  - name: gce-cos-1.14-default
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-default
-  - name: gce-cos-1.14-reboot
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-reboot
-  - name: gce-cos-1.14-serial
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-serial
-  - name: gce-cos-1.14-slow
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-slow
-  - name: gce-cos-1.14-ingress
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-ingress
-  - name: gce-cos-1.14-alphafeatures
-    test_group_name: ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures
   - name: gke-cos-1.14-default
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-default
   - name: gke-cos-1.14-reboot
@@ -4876,28 +4855,14 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
   - name: gke-1.13-1.14-gci-kubectl-skew-serial
     test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
-  - name: gce-device-plugin-gpu-1.14
-    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
   - name: gke-device-plugin-gpu-1.14
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   - name: gke-device-plugin-gpu-p100-1.14
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   - name: kops-aws-1.14
     test_group_name: ci-kubernetes-e2e-kops-aws-beta
-  - name: node-kubelet-1.14
-    test_group_name: ci-kubernetes-node-kubelet-beta
   - name: node-kubelet-1.14-features
     test_group_name: ci-kubernetes-node-kubelet-beta-features
-  - name: gci-gce-scalability-1.14
-    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-beta
-  - name: bazel-build-1.14
-    test_group_name: ci-kubernetes-bazel-build-1-14
-  - name: bazel-test-1.14
-    test_group_name: ci-kubernetes-bazel-test-1-14
-  - name: periodic-bazel-build-1.14
-    test_group_name: periodic-kubernetes-bazel-build-1-14
-  - name: periodic-bazel-test-1.14
-    test_group_name: periodic-kubernetes-bazel-test-1-14
   - name: kubeadm-gce-1.13-on-1.14
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-13-on-1-14
   - name: kubeadm-gce-1.14

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4860,22 +4860,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-slow
   - name: gke-cos-1.14-ingress
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sbeta-ingress
-  - name: gce-1.14-1.13-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
-  - name: gce-1.14-1.13-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
-  - name: gce-1.13-1.14-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster
-  - name: gce-1.13-1.14-upgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
-  - name: gce-1.13-1.14-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
-  - name: gce-1.13-1.14-upgrade-cluster-new-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel
-  - name: gce-1.13-1.14-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
-  - name: gce-1.13-1.14-upgrade-master-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master-parallel
   - name: gce-1.14-1.13-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   - name: gce-1.14-1.13-gci-kubectl-skew-serial
@@ -4884,16 +4868,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
   - name: gce-1.13-1.14-gci-kubectl-skew-serial
     test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
-  - name: gke-1.14-1.13-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
-  - name: gke-1.14-1.13-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
-  - name: gke-1.13-1.14-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
-  - name: gke-1.13-1.14-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
-  - name: gke-1.13-1.14-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
   - name: gke-1.14-1.13-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
   - name: gke-1.14-1.13-gci-kubectl-skew-serial
@@ -4985,10 +4959,32 @@ dashboards:
 
 - name: sig-release-1.14-upgrade
   dashboard_tab:
-  - name: TODO
-    test_group_name: TODO
-
-
+  - name: gce-1.13-1.14-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster
+  - name: gce-1.13-1.14-upgrade-cluster-parallel
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
+  - name: gce-1.13-1.14-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
+  - name: gce-1.13-1.14-upgrade-cluster-new-parallel
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel
+  - name: gce-1.13-1.14-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
+  - name: gce-1.13-1.14-upgrade-master-parallel
+    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master-parallel
+  - name: gce-1.14-1.13-downgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
+  - name: gce-1.14-1.13-downgrade-cluster-parallel
+    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
+  - name: gke-1.14-1.13-downgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
+  - name: gke-1.14-1.13-downgrade-cluster-parallel
+    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
+  - name: gke-1.13-1.14-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
+  - name: gke-1.13-1.14-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
+  - name: gke-1.13-1.14-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
 
 - name: sig-release-1.13-all
   dashboard_tab:


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/issues/11555
More context in: https://github.com/kubernetes/test-infra/pull/10505 and https://github.com/kubernetes/test-infra/pull/10914.

This is in progress; please give feedback/input, particularly on:
- I'm currently implementing a 1-1 mapping, i.e. `1.14-blocking`, `-upgrade`, and `-informing` (similar to the equivalent `master-` ones).
  - Should there be a different structure? How/why?
  - Are there additional jobs that should exist in the non-master boards? Or, are there jobs that could be removed?
- I'm planning to remove jobs with `gke` in their name from `1.14-` dashboards

cc @jberkus @spiffxp @amwat @tpepper @krzyzacy @alejandrox1 