### PR TITLE
[boskos] Update metrics for aws-accounts and clean doc references to 'clean' state

### DIFF
--- a/boskos/README.md
+++ b/boskos/README.md
@@ -16,7 +16,7 @@ A resource yaml looks looks like:
 ---
 resources:
   - type: "aws-account"
-    state: clean
+    state: free
     names:
     - "account1"
     - "account2"
@@ -172,7 +172,7 @@ and reset the stale resources to dirty state for the [`Janitor`] component to pi
 state leaks if a client process is killed unexpectedly.
 
 [`Janitor`] looks for dirty resources from boskos, and will kick off sub-janitor process to clean up the
-resource, finally return them back to boskos in a clean state.
+resource, finally return them back to boskos in a free state.
 
 [`Metrics`] is a separate service, which can display json metric results, and has HTTP endpoint
 opened for prometheus monitoring.
@@ -198,7 +198,7 @@ For the boskos server that handles k8s e2e jobs, the status is available from th
 
 1. Check it out: 
     ```shell
-    curl -X POST "http://localhost:8080/acquire?type=my-resource&state=clean&dest=busy&owner=$(whoami)"
+    curl -X POST "http://localhost:8080/acquire?type=my-resource&state=free&dest=busy&owner=$(whoami)"
     {"type":"my-resource","name":"resource1","state":"busy","owner":"user","lastupdate":"2019-02-07T22:33:38.01350902Z","userdata":null}
     ```
 
@@ -209,7 +209,7 @@ For the boskos server that handles k8s e2e jobs, the status is available from th
 
 1. Check it back in:
     ```shell
-    curl -X POST 'http://localhost:8080/release?name=liz2&dest=clean&owner=user'
+    curl -X POST 'http://localhost:8080/release?name=liz2&dest=free&owner=user'
     ```
 
 ## Local test:

--- a/boskos/metrics/deployment.yaml
+++ b/boskos/metrics/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       - name: metrics
         image: gcr.io/k8s-testimages/metrics:v20180604-ea866c2e8
         args:
-        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project
+        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account
         ports:
           - containerPort: 8080
             protocol: TCP

--- a/boskos/reaper/deployment.yaml
+++ b/boskos/reaper/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         image: gcr.io/k8s-testimages/reaper:v20190319-1a5a7d7fb
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project
+        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2503,7 +2503,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds
   num_columns_recent: 20
 - name: ci-cluster-api-provider-aws-bazel-e2e
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/ci-cluster-api-provider-aws-bazel-e2e
+  gcs_prefix: kubernetes-jenkins/logs/directory/ci-cluster-api-provider-aws-bazel-e2e
   num_columns_recent: 20
 - name: pull-cluster-api-provider-aws-bazel-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-aws-bazel-verify
@@ -6124,7 +6124,7 @@ dashboards:
     test_group_name: periodic-cluster-api-provider-aws-test-creds
   - name: bazel-periodic-e2e
     test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
-  - name: bazel-pr-e2e
+  - name: bazel-ci-e2e
     test_group_name: ci-cluster-api-provider-aws-bazel-e2e
 
 - name: sig-cluster-lifecycle-cluster-api-provider-azure


### PR DESCRIPTION
- Update boskos metrics to add  aws-accounts to the config
- Update boskos reaper to add aws-accounts to the config
- Cleanup boskos doc references to 'clean' state instead of 'free' state
- Also fixes the test-grid config for the ci-cluster-api-provider-aws job