### PR TITLE
Schedule GPU tests to minimise concurrent GPU projects

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 4h
+- cron: "0 0-23/4 * * *"
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-k80
   labels:
     preset-service-account: "true"
@@ -26,7 +26,7 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 4h
+- cron: "0 2-23/4 * * *"
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-p100
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
@@ -13,7 +13,7 @@ presets:
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
-  interval: 2h
+  cron: "30 1-23/2 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -36,7 +36,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
-  interval: 2h
+  cron: "0 0-23/2 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -59,7 +59,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
-  interval: 6h
+  cron: "0 3-23/6 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -81,7 +81,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable2
-  interval: 12h
+  cron: "0 3-23/12 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -103,7 +103,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gce-gpu-stable2
-  interval: 6h
+  cron: "0 5-23/6 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu
-  interval: 2h
+  cron: "0 0-23/2 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -26,7 +26,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
-  interval: 2h
+  cron: "30 0-23/2 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -52,7 +52,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
-  interval: 3h
+  cron: "30 0-23/3 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -78,7 +78,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100
-  interval: 12h #expensive test
+  cron: "30 2-23/12 * * *" #expensive test
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -104,7 +104,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
-  interval: 12h #expensive test
+  cron: "30 8-23/12 * * *" #expensive test
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -130,7 +130,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable1
-  interval: 12h #expensive test
+  cron: "0 0-23/12 * * *" #expensive test
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -156,7 +156,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2
-  interval: 12h #expensive test
+  cron: "0 1-23/12 * * *" #expensive test
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -182,7 +182,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
-  interval: 6h
+  cron: "0 1-23/6 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -208,7 +208,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
-  interval: 12h
+  cron: "0 2-23/12 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -234,7 +234,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-ubuntu
-  interval: 2h
+  cron: "0 1-23/2 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 12h
+- cron: "0 4-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
   labels:
     preset-service-account: "true"
@@ -26,7 +26,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 5-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
   labels:
     preset-service-account: "true"
@@ -53,7 +53,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 6-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
   labels:
     preset-service-account: "true"
@@ -80,7 +80,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 7-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
   labels:
     preset-service-account: "true"
@@ -107,7 +107,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 8-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
   labels:
     preset-service-account: "true"
@@ -134,7 +134,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 9-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
   labels:
     preset-service-account: "true"
@@ -161,7 +161,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 10-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
   labels:
     preset-service-account: "true"
@@ -189,7 +189,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master
 
-- interval: 12h
+- cron: "0 11-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -446,7 +446,7 @@ periodics:
       - ./test/build.sh
 
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
-  interval: 3h
+  cron: "30 1-23/3 * * *"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
Currently we are [regularly exhausting](http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1&from=1553101508256&to=1553187908256&panelId=5&fullscreen) the 17 GPU projects available to boskos, resulting in GPU jobs failing at random.

This PR moves around the jobs so that they occur with the same frequency, but spread out such that we never need more than four projects at any given time.

Below is my work, with visualisation of the schedule at the bottom

-------

### 2 hours
a) `ci-kubernetes-e2e-gke-device-plugin-gpu` (20m) (00:00)
b) `ci-kubernetes-e2e-gke-device-plugin-gpu-beta` (20m) (00:30)
c) `ci-kubernetes-e2e-gke-device-plugin-gpu-ubuntu` (20m) (01:00)
d) `ci-kubernetes-e2e-gce-device-plugin-gpu` (22m) (01:30)
e) `ci-kubernetes-e2e-gce-device-plugin-gpu-beta` (22m) (00:00)

### 3 hours
f) `ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring` (21m) (00:30)
g) `ci-cri-containerd-e2e-gce-device-plugin-gpu` (22m) (01:30)

### 4 hours
h) `ci-kubernetes-e2e-gci-gke-autoscaling-gpu-k80` (1h33m) (00:00)
i) `ci-kubernetes-e2e-gci-gke-autoscaling-gpu-p100` (1h33m) (02:00)

### 6 hours
j) `ci-kubernetes-e2e-gke-device-plugin-gpu-stable1` (21m) (01:00)
k) `ci-kubernetes-e2e-gce-device-plugin-gpu-stable1` (23m) (03:00)
l) `ci-kubernetes-e2e-gce-gpu-stable2` (20m, always fails) (05:00)
m) `ci-kubernetes-e2e-gke-ubuntu1-k8sstable2-gpu` (generated) (18m) (05:30)

### 12 hours
n) `ci-kubernetes-e2e-gke-device-plugin-gpu-p100` (18m) (02:30)
o) `ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta` (19m) (08:30)
p) `ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable1` (20m) (00:00)
q) `ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2` (20m) (01:00)
r) `ci-kubernetes-e2e-gke-device-plugin-gpu-stable2` (21m) (02:00)
s) `ci-kubernetes-e2e-gce-device-plugin-gpu-stable2` (25m) (03:00)
t) `ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade` (40m) (04:00)
u) `ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade` (30m) (05:00)
v) `ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade` (40m) (06:00)
w) `ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade` (30m) (07:00)
x) `ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade` (40m) (08:00)
y) `ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade` (30m - 50m on failure) (09:00)
z) `ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade` (40m) (10:00)
@) `ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade` (40m) (11:00)

```
|00:00|00:30|01:00|01:30|02:00|02:30|03:00|03:30|04:00|04:30|05:00|05:30|06:00|06:30|07:00|07:30|08:00|08:30|09:00|09:30|10:00|10:30|11:00|11:30|
|--a--|--b--|--c--|--d--|--a--|--b--|--c--|--d--|--a--|--b--|--c--|--d--|--a--|--b--|--c--|--d--|--a--|--b--|--c--|--d--|--a--|--b--|--c--|--d--|
|--e--|--f--|--j--|--g--|--e--|--n--|--k--|--f--|--e--|--g--|--l--|--m--|--e--|--f--|--j--|--g--|--e--|--o--|--k--|--f--|--e--|--g--|--l--|--m--|
|-----------h-----------|-----------i-----------|-----------h-----------|-----------i-----------|-----------h-----------|-----------i-----------|
|--p--|     |--q--|     |--r--|     |--s--|     |-----t-----|-----u-----|-----v-----|-----w-----|-----x-----|-----y-----|-----z-----|-----@-----|
```