### PR TITLE
Prevent Prow's GH client from sleeping during unit tests.

### DIFF
--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -54,7 +54,7 @@ func getClient(url string) *Client {
 	}
 
 	return &Client{
-		time:     &standardTime{},
+		time:     &testTime{},
 		getToken: getToken,
 		client: &http.Client{
 			Transport: &http.Transport{


### PR DESCRIPTION
This reduces GH client unit test time from 8 seconds to 2 seconds on my machine. 
Critical path time for prow unit tests is under 5 seconds now.

/assign @stevekuznetsov 