### PR TITLE
Remove duplicate rbe job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -37,26 +37,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-    spec:
-      containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
-        command:
-        - hack/build-then-unit.sh
-        resources:
-          requests:
-            memory: "2Gi"
-
-  # TODO(fejta): delete this job its non-rbe parent is equivalent
-  - name: pull-test-infra-bazel-rbe
-    branches:
-    - master
-    always_run: true
-    skip_report: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
     spec:
       containers:
       - image: launcher.gcr.io/google/bazel:0.24.1

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2768,9 +2768,6 @@ test_groups:
 - name: pull-test-infra-bazel-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
   num_columns_recent: 20
-- name: pull-test-infra-bazel-rbe
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-rbe
-  num_columns_recent: 20
 - name: pull-test-infra-lint
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
   num_columns_recent: 20
@@ -7779,9 +7776,6 @@ dashboards:
   dashboard_tab:
   - name: bazel
     test_group_name: pull-test-infra-bazel
-    base_options: width=10
-  - name: bazel-rbe
-    test_group_name: pull-test-infra-bazel-rbe
     base_options: width=10
   - name: lint
     test_group_name: pull-test-infra-lint


### PR DESCRIPTION
/assign @krzyzacy @spiffxp @cjwagner 

Makes `pull-test-infra-bazel` the same as `pull-test-infra-bazel-rbe` and deletes the `-rbe` version

Will unblock https://github.com/kubernetes/test-infra/pull/12363