### PR TITLE
prow plugin to block merge commits in a PR

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -352,3 +352,14 @@ func (r *Repo) Diff(head, sha string) (changes []string, err error) {
 	}
 	return
 }
+
+// MergeCommitsExistBetween runs 'git log <target>..<head> --merged' to verify
+// if merge commits exist between "target" and "head".
+func (r *Repo) MergeCommitsExistBetween(target, head string) (bool, error) {
+	r.logger.Infof("Verifying if merge commits exist between %s and %s.", target, head)
+	b, err := r.gitCommand("log", fmt.Sprintf("%s..%s", target, head), "--oneline", "--merges").CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("error verifying if merge commits exist between %s and %s: %v. output: %s", target, head, err, string(b))
+	}
+	return len(b) != 0, nil
+}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -18,6 +18,7 @@ package git_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,5 +132,125 @@ func TestCheckoutPR(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(r.Dir, "wow")); err != nil {
 		t.Errorf("Didn't find file in PR after checking out: %v", err)
+	}
+}
+
+func TestMergeCommitsExistBetween(t *testing.T) {
+	lg, c, err := localgit.New()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	r, err := c.Clone("foo/bar")
+	if err != nil {
+		t.Fatalf("Cloning: %v", err)
+	}
+	defer func() {
+		if err := r.Clean(); err != nil {
+			t.Errorf("Cleaning repo: %v", err)
+		}
+	}()
+	var (
+		checkoutPR = func(prNum int) {
+			if err := lg.CheckoutNewBranch("foo", "bar", fmt.Sprintf("pull/%d/head", prNum)); err != nil {
+				t.Fatalf("Creating & checking out pull branch pull/%d/head: %v", prNum, err)
+			}
+		}
+		checkoutBranch = func(branch string) {
+			if err := lg.Checkout("foo", "bar", branch); err != nil {
+				t.Fatalf("Checking out branch %s: %v", branch, err)
+			}
+		}
+		addCommit = func(file string) {
+			if err := lg.AddCommit("foo", "bar", map[string][]byte{file: {}}); err != nil {
+				t.Fatalf("Adding commit: %v", err)
+			}
+		}
+		mergeMaster = func() {
+			if _, err := lg.Merge("foo", "bar", "master"); err != nil {
+				t.Fatalf("Rebasing commit: %v", err)
+			}
+		}
+		rebaseMaster = func() {
+			if _, err := lg.Rebase("foo", "bar", "master"); err != nil {
+				t.Fatalf("Rebasing commit: %v", err)
+			}
+		}
+	)
+
+	type testCase struct {
+		name          string
+		prNum         int
+		checkout      func()
+		mergeOrRebase func()
+		checkoutPR    func() error
+		want          bool
+	}
+	testcases := []testCase{
+		{
+			name:          "PR has merge commits",
+			prNum:         1,
+			checkout:      func() { checkoutBranch("pull/1/head") },
+			mergeOrRebase: mergeMaster,
+			checkoutPR:    func() error { return r.CheckoutPullRequest(1) },
+			want:          true,
+		},
+		{
+			name:          "PR doesn't have merge commits",
+			prNum:         2,
+			checkout:      func() { checkoutBranch("pull/2/head") },
+			mergeOrRebase: rebaseMaster,
+			checkoutPR:    func() error { return r.CheckoutPullRequest(2) },
+			want:          false,
+		},
+	}
+
+	addCommit("wow")
+	// preparation work: branch off all prs upon commit 'wow'
+	for _, tt := range testcases {
+		checkoutPR(tt.prNum)
+	}
+	// switch back to master and create a new commit 'ouch'
+	checkoutBranch("master")
+	addCommit("ouch")
+	masterSHA, err := lg.RevParse("foo", "bar", "HEAD")
+	if err != nil {
+		t.Fatalf("Fetching SHA: %v", err)
+	}
+
+	for _, tt := range testcases {
+		tt.checkout()
+		tt.mergeOrRebase()
+		prSHA, err := lg.RevParse("foo", "bar", "HEAD")
+		if err != nil {
+			t.Fatalf("Fetching SHA: %v", err)
+		}
+		if err := tt.checkoutPR(); err != nil {
+			t.Fatalf("Checking out PR: %v", err)
+		}
+		// verify the content is up to dated
+		ouchPath := filepath.Join(r.Dir, "ouch")
+		if _, err := os.Stat(ouchPath); err != nil {
+			t.Fatalf("Didn't find file 'ouch' in PR %d after merging: %v", tt.prNum, err)
+		}
+
+		got, err := r.MergeCommitsExistBetween(masterSHA, prSHA)
+		key := fmt.Sprintf("foo/bar/%d", tt.prNum)
+		if err != nil {
+			t.Errorf("Case: %v. Expect err is nil, but got %v", key, err)
+		}
+		if tt.want != got {
+			t.Errorf("Case: %v. Expect MergeCommitsExistBetween()=%v, but got %v", key, tt.want, got)
+		}
 	}
 }

--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -152,3 +152,15 @@ func (lg *LocalGit) RevParse(org, repo, commitlike string) (string, error) {
 	rdir := filepath.Join(lg.Dir, org, repo)
 	return runCmdOutput(lg.Git, rdir, "rev-parse", commitlike)
 }
+
+// Merge does git merge.
+func (lg *LocalGit) Merge(org, repo, commitlike string) (string, error) {
+	rdir := filepath.Join(lg.Dir, org, repo)
+	return runCmdOutput(lg.Git, rdir, "merge", "--no-ff", "--no-stat", "-m merge", commitlike)
+}
+
+// Rebase does git rebase.
+func (lg *LocalGit) Rebase(org, repo, commitlike string) (string, error) {
+	rdir := filepath.Join(lg.Dir, org, repo)
+	return runCmdOutput(lg.Git, rdir, "rebase", commitlike)
+}

--- a/prow/labels/labels.go
+++ b/prow/labels/labels.go
@@ -34,6 +34,7 @@ const (
 	LifecycleFrozen = "lifecycle/frozen"
 	LifecycleRotten = "lifecycle/rotten"
 	LifecycleStale  = "lifecycle/stale"
+	MergeCommits    = "do-not-merge/contains-merge-commits"
 	NeedsOkToTest   = "needs-ok-to-test"
 	NeedsRebase     = "needs-rebase"
 	NeedsSig        = "needs-sig"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -76,6 +76,7 @@ filegroup(
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",
+        "//prow/plugins/mergecommitblocker:all-srcs",
         "//prow/plugins/milestone:all-srcs",
         "//prow/plugins/milestonestatus:all-srcs",
         "//prow/plugins/override:all-srcs",

--- a/prow/plugins/mergecommitblocker/BUILD.bazel
+++ b/prow/plugins/mergecommitblocker/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mergecommitblocker.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/mergecommitblocker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/git:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/labels:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mergecommitblocker_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/commentpruner:go_default_library",
+        "//prow/git/localgit:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/labels:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/mergecommitblocker/mergecommitblocker.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mergecommitblocker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	// PluginName defines this plugin's registered name.
+	PluginName = "mergecommitblocker"
+)
+
+var (
+	blockedBody = fmt.Sprintf("Adding label: `%s` because PR contains merge commits.", labels.MergeCommits)
+	fixmeBody   = "Your pull request contains merge commits, which are not allowed in this repository. Use `git rebase` to reapply your commits on top of the target branch."
+)
+
+// init registers out plugin as a pull request handler
+func init() {
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+}
+
+// helpProvider provides information on the plugin
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
+	return &pluginhelp.PluginHelp{
+		Description: fmt.Sprintf("The merge commit blocker plugin adds the %s label to pull requests that contain merge commits", labels.MergeCommits),
+	}, nil
+}
+
+type githubClient interface {
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	CreateComment(org, repo string, number int, comment string) error
+}
+
+type pruneClient interface {
+	PruneComments(func(ic github.IssueComment) bool)
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
+	if pre.Action != github.PullRequestActionOpened &&
+		pre.Action != github.PullRequestActionReopened &&
+		pre.Action != github.PullRequestActionSynchronize {
+		return nil
+	}
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.GitHubClient, pc.GitClient, cp, pc.Logger, &pre)
+}
+
+func handle(ghc githubClient, gc *git.Client, cp pruneClient, log *logrus.Entry, pre *github.PullRequestEvent) error {
+	var (
+		org  = pre.PullRequest.Base.Repo.Owner.Login
+		repo = pre.PullRequest.Base.Repo.Name
+		num  = pre.PullRequest.Number
+	)
+
+	// Clone the repo, checkout the PR.
+	r, err := gc.Clone(fmt.Sprintf("%s/%s", org, repo))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Clean(); err != nil {
+			log.WithError(err).Error("Error cleaning up repo.")
+		}
+	}()
+	if err := r.CheckoutPullRequest(num); err != nil {
+		return err
+	}
+	// We are guaranteed to have both Base.SHA and Head.SHA
+	target, head := pre.PullRequest.Base.SHA, pre.PullRequest.Head.SHA
+	existMergeCommits, err := r.MergeCommitsExistBetween(target, head)
+	if err != nil {
+		return err
+	}
+	issueLabels, err := ghc.GetIssueLabels(org, repo, num)
+	if err != nil {
+		return err
+	}
+	hasLabel := github.HasLabel(labels.MergeCommits, issueLabels)
+	if hasLabel && !existMergeCommits {
+		log.Infof("Removing %q Label for %s/%s#%d", labels.MergeCommits, org, repo, num)
+		if err := ghc.RemoveLabel(org, repo, num, labels.MergeCommits); err != nil {
+			return err
+		}
+		cp.PruneComments(func(ic github.IssueComment) bool {
+			return strings.Contains(ic.Body, blockedBody)
+		})
+	} else if !hasLabel && existMergeCommits {
+		log.Infof("Adding %q Label for %s/%s#%d", labels.MergeCommits, org, repo, num)
+		if err := ghc.AddLabel(org, repo, num, labels.MergeCommits); err != nil {
+			return err
+		}
+		msg := plugins.FormatResponse(pre.PullRequest.User.Login, blockedBody, fixmeBody)
+		return ghc.CreateComment(org, repo, num, msg)
+	}
+	return nil
+}

--- a/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mergecommitblocker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/commentpruner"
+	"k8s.io/test-infra/prow/git/localgit"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
+)
+
+type strSet map[string]struct{}
+
+type fakeGHClient struct {
+	labels   strSet
+	comments map[int]string
+}
+
+func (f *fakeGHClient) AddLabel(org, repo string, number int, label string) error {
+	f.labels[label] = struct{}{}
+	return nil
+}
+
+func (f *fakeGHClient) RemoveLabel(org, repo string, number int, label string) error {
+	delete(f.labels, label)
+	return nil
+}
+
+func (f *fakeGHClient) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	var labels []github.Label
+	for l := range f.labels {
+		labels = append(labels, github.Label{Name: l})
+	}
+	return labels, nil
+}
+
+func (f *fakeGHClient) CreateComment(org, repo string, number int, comment string) error {
+	if _, ok := f.comments[number]; ok {
+		return fmt.Errorf("comment id %d already exists", number)
+	}
+	f.comments[number] = comment
+	return nil
+}
+
+func (f *fakeGHClient) DeleteComment(org, repo string, id int) error {
+	delete(f.comments, id)
+	return nil
+}
+
+func (f *fakeGHClient) BotName() (string, error) {
+	return "foo", nil
+}
+
+func (f *fakeGHClient) ListIssueComments(org, repo string, number int) ([]github.IssueComment, error) {
+	var ghComments []github.IssueComment
+	for id, c := range f.comments {
+		ghComment := github.IssueComment{
+			ID:   id,
+			Body: c,
+			User: github.User{Login: "foo"},
+		}
+		ghComments = append(ghComments, ghComment)
+	}
+	return ghComments, nil
+}
+
+func TestHandle(t *testing.T) {
+	lg, c, err := localgit.New()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	var (
+		checkoutPR = func(prNum int) {
+			if err := lg.CheckoutNewBranch("foo", "bar", fmt.Sprintf("pull/%d/head", prNum)); err != nil {
+				t.Fatalf("Creating & checking out pull branch pull/%d/head: %v", prNum, err)
+			}
+		}
+		checkoutBranch = func(branch string) {
+			if err := lg.Checkout("foo", "bar", branch); err != nil {
+				t.Fatalf("Checking out branch %s: %v", branch, err)
+			}
+		}
+		addCommit = func(file string) {
+			if err := lg.AddCommit("foo", "bar", map[string][]byte{file: {}}); err != nil {
+				t.Fatalf("Adding commit: %v", err)
+			}
+		}
+		mergeMaster = func() {
+			if _, err := lg.Merge("foo", "bar", "master"); err != nil {
+				t.Fatalf("Rebasing commit: %v", err)
+			}
+		}
+		rebaseMaster = func() {
+			if _, err := lg.Rebase("foo", "bar", "master"); err != nil {
+				t.Fatalf("Rebasing commit: %v", err)
+			}
+		}
+	)
+
+	type testCase struct {
+		name          string
+		fakeGHClient  *fakeGHClient
+		prNum         int
+		checkout      func()
+		mergeOrRebase func()
+		wantLabel     bool
+		wantComment   bool
+	}
+	testcases := []testCase{
+		{
+			name: "merge commit label not exist, PR has merge commits",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{},
+				comments: make(map[int]string),
+			},
+			prNum:         11,
+			checkout:      func() { checkoutBranch("pull/11/head") },
+			mergeOrRebase: mergeMaster,
+			wantLabel:     true,
+			wantComment:   true,
+		},
+		{
+			name: "merge commit label exists, PR has merge commits",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{labels.MergeCommits: struct{}{}},
+				comments: map[int]string{12: blockedBody},
+			},
+			prNum:         12,
+			checkout:      func() { checkoutBranch("pull/12/head") },
+			mergeOrRebase: mergeMaster,
+			wantLabel:     true,
+			wantComment:   true,
+		},
+		{
+			name: "merge commit label not exists, PR doesn't have merge commits",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{},
+				comments: make(map[int]string),
+			},
+			prNum:         13,
+			checkout:      func() { checkoutBranch("pull/13/head") },
+			mergeOrRebase: rebaseMaster,
+			wantLabel:     false,
+			wantComment:   false,
+		},
+		{
+			name: "merge commit label exists, PR doesn't have merge commits",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{labels.MergeCommits: struct{}{}},
+				comments: map[int]string{14: blockedBody},
+			},
+			prNum:         14,
+			checkout:      func() { checkoutBranch("pull/14/head") },
+			mergeOrRebase: rebaseMaster,
+			wantLabel:     false,
+			wantComment:   false,
+		},
+	}
+
+	addCommit("wow")
+	// preparation work: branch off all prs upon commit 'wow'
+	for _, tt := range testcases {
+		checkoutPR(tt.prNum)
+	}
+	// switch back to master and create a new commit 'ouch'
+	checkoutBranch("master")
+	addCommit("ouch")
+	masterSHA, err := lg.RevParse("foo", "bar", "HEAD")
+	if err != nil {
+		t.Fatalf("Fetching SHA: %v", err)
+	}
+
+	for _, tt := range testcases {
+		tt.checkout()
+		tt.mergeOrRebase()
+		prSHA, err := lg.RevParse("foo", "bar", "HEAD")
+		if err != nil {
+			t.Fatalf("Fetching SHA: %v", err)
+		}
+		pre := &github.PullRequestEvent{
+			Action: github.PullRequestActionOpened,
+			PullRequest: github.PullRequest{
+				Number: tt.prNum,
+				Base: github.PullRequestBranch{
+					Repo: github.Repo{
+						Owner: github.User{Login: "foo"},
+						Name:  "bar",
+					},
+					SHA: masterSHA,
+				},
+				Head: github.PullRequestBranch{
+					Repo: github.Repo{
+						Owner: github.User{Login: "foo"},
+						Name:  "bar",
+					},
+					SHA: prSHA,
+				},
+			},
+		}
+		log := logrus.NewEntry(logrus.New())
+		fakePruner := commentpruner.NewEventClient(tt.fakeGHClient, log, "foo", "bar", tt.prNum)
+		if err := handle(tt.fakeGHClient, c, fakePruner, log, pre); err != nil {
+			t.Errorf("Expect err is nil, but got %v", err)
+		}
+		// verify if MergeCommits label as expected
+		if _, got := tt.fakeGHClient.labels[labels.MergeCommits]; got != tt.wantLabel {
+			t.Errorf("Case: %v. Expect MergeCommits=%v, but got %v", tt.name, tt.wantLabel, got)
+		}
+		// verify if github comment is created/pruned as expected
+		if _, got := tt.fakeGHClient.comments[tt.prNum]; got != tt.wantComment {
+			t.Errorf("Case: %v. Expect wantComment=%v, but got %v", tt.name, tt.wantComment, got)
+		}
+	}
+}


### PR DESCRIPTION
Add a prow plugin to block merge commits in a PR:

- implement MergeCommitsExistBetween() in git client
- add test cases in both githubClient and gitClient

Fixes #5376.

/cc @stevekuznetsov 

PS: it's my first PR for test-infra. Let me know if anything wrong.