### PR TITLE
image promoter: use stricter run_if_changed regex

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-k8sio-cip
     decorate: true
     skip_report: false
-    run_if_changed: ".*/manifest.yaml"
+    run_if_changed: "k8s.gcr.io/.*/manifest.yaml"
     max_concurrency: 10
     branches:
     - ^master$

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -75,7 +75,7 @@ postsubmits:
   - name: post-k8sio-cip
     cluster: test-infra-trusted
     decorate: true
-    run_if_changed: ".*/manifest.yaml"
+    run_if_changed: "k8s.gcr.io/.*/manifest.yaml"
     # Never run more than 1 job at a time. This is because we don't want to run
     # into a case where an older manifest PR merge gets run last (after a newer
     # one).


### PR DESCRIPTION
    Though unlikely, it could be that a file "manifest.yaml" is used
    elsewhere for a purpose wholly unrelated to image promotion. We don't
    want those unrelated PRs to be gated by the image promotion check.