### PR TITLE
Allow peribolos to dump a fully functional config

### DIFF
--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -60,6 +60,10 @@ func TestOptions(t *testing.T) {
 			args: []string{"--config-path=foo", "--maximum-removal-delta=-0.1"},
 		},
 		{
+			name: "reject --dump-full-config without --dump",
+			args: []string{"--config-path=foo", "--dump-full-config"},
+		},
+		{
 			name: "maximal delta",
 			args: []string{"--config-path=foo", "--maximum-removal-delta=1"},
 			expected: &options{


### PR DESCRIPTION
It is not often intended when using --dump to want only the org snippet
for any deployment of peribolos that does not use the bazel
metaprogramming that is used in kubernetes/org repo. In those cases,
dumping the full config instead of the snippet is more useful.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 
/cc @cblecker @nikhita 