### PR TITLE
triage: Use strings for build numbers

### DIFF
--- a/triage/render.js
+++ b/triage/render.js
@@ -126,7 +126,10 @@ function renderJobs(parent, clusterId) {
 
   var jobList = addElement(parent, 'ul');
   for (let [job, buildNumbersSet] of jobs) {
-    let buildNumbers = Array.from(buildNumbersSet).sort((a,b) => b - a);
+    // This sort isn't strictly correct - our numbers are too large - but in practice we shouldn't
+    // have ID numbers this similar anyway, and it's not fatal if builds this close together
+    // are sorted wrong.
+    let buildNumbers = Array.from(buildNumbersSet).sort((a,b) => Number(b) - Number(a));
     var count = counts[job];
     if (jobs.length > kCollapseThreshold && !jobAllSection && countSum > 0.8 * dayCount) {
       addElement(jobList, 'button', {className: 'rest', title: 'Show Daily Bottom 20%'}, 'More');

--- a/triage/summarize.py
+++ b/triage/summarize.py
@@ -417,7 +417,7 @@ def clusters_to_display(clustered, builds):
         "text": clusters[0][1][0]['failure_text'],
         "tests": [{
             "name": test_name,
-            "jobs": [{"name": n, "builds": b}
+            "jobs": [{"name": n, "builds": [str(x) for x in b]}
                      for n, b in tests_group_by_job(tests, builds)]
             }
                   for test_name, tests in sorted(clusters, key=lambda (n, t): (-len(t), n))
@@ -510,7 +510,7 @@ def annotate_owners(data, builds, owners):
                     continue
                 job_path = job_paths[job['name']]
                 for build in job['builds']:
-                    if builds['%s/%d' % (job_path, build)]['started'] > yesterday:
+                    if builds['%s/%s' % (job_path, build)]['started'] > yesterday:
                         counts[0] += 1
                     else:
                         counts[1] += 1

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -119,7 +119,7 @@ class ClusterTest(unittest.TestCase):
                     'cols': {'started': [now]}
                 },
                 'clustered': [
-                    {'tests': [{'name': test, 'jobs': [{'name': 'somejob', 'builds': [123]}]}]}
+                    {'tests': [{'name': test, 'jobs': [{'name': 'somejob', 'builds': ['123']}]}]}
                 ],
             }
             summarize.annotate_owners(
@@ -237,7 +237,7 @@ class IntegrationTest(unittest.TestCase):
             output['clustered'],
             [{'id': random_hash_1,
               'key': 'some awful stack trace exit 1',
-              'tests': [{'jobs': [{'builds': [4, 3, 2, 1],
+              'tests': [{'jobs': [{'builds': ['4', '3', '2', '1'],
                                    'name': 'some-job'}],
                          'name': 'example test'}],
               'spans': [29],
@@ -245,10 +245,10 @@ class IntegrationTest(unittest.TestCase):
               'text': 'some awful stack trace exit 1'},
              {'id': random_hash_2,
               'key': 'some other error message',
-              'tests': [{'jobs': [{'builds': [7, 5],
+              'tests': [{'jobs': [{'builds': ['7', '5'],
                                    'name': 'other-job'}],
                          'name': 'unrelated test'},
-                        {'jobs': [{'builds': [4], 'name': 'some-job'}],
+                        {'jobs': [{'builds': ['4'], 'name': 'some-job'}],
                          'name': 'another test'}],
               'spans': [24],
               'owner': 'testing',


### PR DESCRIPTION
Snowflake IDs are getting rounded off because they use more than 53 bits, which is resulting in triage being broken.