### PR TITLE
kubeadm: attempt to fix empty buildlog error

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -11,10 +11,13 @@ periodics:
     timeout: 2400000000000 #40m
   extra_refs:
   - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  path_alias: k8s.io/kubeadm
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master


### PR DESCRIPTION
the job as is, results in a empty build log for some reason and i don't know why.
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#kubeadm-kinder-upgrade-stable-master

looking at the artifacts/clone-log.txt i only see the k/k clone but no k/kubeadm.
this PR should clone both repos and also default $pwd to the kubeadm tree as per:
https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md

> periodic jobs will have the working directory set to the root of the repo specified by the first ref in extra_refs (if specified)

hopefully the command will trigger this way.

/assign @fabriziopandini 
/sig cluster-lifecycle
