### PR TITLE
Enable review_acts_as_lgtm for k/t-i.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -126,6 +126,7 @@ lgtm:
   review_acts_as_lgtm: true
 - repos:
   - kubernetes/test-infra
+  review_acts_as_lgtm: true
   store_tree_hash: true
 
 blockades:


### PR DESCRIPTION
This will make GitHub PR reviews submitted in the "Approve" state act as `/lgtm` for all PR reviews in `kubernetes/test-infra`.

This got lazy consensus in [slack](https://kubernetes.slack.com/archives/C09QZ4DQB/p1553208058692200) and at the March 26 [SIG-Testing meeting](https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit#heading=h.iuh8u481zx9s). @spiffxp Also ran it by contributor experience.

/assign @spiffxp @fejta 