### PR TITLE
Remove stale approve plugin tests.

### DIFF
--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -72,12 +72,6 @@ func TestPluginConfig(t *testing.T) {
 			}
 		}
 	}
-	for repo := range repos {
-		org := strings.Split(repo, "/")[0]
-		if orgs[org] {
-			t.Errorf("The repo %q is duplicated with %q in the 'approve' plugin configuration.", repo, org)
-		}
-	}
 }
 
 func newTestComment(user, body string) github.IssueComment {


### PR DESCRIPTION
This test is no longer applicable after https://github.com/kubernetes/test-infra/pull/10438

ref https://github.com/kubernetes/test-infra/pull/12059
/assign @BenTheElder @cblecker 