### PR TITLE
bump promoter image

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
         command:
         - multirun.sh
         args:
@@ -728,7 +728,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.5-0-g314afe0
+    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
       command:
       - multirun.sh
       args:


### PR DESCRIPTION
This includes a fix in the shell code where we were trying to reference
a variable too early, and because of `set -o nounset`, the script was
exiting prematurely.

/cc @Katharine

Logs of (correct behavior) when testing locally:
```
 $ docker run --rm -it -v $HOME/secure:/secure -v $HOME/go:/go gcr.io/cip-demo-staging/cip:latest "multirun.sh /cip/cip /go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/secure/sa1.json /go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/secure/sa1.json"
MULTIRUN: container image promoter version:
Built:   2019-04-05 18:02:02+00:00
Version: v1.0.5-2-g58ea950
Commit:  58ea950d130d5b9bcd6fd8661284ac1031f267d0
MULTIRUN: gcloud version:
Google Cloud SDK 241.0.0
alpha 2019.04.02
app-engine-go 
app-engine-java 1.9.73
app-engine-python 1.9.85
app-engine-python-extras 1.9.85
beta 2019.04.02
bigtable 
bq 2.0.43
cbt 
cloud-datastore-emulator 2.1.0
core 2019.04.02
datalab 20190116
gsutil 4.38
kubectl 2019.04.02
pubsub-emulator 2019.04.02

MULTIRUN: running against /go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
MULTIRUN: activating service account /secure/sa1.json
Activated service account credentials for: [k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com]
No images in manifest --- nothing to do.
MULTIRUN: revoking service account(s) k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
WARNING: [k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com] appears to be a service account. Service account tokens cannot be revoked, but they will expire automatically. To prevent use of the service account token earlier than the expiration, revoke the parent service account or service account key.
Revoked credentials:
 - k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com

MULTIRUN: running against /go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
MULTIRUN: activating service account /secure/sa1.json
Activated service account credentials for: [k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com]
No images in manifest --- nothing to do.
MULTIRUN: revoking service account(s) k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
WARNING: [k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com] appears to be a service account. Service account tokens cannot be revoked, but they will expire automatically. To prevent use of the service account token earlier than the expiration, revoke the parent service account or service account key.
Revoked credentials:
 - k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
```