### PR TITLE
jenkins-operator: handle UNSTABLE Jenkins status

### DIFF
--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -52,9 +52,10 @@ const (
 )
 
 const (
-	success = "SUCCESS"
-	failure = "FAILURE"
-	aborted = "ABORTED"
+	success  = "SUCCESS"
+	failure  = "FAILURE"
+	unstable = "UNSTABLE"
+	aborted  = "ABORTED"
 )
 
 // NotFoundError is returned by the Jenkins client when
@@ -132,7 +133,7 @@ func (jb *Build) IsSuccess() bool {
 
 // IsFailure means the job completed with problems.
 func (jb *Build) IsFailure() bool {
-	return jb.Result != nil && *jb.Result == failure
+	return jb.Result != nil && (*jb.Result == failure || *jb.Result == unstable)
 }
 
 // IsAborted means something stopped the job before it could finish.

--- a/prow/jenkins/jenkins_test.go
+++ b/prow/jenkins/jenkins_test.go
@@ -125,6 +125,7 @@ func TestListBuilds(t *testing.T) {
 					{Number: 1, Result: strP(success), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "first"}, {Name: prowJobID, Value: "first"}}}}},
 					{Number: 2, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "second"}, {Name: prowJobID, Value: "second"}}}}},
 					{Number: 3, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "third"}, {Name: prowJobID, Value: "third"}}}}},
+					{Number: 4, Result: strP(unstable), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "fourth"}, {Name: prowJobID, Value: "fourth"}}}}},
 				},
 				"integration": {
 					{Number: 1, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "first-int"}, {Name: prowJobID, Value: "first-int"}}}}},
@@ -136,6 +137,7 @@ func TestListBuilds(t *testing.T) {
 				"first":      {Number: 1, Result: strP(success), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "first"}, {Name: prowJobID, Value: "first"}}}}},
 				"second":     {Number: 2, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "second"}, {Name: prowJobID, Value: "second"}}}}},
 				"third":      {Number: 3, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "third"}, {Name: prowJobID, Value: "third"}}}}},
+				"fourth":     {Number: 4, Result: strP(unstable), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "fourth"}, {Name: prowJobID, Value: "fourth"}}}}},
 				"first-int":  {Number: 1, Result: strP(failure), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "first-int"}, {Name: prowJobID, Value: "first-int"}}}}},
 				"second-int": {Number: 2, Result: strP(success), Actions: []Action{{Parameters: []Parameter{{Name: statusBuildID, Value: "second-int"}, {Name: prowJobID, Value: "second-int"}}}}},
 			},


### PR DESCRIPTION
Jenkins Operator determines job outcome based on [three Jenkins job statuses](https://github.com/kubernetes/test-infra/blob/006f755f3d6a83f33d6a143570d83acdc22adaa4/prow/jenkins/jenkins.go#L54-L58):

```
const (
	success = "SUCCESS"
	failure = "FAILURE"
	aborted = "ABORTED"
)
```

However, Jenkins job can be `UNSTABLE`, as per [Jenkins terminology](https://wiki.jenkins.io/display/JENKINS/Terminology). An unstable job is supposedly a (partially) successful job. Jenkins documentation isn't very clear on this. From looking at internal Jenkins, unstable builds have failed tests and therefore should not be considered successful.

Currently, when a job reports UNSTABLE, e.g.
```
[Pipeline] // podTemplate
[Pipeline] End of Pipeline

GitHub has been notified of this commit’s build result

Finished: UNSTABLE
```

Jenkins Operator continues to report the job as running, perpetually. Counting `UNSTABLE` as failure addresses that.