### PR TITLE
Round the elapsed time to the nearest second

### DIFF
--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -114,6 +114,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 			metadataViewData.Elapsed =
 				metadataViewData.FinishedTime.Sub(metadataViewData.StartTime)
 		}
+		metadataViewData.Elapsed = metadataViewData.Elapsed.Round(time.Second)
 	}
 
 	metadataViewData.Metadata = map[string]string{"node": started.Node}


### PR DESCRIPTION
Because nanoseconds aren't really very useful. Or probably very true.

Fixes #11633.

/cc @stevekuznetsov 