### PR TITLE
tackle: fix minor issues in cluster YAMLs

### DIFF
--- a/prow/cluster/cert-manager.yaml
+++ b/prow/cluster/cert-manager.yaml
@@ -44,7 +44,7 @@ spec:
     shortNames:
       - cert
       - certs
-      
+
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -147,7 +147,7 @@ spec:
       labels:
         app: cert-manager
         release: cert-manager
-      annotations:
+      annotations: {}
     spec:
       serviceAccountName: cert-manager
       containers:

--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -83,6 +83,5 @@ spec:
     JSONPath: .status.completionTime
   - name: State
     description: The state of the job.
-    name: state
     type: string
     JSONPath: .status.state

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -111,7 +111,6 @@ spec:
     JSONPath: .status.completionTime
   - name: State
     description: The state of the job.
-    name: state
     type: string
     JSONPath: .status.state
 ---


### PR DESCRIPTION
Remove duplicate `name` key from ProwJob CRD and set `cert-manager` annotations to `{}` explicitly.

This changes the effective ProwJob CRD definition from
```
  - JSONPath: .status.state
    description: The state of the job.
    name: state
    type: string
```
to
```
  - JSONPath: .status.state
    description: The state of the job.
    name: State
    type: string
```