### PR TITLE
Add some data dependencies needed for tests to run on RBE

### DIFF
--- a/jenkins/BUILD.bazel
+++ b/jenkins/BUILD.bazel
@@ -7,7 +7,7 @@ py_test(
     data = [
         "//jobs",
         "//prow:config.yaml",
-    ],
+    ] + glob(["fake/**"]),
     deps = ["@yaml"],
 )
 

--- a/kettle/BUILD.bazel
+++ b/kettle/BUILD.bazel
@@ -54,7 +54,10 @@ py_test(
         "stream_test.py",
         ":package-srcs",
     ],
-    data = ["schema.json"],
+    data = [
+        "buckets.yaml",
+        "schema.json",
+    ],
     deps = [
         "@requests",
         "@yaml",


### PR DESCRIPTION
The tests //jenkins:bootstrap_test and //kettle:stream_test depend on
some files in runtime that were not specified in the BUILD file. This
worked when running locally but has to be explicit when running remotely
on RBE.

After adding these files, //kettle:stream_test now passes on RBE but
//jenkins:bootstrap_test does not yet pass. It requires more work to make
it run correctly on RBE.