### PR TITLE
testgrid/cmd: Closing paren in -gcp-service-account help

### DIFF
--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -55,7 +55,7 @@ type options struct {
 
 func gatherOptions() (options, error) {
 	o := options{}
-	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty")
+	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.oneshot, "oneshot", false, "Write proto once and exit instead of monitoring --yaml files for changes")
 	flag.StringVar(&o.output, "output", "", "write proto to gs://bucket/obj or /local/path")
 	flag.BoolVar(&o.printText, "print-text", false, "print generated proto in text format to stdout")

--- a/testgrid/cmd/updater/main.go
+++ b/testgrid/cmd/updater/main.go
@@ -80,7 +80,7 @@ func (o *options) validate() error {
 func gatherOptions() options {
 	o := options{}
 	flag.Var(&o.config, "config", "gs://path/to/config.pb")
-	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty")
+	flag.StringVar(&o.creds, "gcp-service-account", "", "/path/to/gcp/creds (use local creds if empty)")
 	flag.BoolVar(&o.confirm, "confirm", false, "Upload data if set")
 	flag.StringVar(&o.group, "test-group", "", "Only update named group if set")
 	flag.IntVar(&o.groupConcurrency, "group-concurrency", 0, "Manually define the number of groups to concurrently update if non-zero")


### PR DESCRIPTION
Fixing typos from 5be4adf72d (#6773) and ceb8c793b4 (#7423).