### PR TITLE
jenkins-operator: use ProwJobID when looking for enqueued jobs

### DIFF
--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -119,7 +119,7 @@ func (f *fjc) Build(pj *prowapi.ProwJob, buildID string) error {
 	return nil
 }
 
-func (f *fjc) ListBuilds(jobs []string) (map[string]Build, error) {
+func (f *fjc) ListBuilds(jobs []BuildQueryParams) (map[string]Build, error) {
 	f.Lock()
 	defer f.Unlock()
 	if f.err != nil {
@@ -946,7 +946,7 @@ func TestGetJenkinsJobs(t *testing.T) {
 		for _, ej := range test.expected {
 			var found bool
 			for _, gj := range got {
-				if ej == gj {
+				if ej == gj.JobName {
 					found = true
 					break
 				}


### PR DESCRIPTION
ProwJobID is a unique identifier that doesn't depend on how the job was setup.