### PR TITLE
prow: run tests in a different namespace

### DIFF
--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -11,18 +11,25 @@ metadata:
   name: "deck"
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-  - apiGroups:
       - "prow.k8s.io"
     resources:
       - prowjobs
     verbs:
       - get
       - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "deck"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -36,6 +43,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "deck"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "deck"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "deck"
+subjects:
+- kind: ServiceAccount
+  name: "deck"
+  namespace: default
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -11,14 +11,6 @@ metadata:
   name: "plank"
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - list
-  - apiGroups:
       - "prow.k8s.io"
     resources:
       - prowjobs
@@ -27,6 +19,21 @@ rules:
       - create
       - list
       - update
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "plank"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -40,3 +47,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "plank"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "plank"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "plank"
+subjects:
+- kind: ServiceAccount
+  name: "plank"
+  namespace: default

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -11,16 +11,23 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
-      - list
-  - apiGroups:
       - "prow.k8s.io"
     resources:
       - prowjobs
+    verbs:
+      - delete
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
     verbs:
       - delete
       - list
@@ -37,3 +44,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "sinker"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+- kind: ServiceAccount
+  name: "sinker"
+  namespace: default

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -481,6 +481,11 @@ spec:
         configMap:
           name: plugins
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -505,10 +505,38 @@ subjects:
 - kind: ServiceAccount
   name: "deck"
 ---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "deck"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "deck"
+subjects:
+- kind: ServiceAccount
+  name: "deck"
+  namespace: default
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   namespace: default
+  name: "deck"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
   name: "deck"
 rules:
   - apiGroups:
@@ -517,13 +545,6 @@ rules:
       - pods/log
     verbs:
       - get
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - get
-      - list
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -570,14 +591,6 @@ metadata:
   namespace: default
   name: "plank"
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - list
   - apiGroups:
       - "prow.k8s.io"
     resources:
@@ -588,6 +601,21 @@ rules:
       - list
       - update
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "plank"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - list
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -600,6 +628,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "plank"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "plank"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "plank"
+subjects:
+- kind: ServiceAccount
+  name: "plank"
+  namespace: default
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -614,16 +656,23 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
-      - list
-  - apiGroups:
       - "prow.k8s.io"
     resources:
       - prowjobs
+    verbs:
+      - delete
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
     verbs:
       - delete
       - list
@@ -640,6 +689,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "sinker"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+- kind: ServiceAccount
+  name: "sinker"
+  namespace: default
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/cluster/test-pods_namespace.yaml
+++ b/prow/cluster/test-pods_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -261,6 +261,25 @@ label. When you make a change to the plugin config and push it with `make
 update-plugins`, you do not need to redeploy any of your cluster components.
 They will pick up the change within a few minutes.
 
+### Set namespaces for prowjobs and test pods
+
+Add the following to `config.yaml`:
+
+```yaml
+prowjob_namespace: default
+pod_namespace: test-pods
+```
+
+By doing so, we keep prowjobs in the `default` namespace and test pods in the
+`test_pods` namespace.
+
+You can also choose other names. Remember to update the RBAC roles and
+rolebindings afterwards.
+
+**Note**: If you set or update the `prowjob_namespace` or `pod_namespace`
+fields after deploying the prow components, you will need to redeploy them
+so that they pick up the change.
+
 ### Add more jobs by modifying `config.yaml`
 
 Add the following to `config.yaml`:
@@ -327,26 +346,6 @@ the change within a few minutes.
 When you push or merge a new change to the git repo, the postsubmit job will run.
 
 For more information on the job environment, see [`jobs.md`](/prow/jobs.md)
-
-### Run test pods in a different namespace
-
-You may choose to keep prowjobs or run tests in a different namespace. First
-create the namespace by `kubectl create -f`ing this:
-
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: prow
-```
-
-Now, in `config.yaml`, set `prowjob_namespace` or `pod_namespace` to the
-name from the YAML file. You can then use RBAC roles to limit what test pods
-can do.
-
-**Note**: If you set or update the `prowjob_namespace` or `pod_namespace`
-fields after deploying the prow components, you will need to redeploy them
-so that they pick up the change.
 
 ### Run test pods in different clusters
 


### PR DESCRIPTION
This is based on https://github.com/kubernetes/test-infra/issues/10787#issuecomment-455031845.

Since the current config is https://github.com/kubernetes/test-infra/blob/006066e40f57e8de48790c959a16b9adb02dbdaf/prow/config.yaml#L45-L46

we need Roles and RoleBindings for `test-pods` namespace in several `*_rbac.yaml` files.

The diff might be a bit hard to read, but it's moving the accesses of `pods` to `test-pods` namespace while keeping accesses of `prowjobs` in `default` namespace.

This PR also updated `starter.yaml` and `getting_started_deploy.md` so it will fix https://github.com/kubernetes/test-infra/issues/10787.