### PR TITLE
Require full path to custom logo for Deck

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -55,6 +55,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *March 29, 2019* Custom logos should be provided as full paths in the configuration
+   under `deck.branding.logos` and will not implicitly be assumed to be under the static
+   assets directory.
  - *February 26, 2019* The `job_url_prefix` option from `plank` has been deprecated in
     favor of the new `job_url_prefix_config` option which allows configuration on a global,
     organization or repo level. `job_url_prefix` will be removed in September 2019.

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -16,9 +16,9 @@
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   {{block "scripts" .Arguments}}{{end}}
 </head>
-{{$defaultLogo := "logo-light.png"}}
+{{$defaultLogo := "/static/logo-light.png"}}
 {{- if .DarkMode -}}
-{{- $defaultLogo = "logo-dark.png" -}}
+{{- $defaultLogo = "/static/logo-dark.png" -}}
 {{- end -}}
 <body id="{{.PageName}}"{{if branding.BackgroundColor}} style="background-color: {{branding.BackgroundColor}};"{{end}}>
 <div id="alert-container"></div>
@@ -26,7 +26,7 @@
   <header class="mdl-layout__header"{{if branding.HeaderColor}} style="background-color: {{branding.HeaderColor}};"{{end}}>
     <div class="mdl-layout__header-row">
       <a href="/"
-         class="logo"><img src="/static/{{or branding.Logo $defaultLogo}}" alt="kubernetes logo" class="logo"/></a>
+         class="logo"><img src="{{or branding.Logo $defaultLogo}}" alt="kubernetes logo" class="logo"/></a>
       <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
     </div>
   </header>


### PR DESCRIPTION
A user can provide a custom Deck logo as an image to be fetched fom the
internet as well as a file in the local static asset directory. Deck is
not opinionated as to where the static assets are stored, though, so we
need to be sure to honor user-defined static asset directories in
templates.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @Katharine 