### PR TITLE
Prevent tooltips from inheriting 'pre' white-space style.

### DIFF
--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -163,6 +163,7 @@ export namespace tooltip {
     tip.appendChild(tipElem);
     tip.setAttribute("data-mdl-for", elemID);
     tip.classList.add("mdl-tooltip", "mdl-tooltip--large");
+    tip.style.whiteSpace = "normal";
     return tip;
   }
 }


### PR DESCRIPTION
Some `td` elements on the tide-history page use `"white-space": "pre"` which is inherited by the PR title tooltips and causes them to display incorrectly. This PR prevents that by explicitly setting the tooltip's `white-space` style property.

I validated this has the intended effect with Deck's `runlocal` script.
/assign @Katharine 