### PR TITLE
Cap the maximum duration on heat map and add labels

### DIFF
--- a/prow/cmd/deck/static/prow/histogram.ts
+++ b/prow/cmd/deck/static/prow/histogram.ts
@@ -83,6 +83,12 @@ export class JobBuckets {
               public end: number,
               public max: number) { }
 
+  public limitMaximum(maximum: number) {
+    if (this.max > maximum) {
+        this.max = maximum;
+    }
+  }
+
   public linearChunks(bucket: JobSample[], rows: number): JobSample[][] {
       const stride = Math.ceil((this.max) / rows);
       const chunks: JobSample[][] = [];
@@ -95,10 +101,20 @@ export class JobBuckets {
           }
           next = next + stride;
           while (next < sample.duration) {
-              chunks.push([]);
-              next = next + stride;
+            if (chunks.length > (rows - 1)) {
+                break;
+            }
+            chunks.push([]);
+            next = next + stride;
           }
-          chunks.push([sample]);
+          if (chunks.length > (rows - 1)) {
+            chunks[chunks.length - 1].push(sample);
+        } else {
+            chunks.push([sample]);
+          }
+      }
+      if (chunks.length > rows) {
+        throw new Error("invalid rows");
       }
       return chunks;
   }

--- a/prow/cmd/deck/static/prow/histogram_test.ts
+++ b/prow/cmd/deck/static/prow/histogram_test.ts
@@ -17,6 +17,84 @@ describe('JobHistogram', () => {
     expect(h.buckets(0, 9, 1).data).toEqual([[]]);
     expect(h.buckets(0, 9, 2).data).toEqual([[], []]);
   });
+  it('should create chunks for each bucket', () => {
+    const h = new JobHistogram();
+    const samples = [
+      new JobSample(10, 100, "failure", 0),
+      new JobSample(10, 101, "success", 1),
+      new JobSample(300, 200, "success", 2),
+      new JobSample(200, 300, "success", 3),
+      new JobSample(200, 300, "success", 4),
+      new JobSample(0, 500, "success", 5),
+      new JobSample(200, 11, "failure", 6),
+      new JobSample(201, 10, "failure", 7),
+    ];
+    for (const sample of samples) {
+      h.add(sample);
+    }
+    const buckets = h.buckets(0, 1000, 10);
+    expect(buckets.linearChunks(buckets.data[0], 4)).toEqual([
+      [samples[0], samples[1]],
+      [],
+      [],
+      [samples[5]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[1], 4)).toEqual([
+      [],
+      [],
+      [samples[3]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[2], 4)).toEqual([
+      [samples[7], samples[6]],
+      [],
+      [samples[4]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[3], 4)).toEqual([
+      [],
+      [samples[2]],
+    ]);
+  });
+  it('should create limited chunks for each bucket', () => {
+    const h = new JobHistogram();
+    const samples = [
+      new JobSample(10, 100, "failure", 0),
+      new JobSample(10, 101, "success", 1),
+      new JobSample(300, 200, "success", 2),
+      new JobSample(200, 300, "success", 3),
+      new JobSample(200, 300, "success", 4),
+      new JobSample(0, 500, "success", 5),
+      new JobSample(200, 11, "failure", 6),
+      new JobSample(201, 10, "failure", 7),
+    ];
+    for (const sample of samples) {
+      h.add(sample);
+    }
+    const buckets = h.buckets(0, 1000, 10);
+    buckets.limitMaximum(300);
+    expect(buckets.linearChunks(buckets.data[0], 4)).toEqual([
+      [],
+      [samples[0], samples[1]],
+      [],
+      [samples[5]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[1], 4)).toEqual([
+      [],
+      [],
+      [],
+      [samples[3]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[2], 4)).toEqual([
+      [samples[7], samples[6]],
+      [],
+      [],
+      [samples[4]],
+    ]);
+    expect(buckets.linearChunks(buckets.data[3], 4)).toEqual([
+      [],
+      [],
+      [samples[2]],
+    ]);
+  });
   it('should create buckets that contain the correct results', () => {
     const h = new JobHistogram();
     const samples = [

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -215,6 +215,26 @@ i.state {
     float: right;
 }
 
+#job-histogram-container {
+    position: relative;
+}
+
+#job-histogram-labels-y-max {
+    position: absolute;
+    top: 0;
+    left: 6px;
+    font-size: 0.75rem;
+    color: #888;
+}
+
+#job-histogram-labels-y-mid {
+    position: absolute;
+    top: 42%;
+    left: 6px;
+    font-size: 0.75rem;
+    color: #666;
+}
+
 #job-count {
     float: right;
     font-size: 12px;

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -49,7 +49,11 @@
     <div id="job-bar-unknown" class="job-bar-state"></div>
     <div id="unknown-tooltip" class="mdl-tooltip" for="job-bar-unknown"></div>
     </div>
-    <table id="job-histogram"><tbody id="job-histogram-content"></tbody></table>
+    <div id="job-histogram-container">
+      <span id="job-histogram-labels-y-max"></span>
+      <span id="job-histogram-labels-y-mid"></span>
+      <table id="job-histogram"><tbody id="job-histogram-content"></tbody></table>
+    </div>
     <div id="job-histogram-labels"><span>Now</span><span id="job-histogram-start"></span></div>
   </aside>
   <article>


### PR DESCRIPTION
Two bits of important feedback from users (who are tasked with being build-cop on openshift prow) have been raised about the heatmap:

1. Kube prow (unlike other prows) has a very extreme distribution of jobs with most being under 30m and some at 6h which causes the heat map to look squashed
2. Understanding the vertical axis was hard and not immediately obvious

Since the goal of the heatmap is to guide quick estimation of job
failure rates over time, cap the y-axis at 2h which is a "long job"
for most users and add two labels that indicate how long the job
takes. This should allow new users to understand what the heatmap
shows.

![image](https://www.dropbox.com/s/iv7nyua8pn7rvpr/Screenshot%202019-03-28%2014.47.45.png?raw=1)

I can't run this against Kube prow but it should dramatically improve the appearance of the graph.