### PR TITLE
Enable needs-rebase plugin for Kubespray repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -724,3 +724,7 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  kubernetes-sigs/kubespray:
+  - name: needs-rebase
+    events:
+      - pull_request


### PR DESCRIPTION
Adding the `needs-rebase` bot plugin in Kubespray would save us time and automate the "Can you rebase this on latest master?" type reviews.

CC @mattymo @ant31 and @chadswen