### PR TITLE
Fix path alias for vSphere pre-submits

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -52,6 +52,8 @@ presubmits:
     decorate: true
     branches:
     - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
     always_run: false
     skip_report: true
     spec:
@@ -67,6 +69,8 @@ presubmits:
     decorate: true
     branches:
     - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
     always_run: false
     skip_report: true
     spec:
@@ -82,6 +86,8 @@ presubmits:
     decorate: true
     branches:
     - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
     always_run: false
     skip_report: true
     spec:
@@ -97,6 +103,8 @@ presubmits:
     decorate: true
     branches:
     - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
     always_run: false
     skip_report: true
     spec:
@@ -118,6 +126,8 @@ postsubmits:
     max_concurrency: 1
     branches:
     - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
     spec:
       containers:
       - image: gcr.io/cloud-provider-vsphere/ci:523c54f4

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -101,6 +101,9 @@ presubmits:
   # Executes the integration tests.
   - name: pull-cloud-provider-vsphere-integration-test
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     branches:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
@@ -123,6 +126,9 @@ postsubmits:
   # Deploys the CCM and CSI images if both the unit and integration tests succeed.
   - name: post-cloud-provider-vsphere-deploy
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     max_concurrency: 1
     branches:
     - ^master$
@@ -147,6 +153,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -170,6 +177,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -193,6 +201,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -216,6 +225,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -243,6 +253,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -268,6 +279,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -293,6 +305,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes
@@ -318,6 +331,7 @@ periodics:
   interval: 12h
   decorate: true
   labels:
+    preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
This patch fixes the path alias for the vSphere CCM pre-submits. Sub-modules are also disabled for the pre-submits.

This patch also fixes the issue of DinD and Kind not working as expected.

cc @figo @dvonthenen @frapposelli 