### PR TITLE
Add fejta-bot to kubernetes-sigs/kubespray

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- ant31
+- mattymo
+- atoms
+- chadswen
+- rsmitty
+- bogdando
+- bradbeam
+- woopstar
+- riverzhang
+- holser
+- smana
+- verwilst

--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-fejta-bot-periodics.yaml
@@ -1,0 +1,106 @@
+# this file should contain all periodic jobs that use the fejta-bot token
+periodics:
+- name: periodic-kubespray-close
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20190408-5796ba99f
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=repo:kubernetes-sigs/kubespray
+        -label:lifecycle/frozen
+        label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Rotten issues close after 30d of inactivity.
+        Reopen the issue with `/reopen`.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+        Send feedback to sig-testing, kubernetes/test-infra and/or [fejta](https://github.com/fejta).
+        /close
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+- name: periodic-kubespray-rotten
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20190408-5796ba99f
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=repo:kubernetes-sigs/kubespray
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Stale issues rot after 30d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+        Rotten issues close after an additional 30d of inactivity.
+
+        If this issue is safe to close now please do so with `/close`.
+
+        Send feedback to sig-testing, kubernetes/test-infra and/or [fejta](https://github.com/fejta).
+        /lifecycle rotten
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+- name: periodic-kubespray-stale
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20190408-5796ba99f
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=repo:kubernetes-sigs/kubespray
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=2160h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Issues go stale after 90d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle stale`.
+        Stale issues rot after an additional 30d of inactivity and eventually close.
+
+        If this issue is safe to close now please do so with `/close`.
+
+        Send feedback to sig-testing, kubernetes/test-infra and/or [fejta](https://github.com/fejta).
+        /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2236,6 +2236,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-rotten
 - name: periodic-test-infra-close
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-close
+- name: periodic-kubespray-close
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubespray-close
+- name: periodic-kubespray-rotten
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubespray-rotten
+- name: periodic-kubespray-stale
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubespray-stale
 - name: periodic-api-review-help
   gcs_prefix: kubernetes-jenkins/logs/periodic-api-review-help
 - name: periodic-test-infra-retester
@@ -7064,6 +7070,18 @@ dashboards:
     test_group_name: issue-creator
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+
+- name: sig-kubespray-fejtabot
+  dashboard_tab:
+  - name: stale
+    description: Adds lifecycle/stale to issues after 30d of inactivity
+    test_group_name: periodic-kubespray-stale
+  - name: rotten
+    description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    test_group_name: periodic-kubespray-rotten
+  - name: close
+    description: Closes rotten issues after 30d of inactivity
+    test_group_name: periodic-kubespray-close
 
 - name: sig-testing-prow
   dashboard_tab:


### PR DESCRIPTION
In kubernetes/kubespray we would love to see fejta-bot help out with marking stales/rotten issues. 

A follow up on https://github.com/kubernetes/test-infra/issues/11054#issuecomment-46979483 from @Atoms 

Nice if someone can check if `fejta-bot-token` has appropriate access.

The proposed `OWNERS` file is from https://github.com/kubernetes-sigs/kubespray/blob/master/OWNERS_ALIASES