### PR TITLE
Enable release-note automation on kubernetes-csi

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -560,6 +560,7 @@ plugins:
   - lifecycle
   - owners-label
   - pony
+  - release-note
   - shrug
   - size
   - skip


### PR DESCRIPTION
All repos under kubernetes-csi should have release-note plugin enabled and require PRs to have ` ```release-note`.

We want to use the same release-notes script as kubernetes/kubernetes to automate CHANGELOG creation. Most repos under kubernetes-csi already have appropriate PR template.

cc @msau42 @saad-ali @childsb from sig-storage side.