### PR TITLE
Increase verify timeout for ci-kubernetes-verify-stable2

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -212,7 +212,7 @@ periodics:
     - image: gcr.io/k8s-testimages/bootstrap:v20190213-2f4f06285
       args:
       - --repo=k8s.io/kubernetes=release-1.12
-      - --timeout=75
+      - --timeout=90
       - --scenario=kubernetes_verify
       - --
       - --branch=release-1.12


### PR DESCRIPTION
[ci-kubernetes-verify-stable2](https://testgrid.k8s.io/sig-release-1.12-blocking#verify-1.12) for release-1.12 branch is failing now because of timeout. 

This PR increases the timeout to 90.