### PR TITLE
Add 'area/prow/config-bootstrapper' label to label_sync.

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -239,6 +239,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/prow/branchprotector" href="#area/prow/branchprotector">`area/prow/branchprotector`</a> | Issues or PRs related to prow's branchprotector component| label | |
 | <a id="area/prow/bump" href="#area/prow/bump">`area/prow/bump`</a> | Updates to the k8s prow cluster| label | |
 | <a id="area/prow/clonerefs" href="#area/prow/clonerefs">`area/prow/clonerefs`</a> | Issues or PRs related to prow's clonerefs component| label | |
+| <a id="area/prow/config-bootstrapper" href="#area/prow/config-bootstrapper">`area/prow/config-bootstrapper`</a> | Issues or PRs related to prow's config-bootstrapper utility| label | |
 | <a id="area/prow/deck" href="#area/prow/deck">`area/prow/deck`</a> | Issues or PRs related to prow's deck component| label | |
 | <a id="area/prow/entrypoint" href="#area/prow/entrypoint">`area/prow/entrypoint`</a> | Issues or PRs related to prow's entrypoint component| label | |
 | <a id="area/prow/gcsupload" href="#area/prow/gcsupload">`area/prow/gcsupload`</a> | Issues or PRs related to prow's gcsupload component| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -856,6 +856,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to prow's config-bootstrapper utility
+        name: area/prow/config-bootstrapper
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to prow's deck component
         name: area/prow/deck
         target: both


### PR DESCRIPTION
Hold until https://github.com/kubernetes/test-infra/pull/11841#issuecomment-475042458 goes in so that this will trigger the label config to be uploaded to the new namespace.
/hold

/assign @Katharine 