### PR TITLE
Added Config Slice For GitHub API Endpoints

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -46,6 +46,11 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
+github:
+  api_endpoints:
+    - http://ghproxy
+    - https://api.github.com
+
 branch-protection:
   allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
   orgs:

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -53,7 +53,7 @@ const (
 	DefaultJobTimeout = 24 * time.Hour
 
 	// githubAPIEndpoints represents the default github api endpoints.
-	githubAPIEndpoints = []string{"https://api.github.com"}
+	githubAPIEndpoint = "https://api.github.com"
 )
 
 // Config is a read-only snapshot of the config.
@@ -1064,7 +1064,7 @@ func parseProwConfig(c *Config) error {
 	}
 	c.GitHubOptions.LinkURL = linkURL
 	if len(c.GitHubOptions.APIEndpoints) == 0 {
-		c.GitHubOptions.APIEndpoints = githubAPIEndpoints
+		c.GitHubOptions.APIEndpoints = []string{githubAPIEndpoint}
 	}
 	for k, v := range c.GitHubOptions.APIEndpoints {
 		_, err := url.Parse(v)


### PR DESCRIPTION
Fixes: #11224 

This PR adds a config slice option for overriding the default GitHub API Endpoint of `https://api.github.com`. This option would be used like so:

config.yaml
```
github:
  api_endpoints:
    - http://ghproxy
    - https://api.github.com
```

This PR hasn't converted any applications to use this functionality, just introduces the config option.

/cc @fejta @stevekuznetsov 