### PR TITLE
Fix status contexts for CLA plugin

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1284,12 +1284,18 @@ func (c *Client) CreateStatus(org, repo, SHA string, s Status) error {
 // See https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
 func (c *Client) ListStatuses(org, repo, ref string) ([]Status, error) {
 	c.log("ListStatuses", org, repo, ref)
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, ref)
 	var statuses []Status
-	_, err := c.request(&request{
-		method:    http.MethodGet,
-		path:      fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, ref),
-		exitCodes: []int{200},
-	}, &statuses)
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		func() interface{} {
+			return &[]Status{}
+		},
+		func(obj interface{}) {
+			statuses = append(statuses, *(obj.(*[]Status))...)
+		},
+	)
 	return statuses, err
 }
 

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -345,10 +345,11 @@ func TestCheckCLA(t *testing.T) {
 				Number:     3,
 				IssueState: tc.issueState,
 			}
-			fc.CreatedStatuses["sha"] = []github.Status{
-				{
-					State:   tc.state,
-					Context: tc.context,
+			fc.CombinedStatuses = map[string]*github.CombinedStatus{
+				tc.SHA: {
+					Statuses: []github.Status{
+						{State: tc.state, Context: tc.context},
+					},
 				},
 			}
 			if tc.hasCLAYes {


### PR DESCRIPTION
The CLA plugin's `/check-cla` command wasn't working some of the time.

In looking into it, I saw two issues:
- For anything that uses [`ListStatuses`](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref), you were only getting the 30 most recent contexts pushed for a commit. This includes when a specific commit was retested, so you can have duplicates for a context name. This fixes our client to use paginated results to get all statuses for a SHA.
- Additionally, this moves the CLA plugin over to use the [`GetCombinedStatus`](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref) endpoint instead. This endpoint returns the most recent result of each context pushed for a SHA. It also paginates at 100, instead of 30. This appears to be a more efficient endpoint for this use case, as we only care about the most recent result of the `cla/linuxfoundation` context anyways.

/assign @cjwagner 