### PR TITLE
[cluster-api-provider-aws] add configuration for kind

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -34,6 +34,23 @@ periodics:
         value: "boskos.test-pods.svc.cluster.local"
       securityContext:
         privileged: true
+      # volumeMounts for kind
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
 postsubmits:
   kubernetes-sigs/cluster-api-provider-aws:
   - name: ci-cluster-api-provider-aws-bazel-e2e
@@ -61,3 +78,19 @@ postsubmits:
           value: "boskos.test-pods.svc.cluster.local"
         securityContext:
           privileged: true
+      # volumeMounts for kind
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory


### PR DESCRIPTION
I believe we are missing some critical mounts from the host for the pods trying to run `kind`

Signed-off-by: Chuck Ha <chuckh@vmware.com>