### PR TITLE
Update vSphere CCM job and test-grid configs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -58,7 +58,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
         command:
         - "make"
         args:
@@ -75,7 +75,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
         command:
         - "make"
         args:
@@ -92,7 +92,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
         command:
         - "make"
         args:
@@ -112,7 +112,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
         command:
         - "make"
         args:
@@ -136,7 +136,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
         command:
         - "make"
         args:
@@ -163,7 +163,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -187,7 +187,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -211,7 +211,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -235,7 +235,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -263,7 +263,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -289,7 +289,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -315,7 +315,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:
@@ -341,7 +341,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:523c54f4
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
       command:
       - "make"
       args:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -175,6 +175,32 @@ periodics:
     env:
     - name: K8S_VERSION
       value: ci/latest.txt
+- name: ci-cloud-provider-vsphere-conformance-stable-1-14
+  interval: 12h
+  decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
+  labels:
+    preset-dind-enabled: "true"
+    preset-cloud-provider-vsphere-e2e-config: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-vsphere
+    base_ref: master
+  path_alias: k8s.io/cloud-provider-vsphere
+  skip_submodules: true
+  spec:
+    containers:
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      command:
+      - "make"
+      args:
+      - "conformance-test"
+      securityContext:
+        privileged: true
+    env:
+    - name: K8S_VERSION
+      value: release/stable-1.14.txt
 - name: ci-cloud-provider-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
@@ -227,32 +253,6 @@ periodics:
     env:
     - name: K8S_VERSION
       value: release/stable-1.12.txt
-- name: ci-cloud-provider-vsphere-conformance-stable-1-11
-  interval: 12h
-  decorate: true
-  decoration_config:
-    timeout: 10800000000000 # 3h in nanoseconds
-  labels:
-    preset-dind-enabled: "true"
-    preset-cloud-provider-vsphere-e2e-config: "true"
-  extra_refs:
-  - org: kubernetes
-    repo: cloud-provider-vsphere
-    base_ref: master
-  path_alias: k8s.io/cloud-provider-vsphere
-  skip_submodules: true
-  spec:
-    containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
-      command:
-      - "make"
-      args:
-      - "conformance-test"
-      securityContext:
-        privileged: true
-    env:
-    - name: K8S_VERSION
-      value: release/stable-1.11.txt
 
 # Runs the e2e conformance suite against a cluster turned up with the
 # in-tree vSphere cloud provider. This job is duplicated for multiple versions
@@ -285,6 +285,34 @@ periodics:
       value: vsphere
     - name: K8S_VERSION
       value: ci/latest.txt
+- name: ci-vsphere-conformance-stable-1-14
+  interval: 12h
+  decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
+  labels:
+    preset-dind-enabled: "true"
+    preset-cloud-provider-vsphere-e2e-config: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-vsphere
+    base_ref: master
+  path_alias: k8s.io/cloud-provider-vsphere
+  skip_submodules: true
+  spec:
+    containers:
+    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      command:
+      - "make"
+      args:
+      - "conformance-test"
+      securityContext:
+        privileged: true
+    env:
+    - name: CLOUD_PROVIDER
+      value: vsphere
+    - name: K8S_VERSION
+      value: release/stable-1.14.txt
 - name: ci-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
@@ -341,31 +369,3 @@ periodics:
       value: vsphere
     - name: K8S_VERSION
       value: release/stable-1.12.txt
-- name: ci-vsphere-conformance-stable-1-11
-  interval: 12h
-  decorate: true
-  decoration_config:
-    timeout: 10800000000000 # 3h in nanoseconds
-  labels:
-    preset-dind-enabled: "true"
-    preset-cloud-provider-vsphere-e2e-config: "true"
-  extra_refs:
-  - org: kubernetes
-    repo: cloud-provider-vsphere
-    base_ref: master
-  path_alias: k8s.io/cloud-provider-vsphere
-  skip_submodules: true
-  spec:
-    containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
-      command:
-      - "make"
-      args:
-      - "conformance-test"
-      securityContext:
-        privileged: true
-    env:
-    - name: CLOUD_PROVIDER
-      value: vsphere
-    - name: K8S_VERSION
-      value: release/stable-1.11.txt

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -152,6 +152,8 @@ periodics:
 - name: ci-cloud-provider-vsphere-conformance-latest
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -176,6 +178,8 @@ periodics:
 - name: ci-cloud-provider-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -200,6 +204,8 @@ periodics:
 - name: ci-cloud-provider-vsphere-conformance-stable-1-12
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -224,6 +230,8 @@ periodics:
 - name: ci-cloud-provider-vsphere-conformance-stable-1-11
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -252,6 +260,8 @@ periodics:
 - name: ci-vsphere-conformance-latest
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -278,6 +288,8 @@ periodics:
 - name: ci-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -304,6 +316,8 @@ periodics:
 - name: ci-vsphere-conformance-stable-1-12
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"
@@ -330,6 +344,8 @@ periodics:
 - name: ci-vsphere-conformance-stable-1-11
   interval: 12h
   decorate: true
+  decoration_config:
+    timeout: 10800000000000 # 3h in nanoseconds
   labels:
     preset-dind-enabled: "true"
     preset-cloud-provider-vsphere-e2e-config: "true"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -58,7 +58,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
         command:
         - "make"
         args:
@@ -75,7 +75,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
         command:
         - "make"
         args:
@@ -92,7 +92,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
         command:
         - "make"
         args:
@@ -112,7 +112,7 @@ presubmits:
     skip_report: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
         command:
         - "make"
         args:
@@ -136,7 +136,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+      - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
         command:
         - "make"
         args:
@@ -165,7 +165,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -191,7 +191,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -217,7 +217,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -243,7 +243,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -273,7 +273,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -301,7 +301,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -329,7 +329,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:
@@ -357,7 +357,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:f2a0d372
+    - image: gcr.io/cloud-provider-vsphere/ci:deb4a65c
       command:
       - "make"
       args:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2766,13 +2766,8 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 4
-- name: ci-cloud-provider-vsphere-conformance-stable-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-cloud-provider-vsphere-conformance-stable-1-11
-  num_columns_recent: 20
-  alert_stale_results_hours: 16
-  num_failures_to_alert: 1
-- name: ci-cloud-provider-vsphere-conformance-stable-1-12
-  gcs_prefix: kubernetes-jenkins/logs/ci-cloud-provider-vsphere-conformance-stable-1-12
+- name: ci-cloud-provider-vsphere-conformance-stable-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-cloud-provider-vsphere-conformance-stable-1-14
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 1
@@ -2781,23 +2776,28 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 1
+- name: ci-cloud-provider-vsphere-conformance-stable-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-cloud-provider-vsphere-conformance-stable-1-12
+  num_columns_recent: 20
+  alert_stale_results_hours: 16
+  num_failures_to_alert: 1
 - name: ci-vsphere-conformance-latest
   gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-latest
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 4
-- name: ci-vsphere-conformance-stable-1-11
-  gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-stable-1-11
-  num_columns_recent: 20
-  alert_stale_results_hours: 16
-  num_failures_to_alert: 1
-- name: ci-vsphere-conformance-stable-1-12
-  gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-stable-1-12
+- name: ci-vsphere-conformance-stable-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-stable-1-14
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 1
 - name: ci-vsphere-conformance-stable-1-13
   gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-stable-1-13
+  num_columns_recent: 20
+  alert_stale_results_hours: 16
+  num_failures_to_alert: 1
+- name: ci-vsphere-conformance-stable-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-vsphere-conformance-stable-1-12
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 1
@@ -3633,28 +3633,28 @@ dashboards:
   - name: vSphere-cloud-provider, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere
     test_group_name: ci-cloud-provider-vsphere-conformance-latest
-  - name: vSphere-cloud-provider, v1.11 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.11 branch with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-11
-  - name: vSphere-cloud-provider, v1.12 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
+  - name: vSphere-cloud-provider, v1.14 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
   - name: vSphere-cloud-provider, v1.13 (dev)
     description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with cloud-provider-vsphere
     test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
+  - name: vSphere-cloud-provider, v1.12 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
 
   - name: vSphere, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with the in-tree vSphere cloud provider
     test_group_name: ci-vsphere-conformance-latest
-  - name: vSphere, v1.11 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.11 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-stable-1-11
-  - name: vSphere, v1.12 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-stable-1-12
+  - name: vSphere, v1.14 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with the in-tree vSphere cloud provider
+    test_group_name: ci-vsphere-conformance-stable-1-14
   - name: vSphere, v1.13 (dev)
     description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with the in-tree vSphere cloud provider
     test_group_name: ci-vsphere-conformance-stable-1-13
+  - name: vSphere, v1.12 (dev)
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with the in-tree vSphere cloud provider
+    test_group_name: ci-vsphere-conformance-stable-1-12
 
   - name: Gardener, v1.13 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
@@ -3763,15 +3763,15 @@ dashboards:
   - name: periodic-latest
     description: Runs conformance tests using kubetest against kubernetes ci/latest with in-tree vSphere components
     test_group_name: ci-vsphere-conformance-latest
-  - name: periodic-v1.11
-    description: Runs conformance tests using kubetest against kubernetes v1.11 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-11
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-12
+  - name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes v1.14 with in-tree vSphere components
+    test_group_name: ci-vsphere-conformance-stable-1-14
   - name: periodic-v1.13
     description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
     test_group_name: ci-vsphere-conformance-stable-1-13
+  - name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
+    test_group_name: ci-vsphere-conformance-stable-1-12
 
 - name: vmware-conformance
   dashboard_tab:
@@ -3780,19 +3780,19 @@ dashboards:
     test_group_name: ci-vsphere-conformance-latest
     alert_options:
       alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.11
-    description: Runs conformance tests using kubetest against kubernetes v1.11 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-11
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-12
+  - name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes v1.14 with in-tree vSphere components
+    test_group_name: ci-vsphere-conformance-stable-1-14
     alert_options:
       alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
   - name: periodic-v1.13
     description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
     test_group_name: ci-vsphere-conformance-stable-1-13
+    alert_options:
+      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
+  - name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
+    test_group_name: ci-vsphere-conformance-stable-1-12
     alert_options:
       alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
 
@@ -3834,15 +3834,15 @@ dashboards:
   - name: periodic-latest
     description: Runs conformance tests using kubetest against kubernetes ci/latest with cloud-provider-vsphere
     test_group_name: ci-cloud-provider-vsphere-conformance-latest
-  - name: periodic-v1.11
-    description: Runs conformance tests using kubetest against kubernetes v1.11 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-11
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
+  - name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes v1.14 with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
   - name: periodic-v1.13
     description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
     test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
+  - name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
 
 - name: vmware-conformance-cloud-provider
   dashboard_tab:
@@ -3851,19 +3851,19 @@ dashboards:
     test_group_name: ci-cloud-provider-vsphere-conformance-latest
     alert_options:
       alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.11
-    description: Runs conformance tests using kubetest against kubernetes v1.11 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-11
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
+  - name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes v1.14 with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
     alert_options:
       alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
   - name: periodic-v1.13
     description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
     test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
+    alert_options:
+      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
+  - name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
+    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
     alert_options:
       alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 


### PR DESCRIPTION
This PR updates the vSphere CCM job and test-grid configs:
1. Uses the new CI image `gcr.io/cloud-provider-vsphere/ci:f2a0d372`
2. Increases the conformance job timeouts to three hours
3. Rotates to 1.14, removing 1.11
4. Updated the CI image to `gcr.io/cloud-provider-vsphere/ci:deb4a65c` for VMC NSX update (kubernetes/cloud-provider-vsphere#175)

/assign @figo