### PR TITLE
Add postsubmit testing to cluster-api-provider-aws for release branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -56,6 +56,7 @@ postsubmits:
       preset-aws-credential: "true"
     branches:
     - ^master$
+    - ^release-.*$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-1.14


### PR DESCRIPTION
Previously we were only doing postsubmit testing for master.

/assign @chuckha 