### PR TITLE
bump promoter images

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
+      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
         command:
         - multirun.sh
         args:
@@ -728,7 +728,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.6-0-gca782a0
+    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
       command:
       - multirun.sh
       args:


### PR DESCRIPTION
This change pulls in this upstream fix: https://github.com/kubernetes-sigs/k8s-container-image-promoter/commit/f2e043734db636b4b83b2ab2f4eceef27cd058b0