### PR TITLE
Update owners for cluster-api and cluster-api-provider-aws jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -1,9 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- detiber
 - chuckha
 - davidewatson
+- detiber
 - d-nishi
 - enxebre
 - ingvagabund
+- kris-nova
+- luxas
+- randomvariable
+- timothysc
+- vincepri

--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- davidewatson
+- detiber
 - justinsb
-- kris-nova
-- krousey
 - luxas
-- roberthbailey
+- timothysc
 - vincepri


### PR DESCRIPTION
These changes align with the recent updates to cluster-api OWNERS_ALIASES