### PR TITLE
bump promoter images

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
+      - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
+      - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
         command:
         - multirun.sh
         args:
@@ -753,7 +753,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190405-v1.0.7-0-ge12c3f3
+    - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
       command:
       - multirun.sh
       args:


### PR DESCRIPTION
This pulls in the upstream fix around renaming images (subdirs) during
the promotion: https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/40