### PR TITLE
opt kubernetes-sigs/kind approvals into ignore_review_state: false

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -86,6 +86,7 @@ approve:
   - kubernetes/community
   - kubernetes/org
   - kubernetes/test-infra
+  - kubernetes-sigs/kind
   require_self_approval: false
   ignore_review_state: false
 - repos:
@@ -128,6 +129,9 @@ lgtm:
   - kubernetes/test-infra
   review_acts_as_lgtm: true
   store_tree_hash: true
+- repos:
+  - kubernetes-sigs/kind
+  review_acts_as_lgtm: true
 
 blockades:
 - repos:


### PR DESCRIPTION
This mode is nice. Looking forward to it being the default, going to go ahead and opt our repo into it as well.

/cc @fejta 
/assign @fejta 

FYI @amwat @neolit123 @munnerz -- github approval via the native approval mechanism will equal `/lgtm`+`/approve`, which may be the default for more repos at some point.