### PR TITLE
vSphere CCM: Mark new pre-submits as always run; Remove old test job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -54,8 +54,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     spec:
       containers:
       - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
@@ -71,8 +71,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     spec:
       containers:
       - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
@@ -88,8 +88,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     spec:
       containers:
       - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
@@ -108,8 +108,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     spec:
       containers:
       - image: gcr.io/cloud-provider-vsphere/ci:523c54f4

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -26,26 +26,6 @@ presets:
 
 presubmits:
   kubernetes/cloud-provider-vsphere:
-  - name: pull-cloud-provider-vsphere-test
-    branches:
-    - ^master$
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190322-1960d2fdd-master
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--timeout=30"
-        - "--" # end bootstrap args, scenario args below
-        - "make"
-        - "test"
 
   # Runs "gofmt", "go vet", and "golint" on the sources.
   - name: pull-cloud-provider-vsphere-check

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2749,9 +2749,6 @@ test_groups:
 - name: pull-cloud-provider-vsphere-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-vsphere-build
   num_columns_recent: 20
-- name: pull-cloud-provider-vsphere-test
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-vsphere-test
-  num_columns_recent: 20
 - name: pull-cloud-provider-vsphere-unit-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-vsphere-unit-test
   num_columns_recent: 20
@@ -7386,9 +7383,6 @@ dashboards:
   - name: pull-cloud-provider-vsphere-build
     test_group_name: pull-cloud-provider-vsphere-build
     base_options: width=10
-  - name: pull-cloud-provider-vsphere-test
-    test_group_name: pull-cloud-provider-vsphere-test
-    base_options: width=10
   - name: pull-cloud-provider-vsphere-unit-test
     test_group_name: pull-cloud-provider-vsphere-unit-test
     base_options: width=10
@@ -7403,9 +7397,6 @@ dashboards:
     base_options: width=10
   - name: pull-cloud-provider-vsphere-build
     test_group_name: pull-cloud-provider-vsphere-build
-    base_options: width=10
-  - name: pull-cloud-provider-vsphere-test
-    test_group_name: pull-cloud-provider-vsphere-test
     base_options: width=10
   - name: pull-cloud-provider-vsphere-unit-test
     test_group_name: pull-cloud-provider-vsphere-unit-test


### PR DESCRIPTION
This PR marks the new pre-submits for the vSphere cloud controller manager as `alwaysRun: true` and `skipReport: false` as well as removes the old test job in favor of the new pre-submit `unit-test`.

/assign @figo