### PR TITLE
Replace incorrect github.com/golang/lint with actual golang.org/x/lint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module k8s.io/test-infra
 
+replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f
+
 require (
 	cloud.google.com/go v0.37.1
 	github.com/Azure/azure-pipeline-go v0.0.0-20180507050906-098e490af5dc // indirect


### PR DESCRIPTION
/assign @Katharine @cjwagner @michelle192837 

This is still causing problems, https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-autoupdate-minor/3:
```
go: github.com/golang/lint@v0.0.0-20190313153728-d0100b6bd8b3: parsing go.mod: unexpected module path "golang.org/x/lint"
```

For now just pinning this
ref  golang/lint#436