### PR TITLE
Added a pull-test-infra-bazel-rbe job.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -197,3 +197,15 @@ filegroup(
 )
 
 exports_files(["tsconfig.json"])
+
+platform(
+    name = "rbe_with_network",
+    parents = ["@rbe_default//config:platform"],
+    remote_execution_properties = """
+      properties: {
+        name: "dockerNetwork"
+        value: "standard"
+      }
+      {PARENT_REMOTE_EXECUTION_PROPERTIES}
+    """,
+)

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -53,6 +53,31 @@ presubmits:
           requests:
             memory: "2Gi"
 
+  - name: pull-test-infra-bazel-rbe
+    branches:
+    - master
+    always_run: true
+    skip_report: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-experimental
+        command:
+        - runner.sh
+        - ./scenarios/kubernetes_execute_bazel.py
+        args:
+        - hack/rbe-build-then-unit.sh
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "2Gi"
+
   - name: pull-test-infra-gubernator
     branches:
     - master

--- a/hack/rbe-build-then-unit.sh
+++ b/hack/rbe-build-then-unit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# used in presubmits / CI testing
+# bazel build then unit test, exiting non-zero if either failed
+
+res=0
+
+bazel --bazelrc=rbe.bazelrc build //... --config=remote --remote_instance_name=projects/rbe-eytankidron-prod-0/instances/default_instance
+if [[ $? -ne 0 ]]; then
+    res=1
+fi
+
+bazel --bazelrc=rbe.bazelrc test //... --config=unit --config=remote --remote_instance_name=projects/rbe-eytankidron-prod-0/instances/default_instance
+if [[ $? -ne 0 ]]; then
+    res=1
+fi
+
+exit ${res}

--- a/rbe.bazelrc
+++ b/rbe.bazelrc
@@ -24,9 +24,9 @@ build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 # by "extra_execution_platforms", "host_platform" and "platforms".
 # More about platforms: https://docs.bazel.build/versions/master/platforms.html
 build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
-build:remote --extra_execution_platforms=@rbe_default//config:platform
-build:remote --host_platform=@rbe_default//config:platform
-build:remote --platforms=@rbe_default//config:platform
+build:remote --extra_execution_platforms=:rbe_with_network
+build:remote --host_platform=:rbe_with_network
+build:remote --platforms=:rbe_with_network
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2743,6 +2743,9 @@ test_groups:
 - name: pull-test-infra-bazel-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
   num_columns_recent: 20
+- name: pull-test-infra-bazel-rbe
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-rbe
+  num_columns_recent: 20
 - name: pull-test-infra-lint
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
   num_columns_recent: 20
@@ -7521,6 +7524,9 @@ dashboards:
   dashboard_tab:
   - name: bazel
     test_group_name: pull-test-infra-bazel
+    base_options: width=10
+  - name: bazel-rbe
+    test_group_name: pull-test-infra-bazel-rbe
     base_options: width=10
   - name: lint
     test_group_name: pull-test-infra-lint


### PR DESCRIPTION
This job is similar to pull-test-infra-bazel except it runs
hack/rbe-build-then-unit.sh instead of hack/build-then-unit.sh.

hack/rbe-build-then-unit.sh runs the build and test on RBE (Remote Build Execution).

This is temporary. Eventually, if this workes well, the plan is to
remove this new job and just have hack/build-then-unit.sh run on RBE. We
would also need to use a dedicated k8s GCP project, not
rbe-eytankidron-prod-0.

When I tested this manually (not through prow), I saw that the RBE tests
run faster, but they don't all pass (I see four tests failing and one
timing out). We would need to debug these tests and see why that is.