### PR TITLE
Differentiate resource not found from type not found

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -106,6 +106,8 @@ func ErrorToStatus(err error) int {
 		return http.StatusUnauthorized
 	case *ranch.ResourceNotFound:
 		return http.StatusNotFound
+	case *ranch.ResourceTypeNotFound:
+		return http.StatusNotFound
 	case *ranch.StateNotMatch:
 		return http.StatusConflict
 	}

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -60,6 +60,13 @@ func AreErrorsEqual(got error, expect error) bool {
 			}
 		}
 		return false
+	case *ResourceTypeNotFound:
+		if o, ok := expect.(*ResourceTypeNotFound); ok {
+			if o.rType == got.(*ResourceTypeNotFound).rType {
+				return true
+			}
+		}
+		return false
 	case *StateNotMatch:
 		if o, ok := expect.(*StateNotMatch); ok {
 			if o.expect == got.(*StateNotMatch).expect && o.current == got.(*StateNotMatch).current {
@@ -90,7 +97,7 @@ func TestAcquire(t *testing.T) {
 			rtype:     "t",
 			state:     "s",
 			dest:      "d",
-			expectErr: &ResourceNotFound{"t"},
+			expectErr: &ResourceTypeNotFound{"t"},
 		},
 		{
 			name: "no match type",
@@ -101,7 +108,7 @@ func TestAcquire(t *testing.T) {
 			rtype:     "t",
 			state:     "s",
 			dest:      "d",
-			expectErr: &ResourceNotFound{"t"},
+			expectErr: &ResourceTypeNotFound{"t"},
 		},
 		{
 			name: "no match state",


### PR DESCRIPTION
To better highlight configuration issues.