### PR TITLE
[cluster-api-provider-aws] revert extra_refs and wrap in runner

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -1,19 +1,22 @@
 periodics:
 - name: periodic-cluster-api-provider-aws-test-creds
-  path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   decorate: true
   interval: 4h
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-1.14
       command:
       - "./scripts/ci-aws-cred-test.sh"
 - name: periodic-cluster-api-provider-aws-bazel-e2e
-  path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   decorate: true
   interval: 1h
   labels:
@@ -22,14 +25,16 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-1.14
-      command:
-      - runner.sh
-      args:
-      - make
-      - e2e
+      command: ["runner.sh"]
+      args: ["make", "e2e"]
       env:
       - name: BOSKOS_HOST
         value: "boskos.test-pods.svc.cluster.local"
@@ -53,11 +58,8 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-1.14
-        command:
-        - runner.sh
-        args:
-        - make
-        - e2e
+        command: ["runner.sh"]
+        args: ["make", "e2e"]
         env:
         - name: BOSKOS_HOST
           value: "boskos.test-pods.svc.cluster.local"


### PR DESCRIPTION
Outline of changes:

1. `extra_refs` are added back in to periodics because periodic jobs are not associated with *any* repository and require an explicit reference to a repository to clone.
2. Setting the extra-ref for periodics will put the working directory in the root of the first extra_ref cloned repository.
3. The commands are wrapped in runner.sh (which is available on the image's $PATH from `/usr/local/bin`) which will start the docker service and then run our commands which rely on docker running

Signed-off-by: Chuck Ha <chuckh@vmware.com>