### PR TITLE
Configure Tide to respect branchprotection policies.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -445,6 +445,7 @@ tide:
   blocker_label: merge-blocker
   squash_label: tide/squash
   context_options:
+    from-branch-protection: true
     optional-contexts:
     - "Submit Queue"
     orgs:


### PR DESCRIPTION
I [noticed](https://prow.k8s.io/tide-history?repo=kubernetes%2Fgit-sync&branch=master) that Tide is getting stuck trying to merge a PR in `kubernetes/git-sync` because it is missing the `cla/linuxfoundation` status context. This seemed strange because Tide should know about this context from [branchprotection config](https://github.com/kubernetes/test-infra/blob/fba849bac165f54f94ccdd964b5c548ad911ac05/prow/config.yaml#L55) and not attempt a merge in the first place.

I'm not sure how we've gone this long without seeing Tide get stuck like this due to not knowing all the merge requirements enforced by GH, but this is definitely something we should have enabled.

/assign @Katharine @stevekuznetsov 