### PR TITLE
Set `--configPath` flag for deployments

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -55,6 +55,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 2, 2019* `hook`, `deck`, `horologium`, `tide`, `plank` and `sinker` will no 
+   longer provide a default value for the `--config-path` flag.
+   It is required to explicitly provide `--config-path` when upgrading to a new version of 
+   these components that were previously relying on the default `--config-path=/etc/config/config.yaml`.
  - *March 29, 2019* Custom logos should be provided as full paths in the configuration
    under `deck.branding.logos` and will not implicitly be assumed to be under the static
    assets directory.

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -46,6 +46,7 @@ spec:
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=prow.k8s.io
         - --oauth-url=/github-login
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true
         volumeMounts:

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --slack-token-file=/etc/slack/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         ports:
           - name: http

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -34,6 +34,7 @@ spec:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20190405-651ad49e6
         args:
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
         volumeMounts:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -37,6 +37,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         volumeMounts:
         - mountPath: /etc/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -17,6 +17,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
         image: gcr.io/k8s-prow/sinker:v20190405-651ad49e6

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -142,6 +142,7 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --config-path=/etc/config/config.yaml
         ports:
           - name: http
             containerPort: 8888
@@ -219,6 +220,7 @@ spec:
         image: gcr.io/k8s-prow/plank:v20190405-651ad49e6
         args:
         - --dry-run=false
+        - --config-path=/etc/config/config.yaml
         volumeMounts:
         - name: oauth
           mountPath: /etc/github
@@ -252,6 +254,8 @@ spec:
       containers:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20190405-651ad49e6
+        args:
+        - --config-path=/etc/config/config.yaml
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -286,6 +290,7 @@ spec:
       - name: deck
         image: gcr.io/k8s-prow/deck:v20190405-651ad49e6
         args:
+        - --config-path=/etc/config/config.yaml
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -347,6 +352,8 @@ spec:
       containers:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20190405-651ad49e6
+        args:
+        - --config-path=/etc/config/config.yaml
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -378,6 +385,7 @@ spec:
         image: gcr.io/k8s-prow/tide:v20190405-651ad49e6
         args:
         - --dry-run=false
+        - --config-path=/etc/config/config.yaml
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --gcs-credentials-file=/etc/service-account/service-account.json
         - --history-uri=gs://k8s-prow/tide-history.json

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -110,7 +110,7 @@ func (o *options) Validate() error {
 func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.tideURL, "tide-url", "", "Path to tide. If empty, do not serve tide data.")
 	fs.StringVar(&o.hookURL, "hook-url", "", "Path to hook plugin help endpoint.")
@@ -147,6 +147,8 @@ func main() {
 	)
 
 	pjutil.ServePProf()
+
+	o.configPath = config.ConfigPath(o.configPath)
 
 	// setup config agent, pod log clients etc.
 	configAgent := &config.Agent{}

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -74,7 +74,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
 
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
 
@@ -96,6 +96,8 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 	logrus.SetFormatter(logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "hook"}))
+
+	o.configPath = config.ConfigPath(o.configPath)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -44,12 +44,9 @@ type options struct {
 	dryRun     flagutil.Bool
 }
 
-// TODO(fejta): require setting this explicitly
-const defaultConfigPath = "/etc/config/config.yaml"
-
 func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	var o options
-	fs.StringVar(&o.configPath, "config-path", defaultConfigPath, "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 
 	// TODO(fejta): switch dryRun to be a bool, defaulting to true after March 15, 2019.
@@ -84,8 +81,10 @@ func main() {
 
 	pjutil.ServePProf()
 
+	o.configPath = config.ConfigPath(o.configPath)
+
 	if !o.dryRun.Explicit {
-		logrus.Warning("Horologium requies --dry-run=false to function correctly in production.")
+		logrus.Warning("Horologium requires --dry-run=false to function correctly in production.")
 		logrus.Warning("--dry-run will soon default to true. Set --dry-run=false by March 15.")
 	}
 

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -253,10 +253,12 @@ func TestFlags(t *testing.T) {
 			name: "minimal flags work",
 		},
 		{
-			name: "config-path defaults to something valid",
-			del:  sets.NewString("--config-path"),
+			name: "explicitly set --config-path",
+			args: map[string]string{
+				"--config-path": "/etc/config/config.yaml",
+			},
 			expected: func(o *options) {
-				o.configPath = defaultConfigPath
+				o.configPath = "/etc/config/config.yaml"
 			},
 		},
 		{

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -60,7 +60,7 @@ func gatherOptions() options {
 
 	fs.StringVar(&o.totURL, "tot-url", "", "Tot URL")
 
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.buildCluster, "build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	fs.StringVar(&o.selector, "label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
@@ -100,6 +100,8 @@ func main() {
 	)
 
 	pjutil.ServePProf()
+
+	o.configPath = config.ConfigPath(o.configPath)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -50,9 +50,6 @@ type options struct {
 }
 
 const (
-	// TODO(fejta): require setting this explicitly
-	defaultConfigPath = "/etc/config/config.yaml"
-
 	reasonPodAged     = "aged"
 	reasonPodOrphaned = "orphaned"
 
@@ -63,7 +60,7 @@ const (
 func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	o := options{}
 	fs.BoolVar(&o.runOnce, "run-once", false, "If true, run only once then quit.")
-	fs.StringVar(&o.configPath, "config-path", defaultConfigPath, "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 
 	// TODO(fejta): switch dryRun to be a bool, defaulting to true after March 15, 2019.
@@ -103,10 +100,13 @@ func main() {
 	logrus.SetFormatter(
 		logrusutil.NewDefaultFieldsFormatter(nil, logrus.Fields{"component": "sinker"}),
 	)
+
 	if !o.dryRun.Explicit {
-		logrus.Warning("Sinker requies --dry-run=false to function correctly in production.")
+		logrus.Warning("Sinker requires --dry-run=false to function correctly in production.")
 		logrus.Warning("--dry-run will soon default to true. Set --dry-run=false by March 15.")
 	}
+
+	o.configPath = config.ConfigPath(o.configPath)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -439,10 +439,12 @@ func TestFlags(t *testing.T) {
 			name: "minimal flags work",
 		},
 		{
-			name: "config-path defaults to something valid",
-			del:  sets.NewString("--config-path"),
+			name: "explicitly set --config-path",
+			args: map[string]string{
+				"--config-path": "/etc/config/config.yaml",
+			},
 			expected: func(o *options) {
-				o.configPath = defaultConfigPath
+				o.configPath = "/etc/config/config.yaml"
 			},
 		},
 		{

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -85,7 +85,7 @@ func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
-	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to mutate any real-world state.")
 	fs.BoolVar(&o.runOnce, "run-once", false, "If true, run only once then quit.")
@@ -115,6 +115,8 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
+
+	o.configPath = config.ConfigPath(o.configPath)
 
 	opener, err := io.NewOpener(context.Background(), o.gcsCredentialsFile)
 	if err != nil {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -818,6 +818,20 @@ func (c *Config) validateJobConfig() error {
 	return nil
 }
 
+// ConfigPath returns the value for the component's configPath if provided
+// explicityly or default otherwise.
+func ConfigPath(value string) string {
+
+	// TODO: require setting this explicitly
+	defaultConfigPath := "/etc/config/config.yaml"
+
+	if value != "" {
+		return value
+	}
+	logrus.Warningf("defaulting to %s until 15 July 2019, please migrate", defaultConfigPath)
+	return defaultConfigPath
+}
+
 func parseProwConfig(c *Config) error {
 	if err := ValidateController(&c.Plank.Controller); err != nil {
 		return fmt.Errorf("validating plank config: %v", err)


### PR DESCRIPTION
Adds `--configPath` flag  and set the default to `""`  for the following deployments: 

- Deck
- Hook
- Horologium
- Plank
- Sinker
- Tide 