### PR TITLE
deck: Fix off-by-one overflow when jobs are older than 48h

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -516,7 +516,7 @@ function redraw(fz: FuzzySearch): void {
             }
             jobInterval[currentInterval][1] = successCount / totalJob;
             currentInterval++;
-            if (currentInterval > jobInterval.length) {
+            if (currentInterval >= jobInterval.length) {
                 currentInterval = -1;
             }
         }


### PR DESCRIPTION
If the prow list contained a job older than 48h (which it didn't a few hours ago, but does now) then the page would partially render and error.  Would affect current prow overview page but varies during the day.