### PR TITLE
Stop compressing build-log.txt files

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -371,9 +371,10 @@ class GSUtil(object):
                 'cp', fp.name, path]
             self.call(cmd)
 
-    def copy_file(self, dest, orig):
+    def copy_file(self, dest, orig, compress):
         """Copy the file to the specified path using compressed encoding."""
-        cmd = [self.gsutil, '-q', 'cp', '-Z', orig, dest]
+        compress = ['-Z'] if compress else []
+        cmd = [self.gsutil, '-q', 'cp'] + compress + [orig, dest]
         self.call(cmd)
 
     def upload_text(self, path, txt, additional_headers=None, cached=True):
@@ -1123,7 +1124,7 @@ def bootstrap(args):
     logging.getLogger('').removeHandler(build_log)
     build_log.close()
     if upload:
-        gsutil.copy_file(paths.build_log, build_log_path)
+        gsutil.copy_file(paths.build_log, build_log_path, args.compress)
     if exc_type:
         raise exc_type, exc_value, exc_traceback  # pylint: disable=raising-bad-type
     if not success:
@@ -1140,6 +1141,11 @@ def parse_args(arguments=None):
     parser.add_argument('--root', default='.', help='Root dir to work with')
     parser.add_argument(
         '--timeout', type=float, default=0, help='Timeout in minutes if set')
+    parser.add_argument(
+        '--compress',
+        action='store_true',
+        help='Compress build-log.txt when set',
+    )
     parser.add_argument(
         '--repo',
         action='append',

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1082,6 +1082,7 @@ class FakeArgs(object):
     upload = UPLOAD
     json = False
     scenario = ''
+    compress = False
 
     def __init__(self, **kw):
         self.branch = BRANCH
@@ -1120,6 +1121,18 @@ class BootstrapTest(unittest.TestCase):
         for stub in self.boiler:
             with stub:  # Leaving with restores things
                 pass
+
+
+    def test_compress(self):
+        compressed = lambda s, d, o, c: self.assertTrue(c, 'failed to find compression')
+        uncompressed = lambda s, d, o, c: self.assertFalse(c, 'failed to find uncompression')
+        with Stub(bootstrap.GSUtil, 'copy_file', uncompressed):
+            test_bootstrap()
+        with Stub(bootstrap.GSUtil, 'copy_file', compressed):
+            test_bootstrap(compress=True)
+        with Stub(bootstrap.GSUtil, 'copy_file', uncompressed):
+            test_bootstrap(compress=False)
+
 
     def test_setcreds_setroot_fails(self):
         """We should still call setup_credentials even if setup_root blows up."""


### PR DESCRIPTION
/assign @michelle192837 @Katharine 

Eventually I want to do the reverse -- enable pod utils to upload using compression. But there's actually a bug in ResultStore right now where it can't display compressed logs.

So until then lets use uncompressed. Once it is fixed I'll switch back.