### PR TITLE
More, weaker workers

### DIFF
--- a/rbe/install.sh
+++ b/rbe/install.sh
@@ -27,10 +27,10 @@ fi
 # More info: https://cloud.google.com/remote-build-execution/docs/overview
 
 proj=$1
-pool=${2:-prow-pool}
-workers=25
-disk=500
-machine=n1-standard-8
+pool=${2:-}
+workers=100
+disk=300
+machine=n1-standard-2
 
 users=()
 groups=()
@@ -52,6 +52,18 @@ check=(
   worker-pools describe
   "$pool" "--project=$proj" --instance=default_instance
 )
+
+if [[ -z $pool ]]; then
+    echo "Existing pools:" >&2
+    for i in $(gcloud alpha remote-build-execution worker-pools list \
+        "--project=$proj" \
+        --instance=default_instance \
+        --format='value(name)'); do
+      echo "  $(basename "$i")" >&2
+    done
+    echo "Usage: $0 $1 <pool>" >&2
+    exit 1
+fi
 
 if ! "${check[@]}" 2>/dev/null; then
   log gcloud alpha remote-build-execution worker-pools create  \


### PR DESCRIPTION
/assign @mikedanese @cjwagner 

Also making it easier to figure out worker pool names

Remote execution team recommends 1 or 2 core nodes for go builds. AKA better to have many small nodes than a few large nodes.