### PR TITLE
Increase branchprotector timeout from 2hr default to 5hrs.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -258,6 +258,8 @@ periodics:
   labels:
     app: branchprotector
   decorate: true
+  decoration_config:
+    timeout: 18000000000000 # 5 hours
   extra_refs:
   - org: kubernetes
     repo: test-infra


### PR DESCRIPTION
The default job timeout of 2hrs is not long enough for the branchprotector job.  e.g. https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-branchprotector/8
It typically took about 4 hours when it was running as a cronjob IIRC so this sets the timeout to 5 hours.

/assign @Katharine 