### PR TITLE
Enable debug level logs in label_sync.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -302,6 +302,7 @@ periodics:
       - --confirm=true
       - --orgs=kubernetes,kubernetes-client,kubernetes-csi,kubernetes-incubator,kubernetes-sigs
       - --token=/etc/github/oauth
+      - --debug
       volumeMounts:
       - name: oauth
         mountPath: /etc/github


### PR DESCRIPTION
Enables this flag: https://github.com/kubernetes/test-infra/blob/6e0851f29f783473c19da4b3f4e91c956d88e434/label_sync/main.go#L120

So that I can ensure that this log message is being reached: https://github.com/kubernetes/test-infra/blob/6e0851f29f783473c19da4b3f4e91c956d88e434/prow/github/client.go#L172