### PR TITLE
Add pre/post-submit jobs for vsphere-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- akutz
+- codenrhoden
+- dvonthenen
+- figo
+- frapposelli

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -1,0 +1,78 @@
+presubmits:
+  kubernetes-sigs/vsphere-csi-driver:
+
+  # Runs "gofmt", "go vet", and "golint" on the sources.
+  - name: pull-vsphere-csi-driver-check
+    decorate: true
+    branches:
+    - ^master$
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    skip_submodules: true
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+        command:
+        - "make"
+        args:
+        - "check"
+
+  # Builds the CSI binary
+  - name: pull-vsphere-csi-driver-build
+    decorate: true
+    branches:
+    - ^master$
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    skip_submodules: true
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+        command:
+        - "make"
+        args:
+        - "build"
+
+  # Executes the unit tests.
+  - name: pull-vsphere-csi-driver-unit-test
+    decorate: true
+    branches:
+    - ^master$
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    skip_submodules: true
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+        command:
+        - "make"
+        args:
+        - "unit-test"
+
+postsubmits:
+  kubernetes-sigs/vsphere-csi-driver:
+
+  # Deploys the CSI image
+  - name: post-vsphere-csi-driver-deploy
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-cloud-provider-vsphere-e2e-config: "true"
+    max_concurrency: 1
+    branches:
+    - ^master$
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    skip_submodules: true
+    spec:
+      containers:
+      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+        command:
+        - "make"
+        args:
+        - "deploy"
+        securityContext:
+          privileged: true

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -359,6 +359,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/poseidon",
 		"kubernetes-sigs/kube-batch",
 		"kubernetes-sigs/structured-merge-diff",
+		"kubernetes-sigs/vsphere-csi-driver",
 		"tensorflow/minigo",
 	}) {
 		jobs[job.Name] = false

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2857,6 +2857,18 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 16
   num_failures_to_alert: 1
+- name: pull-vsphere-csi-driver-check
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-vsphere-csi-driver-check
+  num_columns_recent: 20
+- name: pull-vsphere-csi-driver-build
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-vsphere-csi-driver-build
+  num_columns_recent: 20
+- name: pull-vsphere-csi-driver-unit-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-vsphere-csi-driver-unit-test
+  num_columns_recent: 20
+- name: post-vsphere-csi-driver-deploy
+  gcs_prefix: kubernetes-jenkins/logs/post-vsphere-csi-driver-deploy
+  num_columns_recent: 20
 - name: ci-kubernetes-e2e-gce-cos-k8sstable1-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable1-default
 - name: ci-kubernetes-e2e-gke-cos-k8sstable1-default
@@ -7652,6 +7664,26 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
+- name: vmware-presubmits-vsphere-csi-driver
+  dashboard_tab:
+  - name: pull-vsphere-csi-driver-check
+    test_group_name: pull-vsphere-csi-driver-check
+    base_options: width=10
+  - name: pull-vsphere-csi-driver-build
+    test_group_name: pull-vsphere-csi-driver-build
+    base_options: width=10
+  - name: pull-vsphere-csi-driver-unit-test
+    test_group_name: pull-vsphere-csi-driver-unit-test
+    base_options: width=10
+
+- name: vmware-postsubmits-vsphere-csi-driver
+  dashboard_tab:
+  - name: post-vsphere-csi-driver-deploy
+    test_group_name: post-vsphere-csi-driver-deploy
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
+
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance
@@ -8448,6 +8480,8 @@ dashboard_groups:
   dashboard_names:
   - vmware-presubmits-cloud-provider-vsphere
   - vmware-postsubmits-cloud-provider-vsphere
+  - vmware-presubmits-vsphere-csi-driver
+  - vmware-postsubmits-vsphere-csi-driver
   - vmware-conformance
   - vmware-conformance-cloud-provider
   - vmware-cluster-api-provider-vsphere


### PR DESCRIPTION
All tests are added to the vmware dashboard

These tests are modeled after the cloud-provider-vsphere tests.

/cc @akutz 
^ for approval to use `preset-cloud-provider-vsphere-e2e-config: "true"`, which gives the job access to a secret for use to push new images to gcr.io