### PR TITLE
Initialize ConfigMap name in all cases

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -94,7 +94,7 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 		return fmt.Errorf("failed to fetch current state of configmap: %v", getErr)
 	}
 
-	if cm == nil {
+	if cm == nil || isNotFound {
 		cm = &coreapi.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,


### PR DESCRIPTION
When the Kubernetes client fails to find a ConfigMap it returns a
NotFound error but not a nil entry for the map, so we need to populate
the metadata for the ConfigMap in that case as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 