### PR TITLE
Update kubekins image in scalability tests.

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1885,7 +1885,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-100-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         name: ""
         resources:
           requests:
@@ -1948,7 +1948,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-big-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         name: ""
         resources:
           requests:
@@ -2011,7 +2011,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-large-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         name: ""
         resources:
           requests:
@@ -2085,7 +2085,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         name: ""
         resources:
           requests:
@@ -2447,7 +2447,7 @@ presubmits:
         - --timeout=1200m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-scale
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -47,7 +47,7 @@ periodics:
     preset-e2e-scalability-node: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -114,7 +114,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -162,7 +162,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -196,7 +196,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8
       - --timeout=210m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -243,7 +243,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1270m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -262,7 +262,7 @@ periodics:
     preset-e2e-kubemark-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -309,7 +309,6 @@ periodics:
     preset-e2e-kubemark-gce-big: "true"
   spec:
     containers:
-      # TODO(mm4tt): Update it everywhere if it works.
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
@@ -358,7 +357,7 @@ periodics:
     preset-e2e-kubemark-gce-scale: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -407,7 +406,7 @@ periodics:
     preset-e2e-kubemark-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -449,7 +448,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -476,7 +475,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -495,7 +494,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=55
@@ -520,7 +519,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -552,7 +551,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         args:
           - --timeout=300
           - --bare

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -43,7 +43,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         resources:
           requests:
             memory: "6Gi"
@@ -90,7 +90,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         resources:
           requests:
             memory: "6Gi"
@@ -137,7 +137,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         resources:
           requests:
             memory: "6Gi"
@@ -161,7 +161,7 @@ presubmits:
       preset-e2e-kubemark-gce-big: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -470,7 +470,7 @@ presubmits:
       preset-e2e-kubemark-gce-scale: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -27,7 +27,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=210m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -73,7 +73,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       resources:
         requests:
           cpu: 6
@@ -91,7 +91,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
       args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=master
@@ -158,7 +158,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
 
 # This is a sig-release-<stable1>-blocking job.
 - cron: "0 0/12 * * *" # every six hours, disjoint with ci-kubernetes-e2e-gci-gce-scalability-stable2 and ci-kubernetes-e2e-gci-gce-scalability-stable3
@@ -201,7 +201,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
 
 # This is a sig-release-<stable2>-blocking job.
 - cron: "0 4-16/12 * * *" # every six hours, disjoint with ci-kubernetes-e2e-gci-gce-scalability-stable1 and ci-kubernetes-e2e-gci-gce-scalability-stable3
@@ -244,7 +244,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master
 
 # This is a sig-release-<stable3>-blocking job.
 - cron: "0 8-20/12 * * *" # every six hours, disjoint with ci-kubernetes-e2e-gci-gce-scalability-stable1 and ci-kubernetes-e2e-gci-gce-scalability-stable2
@@ -287,4 +287,4 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190418-925ad44-master


### PR DESCRIPTION
Update from `v20190329-811f7954b-master` to `v20190418-925ad44-master`.

This is to propagate change from https://github.com/kubernetes/test-infra/pull/12251.

The new version has been tested in kubemark-500 (https://github.com/kubernetes/test-infra/pull/12254) and seems to be working there without any issues.

Ref. https://github.com/kubernetes/perf-tests/issues/503