### PR TITLE
Enable gzipping job config

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -270,6 +270,7 @@ config_updater:
       name: plugins
     config/jobs/**/*.yaml:
       name: job-config
+      gzip: true
 
 welcome:
 - repos:


### PR DESCRIPTION
gzip (only) `job-config`. This should be transparent to everything and buy us back some desperately needed configmap space.

/cc @cjwagner 