### PR TITLE
Set up tempelis jobs

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -17,3 +17,25 @@ presubmits:
         - --
         - make
         - verify
+  - name: pull-community-tempelis-check
+    decorate: true
+    branches:
+    - ^master$
+    run_if_changed: '^communication/slack-config'
+    spec:
+      containers:
+        - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+          command:
+          - /tempelis
+          args:
+          - --config=communication/slack-config/
+          - --restrictions=communication/slack-config/restrictions.yaml
+          - --auth=/etc/slack-auth/auth.json
+          volumeMounts:
+            - name: tempelis-readonly-creds
+              mountPath: /etc/slack-auth
+              readOnly: true
+      volumes:
+        - name: tempelis-readonly-creds
+          secret:
+            secretName: slack-tempelis-auth

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -452,6 +452,31 @@ postsubmits:
       - name: k8s-gcr-prod-service-account-creds
         secret:
           secretName: k8s-gcr-prod-service-account
+  kubernetes/community:
+  - name: post-community-tempelis-apply
+    cluster: test-infra-trusted
+    decorate: true
+    branches:
+      - ^master$
+    run_if_changed: '^communication/slack-config'
+    spec:
+      containers:
+        - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+          command:
+            - /tempelis
+          args:
+            - --config=communication/slack-config/
+            - --restrictions=communication/slack-config/restrictions.yaml
+            - --auth=/etc/slack-auth/auth.json
+            - --dry-run=false
+          volumeMounts:
+            - name: tempelis-creds
+              mountPath: /etc/slack-auth
+              readOnly: true
+      volumes:
+        - name: tempelis-creds
+          secret:
+            secretName: slack-tempelis-auth
 
 
 periodics:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3654,6 +3654,14 @@ test_groups:
   alert_stale_results_hours: 24
   num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
 
+- name: pull-community-tempelis-check
+  gcs_prefix: kubernetes-jenkins/pr-logs/community/directory/pull-community-tempelis-check
+- name: post-community-tempelis-apply
+  gcs_prefix: kubernetes-jenkins/logs/community/post-community-tempelis-apply
+  alert_options:
+    alert_mail_to_addresses: ktbry@google.com
+    num_failures_to_alert: 1
+
 #
 # Start dashboards
 #
@@ -5337,6 +5345,13 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
   - name: gke-gci-1.13-gci-1.12-downgrade-cluster-parallel
     test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
+
+- name: sig-contribex-tempelis
+  dashboard_tab:
+  - name: presubmit
+    test_group_name: pull-community-tempelis-check
+  - name: postsubmit
+    test_group_name: post-community-tempelis-apply
 
 - name: sig-release-misc
   dashboard_tab:
@@ -8287,6 +8302,10 @@ dashboard_groups:
   - sig-cluster-lifecycle-cluster-api-provider-gcp
   - sig-cluster-lifecycle-cluster-api-provider-openstack
   - sig-cluster-lifecycle-kops
+
+- name: sig-contribex
+  dashboard_names:
+  - sig-contribex-tempelis
 
 - name: sig-multicluster
   dashboard_names:


### PR DESCRIPTION
Add two jobs to kubernetes/community:

- An untrusted presubmit that runs using a read-only slack token that verifies the configuration and reports what it will change
- A trusted postsubmit that runs using a read/write slack token and effects the requested changes