### PR TITLE
Enable invalidcommitmsg plugin across all active Kubernetes GitHub orgs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -392,6 +392,7 @@ tide:
     - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
@@ -407,6 +408,7 @@ tide:
     - do-not-merge/blocked-paths
     - do-not-merge/cherry-pick-not-approved
     - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -395,6 +395,7 @@ plugins:
   - heart
   - help
   - hold
+  - invalidcommitmsg
   - label
   - lgtm
   - lifecycle
@@ -533,6 +534,7 @@ plugins:
   - heart
   - help
   - hold
+  - invalidcommitmsg
   - label
   - lgtm
   - lifecycle
@@ -555,6 +557,7 @@ plugins:
   - heart
   - help
   - hold
+  - invalidcommitmsg
   - label
   - lgtm
   - lifecycle
@@ -578,6 +581,7 @@ plugins:
   - heart
   - help
   - hold
+  - invalidcommitmsg
   - label
   - lgtm
   - lifecycle
@@ -609,6 +613,7 @@ plugins:
   - heart
   - help
   - hold
+  - invalidcommitmsg
   - label
   - lgtm
   - lifecycle
@@ -667,7 +672,6 @@ plugins:
   - trigger
 
   kubernetes-sigs/contributor-playground:
-  - invalidcommitmsg
   - require-sig
   - welcome
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/9360

Test run here - https://github.com/kubernetes-sigs/contributor-playground/pull/232

/assign @cblecker @cjwagner  

/hold
needs consensus, sending an email to k-dev