### PR TITLE
Fix typo of ginkgo-parallel

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2492,7 +2492,7 @@ presubmits:
         - --extract=local
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
-        - --gingko-parallel=30
+        - --ginkgo-parallel=30
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -36,7 +36,7 @@ presubmits:
         - --extract=local
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
-        - --gingko-parallel=30
+        - --ginkgo-parallel=30
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow


### PR DESCRIPTION
Two jobs were configured with a typo on the flags, causing
certain failure.

Fixes #12184