### PR TITLE
Use bazel image that has docker

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel
+      - image: gcr.io/cloud-builders/bazel
         command:
         - bazel
         args:


### PR DESCRIPTION
Based on the errors that I'm seeing in prow for pull-test-infra-bazel-rbe, it looks like bazel needs docker to be installed in order to get the platform configuration.
Using gcr.io/cloud-builders/bazel which is an image that contains both bazel and docker.
