### PR TITLE
bump promoter images

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
         command:
         - multirun.sh
         args:
@@ -727,7 +727,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.3-0-gdf34e5f
+    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
       command:
       - multirun.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -704,6 +704,7 @@ periodics:
 # ci-k8sio-cip runs daily, to make sure that the destination GCRs do not deviate
 # away from the intent of the manifest.
 - interval: 24h
+  cluster: test-infra-trusted
   max_concurrency: 1
   # This name is the "job name", passed in as "--job=NAME" for mkpj.
   name: ci-k8sio-cip


### PR DESCRIPTION
This fixes a Google SDK crash (version 234.0.0) by updating the
promoter's base image to version 241.0.0, and also increases verbosity
of the promoter to make Prow job logs more informative.

/cc @fejta 