### PR TITLE
Disable strict context requirement in k/git-sync.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -123,8 +123,6 @@ branch-protection:
             required_approving_review_count: 1
         git-sync:
           enforce_admins: true
-          required_status_checks:
-            strict: true
           restrictions: # only allow admins
             users: []
             teams: []


### PR DESCRIPTION
Fixes https://github.com/kubernetes/git-sync/issues/159

/cc @stevekuznetsov @Katharine @fejta 