### PR TITLE
Allow negative warning matching for checkconfig

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -60,8 +60,9 @@ type options struct {
 	jobConfigPath string
 	pluginConfig  string
 
-	warnings flagutil.Strings
-	strict   bool
+	warnings        flagutil.Strings
+	excludeWarnings flagutil.Strings
+	strict          bool
 }
 
 func reportWarning(strict bool, errs errorutil.Aggregate) {
@@ -74,12 +75,7 @@ func reportWarning(strict bool, errs errorutil.Aggregate) {
 }
 
 func (o *options) warningEnabled(warning string) bool {
-	for _, registeredWarning := range o.warnings.Strings() {
-		if warning == registeredWarning {
-			return true
-		}
-	}
-	return false
+	return sets.NewString(o.warnings.Strings()...).Difference(sets.NewString(o.excludeWarnings.Strings()...)).Has(warning)
 }
 
 const (
@@ -132,7 +128,8 @@ func gatherOptions() options {
 	flag.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	flag.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	flag.StringVar(&o.pluginConfig, "plugin-config", "", "Path to plugin config file.")
-	flag.Var(&o.warnings, "warnings", "Warnings to validate. Use repeatedly to provide a list of warnings.")
+	flag.Var(&o.warnings, "warnings", "Warnings to validate. Use repeatedly to provide a list of warnings")
+	flag.Var(&o.excludeWarnings, "exclude-warning", "Warnings to exclude. Use repeatedly to provide a list of warnings to exclude")
 	flag.BoolVar(&o.strict, "strict", false, "If set, consider all warnings as errors.")
 	flag.Parse()
 	return o


### PR DESCRIPTION
It is very common to either want to subscribe to a specific set of
checks or to subscribe to everything but a specific set. The latter
approach was not possible with a whitelist, but adding a blacklist
allows it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cblecker @fejta @cjwagner 