### PR TITLE
Revert "Merge pull request #11861 from Katharine/gzip-job-config"

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -270,7 +270,6 @@ config_updater:
       name: plugins
     config/jobs/**/*.yaml:
       name: job-config
-      gzip: true
 
 welcome:
 - repos:


### PR DESCRIPTION
This reverts commit 7e9bb028aae0b023bbe7ca685c645fb9c30709ba, reversing
changes made to 3a56ac1e29db24b9e557486e8b68d1b60765539d.

Fun fact: we can't actually store binary data.