### PR TITLE
Fix BOSKOS_HOST value

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -39,7 +39,7 @@ periodics:
       - e2e
       env:
       - name: BOSKOS_HOST
-        value: "http://boskos.test-pods.svc.cluster.local."
+        value: "boskos.test-pods.svc.cluster.local"
       securityContext:
         privileged: true
 postsubmits:
@@ -65,6 +65,6 @@ postsubmits:
         - e2e
         env:
         - name: BOSKOS_HOST
-          value: "http://boskos.test-pods.svc.cluster.local."
+          value: "boskos.test-pods.svc.cluster.local"
         securityContext:
           privileged: true


### PR DESCRIPTION
Remove the leading http:// as the Python httplib expects only a
hostname.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>

/cc @harishspqr @detiber 