### PR TITLE
Add an area/blog label for the website repo

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -278,6 +278,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/blog" href="#area/blog">`area/blog`</a> | Issues or PRs related to the Kubernetes Blog subproject| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/de" href="#language/de">`language/de`</a> | Issues or PRs related to German language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/en" href="#language/en">`language/en`</a> | Issues or PRs related to English language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/fr" href="#language/fr">`language/fr`</a> | Issues or PRs related to French language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1031,6 +1031,12 @@ repos:
         addedBy: label
   kubernetes/website:
     labels:
+      - color: 0ffa16
+        description: Issues or PRs related to the Kubernetes Blog subproject
+        name: area/blog
+        target: both
+        prowPlugin: label 
+        addedBy: anyone
       - color: e9b3f9
         description: Issues or PRs related to German language
         name: language/de


### PR DESCRIPTION
This PR adds a new label to k/website: `area/blog`, for issues and PRs related to the Kubernetes blog.

/sig docs
/area label_sync

/cc @kbarnard10 @parispittman 