### PR TITLE
Map the InClusterContext to DefaultClusterAlias to prevent from deleting the builds created for DefaultCluserAlias

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -173,7 +173,7 @@ func newController(opts controllerOptions) (*controller, error) {
 				logrus.Warnf("Ignoring bad prowjob add: %v", obj)
 				return
 			}
-			c.enqueueKey(pj.Spec.Cluster, pj)
+			c.enqueueKey(clusterToCtx(pj.Spec.Cluster), pj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			pj, ok := new.(*prowjobv1.ProwJob)
@@ -181,7 +181,7 @@ func newController(opts controllerOptions) (*controller, error) {
 				logrus.Warnf("Ignoring bad prowjob update: %v", new)
 				return
 			}
-			c.enqueueKey(pj.Spec.Cluster, pj)
+			c.enqueueKey(clusterToCtx(pj.Spec.Cluster), pj)
 		},
 		DeleteFunc: func(obj interface{}) {
 			pj, ok := obj.(*prowjobv1.ProwJob)
@@ -189,7 +189,7 @@ func newController(opts controllerOptions) (*controller, error) {
 				logrus.Warnf("Ignoring bad prowjob delete: %v", obj)
 				return
 			}
-			c.enqueueKey(pj.Spec.Cluster, pj)
+			c.enqueueKey(clusterToCtx(pj.Spec.Cluster), pj)
 		},
 	})
 
@@ -210,6 +210,14 @@ func newController(opts controllerOptions) (*controller, error) {
 	}
 
 	return c, nil
+}
+
+// clusterToCtx converts the prow job's cluster to a cluster context
+func clusterToCtx(cluster string) string {
+	if cluster == kube.InClusterContext {
+		return kube.DefaultClusterAlias
+	}
+	return cluster
 }
 
 // Run starts threads workers, returning after receiving a stop signal.
@@ -402,9 +410,9 @@ func reconcile(c reconciler, key string) error {
 		return fmt.Errorf("get prowjob: %v", err)
 	case pj.Spec.Agent != prowjobv1.KnativeBuildAgent:
 		// Do not want a build for this job
-	case pj.Spec.Cluster != ctx:
+	case clusterToCtx(pj.Spec.Cluster) != ctx:
 		// Build is in wrong cluster, we do not want this build
-		logrus.Warnf("%s found in context %s not %s", key, ctx, pj.Spec.Cluster)
+		logrus.Warnf("%s found in context %s not %s", key, ctx, clusterToCtx(pj.Spec.Cluster))
 	case pj.DeletionTimestamp == nil:
 		wantBuild = true
 	}

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -1178,6 +1178,9 @@ func TestReconcile(t *testing.T) {
 			} else if tc.namespace == errorUpdateProwJob {
 				name = errorUpdateProwJob
 			}
+			if tc.context == "" {
+				tc.context = kube.DefaultClusterAlias
+			}
 			bk := toKey(tc.context, tc.namespace, name)
 			jk := toKey(fakePJCtx, fakePJNS, name)
 			r := &fakeReconciler{

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -82,14 +82,6 @@ func (r *fakeReconciler) terminateDupProwJobs(ctx string, namespace string) erro
 	return nil
 }
 
-func (r *fakeReconciler) getProwJobs() ([]prowjobv1.ProwJob, error) {
-	var jobs []prowjobv1.ProwJob
-	for _, j := range r.jobs {
-		jobs = append(jobs, j)
-	}
-	return jobs, nil
-}
-
 func (r *fakeReconciler) updateProwJob(pj *prowjobv1.ProwJob) (*prowjobv1.ProwJob, error) {
 	if pj.Name == errorUpdateProwJob {
 		return nil, errors.New("injected update prowjob error")

--- a/prow/cmd/build/main.go
+++ b/prow/cmd/build/main.go
@@ -160,7 +160,6 @@ func main() {
 	if !o.allContexts { // Just the default context please
 		logrus.Warn("Truncating to local and default contexts")
 		configs = map[string]rest.Config{
-			kube.InClusterContext:    configs[kube.InClusterContext],
 			kube.DefaultClusterAlias: configs[kube.DefaultClusterAlias],
 		}
 	}


### PR DESCRIPTION
During the reconciliation the builds started for `InCluserContext` context are removed by the `DefaultClusterAlias` context because both are pointing to the same cluster when no `DefaultClusterAlias` is explicitly defined in the configuration.
