### PR TITLE
Giving 'client' user cluster admin role

### DIFF
--- a/prow/cmd/mkbuild-cluster/README.md
+++ b/prow/cmd/mkbuild-cluster/README.md
@@ -61,6 +61,22 @@ By default we validate the new client works before printing out its credentials.
 
 The `--get-client-cert` flag may fix these errors.
 
+On some platform, MasterAuth has [no RBAC permissions](https://github.com/kubernetes/kubernetes/issues/65400) on the server.
+If you see an error of the following form, this is likely the case.
+
+```console
+Failed: authenticated client could not list pods: response has status "403 Forbidden" and body "{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods is forbidden: User \"client\" cannot list pods in the namespace \"kube-system\"","reason":"Forbidden","details":{"kind":"pods"},"code":403}
+```
+
+You need to give the user access to pods in that cluster.
+
+```sh
+# Create the pod-reader role
+kubectl create clusterrole cluster-pod-admin --verb=* --resource=pods
+# Give the user access to read pods. The user in this example is 'client'.
+kubectl create clusterrolebinding cluster-pod-admin-binding --clusterrole=cluster-pod-admin --user=client
+```
+
 ### All options
 
 ```sh


### PR DESCRIPTION
Giving the 'client' user cluster-admin role.
This is actually the same PR as #12173 because I messed up the commit history on that PR. Let's continue the discussion in this PR. (Sorry for the inconvenience)


TLDR:
The [instruction](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#run-test-pods-in-different-clusters) to setup a new PROW does not work because GKE cluster does not give 'client' RBAC access on the cluster(https://github.com/googleapis/google-api-go-client/issues/278)

@stevekuznetsov:
We should change the tool to do a SAR check. Or change the namespace to the namespace that the pods will actually be scheduled into. This is the incorrect approach to fixing the issue.
Also, in starter.yaml you are adding RBAC to the service cluster. You want RBAC for the delegated credentials in the build cluster.


@fejta 