### PR TITLE
 Fix poll optimization in SecretAgent 

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -822,7 +822,7 @@ func (c *Config) validateJobConfig() error {
 const DefaultConfigPath = "/etc/config/config.yaml"
 
 // ConfigPath returns the value for the component's configPath if provided
-// explicityly or default otherwise.
+// explicitly or default otherwise.
 func ConfigPath(value string) string {
 
 	if value != "" {

--- a/prow/config/secret/agent.go
+++ b/prow/config/secret/agent.go
@@ -79,6 +79,7 @@ func (a *Agent) reloadSecret(secretPath string) {
 				WithError(err).Error("Error loading secret.")
 		} else {
 			a.setSecret(secretPath, secretValue)
+			skips = 0
 		}
 	}
 }


### PR DESCRIPTION
Properly reset the counter for skips (=not loading a secret because the
underlying file was not observably changed) when the secret is reloaded.

The watch mechanism is supposed to reload a secret even after no changes
were observed for X iterations. The counter for skips was never zeroed
so after 10 minutes the Agent started to reload the secrets each second.

Also fix a typo I noticed.