### PR TITLE
Change cluster name to private-gce-test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -563,7 +563,7 @@ periodics:
           - --gcp-nodes=5
           - --gcp-zone=us-east1-b
           - --provider=gce
-          - --cluster=private-gce-correctness
+          - --cluster=private-gce-test
           # TODO(mm4tt): Start setting --ssh-proxy-instance-name= when it's supported in kubetest
           - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
           - --timeout=120m


### PR DESCRIPTION
The previous name, `private-gce-correctness`, results in attempt to create a firewall-rule named `private-gce-correctness-minion-private-gce-correctness-nodeports` which exceeds 64 character limit and makes the test fail.