### PR TITLE
Use kubekins (which has bash 4.4+) to push images

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -58,7 +58,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190131-v0.1-7-gd9aa1d2
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190315-49d62eb51-master # whatever image you use here must have bash 4.4+
         command:
         - prow/push.sh
         env:


### PR DESCRIPTION
Our near-total inability to push images is caused by a bug that was fixed in bash 4.4 (thanks ixdy!). The gcloud-bazel image has bash 4.3. It's also based on an image that is based on an image that cannot easily have bash 4.4, so fixing this is a pain.

Switch to kubekins, which is more up to date and does not have this bug. I [manually invoked this](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-prow/1642) and it works.