### PR TITLE
Adding istio e2e-kind-simpleTests postsubmit test to testgrid

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3103,6 +3103,9 @@ test_groups:
 - name: istio-e2e-simpleTests-minProfile
   gcs_prefix: istio-prow/logs/e2e-simpleTestsMinProfile
   num_failures_to_alert: 1
+- name: istio-e2e-kind-simpleTests
+  gcs_prefix: istio-prow/logs/e2e-kind-simpleTests
+  num_failures_to_alert: 1
 # Istio CircleCI Presubmits
 - name: istio-circleci-e2e-simple-presubmit
   gcs_prefix: istio-circleci/presubmit/e2e-simple


### PR DESCRIPTION
we want to see whether e2e tests on KIND is less flaky compared to using boskos resources.
Adding e2e-kind-simpleTests onto test grid for easier observation.
https://github.com/istio/istio/issues/12230