### PR TITLE
bump promoter image

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
         command:
         - multirun.sh
         args:
@@ -728,7 +728,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.4-0-gc882e4a
+    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
       command:
       - multirun.sh
       args:


### PR DESCRIPTION
This fixes a bug in the promoter's multirun.sh where it was calling the promoter binary without the correct `-version` argument, causing it to terminate prematurely (because it attempted to run with the default `manifest.yaml` path, which is invalid for these jobs).

Upstream fix here: https://github.com/kubernetes-sigs/k8s-container-image-promoter/commit/36b6c52c5dc2e3964dcf833c2ba340b6198f11c5