### PR TITLE
Fix environment variable for Windows node binaries.

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
@@ -55,8 +55,8 @@ periodics:
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
       env:
-      - name: USE_RELEASE_NODE_BINARIES
-        value: "true"
+      - name: OVERRIDE_NODE_BINARY_TAR_URL
+        value: "https://storage.googleapis.com/kubernetes-release/release/v1.14.1/kubernetes-node-windows-amd64.tar.gz"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
       resources:
         requests:


### PR DESCRIPTION
Use `OVERRIDE_NODE_BINARY_TAR_URL` instead of `USE_RELEASE_NODE_BINARIES` for Windows node binaries. This was accidentally changed in https://github.com/kubernetes/test-infra/pull/12305.