### PR TITLE
Tell kettle to not assume sequential numbering

### DIFF
--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -10,6 +10,7 @@
 gs://kubernetes-jenkins/logs/:
   contact: "fejta"
   prefix: ""
+  sequential: false
 gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"


### PR DESCRIPTION
As part of the plan to kill tot (#9604), Kettle needs to stop assuming sequential IDs. This is the last change needed before we can switch to snowflake numbers.

/cc @spiffxp 