### PR TITLE
Provide a simple summary of success rate for the currently selected jobs

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -206,13 +206,22 @@ i.state {
     cursor: pointer;
 }
 
-#job-histogram-labels span {
+#job-histogram-labels {
+    text-align: center;
+}
+
+#job-histogram-labels > span {
     padding: 0 6px;
     font-size: 12px;
+    color: #777;
 }
 
 #job-histogram-start {
     float: right;
+}
+
+#job-histogram-end {
+    float: left;
 }
 
 #job-histogram-container {

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -54,7 +54,7 @@
       <span id="job-histogram-labels-y-mid"></span>
       <table id="job-histogram"><tbody id="job-histogram-content"></tbody></table>
     </div>
-    <div id="job-histogram-labels"><span>Now</span><span id="job-histogram-start"></span></div>
+    <div id="job-histogram-labels"><span id="job-histogram-end">Now</span><span id="job-histogram-start"></span><span id="job-histogram-summary"></span></div>
   </aside>
   <article>
     <div class="table-container">


### PR DESCRIPTION
To assist visual estimation of the success rate for the set of selected 
prow jobs, provide a small summary below the heat map that describes the
% of jobs that succeeded in the last 3, 12, and 48 hours, truncated to 
whatever has been pruned from prow.

E.g.

    Success rate over time: 3h: 68%, 12h: 67%, 48: 74%

Which allows a human to leverage the job filter functions to quickly answer
assess a subset of jobs for trend (either by job name or by repository).

The summary is displayed below the heat map to avoid cluttering other 
higher visibility areas.

Includes commit from #11985 because the styles should work together

![image](https://www.dropbox.com/s/ot6b8a1ogqdxxzx/Screenshot%202019-03-28%2016.57.43.png?raw=1)