### PR TITLE
Presubmit job for sig-windows

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3639,3 +3639,66 @@ presubmits:
           defaultMode: 256
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-verify,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-aks-engine-azure-windows
+    labels:
+      preset-azure-acsengine: "true"
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-aks-engine-azure-windows
+    optional: true
+    rerun_command: /test pull-security-kubernetes-e2e-aks-engine-azure-windows
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --job=$(JOB_NAME)
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=480
+        - --scenario=kubernetes_e2e
+        - --
+        - --test=true
+        - --up=true
+        - --down=true
+        - --deployment=acsengine
+        - --provider=skeleton
+        - --build=bazel
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aks-engine-azure-windows
+        - --ginkgo-parallel=4
+        - --acsengine-admin-username=azureuser
+        - --acsengine-admin-password=AdminPassw0rd
+        - --acsengine-creds=$AZURE_CREDENTIALS
+        - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.31.2/aks-engine-v0.31.2-linux-amd64.tar.gz
+        - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
+        - --acsengine-winZipBuildScript=$WIN_BUILD
+        - --acsengine-orchestratorRelease=1.14
+        - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json
+        - --acsengine-win-binaries
+        - --acsengine-hyperkube
+        - --acsengine-agentpoolcount=2
+        - --test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --node-os-distro=windows
+          --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
+          --ginkgo.skip=\[LinuxOnly\]|GMSA|\[Serial\]
+        - --timeout=450m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aks-engine-azure-windows
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        name: ""
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-aks-engine-azure-windows,?($|\s.*)

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -33,6 +33,55 @@ presets:
     mountPath: /etc/azure-ssh
     readOnly: true
 
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-aks-engine-azure-windows
+    always_run: false
+    optional: true
+    trigger: (?m)^/test( | .* )pull-kubernetes-e2e-aks-engine-azure-windows,?($|\s.*)
+    rerun_command: /test pull-kubernetes-e2e-aks-engine-azure-windows
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-acsengine: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--root=/go/src"
+        - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--upload=gs://kubernetes-jenkins/pr-logs/"
+        - "--timeout=480"
+        - "--scenario=kubernetes_e2e"
+        - --
+        - "--test=true"
+        - "--up=true"
+        - "--down=true"
+        - "--deployment=acsengine"
+        - "--provider=skeleton"
+        - "--build=bazel"
+        - "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aks-engine-azure-windows"
+        - "--ginkgo-parallel=4"
+        - "--acsengine-admin-username=azureuser"
+        - "--acsengine-admin-password=AdminPassw0rd"
+        - "--acsengine-creds=$AZURE_CREDENTIALS"
+        - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.31.2/aks-engine-v0.31.2-linux-amd64.tar.gz"
+        - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
+        - "--acsengine-winZipBuildScript=$WIN_BUILD"
+        - "--acsengine-orchestratorRelease=1.14"
+        - "--acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json"
+        - "--acsengine-win-binaries"
+        - "--acsengine-hyperkube"
+        - "--acsengine-agentpoolcount=2"
+        - "--test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|GMSA|\\[Serial\\]"
+        - "--timeout=450m"
+        securityContext:
+          privileged: true
+
 
 periodics:
 - interval: 6h

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3345,6 +3345,9 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
 - name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-14-windows
+- name: pull-kubernetes-e2e-aks-engine-azure-windows
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-aks-engine-azure-windows
+  num_columns_recent: 30
 # Cloud-provider-azure e2e tests
 - name: pull-cloud-provider-azure-e2e
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-azure-e2e
@@ -7865,6 +7868,9 @@ dashboards:
   - name: aks-engine-azure-1-14-windows
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
     test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
+  - name: aks-engine-azure-windows-presubmit
+    description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
+    test_group_name: pull-kubernetes-e2e-aks-engine-azure-windows
   - name: gce-windows-master
     description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
     test_group_name: ci-kubernetes-e2e-windows-gce


### PR DESCRIPTION
The purpose of this PR is to add a presubmit job for testing PRs that relate to sig-windows on Windows clusters.

As we don't have the capacity right now to test each and every PR, this test will only be triggered manually with the /test pull-kubernetes-e2e-aks-engine-azure-windows . Sig-windows developers will benefit greatly from having such a job, more so since we have planned to add a bunch of new tests to cover Windows.