### PR TITLE
Fix GCE conformance latest 1.14 (using latest release instead of latest commit)

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
@@ -96,7 +96,7 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --extract=release/latest-1.14
+      - --extract=ci/latest-1.14
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
Fix for kubernetes/release#694 (job is using stable instead of latest)

cc @tpepper 