### PR TITLE
kubernetes-csi: automatic testing with Prow

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: []
@@ -41,7 +38,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-13-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -76,10 +73,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: []
@@ -114,7 +108,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-14-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -149,10 +143,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: []
@@ -187,10 +178,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: []
@@ -225,10 +213,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     labels:

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -25,18 +25,3 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
-  - name: pull-sig-storage-csi-lib-utils-stable
-    always_run: true
-    decorate: true
-    skip_report: false
-    spec:
-      containers:
-      # This image was chosen over the more often used kubekins-e2e because
-      # it is smaller and has everything we need (basically just a Go environment).
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20180927-6b4facbe6
-        command:
-        - make
-        args:
-        - -k # report as many failures as possible (if any) before finally failing
-        - all # build...
-        - test # ... and test

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/external-attacher:
   - name: pull-kubernetes-csi-external-attacher-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
@@ -41,7 +38,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-13-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -76,10 +73,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
@@ -114,7 +108,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-14-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -149,10 +143,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-alpha-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
@@ -187,10 +178,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-alpha-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
@@ -225,10 +213,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     labels:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/external-provisioner:
   - name: pull-kubernetes-csi-external-provisioner-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
@@ -41,7 +38,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-13-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -76,10 +73,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
@@ -114,7 +108,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-14-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -149,10 +143,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
@@ -187,10 +178,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
@@ -225,10 +213,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     labels:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/external-snapshotter:
   - name: pull-kubernetes-csi-external-snapshotter
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(errorhandling|k8s_1.12.0-beta.1|release-0.4|release-1.0|revert-72-pvclister|saad-ali-patch-1|saad-ali-patch-2|test-yang|updateSize)$"]
@@ -32,10 +29,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(errorhandling|k8s_1.12.0-beta.1|release-0.4|release-1.0|revert-72-pvclister|saad-ali-patch-1|saad-ali-patch-2|test-yang|updateSize)$"]
@@ -61,10 +55,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-alpha
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(errorhandling|k8s_1.12.0-beta.1|release-0.4|release-1.0|revert-72-pvclister|saad-ali-patch-1|saad-ali-patch-2|test-yang|updateSize)$"]

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -160,10 +160,7 @@ EOF
                 if echo "$kubernetes" | grep -q "^$deployment"; then
                     cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment" "$kubernetes")
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]
@@ -202,7 +199,7 @@ EOF
             if [ "$tests" != "alpha" ]; then
                 cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment" master)
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -237,10 +234,7 @@ EOF
 
     cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "unit")
-    # Experimental job, explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     labels:
@@ -277,10 +271,7 @@ EOF
     for tests in non-alpha unit alpha; do
         cat >>"$base/$repo/$repo-config.yaml" <<EOF
   - name: $(job_name "pull" "$repo" "$tests")
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]
@@ -459,22 +450,3 @@ $(resources_for_kubernetes "$actual")
 EOF
     done
 done
-
-# This job can eventually get replaced by the generated job above.
-cat >>"$base/csi-lib-utils/csi-lib-utils-config.yaml" <<EOF
-  - name: pull-sig-storage-csi-lib-utils-stable
-    always_run: true
-    decorate: true
-    skip_report: false
-    spec:
-      containers:
-      # This image was chosen over the more often used kubekins-e2e because
-      # it is smaller and has everything we need (basically just a Go environment).
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20180927-6b4facbe6
-        command:
-        - make
-        args:
-        - -k # report as many failures as possible (if any) before finally failing
-        - all # build...
-        - test # ... and test
-EOF

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/livenessprobe:
   - name: pull-kubernetes-csi-livenessprobe
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(re|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|saad-ali-patch-4)$"]
@@ -32,10 +29,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(re|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|saad-ali-patch-4)$"]
@@ -61,10 +55,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-alpha
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(re|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|saad-ali-patch-4)$"]

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -3,10 +3,7 @@
 presubmits:
   kubernetes-csi/node-driver-registrar:
   - name: pull-kubernetes-csi-node-driver-registrar-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -41,7 +38,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-13-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -76,10 +73,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -114,7 +108,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-14-on-kubernetes-master
-    # Experimental job, explicitly needs to be started with /test.
+    # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
     always_run: false
@@ -149,10 +143,7 @@ presubmits:
           # during the tests more like 3-20m is used
           cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-13-on-kubernetes-1-13
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -187,10 +178,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-14-on-kubernetes-1-14
-    # Experimental job, explicitly needs to be started with /test.
-    # This can be enabled once the components have the necessary configuration
-    # for this combination of deployment+Kubernetes.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -225,10 +213,7 @@ presubmits:
           requests:
             cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-unit
-    # Experimental job, explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
+    always_run: true
     decorate: true
     skip_report: false
     labels:


### PR DESCRIPTION
All repos should now be ready to be tested automatically with
Prow. The only exception are pull-*-on-master jobs because those use a
varying target branch and could get broken by changes in that branch.

The old, manually created pull-sig-storage-csi-lib-utils-stable branch
can be removed, pull-sig-storage-csi-lib-utils replaced it.