### PR TITLE
Add PullRequestActionReadyForReview in events

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -184,6 +184,8 @@ const (
 	PullRequestActionReopened = "reopened"
 	// PullRequestActionSynchronize means the git state changed.
 	PullRequestActionSynchronize = "synchronize"
+	// PullRequestActionReadyForReview means the draft PR is now ready for review
+	PullRequestActionReadyForReview = "ready_for_review"
 )
 
 // PullRequestEvent is what GitHub sends us when a PR is changed.

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -46,6 +46,7 @@ var (
 		github.PullRequestActionClosed:               true,
 		github.PullRequestActionReopened:             true,
 		github.PullRequestActionSynchronize:          true,
+		github.PullRequestActionReadyForReview:       true,
 	}
 )
 


### PR DESCRIPTION
The k8s-ci-bot adds a do-not-merge/wip label to draft PRs when they are sent. Even when the status of the PR changes from draft to ready-for-review the label is not removed. Earlier github did not send events when the status of a PR changed but that is fixed now. The PRs fixes this bug by adding an event PullRequestActionReadyForReview.

Related issue [11939](https://github.com/kubernetes/test-infra/issues/11939)