### PR TITLE
Update Prow config files to resolve problems identified by `check-config`.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -101,7 +101,7 @@ presubmits:
           privileged: true
 
 postsubmits:
-  kubernetes/cloud-provider-vpshere:
+  kubernetes/cloud-provider-vsphere:
 
   # Deploys the CCM and CSI images if both the unit and integration tests succeed.
   - name: post-cloud-provider-vsphere-deploy

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -96,6 +96,7 @@ const (
 
 var allWarnings = []string{
 	mismatchedTideWarning,
+	tideStrictBranchWarning,
 	nonDecoratedJobsWarning,
 	jobNameLengthWarning,
 	needsOkToTestWarning,

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,10 +341,8 @@ tide:
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
-    - do-not-merge/cherry-pick-not-approved
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
-    - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
     - needs-rebase
   - orgs:
@@ -389,7 +387,6 @@ tide:
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
-    - do-not-merge/cherry-pick-not-approved
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -244,8 +244,7 @@ repo_milestone:
 project_config:
   project_org_configs:
     kubernetes:
-      org_maintainers_team_id: 3162587
-      org_maintainers_team_name: sig-testing-dummy-project-team
+      org_maintainers_team_id: 3162587 # sig-testing-dummy-project-team
       org_default_column_map:
         test-infra-dummy-testing-project-plugin:
           To do
@@ -253,17 +252,14 @@ project_config:
           To do
       project_repo_configs:
         kubernetes:
-          repo_maintainers_team_id: 2460384
-          repo_maintainers_team_name: kubernetes-milestone-maintainers
+          repo_maintainers_team_id: 2460384 # kubernetes-milestone-maintainers
           repo_default_column_map:
             component-base:
               To do
             Workloads:
               Backlog
     kubeflow:
-      org_maintainers_team_id: 2460384
-      org_maintainers_team_name: kubernetes-milestone-maintainers
-
+      org_maintainers_team_id: 2460384 # kubernetes-milestone-maintainers
 config_updater:
   maps:
     label_sync/labels.yaml:
@@ -376,6 +372,7 @@ plugins:
   - lgtm
   - trigger
   - verify-owners
+  - wip
 
   kubernetes:
   - approve
@@ -471,6 +468,9 @@ plugins:
   - override
   - release-note
   - require-matching-label
+  - trigger
+
+  kubernetes/minikube:
   - trigger
 
   kubernetes/node-problem-detector:


### PR DESCRIPTION
This addresses the most of the problems identified by `check-config` so that we can enable it as part of presubmit validation. (ref https://github.com/kubernetes/test-infra/pull/9395)

/hold
/assign @stevekuznetsov @fejta 