### PR TITLE
Enable area/code-organization in k/enhancements

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -183,6 +183,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="kind/kep" href="#kind/kep">`kind/kep`</a> | Categorizes KEP tracking issues and PRs modifying the KEP directory| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -737,6 +737,11 @@ repos:
   kubernetes/enhancements:
     labels:
       - color: 0052cc
+        description: Issues or PRs related to kubernetes code organization
+        name: area/code-organization
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to the Release Engineering subproject
         name: area/release-eng
         previously:


### PR DESCRIPTION
Would like to label issues/prs in k/enhancements as well to track

Change-Id: Ibde59318c6b184e8066b84fff1550b03856e5be0