### PR TITLE
Fix the aws-janitor-boskos entrypoint

### DIFF
--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/Dockerfile
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/Dockerfile
@@ -21,5 +21,4 @@ RUN apt-get -y update && \
 
 COPY aws-janitor-boskos /usr/local/bin/
 
-CMD ["aws-janitor-boskos"]
-ENTRYPOINT ["/bin/bash", "-c"]
+ENTRYPOINT ["/bin/sh", "-c", "/bin/echo started && /usr/local/bin/aws-janitor-boskos \"$@\"", "--"]


### PR DESCRIPTION
The existing one did not let us pass flags, which we then tried to do. It also probably didn't achieve what it was trying to, because bash is smart like that.

/cc @akutz @detiber 