### PR TITLE
Revert gubernator Github/GitHub spelling changes

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -39,10 +39,10 @@ def classify_issue(repo, number):
         payload: a dict, see full description for classify below.
         last_event_timestamp: the timestamp of the most recent event.
     """
-    ancestor = models.GitHubResource.make_key(repo, number)
+    ancestor = models.GithubResource.make_key(repo, number)
     logging.info('finding webhooks for %s %s', repo, number)
-    event_keys = list(models.GitHubWebhookRaw.query(ancestor=ancestor)
-        .order(models.GitHubWebhookRaw.timestamp)
+    event_keys = list(models.GithubWebhookRaw.query(ancestor=ancestor)
+        .order(models.GithubWebhookRaw.timestamp)
         .fetch(keys_only=True))
 
     logging.info('classifying %s %s (%d events)', repo, number, len(event_keys))

--- a/gubernator/github/handlers.py
+++ b/gubernator/github/handlers.py
@@ -48,7 +48,7 @@ def make_signature(body):
     return 'sha1=' + hmac_instance.hexdigest()
 
 
-class GitHubHandler(webapp2.RequestHandler):
+class GithubHandler(webapp2.RequestHandler):
     """
     Handle POSTs delivered using GitHub's webhook interface. Posts are
     authenticated with HMAC signatures and a shared secret.
@@ -76,7 +76,7 @@ class GitHubHandler(webapp2.RequestHandler):
 
         parent = None
         if number:
-            parent = models.GitHubResource.make_key(repo, number)
+            parent = models.GithubResource.make_key(repo, number)
 
         kwargs = {}
         timestamp = self.request.headers.get('x-timestamp')
@@ -84,7 +84,7 @@ class GitHubHandler(webapp2.RequestHandler):
             kwargs['timestamp'] = datetime.datetime.strptime(
                 timestamp, '%Y-%m-%d %H:%M:%S.%f')
 
-        webhook = models.GitHubWebhookRaw(
+        webhook = models.GithubWebhookRaw(
             parent=parent,
             repo=repo,
             number=number,
@@ -136,12 +136,12 @@ class Events(BaseHandler):
         number = int(self.request.get('number', 0)) or None
         count = int(self.request.get('count', 500))
         if repo is not None and number is not None:
-            q = models.GitHubWebhookRaw.query(
-                models.GitHubWebhookRaw.repo == repo,
-                models.GitHubWebhookRaw.number == number)
+            q = models.GithubWebhookRaw.query(
+                models.GithubWebhookRaw.repo == repo,
+                models.GithubWebhookRaw.number == number)
         else:
-            q = models.GitHubWebhookRaw.query()
-        q = q.order(models.GitHubWebhookRaw.timestamp)
+            q = models.GithubWebhookRaw.query()
+        q = q.order(models.GithubWebhookRaw.timestamp)
         events, next_cursor, more = q.fetch_page(count, start_cursor=cursor)
         out = []
         for event in events:
@@ -189,9 +189,9 @@ class Timeline(BaseHandler):
             self.response.write('<pre>%s</pre>' % traceback.format_exc())
 
     def emit_events(self, repo, number):
-        ancestor = models.GitHubResource.make_key(repo, number)
-        events = list(models.GitHubWebhookRaw.query(ancestor=ancestor)
-            .order(models.GitHubWebhookRaw.timestamp))
+        ancestor = models.GithubResource.make_key(repo, number)
+        events = list(models.GithubWebhookRaw.query(ancestor=ancestor)
+            .order(models.GithubWebhookRaw.timestamp))
 
         self.response.write('<h3>Distilled Events</h3>')
         self.response.write('<pre>')
@@ -228,8 +228,8 @@ class Timeline(BaseHandler):
         repo = self.request.get('repo')
         number = self.request.get('number')
         if self.request.get('format') == 'json':
-            ancestor = models.GitHubResource.make_key(repo, number)
-            events = list(models.GitHubWebhookRaw.query(ancestor=ancestor))
+            ancestor = models.GithubResource.make_key(repo, number)
+            events = list(models.GithubWebhookRaw.query(ancestor=ancestor))
             self.response.headers['content-type'] = 'application/json'
             self.response.write(json.dumps([e.body for e in events], indent=True))
             return

--- a/gubernator/github/index.yaml
+++ b/gubernator/github/index.yaml
@@ -2,7 +2,7 @@ indexes:
 
 # This index allows us to iterate through events sorted by timestamp,
 # without fetching all the events into memory first.
-- kind: GitHubWebhookRaw
+- kind: GithubWebhookRaw
   ancestor: yes
   properties:
   - name: timestamp
@@ -17,7 +17,7 @@ indexes:
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
 
-- kind: GitHubWebhookRaw
+- kind: GithubWebhookRaw
   properties:
   - name: event
   - name: timestamp

--- a/gubernator/github/main.py
+++ b/gubernator/github/main.py
@@ -29,7 +29,7 @@ class Warmup(webapp2.RequestHandler):
 
 app = webapp2.WSGIApplication([
     ('/_ah/warmup', Warmup),
-    (r'/webhook', handlers.GitHubHandler),
+    (r'/webhook', handlers.GithubHandler),
     (r'/events', handlers.Events),
     (r'/status', handlers.Status),
     (r'/timeline', handlers.Timeline),

--- a/gubernator/github/main_test.py
+++ b/gubernator/github/main_test.py
@@ -60,7 +60,7 @@ class AppTest(TestBase):
             body = json.dumps(body)
         signature = handlers.make_signature(body)
         resp = app.post('/webhook', body,
-            {'X-GitHub-Event': event,
+            {'X-Github-Event': event,
              'X-Hub-Signature': signature})
         for task in self.taskqueue.get_filtered_tasks():
             deferred.run(task.payload)
@@ -68,7 +68,7 @@ class AppTest(TestBase):
 
     def test_webhook(self):
         self.get_response('test', {'action': 'blah'})
-        hooks = list(models.GitHubWebhookRaw.query())
+        hooks = list(models.GithubWebhookRaw.query())
         self.assertEqual(len(hooks), 1)
         self.assertIsNotNone(hooks[0].timestamp)
 
@@ -76,12 +76,12 @@ class AppTest(TestBase):
         body = json.dumps({'action': 'blah'})
         signature = handlers.make_signature(body + 'foo')
         app.post('/webhook', body,
-            {'X-GitHub-Event': 'test',
+            {'X-Github-Event': 'test',
              'X-Hub-Signature': signature}, status=400)
 
     def test_webhook_missing_sig(self):
         app.post('/webhook', '{}',
-            {'X-GitHub-Event': 'test'}, status=400)
+            {'X-Github-Event': 'test'}, status=400)
 
     def test_webhook_unicode(self):
         self.get_response('test', {'action': u'blah\u03BA'})

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -19,16 +19,16 @@ import json
 import google.appengine.ext.ndb as ndb
 
 
-class GitHubResource(ndb.Model):
+class GithubResource(ndb.Model):
     # A key holder used to define an entitygroup for
     # each Issue/PR, for easy ancestor queries.
     @staticmethod
     def make_key(repo, number):
-        return ndb.Key(GitHubResource, '%s %s' % (repo, number))
+        return ndb.Key(GithubResource, '%s %s' % (repo, number))
 
 
 def shrink(body):
-    """Recursively remove GitHub API urls from an object to make it more human-readable."""
+    """Recursively remove Github API urls from an object to make it more human-readable."""
     toremove = []
     for key, value in body.iteritems():
         if isinstance(value, basestring):
@@ -47,7 +47,7 @@ def shrink(body):
     return body
 
 
-class GitHubWebhookRaw(ndb.Model):
+class GithubWebhookRaw(ndb.Model):
     repo = ndb.StringProperty()
     number = ndb.IntegerProperty(indexed=False)
     event = ndb.StringProperty()

--- a/gubernator/github/periodic_sync.py
+++ b/gubernator/github/periodic_sync.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Periodically synchronize our Datastore view of PRs with GitHub.
+"""Periodically synchronize our Datastore view of PRs with Github.
 
 Various things can cause the local status of a PR to diverge from upstream:
 dropped hooks from bugs in the app, upstream GitHub bugs (webhooks aren't
@@ -26,13 +26,13 @@ and clutter out real items, decreasing signal-to-noise ratio and user trust.
 To handle these, on a regular schedule we perform a reconciliation step:
 - for each repository that we're tracking:
   - A = all open PRs from Datastore
-  - B = all open PRs from GitHub
+  - B = all open PRs from Github
   - A-B is the set of improperly open PRs. For each PR, add a synthetic
     webhook event to Datastore with state=closed, and reprocess.
   - B-A is the set of improperly closed or missing PRs. Again, inject a
     synthetic webhook with the details received from GitHub and reprocess.
 
-This requires a GitHub token set like other secrets with /config in the root.
+This requires a Github token set like other secrets with /config in the root.
 Total token usage is low: number of open PRs / 100 PRs per list call.
 As of 2018-01-10, 1666 open PRs in the k8s org translates into ~56 list calls.
 """
@@ -79,9 +79,9 @@ def get_prs_from_github(token, repo):
 
 
 def inject_event_and_reclassify(repo, number, action, body):
-    # this follows similar code as handlers.GitHubHandler
-    parent = models.GitHubResource.make_key(repo, number)
-    hook = models.GitHubWebhookRaw(
+    # this follows similar code as handlers.GithubHandler
+    parent = models.GithubResource.make_key(repo, number)
+    hook = models.GithubWebhookRaw(
         parent=parent, repo=repo, number=number, event='pull_request',
         body=json.dumps({'action': action, 'pull_request': body}, sort_keys=True))
     hook.put()

--- a/gubernator/github_auth_test.py
+++ b/gubernator/github_auth_test.py
@@ -37,7 +37,7 @@ app = webtest.TestApp(main.app)
 VEND_URL = 'https://github.com/login/oauth/access_token'
 USER_URL = 'https://api.github.com/user'
 
-class TestGitHubAuth(unittest.TestCase):
+class TestGithubAuth(unittest.TestCase):
     def setUp(self):
         app.reset()
         self.testbed.init_app_identity_stub()
@@ -89,7 +89,7 @@ class TestGitHubAuth(unittest.TestCase):
             'redirect_uri': ['http://localhost/github_auth/done'],
             'client_id': [CLIENT_ID]})
 
-        # 2) GitHub redirects back
+        # 2) Github redirects back
         resp = self.do_phase2(resp)
         self.assertIn('Welcome, foo', resp)
 

--- a/hack/verify-github-spelling.sh
+++ b/hack/verify-github-spelling.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 failed="false"
-for file in $(  find . \( -not -path '*vendor*' -and -not -path '*.git*' -and -not -path '*hack/verify-github-spelling.sh*' \) -type f )
+for file in $(  find . \( -not -path '*vendor*' -and -not -path '*gubernator/*' -and -not -path '*.git*' -and -not -path '*hack/verify-github-spelling.sh*' \) -type f )
 do
   if grep -q 'Github' "${file}"; then
       echo "[ERROR] ${file}: contains mis-spelling 'Github'"


### PR DESCRIPTION
#11294 broke Gubernator. Revert the gubernator-related parts of it, and exclude gubernator from the verify script.

/cc @fejta @stevekuznetsov 