### PR TITLE
Allow OwnersDirBlacklist to include regular expressions

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -61,6 +61,11 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 26, 2019* `blunderbuss`, `approve`, and other plugins that read OWNERS
+   now treat `owners_dir_blacklist` as a list of regular expressions matched
+   against the entire (repository-relative) directory path of the OWNERS file rather
+   than as a list of strings matched exactly against the basename only of the directory
+   containing the OWNERS file.
  - *April 2, 2019* `hook`, `deck`, `horologium`, `tide`, `plank` and `sinker` will no
    longer provide a default value for the `--config-path` flag.
    It is required to explicitly provide `--config-path` when upgrading to a new version of

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -107,8 +107,8 @@ type ProwConfig struct {
 	// PushGateway is a prometheus push gateway.
 	PushGateway PushGateway `json:"push_gateway,omitempty"`
 
-	// OwnersDirBlacklist is used to configure which directories to ignore when
-	// searching for OWNERS{,_ALIAS} files in a repo.
+	// OwnersDirBlacklist is used to configure regular expressions matching directories
+	// to ignore when searching for OWNERS{,_ALIAS} files in a repo.
 	OwnersDirBlacklist OwnersDirBlacklist `json:"owners_dir_blacklist,omitempty"`
 
 	// Pub/Sub Subscriptions that we want to listen to
@@ -127,8 +127,8 @@ type ProwConfig struct {
 	DefaultJobTimeout time.Duration `json:"default_job_timeout,omitempty"`
 }
 
-// OwnersDirBlacklist is used to configure which directories to ignore when
-// searching for OWNERS{,_ALIAS} files in a repo.
+// OwnersDirBlacklist is used to configure regular expressions matching directories
+// to ignore when searching for OWNERS{,_ALIAS} files in a repo.
 type OwnersDirBlacklist struct {
 	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`
@@ -137,7 +137,7 @@ type OwnersDirBlacklist struct {
 	Default []string `json:"default"`
 }
 
-// DirBlacklist returns directories which are used to ignore when
+// DirBlacklist returns regular expressions matching directories to ignore when
 // searching for OWNERS{,_ALIAS} files in a repo.
 func (ownersDirBlacklist OwnersDirBlacklist) DirBlacklist(org, repo string) (blacklist []string) {
 	blacklist = append(blacklist, ownersDirBlacklist.Default...)

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -331,8 +331,23 @@ func TestOwnersDirBlacklist(t *testing.T) {
 		includeDirs: []string{"", "src", "src/dir", "src/dir/conformance", "src/dir/subdir"},
 	}
 	tests["non-matching blacklist"] = testConf{
-		blacklistDefault: []string{"sr"},
+		blacklistDefault: []string{"sr$"},
 		includeDirs:      []string{"", "src", "src/dir", "src/dir/conformance", "src/dir/subdir"},
+	}
+	tests["path blacklist"] = testConf{
+		blacklistDefault: []string{"src/dir"},
+		includeDirs:      []string{"", "src"},
+		excludeDirs:      []string{"src/dir", "src/dir/conformance", "src/dir/subdir"},
+	}
+	tests["regexp blacklist path"] = testConf{
+		blacklistDefault: []string{"src/dir/."},
+		includeDirs:      []string{"", "src", "src/dir"},
+		excludeDirs:      []string{"src/dir/conformance", "src/dir/subdir"},
+	}
+	tests["path substring"] = testConf{
+		blacklistDefault: []string{"/c"},
+		includeDirs:      []string{"", "src", "src/dir", "src/dir/subdir"},
+		excludeDirs:      []string{"src/dir/conformance"},
 	}
 
 	for name, conf := range tests {


### PR DESCRIPTION
As discussed in #12136, this will allow people to obey `vendor/OWNERS` while ignoring `vendor/.*/OWNERS`.

Previously, blacklist entries were matched only against the basename of the directory, so just changing from string matching to regexp matching doesn't let you match `vendor/.*`. To try and minimize the semantic changes, I made it so that blacklist entries not containing `/` continue to be matched against the basename, while entries containing `/` get matched against the (basedir-relative) path, and all matches are implicitly anchored with `^` and `$`. This is all sort of fiddly and I'm willing to change any of it.

Fixes #12136

/cc @stevekuznetsov @cblecker @cjwagner 