### PR TITLE
Make trigger ignore PR events if no jobs are configured.

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -19,17 +19,21 @@ package trigger
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/test-infra/prow/pjutil"
 	"net/url"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/errorutil"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/plugins"
 )
 
 func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) error {
+	if len(c.Config.Presubmits[pr.PullRequest.Base.Repo.FullName]) == 0 {
+		return nil
+	}
+
 	org, repo, a := orgRepoAuthor(pr.PullRequest)
 	author := string(a)
 	num := pr.PullRequest.Number


### PR DESCRIPTION
This will let us enable the `trigger` plugin org wide without wasting API tokens on repos that don't have any jobs configured.
The handlers for push events and generic comment events are already token efficient.

This will also prevent the `needs-ok-to-test` label from being added in repos where no jobs are configured. fixes #12225 

/assign @cblecker @stevekuznetsov @nikhita 