### PR TITLE
Fix a couple bugs in assign plugin team review requests

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1700,24 +1700,26 @@ func (c *Client) CreateReview(org, repo string, number int, r DraftReview) error
 //
 // https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
 func prepareReviewersBody(logins []string, org string) (map[string][]string, error) {
-	body := map[string][]string{}
 	var errors []error
+
+	// form initial body with empty arrays
+	body := map[string][]string{}
+	body["reviewers"] = []string{}
+	body["team_reviewers"] = []string{}
+
+	// iterate through list of logins, and split up users from teams
 	for _, login := range logins {
 		mat := teamRe.FindStringSubmatch(login)
 		if mat == nil {
-			if _, exists := body["reviewers"]; !exists {
-				body["reviewers"] = []string{}
-			}
 			body["reviewers"] = append(body["reviewers"], login)
 		} else if mat[1] == org {
-			if _, exists := body["team_reviewers"]; !exists {
-				body["team_reviewers"] = []string{}
-			}
 			body["team_reviewers"] = append(body["team_reviewers"], mat[2])
 		} else {
 			errors = append(errors, fmt.Errorf("team %s is not part of %s org", login, org))
 		}
 	}
+
+	// return the completed body
 	return body, errorutil.NewAggregate(errors...)
 }
 

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -90,7 +90,7 @@ func parseLogins(text string) []string {
 		if t == "" {
 			continue
 		}
-		parts = append(parts, t)
+		parts = append(parts, github.NormLogin(t))
 	}
 	return parts
 }

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -388,6 +388,12 @@ func TestAssignAndReview(t *testing.T) {
 			commenter:   "rando",
 			unrequested: []string{"kubernetes/sig-testing-misc"},
 		},
+		{
+			name:      "add mixed case user",
+			body:      "/assign BenTheElder",
+			commenter: "rando",
+			assigned:  []string{"bentheelder"},
+		},
 	}
 	for _, tc := range testcases {
 		fc := newFakeClient([]string{"hello-world", "allow_underscore", "cjwagner", "merlin", "kubernetes/sig-testing-misc"})


### PR DESCRIPTION
- Normalizes usernames as passed into the assign plugin
- Always prepare full reviewers body, including both reviewers and team_reviewers.

When doing local testing, I'm guessing this was the issue we hit:
```json
{"message":"Invalid request.\n\n\"reviewers\" wasn't supplied.","documentation_url":"https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request"} 
```