### PR TITLE
Disable ENABLE_PROMETHEUS_SERVER for Scalability

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -128,7 +128,8 @@ presets:
   - name: KUBE_GCE_MASTER_IMAGE
     value: cos-69-10895-138-0
   - name: ENABLE_PROMETHEUS_SERVER
-    value: "true"
+    # TODO(https://github.com/kubernetes/kubernetes/issues/74213#issuecomment-473526965): Set back to true
+    value: "false"
 
 ###### Scalability Envs
 ### Common env variables for all scalability-related suites.


### PR DESCRIPTION
Now pull-kubernetes-e2e-gce-100-performance job is constantly failed.
The reason seems the same as [1]. So this makes ENABLE_PROMETHEUS_SERVER
disabled for Scalability environments also.

[1]: https://github.com/kubernetes/kubernetes/issues/74213#issuecomment-473526965