### PR TITLE
Allow the commenter to iterate randomly through results

### DIFF
--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -19,11 +19,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"k8s.io/test-infra/prow/github"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/test-infra/prow/github"
 )
 
 func TestParseHTMLURL(t *testing.T) {
@@ -270,7 +271,7 @@ func TestRun(t *testing.T) {
 	for _, tc := range cases {
 		ignoreSorting := ""
 		ignoreOrder := false
-		err := run(&tc.client, tc.query, ignoreSorting, ignoreOrder, makeCommenter(tc.comment, tc.template), tc.ceiling)
+		err := run(&tc.client, tc.query, ignoreSorting, ignoreOrder, false, makeCommenter(tc.comment, tc.template), tc.ceiling)
 		if tc.err && err == nil {
 			t.Errorf("%s: failed to received an error", tc.name)
 			continue


### PR DESCRIPTION
When the commenter has a low ceiling compared to the total result set,
it is very common for it to target a small subset of alphabetically
first results to comment on, on every iteration. A new flag allows the
commenter to be configured to choose issues at random from the result
pool.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 