### PR TITLE
Added Contributor Summit labels for all three contributor summits, so…

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -160,13 +160,16 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/cn-summit" href="#area/cn-summit">`area/cn-summit`</a> | Issues or PRs related to the Contributor Summit in China| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/contributor-guide" href="#area/contributor-guide">`area/contributor-guide`</a> | Issues or PRs related to the contributor guide| label | |
-| <a id="area/contributor-summit" href="#area/contributor-summit">`area/contributor-summit`</a> | Issues or PRs related to contributor summit events| label | |
+| <a id="area/contributor-summit" href="#area/contributor-summit">`area/contributor-summit`</a> | Issues or PRs related to all contributor summit events| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/developer-guide" href="#area/developer-guide">`area/developer-guide`</a> | Issues or PRs related to the developer guide| label | |
 | <a id="area/devstats" href="#area/devstats">`area/devstats`</a> | Issues or PRs related to the devstats subproject| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
+| <a id="area/eu-summit" href="#area/eu-summit">`area/eu-summit`</a> | Issues or PRs related to the Contributor Summit in Europe| label | |
+| <a id="area/na-summit" href="#area/na-summit">`area/na-summit`</a> | Issues or PRs related to the contributor summit in North America| label | |
 | <a id="area/release-team" href="#area/release-team">`area/release-team`</a> | Issues or PRs related to the release-team subproject| label | |
 
 ## Labels that apply to kubernetes/enhancements, for both issues and PRs

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -649,8 +649,23 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
-        description: Issues or PRs related to contributor summit events
+        description: Issues or PRs related to all contributor summit events
         name: area/contributor-summit
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the contributor summit in North America
+        name: area/na-summit
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the Contributor Summit in China
+        name: area/cn-summit
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the Contributor Summit in Europe
+        name: area/eu-summit
         target: both
         addedBy: label
       - color: 0052cc


### PR DESCRIPTION
… that we can pull out summits by label.

After discussion on #summit-staff, this adds three area/ labels to k/community, so that we can tag all issues & PRs by which specific summit they belong to.

/kind feature
/assign @mrbobbytables 
cc
@parispittman 