### PR TITLE
Fix lastUpdated behavior.

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -296,7 +296,7 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 
 			// process if updated later than last updated
 			// stop if update was stale
-			if !updated.Before(lastUpdate) {
+			if updated.After(lastUpdate) {
 				switch change.Status {
 				case Merged:
 					submitted := parseStamp(*change.Submitted)


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/12311.

Now that the lastSyncTime is one of the change update values, we want to only consider new changes that are strictly after it.  

/cc @krzyzacy 