### PR TITLE
Revert "Configure Tide to respect branchprotection policies."

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -448,7 +448,6 @@ tide:
   blocker_label: merge-blocker
   squash_label: tide/squash
   context_options:
-    from-branch-protection: true
     optional-contexts:
     - "Submit Queue"
     orgs:


### PR DESCRIPTION
This reverts commit 03f8ea30ff514f6c10f3e647f54c823787a18331.

After enabling `from-branch-protection` globally for Tide to make Tide respect the existing branch protection config we have found that the branch protection config matches what the GitHub settings show, but does not match GitHub's actual behavior. Details of the problem are in this thread:
https://kubernetes.slack.com/archives/C09QZ4DQB/p1553710889855300?thread_ts=1553709732.846500&cid=C09QZ4DQB
I have opened a support ticket with GitHub support, but it usually takes a week or so to get an initial response so we can't wait for a fix to ship.
More slack threads about this:
https://kubernetes.slack.com/archives/C09QZ4DQB/p1553725352905200
https://kubernetes.slack.com/archives/C09QZ4DQB/p1553709338842000

After this revert Tide will still respect the appropriate contexts so long as they exist. The only difference is that Tide won't block merge if they don't exist at all and should be present (very rare). We were in this state up until yesterday without noticing though so we should be able to live with it until we get a response from GitHub support.

/assign @fejta @Katharine 
/area prow/tide
