### PR TITLE
Revert "properly quote the migrator test args"

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -25,7 +25,7 @@ presubmits:
         - --provider=gce
         - --test=false
         - --test-cmd=../test/e2e/test-fully-automated.sh
-        - --test-cmd-args=--focus="\[Disruptive\]"
+        - --test-cmd-args=--focus=\[Disruptive\]
         - --timeout=50m
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
         - --provider=gce
         - --test=false
         - --test-cmd=../test/e2e/test-fully-automated.sh
-        - --test-cmd-args=--skip="\[Disruptive\]"
+        - --test-cmd-args=--skip=\[Disruptive\]
         - --timeout=50m
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Reverts kubernetes/test-infra#12206

Kubetest has already handled the quotes.

/kind bug
/assign @roycaihw 