### PR TITLE
set --kube-root in kind e2e scripts

### DIFF
--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -66,7 +66,7 @@ build() {
     fi
 
     # build the node image w/ kubernetes
-    kind build node-image --type=bazel
+    kind build node-image --type=bazel --kube-root="${PWD}"
 
     # make sure we have e2e requirements
     #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"


### PR DESCRIPTION
temporary work around, but a reasonable enough thing to do anyhow, we specify the path to the kubernetes sources when building. these scripts are also supposed to be temporary.

we need these because the current source directory auto detection doesn't work now that kubernetes is a god module

/cc @dims @fejta @amwat 