### PR TITLE
prow/config.yaml: set merge_method for krew repos

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -437,6 +437,8 @@ tide:
     kubernetes-sigs/cluster-api-provider-gcp: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-sigs/cluster-api-provider-vsphere: squash
+    kubernetes-sigs/krew: squash
+    kubernetes-sigs/krew-index: squash
     kubernetes-sigs/kubespray: squash
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash


### PR DESCRIPTION
`krew` and `krew-index` projects use "squash" commits for merging PRs. Adding this
to unblock Tide merges.

We could lift this restriction for perhaps krew repo, but krew-index should
ideally remain on "squash" mode to ensure linear history as the repo is cloned
on user machines.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>