### PR TITLE
Allow peribolos to manage repo permissions for teams

### DIFF
--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/config/org:go_default_library",
         "//prow/config/secret:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/logrusutil:go_default_library",

--- a/prow/cmd/peribolos/README.md
+++ b/prow/cmd/peribolos/README.md
@@ -46,6 +46,9 @@ orgs:
         - anne
         maintainers:
         - jane
+        repos: # Ensure the team has the following permissions levels on repos in the org
+          some-repo: admin
+          other-repo: read
       another-team:
         ...
       ...
@@ -66,6 +69,7 @@ This config will:
   - Rename the backend team to node
   - Add anne as a member and jane as a maintainer to node
   - Similar things for another-team (details elided)
+* Ensure that the team has admin rights to `some-repo`, read access to `other-repo` and no other privileges
 
 Note that any fields missing from the config will not be managed by peribolos. So if description is missing from the org setting, the current value will remain.
 

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -187,7 +187,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 	out.Metadata.Location = &meta.Location
 	out.Metadata.HasOrganizationProjects = &meta.HasOrganizationProjects
 	out.Metadata.HasRepositoryProjects = &meta.HasRepositoryProjects
-	drp := org.RepoPermissionLevel(meta.DefaultRepositoryPermission)
+	drp := github.RepoPermissionLevel(meta.DefaultRepositoryPermission)
 	out.Metadata.DefaultRepositoryPermission = &drp
 	out.Metadata.MembersCanCreateRepositories = &meta.MembersCanCreateRepositories
 

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -69,6 +69,7 @@ func TestOptions(t *testing.T) {
 				maximumDelta:  1,
 				tokensPerHour: defaultTokens,
 				tokenBurst:    defaultBurst,
+				logLevel:      "info",
 			},
 		},
 		{
@@ -81,6 +82,7 @@ func TestOptions(t *testing.T) {
 				maximumDelta:  0,
 				tokensPerHour: defaultTokens,
 				tokenBurst:    defaultBurst,
+				logLevel:      "info",
 			},
 		},
 		{
@@ -93,6 +95,7 @@ func TestOptions(t *testing.T) {
 				maximumDelta:  defaultDelta,
 				tokensPerHour: defaultTokens,
 				tokenBurst:    defaultBurst,
+				logLevel:      "info",
 			},
 		},
 		{
@@ -121,6 +124,7 @@ func TestOptions(t *testing.T) {
 				maximumDelta:  defaultDelta,
 				tokensPerHour: 0,
 				tokenBurst:    defaultBurst,
+				logLevel:      "info",
 			},
 		},
 		{
@@ -133,6 +137,7 @@ func TestOptions(t *testing.T) {
 				tokensPerHour: defaultTokens,
 				tokenBurst:    defaultBurst,
 				dump:          "frogger",
+				logLevel:      "info",
 			},
 		},
 		{
@@ -145,11 +150,12 @@ func TestOptions(t *testing.T) {
 				maximumDelta:  defaultDelta,
 				tokensPerHour: defaultTokens,
 				tokenBurst:    defaultBurst,
+				logLevel:      "info",
 			},
 		},
 		{
 			name: "full",
-			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--tokens=5", "--token-burst=2", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members"},
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--tokens=5", "--token-burst=2", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members", "--log-level=debug"},
 			expected: &options{
 				config:         "foo",
 				confirm:        true,
@@ -162,6 +168,7 @@ func TestOptions(t *testing.T) {
 				fixOrgMembers:  true,
 				fixTeams:       true,
 				fixTeamMembers: true,
+				logLevel:       "debug",
 			},
 		},
 	}
@@ -177,7 +184,7 @@ func TestOptions(t *testing.T) {
 		case err != nil && tc.expected != nil:
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
-			t.Errorf("%s: actual %v != expected %v", tc.name, actual, *tc.expected)
+			t.Errorf("%s: got incorrect options: %v", tc.name, diff.ObjectReflectDiff(actual, *tc.expected))
 		}
 	}
 }

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1552,7 +1552,7 @@ func TestConfigureOrgMeta(t *testing.T) {
 	no := false
 	str := "random-letters"
 	fail := "fail"
-	read := org.Read
+	read := github.Read
 
 	cases := []struct {
 		name     string
@@ -1713,7 +1713,7 @@ func TestDumpOrgConfig(t *testing.T) {
 	details := "wise and brilliant exemplary human specimens"
 	yes := true
 	no := false
-	perm := org.Write
+	perm := github.Write
 	pub := org.Privacy("")
 	secret := org.Secret
 	closed := org.Closed

--- a/prow/config/org/BUILD.bazel
+++ b/prow/config/org/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["org.go"],
     importpath = "k8s.io/test-infra/prow/config/org",
     visibility = ["//visibility:public"],
+    deps = ["//prow/github:go_default_library"],
 )
 
 filegroup(

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -18,22 +18,24 @@ package org
 
 import (
 	"fmt"
+
+	"k8s.io/test-infra/prow/github"
 )
 
 // Metadata declares metadata about the GitHub org.
 //
 // See https://developer.github.com/v3/orgs/#edit-an-organization
 type Metadata struct {
-	BillingEmail                 *string              `json:"billing_email,omitempty"`
-	Company                      *string              `json:"company,omitempty"`
-	Email                        *string              `json:"email,omitempty"`
-	Name                         *string              `json:"name,omitempty"`
-	Description                  *string              `json:"description,omitempty"`
-	Location                     *string              `json:"location,omitempty"`
-	HasOrganizationProjects      *bool                `json:"has_organization_projects,omitempty"`
-	HasRepositoryProjects        *bool                `json:"has_repository_projects,omitempty"`
-	DefaultRepositoryPermission  *RepoPermissionLevel `json:"default_repository_permission,omitempty"`
-	MembersCanCreateRepositories *bool                `json:"members_can_create_repositories,omitempty"`
+	BillingEmail                 *string                     `json:"billing_email,omitempty"`
+	Company                      *string                     `json:"company,omitempty"`
+	Email                        *string                     `json:"email,omitempty"`
+	Name                         *string                     `json:"name,omitempty"`
+	Description                  *string                     `json:"description,omitempty"`
+	Location                     *string                     `json:"location,omitempty"`
+	HasOrganizationProjects      *bool                       `json:"has_organization_projects,omitempty"`
+	HasRepositoryProjects        *bool                       `json:"has_repository_projects,omitempty"`
+	DefaultRepositoryPermission  *github.RepoPermissionLevel `json:"default_repository_permission,omitempty"`
+	MembersCanCreateRepositories *bool                       `json:"members_can_create_repositories,omitempty"`
 }
 
 // Config declares org metadata as well as its people and teams.
@@ -60,44 +62,13 @@ type Team struct {
 	Children    map[string]Team `json:"teams,omitempty"`
 
 	Previously []string `json:"previously,omitempty"`
-}
 
-// RepoPermissionLevel is admin, write, read or none.
-//
-// See https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
-type RepoPermissionLevel string
-
-const (
-	// Read allows pull but not push
-	Read RepoPermissionLevel = "read"
-	// Write allows Read plus push
-	Write RepoPermissionLevel = "write"
-	// Admin allows Write plus change others' rights.
-	Admin RepoPermissionLevel = "admin"
-	// None disallows everything
-	None RepoPermissionLevel = "none"
-)
-
-var repoPermissionLevels = map[RepoPermissionLevel]bool{
-	Read:  true,
-	Write: true,
-	Admin: true,
-	None:  true,
-}
-
-// MarshalText returns the byte representation of the permission
-func (l RepoPermissionLevel) MarshalText() ([]byte, error) {
-	return []byte(l), nil
-}
-
-// UnmarshalText validates the text is a valid string
-func (l *RepoPermissionLevel) UnmarshalText(text []byte) error {
-	v := RepoPermissionLevel(text)
-	if _, ok := repoPermissionLevels[v]; !ok {
-		return fmt.Errorf("bad repo permission: %s not in %v", v, repoPermissionLevels)
-	}
-	*l = v
-	return nil
+	// This is injected to the Team structure by listing privilege
+	// levels on dump and if set by users will cause privileges to
+	// be added on sync.
+	// https://developer.github.com/v3/teams/#list-team-repos
+	// https://developer.github.com/v3/teams/#add-or-update-team-repository
+	Repos map[string]github.RepoPermissionLevel `json:"repos,omitempty"`
 }
 
 // Privacy is secret or closed.

--- a/prow/config/org/org_test.go
+++ b/prow/config/org/org_test.go
@@ -21,53 +21,6 @@ import (
 	"testing"
 )
 
-func TestRepoPermissionLevel(t *testing.T) {
-	get := func(v RepoPermissionLevel) *RepoPermissionLevel {
-		return &v
-	}
-	cases := []struct {
-		input    string
-		expected *RepoPermissionLevel
-	}{
-		{
-			"admin",
-			get(Admin),
-		},
-		{
-			"write",
-			get(Write),
-		},
-		{
-			"read",
-			get(Read),
-		},
-		{
-			"none",
-			get(None),
-		},
-		{
-			"",
-			nil,
-		},
-		{
-			"unknown",
-			nil,
-		},
-	}
-	for _, tc := range cases {
-		var actual RepoPermissionLevel
-		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
-		switch {
-		case err == nil && tc.expected == nil:
-			t.Errorf("%s: failed to receive an error", tc.input)
-		case err != nil && tc.expected != nil:
-			t.Errorf("%s: unexpected error: %v", tc.input, err)
-		case err == nil && *tc.expected != actual:
-			t.Errorf("%s: actual %v != expected %v", tc.input, tc.expected, actual)
-		}
-	}
-}
-
 func TestPrivacy(t *testing.T) {
 	get := func(v Privacy) *Privacy {
 		return &v

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "client_test.go",
+        "helpers_test.go",
         "hmac_test.go",
         "links_test.go",
         "types_test.go",

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -51,3 +51,34 @@ func ImageTooBig(url string) (bool, error) {
 	}
 	return false, nil
 }
+
+// LevelFromPermissions adapts a repo permissions struct to the
+// appropriate permission level used elsewhere
+func LevelFromPermissions(permissions RepoPermissions) RepoPermissionLevel {
+	if permissions.Pull {
+		return Read
+	} else if permissions.Push {
+		return Write
+	} else if permissions.Admin {
+		return Admin
+	} else {
+		return None
+	}
+}
+
+// PermissionsFromLevel adapts a repo permission level to the
+// appropriate permissions struct used elsewhere
+func PermissionsFromLevel(permission RepoPermissionLevel) RepoPermissions {
+	switch permission {
+	case None:
+		return RepoPermissions{}
+	case Read:
+		return RepoPermissions{Pull: true}
+	case Write:
+		return RepoPermissions{Push: true}
+	case Admin:
+		return RepoPermissions{Admin: true}
+	default:
+		return RepoPermissions{}
+	}
+}

--- a/prow/github/helpers_test.go
+++ b/prow/github/helpers_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRepoPermissionLevel(t *testing.T) {
+	get := func(v RepoPermissionLevel) *RepoPermissionLevel {
+		return &v
+	}
+	cases := []struct {
+		input    string
+		expected *RepoPermissionLevel
+	}{
+		{
+			"admin",
+			get(Admin),
+		},
+		{
+			"write",
+			get(Write),
+		},
+		{
+			"read",
+			get(Read),
+		},
+		{
+			"none",
+			get(None),
+		},
+		{
+			"",
+			nil,
+		},
+		{
+			"unknown",
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		var actual RepoPermissionLevel
+		err := json.Unmarshal([]byte("\""+tc.input+"\""), &actual)
+		switch {
+		case err == nil && tc.expected == nil:
+			t.Errorf("%s: failed to receive an error", tc.input)
+		case err != nil && tc.expected != nil:
+			t.Errorf("%s: unexpected error: %v", tc.input, err)
+		case err == nil && *tc.expected != actual:
+			t.Errorf("%s: actual %v != expected %v", tc.input, tc.expected, actual)
+		}
+	}
+}
+
+func TestLevelFromPermissions(t *testing.T) {
+	var testCases = []struct {
+		permissions RepoPermissions
+		level       RepoPermissionLevel
+	}{
+		{
+			permissions: RepoPermissions{},
+			level:       None,
+		},
+		{
+			permissions: RepoPermissions{Pull: true},
+			level:       Read,
+		},
+		{
+			permissions: RepoPermissions{Push: true},
+			level:       Write,
+		},
+		{
+			permissions: RepoPermissions{Admin: true},
+			level:       Admin,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := LevelFromPermissions(testCase.permissions), testCase.level; actual != expected {
+			t.Errorf("got incorrect level from permissions, expected %v but got %v", expected, actual)
+		}
+	}
+}
+
+func TestPermissionsFromLevel(t *testing.T) {
+	var testCases = []struct {
+		level       RepoPermissionLevel
+		permissions RepoPermissions
+	}{
+		{
+			level:       RepoPermissionLevel("foobar"),
+			permissions: RepoPermissions{},
+		},
+		{
+			level:       None,
+			permissions: RepoPermissions{},
+		},
+		{
+			level:       Read,
+			permissions: RepoPermissions{Pull: true},
+		},
+		{
+			level:       Write,
+			permissions: RepoPermissions{Push: true},
+		},
+		{
+			level:       Admin,
+			permissions: RepoPermissions{Admin: true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := PermissionsFromLevel(testCase.level), testCase.permissions; actual != expected {
+			t.Errorf("got incorrect permissions from level, expected %v but got %v", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
With this patch, the configuration for Peribolos/org management can now
be used to enforce a specific set of repository permissions for the
groups that it manages.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta @cjwagner 