### PR TITLE
Explicitly set namespace in tackle's kubectl calls

### DIFF
--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -366,7 +366,7 @@ func selectContext(co contextOptions) (string, error) {
 //
 // If we use the create verb it will fail if the secret already exists.
 // And kubectl will reject the apply verb with a secret.
-func applyCreate(ctx string, args ...string) error {
+func applyCreate(ctx string, ns string, args ...string) error {
 	create := exec.Command("kubectl", append([]string{"--dry-run=true", "--output=yaml", "create"}, args...)...)
 	create.Stderr = os.Stderr
 	obj, err := create.StdoutPipe()
@@ -377,7 +377,7 @@ func applyCreate(ctx string, args ...string) error {
 	if err := create.Start(); err != nil {
 		return fmt.Errorf("start create: %v", err)
 	}
-	if err := apply(ctx, obj); err != nil {
+	if err := apply(ctx, ns, obj); err != nil {
 		return fmt.Errorf("apply: %v", err)
 	}
 	if err := create.Wait(); err != nil {
@@ -386,8 +386,8 @@ func applyCreate(ctx string, args ...string) error {
 	return nil
 }
 
-func apply(ctx string, in io.Reader) error {
-	apply := exec.Command("kubectl", "--context="+ctx, "apply", "-f", "-")
+func apply(ctx string, ns string, in io.Reader) error {
+	apply := exec.Command("kubectl", "--context="+ctx, "--namespace="+ns, "apply", "-f", "-")
 	apply.Stderr = os.Stderr
 	apply.Stdout = os.Stdout
 	apply.Stdin = in
@@ -397,12 +397,12 @@ func apply(ctx string, in io.Reader) error {
 	return apply.Wait()
 }
 
-func applyRoleBinding(context string) error {
+func applyRoleBinding(context string, namespace string) error {
 	who, err := currentAccount()
 	if err != nil {
 		return fmt.Errorf("current account: %v", err)
 	}
-	return applyCreate(context, "clusterrolebinding", "prow-admin", "--clusterrole=cluster-admin", "--user="+who)
+	return applyCreate(context, namespace, "clusterrolebinding", "prow-admin", "--clusterrole=cluster-admin", "--user="+who)
 }
 
 type options struct {
@@ -459,8 +459,8 @@ func githubClient(tokenPath string, dry bool) (*github.Client, error) {
 	return github.NewClient(gen, "https://api.github.com"), nil
 }
 
-func applySecret(ctx, name, key, path string) error {
-	return applyCreate(ctx, "secret", "generic", name, "--from-file="+key+"="+path)
+func applySecret(ctx, ns, name, key, path string) error {
+	return applyCreate(ctx, ns, "secret", "generic", name, "--from-file="+key+"="+path)
 }
 
 func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bool) error {
@@ -494,7 +494,7 @@ func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bo
 			return errors.New("prow already deployed")
 		}
 	}
-	apply := exec.Command("kubectl", "--context="+ctx, "apply", "-f", choice)
+	apply := exec.Command("kubectl", "--context="+ctx, "--namespace="+ns, "apply", "-f", choice)
 	apply.Stderr = os.Stderr
 	apply.Stdout = os.Stdout
 	return apply.Run()
@@ -774,7 +774,7 @@ func main() {
 	}
 
 	fmt.Println("Applying admin role bindings (to create RBAC rules)...")
-	if err := applyRoleBinding(ctx); err != nil {
+	if err := applyRoleBinding(ctx, "default"); err != nil {
 		logrus.WithError(err).Fatalf("Failed to apply cluster role binding to %s", ctx)
 	}
 
@@ -812,7 +812,7 @@ func main() {
 
 		// create github secrets
 		fmt.Print("Applying github token into oauth-token secret...")
-		if err := applySecret(ctx, "oauth-token", "oauth", token); err != nil {
+		if err := applySecret(ctx, ns, "oauth-token", "oauth", token); err != nil {
 			logrus.WithError(err).Fatal("Could not apply github oauth token secret")
 		}
 

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -500,6 +500,15 @@ func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bo
 	return apply.Run()
 }
 
+func clientConfigNamespace(context string) (string, bool, error) {
+	loader, cfg, err := contextConfig()
+	if err != nil {
+		return "", false, fmt.Errorf("load contexts: %v", err)
+	}
+
+	return clientcmd.NewNonInteractiveClientConfig(*cfg, context, &clientcmd.ConfigOverrides{}, loader).Namespace()
+}
+
 func clientConfig(context string) (*rest.Config, error) {
 	loader, cfg, err := contextConfig()
 	if err != nil {
@@ -758,9 +767,20 @@ func main() {
 	opt := addFlags(fs)
 	fs.Parse(os.Args[1:])
 
+	const ns = "default"
+
 	ctx, err := selectContext(opt.contextOptions)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to select context")
+	}
+
+	ctxNamespace, _, err := clientConfigNamespace(ctx)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to reload ~/.kube/config from any obvious location")
+	}
+
+	if ctxNamespace != ns {
+		logrus.Warnf("Context %s specifies namespace %s, but Prow resources will be installed in namespace %s.", ctx, ctxNamespace, ns)
 	}
 
 	// get kubernetes client
@@ -768,6 +788,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to reload ~/.kube/config from any obvious location")
 	}
+
 	kc, err := kubernetes.NewForConfig(clientCfg)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create kubernetes client")
@@ -778,7 +799,6 @@ func main() {
 		logrus.WithError(err).Fatalf("Failed to apply cluster role binding to %s", ctx)
 	}
 
-	const ns = "default"
 	// configure plugins.yaml and config.yaml
 	// TODO(fejta): throw up an editor
 	if err = ensureConfigMap(kc, ns, "config", "config.yaml"); err != nil {


### PR DESCRIPTION
If the context has a non-default namespace set (e.g., `jx` when working with Jenkins X), then `oauth-token` secret ends up in that namespace, whereas the rest of the components are created in `default` namespace. This also enables namespacing all Prow resources in the future.

For admin role binding I'm passing hardcoded `default` because it's a `clusterrolebinding` and the namespace is ignored.