### PR TITLE
Don't use tot any more

### DIFF
--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -21,7 +21,6 @@ spec:
         image: gcr.io/k8s-prow/build:v20190323-fbd93251f
         args:
         - --all-contexts
-        - --tot-url=http://tot
         - --config=/etc/prow-config/config.yaml
         - --build-cluster=/etc/build-cluster/cluster
         volumeMounts:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -33,7 +33,6 @@ spec:
       - name: plank
         image: gcr.io/k8s-prow/plank:v20190323-fbd93251f
         args:
-        - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false
         - --github-endpoint=http://ghproxy


### PR DESCRIPTION
Stop using tot. This leaves tot running (for now), but stops actually referencing it, so we will default to snowflake IDs.

/hold