### PR TITLE
Simplify pull-test-infra-bazel

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -40,16 +40,14 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-experimental
+      - image: launcher.gcr.io/google/bazel:0.24.1
         command:
-        - runner.sh
-        - ./scenarios/kubernetes_execute_bazel.py
-        args:
         - hack/build-then-unit.sh
         resources:
           requests:
             memory: "2Gi"
 
+  # TODO(fejta): delete this job its non-rbe parent is equivalent
   - name: pull-test-infra-bazel-rbe
     branches:
     - master
@@ -59,15 +57,11 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
       - image: launcher.gcr.io/google/bazel:0.24.1
         command:
         - hack/build-then-unit.sh
-        resources:
-          requests:
-            memory: "2Gi"
 
   - name: pull-test-infra-gubernator
     branches:

--- a/hack/build-then-unit.sh
+++ b/hack/build-then-unit.sh
@@ -16,7 +16,9 @@
 # used in presubmits / CI testing
 # bazel build then unit test, exiting non-zero if either failed
 
-res=0
+set -o nounset
+set -o errexit
+set -o pipefail
 
 bazel=(
   bazel
@@ -31,14 +33,6 @@ if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
   )
 fi
 
-"${bazel[@]}" build --config=ci //...
-if [[ $? -ne 0 ]]; then
-    res=1
-fi
-
-"${bazel[@]}" test --config=ci //... --config=unit
-if [[ $? -ne 0 ]]; then
-    res=1
-fi
-
-exit ${res}
+# --config=unit ignores lint tests
+# --nobuild_tests_only builds all targets, not just test targets
+"${bazel[@]}" test --config=ci --config=unit --nobuild_tests_only //...


### PR DESCRIPTION
* Make `pull-test-infra-bazel` config match the current `pull-test-infra-bazel-rbe` config (that is also passing)
* Simplify `hack/build-then-unit.sh` logic
* Further simplify the job def (remove resource reqs, unneeded preset)

/hold
/assign @cjwagner @BenTheElder 

ref https://github.com/kubernetes/test-infra/issues/12282