### PR TITLE
Bump up the BAZEL version for prow autobump

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -180,7 +180,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20190130-b4da262c0-0.21.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20190401-918468dbb-0.24.0
       command:
       - prow/autobump.sh
       args:

--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -16,8 +16,8 @@ IMG = gcr.io/k8s-testimages/bazelbuild
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # TODO: retire some of these as they become unnecessary
-LATEST_BAZEL_VERSION=0.10.0
-BAZEL_VERSIONS=0.6.1 0.7.0 0.8.1 $(LATEST_BAZEL_VERSION)
+LATEST_BAZEL_VERSION=0.24.0
+BAZEL_VERSIONS=0.6.1 0.7.0 0.8.1 0.10.0, 0.23.2 $(LATEST_BAZEL_VERSION)
 
 all: build
 


### PR DESCRIPTION
Bump up the BAZEL version for the bazelbuild image.
Update the autobump prow image reference to the latest bazelbuild version.
/area prow
/assign fejta
/assign Katharine