### PR TITLE
Add new label for code organization subproject (sig-arch)

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -165,6 +165,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/cn-summit" href="#area/cn-summit">`area/cn-summit`</a> | Issues or PRs related to the Contributor Summit in China| label | |
+| <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/contributor-guide" href="#area/contributor-guide">`area/contributor-guide`</a> | Issues or PRs related to the contributor guide| label | |
 | <a id="area/contributor-summit" href="#area/contributor-summit">`area/contributor-summit`</a> | Issues or PRs related to all contributor summit events| label | |
@@ -187,6 +188,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
@@ -232,6 +234,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/boskos" href="#area/boskos">`area/boskos`</a> | Issues or PRs related to code in /boskos| label | |
+| <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
 | <a id="area/config" href="#area/config">`area/config`</a> | Issues or PRs related to code in /config| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -665,6 +665,11 @@ repos:
   kubernetes/community:
     labels:
       - color: 0052cc
+        description: Issues or PRs related to kubernetes code organization
+        name: area/code-organization
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to kubernetes conformance tests
         name: area/conformance
         target: both
@@ -745,6 +750,11 @@ repos:
         description: Indicates an issue on api area.
         name: area/api
         target: issues
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to kubernetes code organization
+        name: area/code-organization
+        target: both
         addedBy: label
       - color: 0052cc
         description: Issues or PRs related to kubernetes conformance tests
@@ -829,6 +839,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to code in /config
         name: area/config
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to kubernetes code organization
+        name: area/code-organization
         target: both
         addedBy: label
       - color: 0052cc


### PR DESCRIPTION
We need a label to track the work of the code organization sub project. please see https://github.com/kubernetes/community/tree/master/sig-architecture

Change-Id: I2969cad3af30c98f986471b7e642e9c41f16a8be