### PR TITLE
fix promoter arguments and also bump one more time

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190404-v1.0.2-2-g41b62df
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190404-v1.0.2-2-g41b62df
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
         command:
         - multirun.sh
         args:
@@ -727,7 +727,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190404-v1.0.2-2-g41b62df
+    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
       command:
       - multirun.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -438,9 +438,9 @@ postsubmits:
         - multirun.sh
         args:
         - /app/cip-docker-image.binary
-        - k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-        - k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-        - k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
         env:
         - name: CIP_OPTS
           value: "-dry-run=false"
@@ -738,9 +738,9 @@ periodics:
       # If you run mkpj for this postsubmit, the job will query you for the base
       # ref to fetch (name of a branch, not a SHA, e.g. "master").
       - /app/cip-docker-image.binary
-      - k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-      - k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-      - k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
       env:
       - name: CIP_OPTS
         value: "-dry-run=false"


### PR DESCRIPTION
The arguments to the {ci,post}-k8sio-cip jobs are wrong (missing a path prefix). This fix has been verified already in the pull-k8sio-cip job.

Also, use a newer set of images that are more verbose, so that the promoter runs are easier to parse for humans.