### PR TITLE
Use k8s-prow version of label_sync image.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -265,7 +265,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20190314-e8134a3
+      image: gcr.io/k8s-prow/branchprotector:v20190320-08fcf3e
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -292,7 +292,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-testimages/label_sync:v20190126-6c4304780
+      image: gcr.io/k8s-prow/label_sync:v20190320-08fcf3e
       command:
       - /app/label_sync/app.binary
       args:


### PR DESCRIPTION
More touch up for https://github.com/kubernetes/test-infra/pull/11841
The `gcr.io/k8s-testimages/label_sync` version of label sync is old and apparently built differently because the entrypoint I specified only works for the `gcr.io/k8s-prow/label_sync` image (which is what we should be using anyways now that it is available).

This time I validated that both entrypoints work with their respective images.

/assign @Katharine @stevekuznetsov 