### PR TITLE
Add image bumping tool

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -54,6 +54,7 @@ filegroup(
         "//experiment/aws-stockout:all-srcs",
         "//experiment/ci-janitor:all-srcs",
         "//experiment/coverage:all-srcs",
+        "//experiment/image-bumper:all-srcs",
         "//experiment/manual-trigger:all-srcs",
         "//experiment/resultstore:all-srcs",
         "//experiment/slack-oncall-updater:all-srcs",

--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -19,46 +19,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# darwin is great
-SED="sed"
-if which gsed &>/dev/null; then
-  SED="gsed"
-fi
-if ! (${SED} --version 2>&1 | grep -q GNU); then
-  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
-  exit 1
-fi
-
-dirty="$(git status --porcelain)"
-if [[ -n "${dirty}" ]]; then
-  echo "Tree not clean:"
-  echo "${dirty}"
-  exit 1
-fi
-
 TREE="$(git rev-parse --show-toplevel)"
 
-DATE="$(date +v%Y%m%d)"
-TAG="${DATE}-$(git describe --tags --always --dirty)"
- 
-make -C "${TREE}/images/kubekins-e2e" push
-K8S=experimental make -C "${TREE}/images/kubekins-e2e" push
-K8S=1.14 make -C "${TREE}/images/kubekins-e2e" push
-K8S=1.13 make -C "${TREE}/images/kubekins-e2e" push
-K8S=1.12 make -C "${TREE}/images/kubekins-e2e" push
-K8S=1.11 make -C "${TREE}/images/kubekins-e2e" push
-
-echo "TAG = ${TAG}"
-
-${SED} -i "s/\\/kubekins-e2e:v.*$/\\/kubekins-e2e:${TAG}-master/" "${TREE}/experiment/generate_tests.py"
-${SED} -i "s/\\/kubekins-e2e:v.*-\\(.*\\)$/\\/kubekins-e2e:${TAG}-\\1/" "${TREE}/experiment/test_config.yaml"
+bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e "${TREE}/experiment/generate_tests.py" "${TREE}/experiment/test_config.yaml" "${TREE}/prow/config.yaml"
+find "${TREE}/config/jobs/" . -name "*.yaml" | xargs bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e
 
 bazel run //experiment:generate_tests -- \
   "--yaml-config-path=${TREE}/experiment/test_config.yaml" \
   "--output-dir=${TREE}/config/jobs/kubernetes/generated/"
 
-# Scan for kubekins-e2e:v.* as a rudimentary way to avoid
-# replacing :latest.
-${SED} -i "s/\\/kubekins-e2e:v.*-\\(.*\\)$/\\/kubekins-e2e:${TAG}-\\1/" "${TREE}/prow/config.yaml"
-find "${TREE}/config/jobs/" -type f -name \*.yaml -exec ${SED} -i "s/\\/kubekins-e2e:v.*-\\(.*\)$/\\/kubekins-e2e:${TAG}-\\1/" {} \;
-git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}-(master|experimental|releases) (using generate_tests and manual)"
+git commit -am "Bump gcr.io/k8s-testimages/kubekins-e2e (using generate_tests and manual)"

--- a/experiment/image-bumper/BUILD.bazel
+++ b/experiment/image-bumper/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,13 +16,19 @@ go_binary(
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
-    visibility = ["//visibility:private"],
     tags = ["automanaged"],
+    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
-    visibility = ["//visibility:public"],
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
 )

--- a/experiment/image-bumper/BUILD.bazel
+++ b/experiment/image-bumper/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/image-bumper",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "image-bumper",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:private"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "all-srcs",
+    visibility = ["//visibility:public"],
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/experiment/image-bumper/README.md
+++ b/experiment/image-bumper/README.md
@@ -1,0 +1,39 @@
+# image-bumper
+
+`image-bumper` helps update image references to the latest tag in config files. It understands k8s test-infra
+image tagging conventions, and uses this to inform what it considers the latest tag.
+
+In particular, `image-bumper` expects images in either `vYYYYMMDD-githash` form. It also accepts
+`git describe` output in place of `githash`, assuming your tags look like version numbers. In this
+case, your tag might look like e.g. `v1.14.0-alpha.0-4321-gac16ac7cbe`.
+
+`image-bumper` accepts image variants indicated by suffixes on those tags. For instance,
+`v20190404-928d18687-1.11` and `v20190404-928d18687-1.12` are understood to be different, and
+`image-bumper` will find the latest tag for both the `-1.11` and `-1.12` suffixes, and will not
+merge them together.
+
+## Usage
+
+```
+bazel run //experiment/image-bumper -- [options] files...
+```
+
+### Options
+
+* `--image-regex`: only touch image references matching this regex. Note that they must still be
+                   hosted on *.gcr.io even if this is specigfied
+
+### Examples
+
+```
+bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/ config/**.yaml
+```
+
+Updates every image referencing the `k8s-testimages` project in the config directory (assuming
+your shell understands `**`, e.g. fish, or bash with `globstar` enabled)
+
+```
+bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-prow/ prow/**.yaml
+```
+
+Updates prow references to the latest versions.

--- a/experiment/image-bumper/main.go
+++ b/experiment/image-bumper/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	imageRegexp = regexp.MustCompile(`\b(gcr\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\b`)
+	imageRegexp = regexp.MustCompile(`\b((?:[a-z0-9]+\.)?gcr\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\b`)
 	tagRegexp   = regexp.MustCompile(`(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?`)
 	tagCache    = map[string]string{}
 )

--- a/experiment/image-bumper/main.go
+++ b/experiment/image-bumper/main.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+var imageRegexp *regexp.Regexp
+var tagRegexp *regexp.Regexp
+var tagCache map[string]string
+
+func init() {
+	imageRegexp = regexp.MustCompile("\\b(gcr\\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\\b")
+	tagRegexp = regexp.MustCompile("(v?[0-9]{8}-(?:v\\d(?:[.-]\\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?")
+	tagCache = make(map[string]string)
+}
+
+const (
+	imageHostPart  = 1
+	imageImagePart = 2
+	imageTagPart   = 3
+	tagVersionPart = 1
+	tagExtraPart   = 2
+)
+
+func findLatestTag(imageHost, imageName, currentTag string) (string, error) {
+	k := imageHost + "/" + imageName + ":" + currentTag
+	if result, ok := tagCache[k]; ok {
+		return result, nil
+	}
+
+	currentTagParts := tagRegexp.FindStringSubmatch(currentTag)
+	if currentTagParts == nil {
+		return "", fmt.Errorf("couldn't figure out the current tag in %q", currentTag)
+	}
+	if currentTagParts[tagVersionPart] == "latest" {
+		return currentTag, nil
+	}
+
+	resp, err := http.Get("https://" + imageHost + "/v2/" + imageName + "/tags/list")
+	if err != nil {
+		return "", fmt.Errorf("couldn't fetch tag list: %v", err)
+	}
+
+	result := struct {
+		Manifest map[string]struct {
+			TimeCreatedMs string   `json:"timeCreatedMs"`
+			Tags          []string `json:"tag"`
+		}
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("couldn't parse tag information from registry: %v", err)
+	}
+
+	// The approach is to find the most recently created image that has the same suffix as the
+	// current tag. However, if we find one called "latest" (with appropriate suffix), we assume
+	// that's the latest regardless of when it was created.
+
+	var latestTime int64
+	latestTag := ""
+	for _, v := range result.Manifest {
+		bestVariant := ""
+		override := false
+		for _, t := range v.Tags {
+			parts := tagRegexp.FindStringSubmatch(t)
+			if parts == nil {
+				continue
+			}
+			if parts[tagExtraPart] != currentTagParts[tagExtraPart] {
+				continue
+			}
+			if parts[tagVersionPart] == "latest" {
+				override = true
+				continue
+			}
+			if bestVariant == "" || len(t) < len(bestVariant) {
+				bestVariant = t
+			}
+		}
+		if bestVariant == "" {
+			continue
+		}
+		t, err := strconv.ParseInt(v.TimeCreatedMs, 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("couldn't parse timestamp %q: %v", v.TimeCreatedMs, err)
+		}
+		if override || t > latestTime {
+			latestTime = t
+			latestTag = bestVariant
+			if override {
+				break
+			}
+		}
+	}
+
+	if latestTag == "" {
+		return "", fmt.Errorf("failed to find a good tag")
+	}
+
+	tagCache[k] = latestTag
+
+	return latestTag, nil
+}
+
+func updateFile(path string, imageFilter *regexp.Regexp) error {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", path, err)
+	}
+
+	indexes := imageRegexp.FindAllSubmatchIndex(content, -1)
+	// Not finding any images is not an error.
+	if indexes == nil {
+		return nil
+	}
+
+	newContent := make([]byte, 0, len(content))
+	lastIndex := 0
+	for _, m := range indexes {
+		newContent = append(newContent, content[lastIndex:m[imageTagPart*2]]...)
+		host := string(content[m[imageHostPart*2]:m[imageHostPart*2+1]])
+		image := string(content[m[imageImagePart*2]:m[imageImagePart*2+1]])
+		tag := string(content[m[imageTagPart*2]:m[imageTagPart*2+1]])
+		lastIndex = m[1]
+
+		if tag == "" || (imageFilter != nil && !imageFilter.MatchString(host+"/"+image+":"+tag)) {
+			newContent = append(newContent, content[m[imageTagPart*2]:m[1]]...)
+			continue
+		}
+
+		latest, err := findLatestTag(host, image, tag)
+		if err != nil {
+			log.Printf("Failed to update %s/%s:%s: %v.\n", host, image, tag, err)
+			newContent = append(newContent, content[m[imageTagPart*2]:m[1]]...)
+			continue
+		}
+		newContent = append(newContent, []byte(latest)...)
+	}
+	newContent = append(newContent, content[lastIndex:]...)
+	if err := ioutil.WriteFile(path, newContent, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %v", path, err)
+	}
+	return nil
+}
+
+type options struct {
+	imageRegex string
+	files      []string
+}
+
+func parseOptions() options {
+	var o options
+	flag.StringVar(&o.imageRegex, "image-regex", "", "Only touch images matching this regex")
+	flag.Parse()
+	o.files = flag.Args()
+	return o
+}
+
+func main() {
+	o := parseOptions()
+	var imageRegex *regexp.Regexp
+	if o.imageRegex != "" {
+		var err error
+		imageRegex, err = regexp.Compile(o.imageRegex)
+		if err != nil {
+			log.Fatalf("Failed to parse image-regex: %v\n", err)
+		}
+	}
+	for _, f := range o.files {
+		if err := updateFile(f, imageRegex); err != nil {
+			log.Printf("Failed to update %s: %v", f, err)
+		}
+	}
+	log.Println("Done.")
+	for before, after := range tagCache {
+		if before == after {
+			continue
+		}
+		log.Printf("%s -> %s\n", before, after)
+	}
+}

--- a/experiment/image-bumper/main.go
+++ b/experiment/image-bumper/main.go
@@ -28,15 +28,11 @@ import (
 	"strings"
 )
 
-var imageRegexp *regexp.Regexp
-var tagRegexp *regexp.Regexp
-var tagCache map[string]string
-
-func init() {
-	imageRegexp = regexp.MustCompile("\\b(gcr\\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\\b")
-	tagRegexp = regexp.MustCompile("(v?[0-9]{8}-(?:v\\d(?:[.-]\\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?")
-	tagCache = make(map[string]string)
-}
+var (
+	imageRegexp = regexp.MustCompile(`\b(gcr\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\b`)
+	tagRegexp   = regexp.MustCompile(`(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?`)
+	tagCache    = make(map[string]string)
+)
 
 const (
 	imageHostPart  = 1

--- a/experiment/image-bumper/main_test.go
+++ b/experiment/image-bumper/main_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
 
 func TestPickBestTag(t *testing.T) {
 	tests := []struct {
@@ -148,6 +152,82 @@ func TestPickBestTag(t *testing.T) {
 			}
 			if bestTag != test.bestTag {
 				t.Fatalf("Expected tag %q, but got %q instead", test.bestTag, bestTag)
+			}
+		})
+	}
+}
+
+func TestUpdateAllTags(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		expectedResult string
+		imageFilter    *regexp.Regexp
+		newTags        map[string]string
+	}{
+		{
+			name:           "file with no images does nothing",
+			content:        "this is just a normal file",
+			expectedResult: "this is just a normal file",
+		},
+		{
+			name:           "file that has only an image replaces the image",
+			content:        "gcr.io/k8s-testimages/some-image:v20190404-12345678",
+			expectedResult: "gcr.io/k8s-testimages/some-image:v20190405-123456789",
+			newTags: map[string]string{
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
+			name:           "file that has content before and after an image still has it later",
+			content:        `{"image": "gcr.io/k8s-testimages/some-image:v20190404-12345678"}`,
+			expectedResult: `{"image": "gcr.io/k8s-testimages/some-image:v20190405-123456789"}`,
+			newTags: map[string]string{
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
+			name:           "file that has multiple different images replaces both of them",
+			content:        `{"images": ["gcr.io/k8s-testimages/some-image:v20190404-12345678-master", "gcr.io/k8s-testimages/some-image:v20190404-12345678-experimental"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-testimages/some-image:v20190405-123456789-master", "gcr.io/k8s-testimages/some-image:v20190405-123456789-experimental"]}`,
+			newTags: map[string]string{
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678-master":       "v20190405-123456789-master",
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678-experimental": "v20190405-123456789-experimental",
+			},
+		},
+		{
+			name:           "file with an error image is still otherwise updated",
+			content:        `{"images": ["gcr.io/k8s-testimages/some-image:0.2", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-testimages/some-image:0.2", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			newTags: map[string]string{
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
+			name:           "images not matching the filter regex are not updated",
+			content:        `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			newTags: map[string]string{
+				"gcr.io/k8s-prow/prow-thing:v20190404-12345678":       "v20190405-123456789",
+				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+			imageFilter: regexp.MustCompile("gcr.io/k8s-testimages"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tagPicker := func(imageHost string, imageName string, imageTag string) (string, error) {
+				result, ok := test.newTags[imageHost+"/"+imageName+":"+imageTag]
+				if !ok {
+					return "", fmt.Errorf("unknown image %s/%s:%s", imageHost, imageName, imageTag)
+				}
+				return result, nil
+			}
+
+			newContent := updateAllTags(tagPicker, []byte(test.content), test.imageFilter)
+			if test.expectedResult != string(newContent) {
+				t.Fatalf("Expected content:\n%s\n\nActual content:\n%s\n\n", test.expectedResult, string(newContent))
 			}
 		})
 	}

--- a/experiment/image-bumper/main_test.go
+++ b/experiment/image-bumper/main_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestPickBestTag(t *testing.T) {
+	tests := []struct {
+		name      string
+		tag       string
+		manifest  manifest
+		bestTag   string
+		expectErr bool
+	}{
+		{
+			name: "simple lookup",
+			tag:  "v20190329-811f7954b",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190329-811f7954b"},
+				},
+			},
+			bestTag: "v20190404-65af07d",
+		},
+		{
+			name: "'latest' overrides date",
+			tag:  "v20190329-811f7954b",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999", "latest"},
+				},
+			},
+			bestTag: "v20190330-811f79999",
+		},
+		{
+			name: "tags with suffixes only match other tags with the same suffix",
+			tag:  "v20190329-811f7954b-experimental",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999-experimental"},
+				},
+			},
+			bestTag: "v20190330-811f79999-experimental",
+		},
+		{
+			name: "unsuffixed 'latest' has no effect on suffixed tags",
+			tag:  "v20190329-811f7954b-experimental",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d", "latest"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999-experimental"},
+				},
+			},
+			bestTag: "v20190330-811f79999-experimental",
+		},
+		{
+			name: "suffixed 'latest' has no effect on unsuffixed tags",
+			tag:  "v20190329-811f7954b",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+				},
+			},
+			bestTag: "v20190404-65af07d",
+		},
+		{
+			name: "'latest' with the correct suffix overrides date",
+			tag:  "v20190329-811f7954b-experimental",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d-experimental"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+				},
+			},
+			bestTag: "v20190330-811f79999-experimental",
+		},
+		{
+			name: "it is an error when no tags are found",
+			tag:  "v20190329-811f7954b-master",
+			manifest: manifest{
+				"image1": {
+					TimeCreatedMs: "2000",
+					Tags:          []string{"v20190404-65af07d-experimental"},
+				},
+				"image2": {
+					TimeCreatedMs: "1000",
+					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tagParts := tagRegexp.FindStringSubmatch(test.tag)
+			bestTag, err := pickBestTag(tagParts, test.manifest)
+			if err != nil {
+				if !test.expectErr {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				return
+			}
+			if test.expectErr {
+				t.Fatalf("Expected an error, but got result %q", bestTag)
+			}
+			if bestTag != test.bestTag {
+				t.Fatalf("Expected tag %q, but got %q instead", test.bestTag, bestTag)
+			}
+		})
+	}
+}

--- a/experiment/image-bumper/main_test.go
+++ b/experiment/image-bumper/main_test.go
@@ -204,6 +204,14 @@ func TestUpdateAllTags(t *testing.T) {
 			},
 		},
 		{
+			name:           "gcr subdomains are supported",
+			content:        `{"images": ["eu.gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["eu.gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			newTags: map[string]string{
+				"eu.gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+			},
+		},
+		{
 			name:           "images not matching the filter regex are not updated",
 			content:        `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
 			expectedResult: `{"images": ["gcr.io/k8s-prow/prow-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,


### PR DESCRIPTION
Since we now push images automatically, `bump_e2e_image.sh` has become a bad idea. We also have no good way to handle bumping any image other than `kubekins-e2e` (that I know of, anyway).

Add a tool that will bump each image to the latest version of that specific image, while respecting our conventions (in particular, suffixes like `-experimental`, etc. are considered when deciding on "latest image"). This tool can handle handle all the `gcr.io/k8s-testimages` and `gcr.io/k8s-prow` images. Unlike `bump_e2e_image.sh`, it also will avoid mangling files that are not formatted in a specific way.

I also rewrote `experiment/bump_e2e_image.sh` to use it to bump kubekins-e2e (but still nothing else). I imagine in the future an automatic periodic run might be useful, to avoid us inadvertently running ancient images when we have since changed the code.

/cc @fejta 