### PR TITLE
Stop loading full Prow configuration for Peribolos

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,9 @@
 # Announcements
 
 New features added to each component:
+ - *April 25, 2019* `--job-config` in `peribolos` has never been used; it is
+   deprecated and will be removed in July 2019. Remove the flag from any calls
+   to the tool.
  - *April 24, 2019* `file_weight_count` in blunderbuss is being deprecated in
    favour of the more current `max_request_count` functionality. Please ensure
    your configuration is up to date before the end of May 2019.

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/peribolos",
     visibility = ["//visibility:private"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/config/org:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/errorutil:go_default_library",

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/config/org:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -41,7 +41,6 @@ import (
 
 	buildapi "github.com/knative/build/pkg/apis/build/v1alpha1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
@@ -73,14 +72,13 @@ type JobConfig struct {
 
 // ProwConfig is config for all prow controllers
 type ProwConfig struct {
-	Tide             Tide                  `json:"tide,omitempty"`
-	Plank            Plank                 `json:"plank,omitempty"`
-	Sinker           Sinker                `json:"sinker,omitempty"`
-	Deck             Deck                  `json:"deck,omitempty"`
-	BranchProtection BranchProtection      `json:"branch-protection,omitempty"`
-	Orgs             map[string]org.Config `json:"orgs,omitempty"`
-	Gerrit           Gerrit                `json:"gerrit,omitempty"`
-	GitHubReporter   GitHubReporter        `json:"github_reporter,omitempty"`
+	Tide             Tide             `json:"tide,omitempty"`
+	Plank            Plank            `json:"plank,omitempty"`
+	Sinker           Sinker           `json:"sinker,omitempty"`
+	Deck             Deck             `json:"deck,omitempty"`
+	BranchProtection BranchProtection `json:"branch-protection,omitempty"`
+	Gerrit           Gerrit           `json:"gerrit,omitempty"`
+	GitHubReporter   GitHubReporter   `json:"github_reporter,omitempty"`
 
 	// TODO: Move this out of the main config.
 	JenkinsOperators []JenkinsOperator `json:"jenkins_operators,omitempty"`

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+// FullConfig stores the full configuration to be used by the tool, mapping
+// orgs to their configuration at the top level under an `orgs` key.
+type FullConfig struct {
+	Orgs map[string]Config `json:"orgs,omitempty"`
+}
+
 // Metadata declares metadata about the GitHub org.
 //
 // See https://developer.github.com/v3/orgs/#edit-an-organization


### PR DESCRIPTION
Peribolos is a separate tool from Prow and does not need to be loading
the Prow configuration. One interesting side-effect of loading the full
config is that the `--log-level` flag on the tool did not work, as the
config load after the flag parsing set the level differently

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta @cjwagner 