### PR TITLE
Add dashboards to testgrid config for Oracle Cloud Infrastructure

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3551,6 +3551,25 @@ test_groups:
 - name: cloud-provider-aibaba-cloud-e2e-conformance-release-v1.11
   gcs_prefix: k8s-conformance-alibaba/cloud-provider-alibaba-cloud/e2e-conformance-release-v1.11
 
+# Oracle Cloud Infrastructure(OCI) Test Groups
+- name: cloud-provider-oci-e2e-conformance-stable-v1.14
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci/e2e-conformance-stable-1.14
+
+- name: cloud-provider-oci-e2e-conformance-stable-v1.13
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci/e2e-conformance-stable-1.13
+
+- name: cloud-provider-oci-e2e-conformance-stable-v1.12
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci/e2e-conformance-stable-1.12
+
+- name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.12
+
+- name: cloud-provider-oci-oke-e2e-conformance-stable-v1.11
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.11
+
+- name: cloud-provider-oci-oke-e2e-conformance-stable-v1.10
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.10
+
 # kube-storage-version-migrator
 - name: pull-kube-storage-version-migrator-test
   gcs_prefix: kubernetes-jenkins/pr-logs/pull-kube-storage-version-migrator-test
@@ -3899,6 +3918,37 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.10
 
+  - name: OCI, v1.14 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.14
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OCI, v1.13 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OCI, v1.12 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.12
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.12 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.11 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.11 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.11
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.10 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.10
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+
 - name: conformance-gce
   dashboard_tab:
   - name: GCE, master (dev)
@@ -4109,6 +4159,39 @@ dashboards:
   - name: Alibaba Cloud Provider, v1.11
     description: Runs conformance tests for cloud provier alibaba cloud on release v1.11
     test_group_name: cloud-provider-aibaba-cloud-e2e-conformance-release-v1.11
+
+- name: conformance-oracle-cloud-infrastructure
+  dashboard_tab:
+    - name: OCI, v1.14 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure
+      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.14
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OCI, v1.13 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure
+      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OCI, v1.12 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure
+      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.12
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OKE, v1.12 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OKE, v1.11 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.11 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.11
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OKE, v1.10 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.10
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
 
 - name: canonical-ubuntu1-k8sbeta
   dashboard_tab:
@@ -8593,6 +8676,7 @@ dashboard_groups:
   - conformance-arm
   - conformance-ppc64le
   - conformance-eks
+  - conformance-oracle-cloud-infrastructure
 
 - name: vmware
   dashboard_names:


### PR DESCRIPTION
Add following dashboard tabs under https://k8s-testgrid.appspot.com/conformance-all:

- Oracle Cloud Infrastructure, v1.14 (release)

- Oracle Cloud Infrastructure, v1.13 (release)

- Oracle Cloud Infrastructure, v1.12 (release)

- OCI Container Engine for Kubernetes(OKE), v1.12 (release)

- OKE, v1.11 (release)

- OKE, v1.10 (release)

Add a new dashboard called "conformance-oracle-cloud-infrastructure" under dashboard group "conformance" (https://k8s-testgrid.appspot.com) which will also have links to above dashboard tabs.