### PR TITLE
kubernetes-csi: make unit testing jobs mandatory

### DIFF
--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -2,11 +2,8 @@
 
 presubmits:
   kubernetes-csi/csi-lib-utils:
-  - name: pull-sig-storage-csi-lib-utils
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+  - name: pull-kubernetes-csi-csi-lib-utils
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.1|release-0.2)$"]

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -2,11 +2,8 @@
 
 presubmits:
   kubernetes-csi/csi-release-tools:
-  - name: pull-sig-storage-csi-release-tools
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+  - name: pull-kubernetes-csi-csi-release-tools
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: []

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -2,11 +2,8 @@
 
 presubmits:
   kubernetes-csi/csi-test:
-  - name: pull-sig-storage-csi-test
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+  - name: pull-kubernetes-csi-csi-test
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.3|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0|v0.2.0)$"]

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -318,11 +318,8 @@ presubmits:
 EOF
 
     cat >>"$base/$repo/$repo-config.yaml" <<EOF
-  - name: pull-sig-storage-$repo
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+  - name: pull-kubernetes-csi-$repo
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]


### PR DESCRIPTION
The repos are ready and pass the jobs, so we can enable them for all
future PRs. Also rename them so that the names are consistent with the
other jobs.
