### PR TITLE
Make configs extend each other

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,17 +16,44 @@ test:lint --test_tag_filters=lint
 # bazel test //... --config=unit
 test:unit --test_tag_filters=-lint
 
-# --config=remote enable a remote bazel cache
-# Note needs an instance name, see --config=remote-fejta for an example
-build:remote --remote_cache=remotebuildexecution.googleapis.com
-build:remote --tls_enabled=true
-build:remote --remote_timeout=3600
-build:remote --auth_enabled=true
+# --config=remote-cache enables a remote bazel cache
+# Note needs an instance name
+# See --config=remote-fejta-cache for a concrete example
+build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
+build:remote-cache --tls_enabled=true
+build:remote-cache --remote_timeout=3600
+build:remote-cache --auth_enabled=true
 
-# --config=remote-exec rmote execution to the the --config=remote cache
-build:remote-exec --remote_executor=remotebuildexecution.googleapis.com
-build:remote-exec --jobs=500
+# --config=remote adds remote execution to the --config=remote-cache
+# Note needs an instance name
+# See --config=remote-fejta for a concrete example
+build:remote --config=remote-cache
+build:remote --remote_executor=remotebuildexecution.googleapis.com
+build:remote --jobs=500
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=:rbe_with_network
+build:remote --host_platform=:rbe_with_network
+build:remote --platforms=:rbe_with_network
+build:remote --spawn_strategy=remote
+build:remote --strategy=Javac=remote
+build:remote --strategy=Closure=remote
+build:remote --strategy=Genrule=remote
+build:remote --define=EXECUTOR=remote
 
-# --config=remote-fejta is an example instance name
+# Compose the remote configs with an instance name
+# A couple examples below:
+
+# --config=fejta-instance adds the instance name
 # TODO(fejta): see how broadly we can provide this and/or add common corp instances
-build:remote-fejta --remote_instance_name=projects/fejta-prod/instances/default_instance
+build:fejta-instance --remote_instance_name=projects/fejta-prod/instances/default_instance
+
+# --config=remote-fejta runs actions on fejta-instance
+build:remote-fejta --config=remote --config=fejta-instance
+# --config=remote-fejta-cache caches actions on fejta-instance
+build:remote-fejta-cache --config=remote-cache --config=fejta-instance


### PR DESCRIPTION
/assign @BenTheElder @cjwagner 

Looks like `build:foo --config=bar` works just fine, so using that pattern.
Also adding some missing flags for remote execution to get better cache rates and performance.

```shell
# ~2m - remote execution takes about 2m to pass all tests from a clean instance, warm cache
bazel clean --expunge && time bazel test --config=remote-fejta //...

# ~3m - remote cache takes about 3m to pass all tests from a clean instance, warm cache
bazel clean --expunge && time bazel test --config=remote-fejta-cache //...

# ~9m - locally this work takes 9m on a clean instance
bazel clean --expunge && time bazel test //...
```