### PR TITLE
Adds a periodic commenter for checking CLAs

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -28,10 +28,42 @@ periodics:
       - --token=/etc/token/bot-github-token
       - |-
         --comment=This PR [may require API review](https://git.k8s.io/community/sig-architecture/api-review-process.md#what-apis-need-to-be-reviewed).
-        
+
         If so, when the changes are ready, [complete the pre-review checklist and request an API review](https://git.k8s.io/community/sig-architecture/api-review-process.md#mechanics).
-        
+
         Status of requested reviews is tracked in the [API Review project](https://github.com/orgs/kubernetes/projects/13).
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+- name: periodic-test-infra-cla
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20190419-321e4866f
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:kubernetes
+        is:pr
+        is:open
+        -label:"cncf-cla: no"
+        -label:"cncf-cla: yes"
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Unknown CLA label state. Rechecking for CLA labels.
+
+        Send feedback to sig-testing, kubernetes/test-infra and/or [fejta](https://github.com/fejta).
+        /check-cla
+      - --template
       - --ceiling=10
       - --confirm
       volumeMounts:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2239,6 +2239,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-rotten
 - name: periodic-test-infra-close
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-close
+- name: periodic-test-infra-cla
+  gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-cla
 - name: periodic-kubespray-close
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubespray-close
 - name: periodic-kubespray-rotten
@@ -7116,6 +7118,9 @@ dashboards:
   - name: close
     description: Closes rotten issues after 30d of inactivity
     test_group_name: periodic-test-infra-close
+  - name: cla
+    description: Re-checks CLA context when CLA labels are missing
+    test_group_name: periodic-test-infra-cla
   - name: api-review-help
     description: Adds API review process description to kind/api-change PRs
     test_group_name: periodic-api-review-help


### PR DESCRIPTION
Looks like we have 68 PRs in Kubernetes with an unknown CLA state. This creates a @fejta-bot commenter that will hopefully get these into a yes/no state.

/assign @fejta 