### PR TITLE
Fix hook RBAC for updateconfig.

### DIFF
--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -23,6 +23,7 @@ rules:
       - configmaps
     verbs:
       - create
+      - get
       - update
 ---
 kind: RoleBinding

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -613,6 +613,8 @@ rules:
     resources:
       - configmaps
     verbs:
+      - create
+      - get
       - update
 ---
 kind: RoleBinding


### PR DESCRIPTION
It looks like prow.k8s.io does not actually use the RBAC we supply because the cluster still uses legacy authentication. https://github.com/kubernetes/test-infra/blob/16914aa303830147f45fa48d6fa03b70ed621ad4/prow/cluster/hook_deployment.yaml#L34
That is something we should change when switching to a CNCF owned Prow cluster.

In the meantime, fix the RBAC rules.

/assign @stevekuznetsov @verult 