### PR TITLE
Add periodic e2e tests for Cluster API AWS Provider

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,6 +1,5 @@
 periodics:  
-- interval: 4h
-  name: periodic-cluster-api-provider-aws-test-creds
+- name: periodic-cluster-api-provider-aws-test-creds
   decorate: true
   labels:
     preset-service-account: "true"
@@ -16,3 +15,54 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190322-1960d2fdd-1.12
       command:
       - "./scripts/ci-aws-cred-test.sh"
+- name: periodic-cluster-api-provider-aws-bazel-e2e
+  decorate: true
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extxa_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.12
+      command:
+      - make
+      args:
+      - e2e
+      env:
+      - name: BOSKOS_HOST
+        value: "http://boskos.test-pods.svc.cluster.local."
+      securityContext:
+        privileged: true
+postsubmits:
+  kubernetes-sigs/cluster-api-provider-aws:
+  - name: pull-cluster-api-provider-aws-bazel-e2e
+    decorate: true
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190220-615bdbe2e-1.12
+        command:
+        - make
+        args:
+        - e2e
+        env:
+        - name: BOSKOS_HOST
+          value: "http://boskos.test-pods.svc.cluster.local."
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -10,7 +10,7 @@ periodics:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
     base_ref: master
-    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190322-1960d2fdd-1.12

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -25,7 +25,7 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-  extxa_refs:
+  extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
     base_ref: master
@@ -44,7 +44,7 @@ periodics:
         privileged: true
 postsubmits:
   kubernetes-sigs/cluster-api-provider-aws:
-  - name: pull-cluster-api-provider-aws-bazel-e2e
+  - name: ci-cluster-api-provider-aws-bazel-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     decorate: true
     max_concurrency: 5

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,6 +1,7 @@
 periodics:  
 - name: periodic-cluster-api-provider-aws-test-creds
   decorate: true
+  interval: 4h
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -10,7 +10,7 @@ periodics:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
     base_ref: master
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190322-1960d2fdd-1.12
@@ -45,6 +45,7 @@ periodics:
 postsubmits:
   kubernetes-sigs/cluster-api-provider-aws:
   - name: pull-cluster-api-provider-aws-bazel-e2e
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     decorate: true
     max_concurrency: 5
     labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6098,9 +6098,9 @@ dashboards:
     test_group_name: pull-cluster-api-provider-aws-bazel-integration
   - name: test-creds
     test_group_name: periodic-cluster-api-provider-aws-test-creds
-  - name: periodic-bazel-e2e
+  - name: bazel-periodic-e2e
     test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
-  - name: pr-bazel-e2e
+  - name: bazel-pr-e2e
     test_group_name: pull-cluster-api-provider-aws-bazel-e2e
 
 - name: sig-cluster-lifecycle-cluster-api-provider-azure

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2496,8 +2496,8 @@ test_groups:
 - name: periodic-cluster-api-provider-aws-test-creds
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds
   num_columns_recent: 20
-- name: pull-cluster-api-provider-aws-bazel-e2e
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-e2e
+- name: ci-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/ci-cluster-api-provider-aws-bazel-e2e
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-verify
@@ -6101,7 +6101,7 @@ dashboards:
   - name: bazel-periodic-e2e
     test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
   - name: bazel-pr-e2e
-    test_group_name: pull-cluster-api-provider-aws-bazel-e2e
+    test_group_name: ci-cluster-api-provider-aws-bazel-e2e
 
 - name: sig-cluster-lifecycle-cluster-api-provider-azure
   dashboard_tab:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2490,8 +2490,14 @@ test_groups:
 - name: pull-cluster-api-integration
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-integration
   num_columns_recent: 20
+- name: periodic-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-bazel-e2e
+  num_columns_recent: 20
 - name: periodic-cluster-api-provider-aws-test-creds
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-e2e
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-verify
@@ -6092,6 +6098,10 @@ dashboards:
     test_group_name: pull-cluster-api-provider-aws-bazel-integration
   - name: test-creds
     test_group_name: periodic-cluster-api-provider-aws-test-creds
+  - name: periodic-bazel-e2e
+    test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
+  - name: pr-bazel-e2e
+    test_group_name: pull-cluster-api-provider-aws-bazel-e2e
 
 - name: sig-cluster-lifecycle-cluster-api-provider-azure
   dashboard_tab:


### PR DESCRIPTION
The periodic tests run every hour. 

Related to: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/272 
I have taken over this PR from akutz: https://github.com/kubernetes/test-infra/pull/11524 

Blocked by:
    1. boskos: Deploying a new Boskos janitor for AWS (#11511): Waiting for the deployment of aws-janator-boskos in prow.

/hold