### PR TITLE
Revert "Update staging job aks-engine version."

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -144,7 +144,7 @@ periodics:
       - "--acsengine-admin-username=azureuser"
       - "--acsengine-admin-password=AdminPassw0rd"
       - "--acsengine-creds=$AZURE_CREDENTIALS"
-      - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.34.0/aks-engine-v0.34.0-linux-amd64.tar.gz"
+      - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.31.2/aks-engine-v0.31.2-linux-amd64.tar.gz"
       - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
       - "--acsengine-winZipBuildScript=$WIN_BUILD"
       - "--acsengine-orchestratorRelease=1.14"


### PR DESCRIPTION
aks-engine version v0.34.0 has bug: https://github.com/Azure/aks-engine/issues/1079
that makes it unusable for testing at the moment.

This reverts commit d93d6225795403816dbe6c17cd561abe0959ef3e.