### PR TITLE
Prevent Tide from sleeping during unit tests.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -48,6 +48,9 @@ import (
 	"k8s.io/test-infra/prow/tide/history"
 )
 
+// For mocking out sleep during unit tests.
+var sleep = time.Sleep
+
 type prowJobClient interface {
 	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
 	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
@@ -848,7 +851,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 		// If we successfully merged this PR and have more to merge, sleep to give
 		// GitHub time to recalculate mergeability.
 		if err == nil && i+1 < len(prs) {
-			time.Sleep(time.Second * 5)
+			sleep(time.Second * 5)
 		}
 	}
 
@@ -903,7 +906,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 			// merge again.
 			err = fmt.Errorf("base branch was modified: %v", err)
 			if retry+1 < maxRetries {
-				time.Sleep(backoff)
+				sleep(backoff)
 				backoff *= 2
 			}
 		} else if _, ok = err.(github.UnauthorizedToPushError); ok {

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
@@ -820,6 +821,9 @@ func TestPickBatch(t *testing.T) {
 }
 
 func TestTakeAction(t *testing.T) {
+	sleep = func(time.Duration) {}
+	defer func() { sleep = time.Sleep }()
+
 	// PRs 0-9 exist. All are mergable, and all are passing tests.
 	testcases := []struct {
 		name string
@@ -1382,6 +1386,9 @@ func testPR(org, repo, branch string, number int, mergeable githubql.MergeableSt
 }
 
 func TestSync(t *testing.T) {
+	sleep = func(time.Duration) {}
+	defer func() { sleep = time.Sleep }()
+
 	mergeableA := testPR("org", "repo", "A", 5, githubql.MergeableStateMergeable)
 	unmergeableA := testPR("org", "repo", "A", 6, githubql.MergeableStateConflicting)
 	unmergeableB := testPR("org", "repo", "B", 7, githubql.MergeableStateConflicting)


### PR DESCRIPTION
Before:
```console
$ bazel test //prow/tide:go_default_test  --nocache_test_results
INFO: Analysed target //prow/tide:go_default_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //prow/tide:go_default_test up-to-date:
  bazel-bin/prow/tide/linux_amd64_race_stripped/go_default_test
INFO: Elapsed time: 47.723s, Critical Path: 45.94s
INFO: 7 processes: 7 linux-sandbox.
INFO: Build completed successfully, 7 total actions
//prow/tide:go_default_test                                              PASSED in 38.2s

INFO: Build completed successfully, 7 total actions
```
After:
```console
$ bazel test //prow/tide:go_default_test  --nocache_test_results
INFO: Analysed target //prow/tide:go_default_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //prow/tide:go_default_test up-to-date:
  bazel-bin/prow/tide/linux_amd64_race_stripped/go_default_test
INFO: Elapsed time: 12.541s, Critical Path: 10.74s
INFO: 7 processes: 7 linux-sandbox.
INFO: Build completed successfully, 7 total actions
//prow/tide:go_default_test                                              PASSED in 3.1s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 7 total actions
```

/assign @stevekuznetsov 