### PR TITLE
Add the liveness and readiness probes to hook deployment

### DIFF
--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -67,6 +67,19 @@ spec:
         - name: cat-api
           mountPath: /etc/cat-api
           readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
       volumes:
       - name: slack
         secret:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -158,6 +158,19 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
       volumes:
       - name: hmac
         secret:


### PR DESCRIPTION
This PR need to be merged only after https://github.com/kubernetes/test-infra/pull/12011 is released.