### PR TITLE
k/kubeadm: add a presubmit verify job

### DIFF
--- a/config/jobs/kubernetes/kubeadm/OWNERS
+++ b/config/jobs/kubernetes/kubeadm/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- luxas
+- timothysc
+- fabriziopandini
+- neolit123
+reviewers:
+- luxas
+- timothysc
+- fabriziopandini
+- neolit123
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -1,0 +1,12 @@
+# k8s.io/kubeadm presubmits
+presubmits:
+  kubernetes/kubeadm:
+  - name: pull-kubeadm-kinder-verify
+    path_alias: "k8s.io/kubeadm"
+    decorate: true
+    run_if_changed: '^kinder\/.*$'
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        command:
+        - "./kinder/hack/verify-all.sh"

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -467,6 +467,9 @@ plugins:
   kubernetes/kops:
   - trigger
 
+  kubernetes/kubeadm:
+  - trigger
+
   kubernetes/kubernetes:
   - blockade
   - cherry-pick-unapproved


### PR DESCRIPTION
Execute `k8s.io/kubeadm/kinder/hack/verify-all.sh` in a presubmit job
to catch problems in PRs.

/hold
until this PR merges:
https://github.com/kubernetes/kubeadm/pull/1506

script contents:
https://github.com/kubernetes/kubeadm/blob/b1d5563e8376c921bf2fbea7cc3fd8832e0ea18a/kinder/hack/verify-all.sh

```
~/go/src/k8s.io/kubeadm$ time ./kinder/hack/verify-all.sh &> /dev/null

real	0m12,419s
user	0m11,042s
sys	0m3,275s
```

 also include an OWNERS file, as the folder is new.

/assign @spiffxp @timothysc @fabriziopandini 
/sig cluster-lifecycle
