### PR TITLE
Remove Travis CI dependency for k/website

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -210,9 +210,6 @@ branch-protection:
             - continuous-integration/travis-ci
         website:
           protect: false # TODO(fejta): protect all branches soon
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
           branches:
             master:
               protect: true


### PR DESCRIPTION
With [this PR](https://github.com/kubernetes/website/pull/13598) Travis CI will no longer be required for the website repo.