### PR TITLE
updateconfig: support configs with both binary and text keys

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"path"
+	"unicode/utf8"
 
 	zglob "github.com/mattn/go-zglob"
 	"github.com/sirupsen/logrus"
@@ -104,11 +105,15 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}
+	if cm.BinaryData == nil {
+		cm.BinaryData = map[string][]byte{}
+	}
 
 	for _, upd := range updates {
 		if upd.Filename == "" {
 			logger.WithField("key", upd.Key).Debug("Deleting key.")
 			delete(cm.Data, upd.Key)
+			delete(cm.BinaryData, upd.Key)
 			continue
 		}
 
@@ -117,7 +122,7 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 			return fmt.Errorf("get file err: %v", err)
 		}
 		logger.WithFields(logrus.Fields{"key": upd.Key, "filename": upd.Filename}).Debug("Populating key.")
-		value := string(content)
+		value := content
 		if upd.GZIP {
 			buff := bytes.NewBuffer([]byte{})
 			// TODO: this error is wildly unlikely for anything that
@@ -126,10 +131,16 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 			if _, err := gzip.NewWriter(buff).Write(content); err != nil {
 				logger.WithError(err).Error("failed to gzip content, falling back to raw")
 			} else {
-				value = buff.String()
+				value = buff.Bytes()
 			}
 		}
-		cm.Data[upd.Key] = value
+		if utf8.ValidString(string(value)) {
+			delete(cm.BinaryData, upd.Key)
+			cm.Data[upd.Key] = string(value)
+		} else {
+			delete(cm.Data, upd.Key)
+			cm.BinaryData[upd.Key] = value
+		}
 	}
 
 	var updateErr error

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -603,8 +603,8 @@ func TestUpdateConfig(t *testing.T) {
 						Name:      "config",
 						Namespace: defaultNamespace,
 					},
-					Data: map[string]string{
-						"config.yaml": "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff",
+					BinaryData: map[string][]byte{
+						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
 					},
 				},
 			},
@@ -645,8 +645,8 @@ func TestUpdateConfig(t *testing.T) {
 						Name:      "config",
 						Namespace: defaultNamespace,
 					},
-					Data: map[string]string{
-						"config.yaml": "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff",
+					BinaryData: map[string][]byte{
+						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
 					},
 				},
 				{
@@ -696,8 +696,8 @@ func TestUpdateConfig(t *testing.T) {
 						Name:      "config",
 						Namespace: defaultNamespace,
 					},
-					Data: map[string]string{
-						"config.yaml": "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff",
+					BinaryData: map[string][]byte{
+						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
 					},
 				},
 				{

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -723,6 +723,270 @@ func TestUpdateConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "adds both binary and text keys for a single configmap",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/config.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+				{
+					Filename:  "prow/binary.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"config.yaml": "new-config",
+					},
+					BinaryData: map[string][]byte{
+						"binary.yaml": []byte("new-binary\x00\xFF\xFF"),
+					},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
+		{
+			name:        "converts a text key to a binary key when it becomes binary",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/becoming-binary.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"becoming-binary.yaml": "not-yet-binary",
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"becoming-binary.yaml": []byte("now-binary\x00\xFF\xFF"),
+					},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
+		{
+			name:        "converts a binary key to a text key when it becomes text",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/becoming-text.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"becoming-text.yaml": []byte("not-yet-text\x00\xFF\xFF"),
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"becoming-text.yaml": "now-text",
+					},
+					BinaryData: map[string][]uint8{},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
+		{
+			name:        "simultaneously converts text to binary and binary to text",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/becoming-text.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+				{
+					Filename:  "prow/becoming-binary.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"becoming-text.yaml": []byte("not-yet-text\x00\xFF\xFF"),
+					},
+					Data: map[string]string{
+						"becoming-binary.yaml": "not-yet-binary",
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"becoming-binary.yaml": []byte("now-binary\x00\xFF\xFF"),
+					},
+					Data: map[string]string{
+						"becoming-text.yaml": "now-text",
+					},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
+		{
+			name:        "correctly converts to binary when gzipping",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/config.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"config.yaml": "old-config",
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+					},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				GZIP: true,
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
+		{
+			name:        "correctly converts to text when ungzipping",
+			prAction:    github.PullRequestActionClosed,
+			merged:      true,
+			mergeCommit: "12345",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "prow/config.yaml",
+					Status:    "modified",
+					Additions: 1,
+				},
+			},
+			existConfigMaps: []runtime.Object{
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					BinaryData: map[string][]byte{
+						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+					},
+				},
+			},
+			expectedConfigMaps: []*coreapi.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"config.yaml": "new-config",
+					},
+				},
+			},
+			config: &plugins.ConfigUpdater{
+				GZIP: false,
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/*.yaml": {
+						Name: "config",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -749,6 +1013,18 @@ func TestUpdateConfig(t *testing.T) {
 				"prow/config.yaml": {
 					"master": "old-config",
 					"12345":  "new-config",
+				},
+				"prow/binary.yaml": {
+					"master": "old-binary\x00\xFF\xFF",
+					"12345":  "new-binary\x00\xFF\xFF",
+				},
+				"prow/becoming-binary.yaml": {
+					"master": "not-yet-binary",
+					"12345":  "now-binary\x00\xFF\xFF",
+				},
+				"prow/becoming-text.yaml": {
+					"master": "not-yet-text\x00\xFF\xFF",
+					"12345":  "now-text",
 				},
 				"prow/plugins.yaml": {
 					"master": "old-plugins",

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -604,7 +604,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					BinaryData: map[string][]byte{
-						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
 				},
 			},
@@ -646,7 +646,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					BinaryData: map[string][]byte{
-						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
 				},
 				{
@@ -697,7 +697,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					BinaryData: map[string][]byte{
-						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
 				},
 				{
@@ -931,7 +931,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					BinaryData: map[string][]byte{
-						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
 				},
 			},
@@ -963,7 +963,7 @@ func TestUpdateConfig(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					BinaryData: map[string][]byte{
-						"config.yaml": {0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff},
+						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
 				},
 			},


### PR DESCRIPTION
Kubernetes wants non-UTF-8 configmap keys to be in `BinaryData` rather than `Data`, and also requires that they have no overlapping keys.

This PR adds support for `BinaryData` keys, using them if the value does not look like it's valid UTF-8. It maintains the invariant that only one of `Data` and `BinaryData` may contain a key by deleting it from one when setting it in the other. It also deletes from both where applicable.

This needs more tests around the `BinaryData` / `Data` setting dance, thus the WIP.

It may also be possible to simplify slightly by exclusively using `BinaryData`, but we'd still need most of this code to migrate in at least one direction anyway so I'm not sure this is valuable. Using `BinaryData` exclusively would render the configmap harder to read using `kubectl`.

This is not gzip-specific, and should add general support for binary files to updateconfig.

Mounting configmaps as files still behaves the same, so we shouldn't need changes elsewhere. `tackle` and the `k8s_configmap` bazel rule both create configmaps and aren't touched here (and so can still only be UTF-8), but given their respective use contexts I don't think it's necessary to change them.

This PR also assumes kubernetes >= 1.10, which is when `BinaryData` became a thing. I imagine this is fine.

/cc @cjwagner @stevekuznetsov 