### PR TITLE
Actually make label_sync use ghproxy.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -302,6 +302,8 @@ periodics:
       - --confirm=true
       - --orgs=kubernetes,kubernetes-client,kubernetes-csi,kubernetes-incubator,kubernetes-sigs
       - --token=/etc/github/oauth
+      - --endpoint=http://ghproxy.default.svc.cluster.local
+      - --endpoint=https://api.github.com
       - --debug
       volumeMounts:
       - name: oauth


### PR DESCRIPTION
Well this explains why `label_sync`'s API throttling is not getting token refunds :man_facepalming: 
I could have sworn we did this already.

The flag is defined here: https://github.com/kubernetes/test-infra/blob/279855f786923a5b8a4d380a8632d07bec852075/label_sync/main.go#L138
/assign @stevekuznetsov @fejta 