### PR TITLE
bump promoter images

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
+      - image: gcr.io/cip-demo-staging/cip:20190423-v2.0.1-0-g4db722e
         command:
         - multirun.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -433,7 +433,7 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
+      - image: gcr.io/cip-demo-staging/cip:20190423-v2.0.1-0-g4db722e
         command:
         - multirun.sh
         args:
@@ -753,7 +753,7 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: gcr.io/cip-demo-staging/cip:20190416-v2.0.0-0-g2d2e61b
+    - image: gcr.io/cip-demo-staging/cip:20190423-v2.0.1-0-g4db722e
       command:
       - multirun.sh
       args:


### PR DESCRIPTION
This brings in a small fix to the rename logic [1] so that we don't have
to treat "gcr.io" as a special case when splitting image paths into
registry + image name.

[1]: https://github.com/kubernetes-sigs/k8s-container-image-promoter/commit/93cc2a638a0631ff8a199d0d5ebfcb7dc20658d6