### PR TITLE
Fix bug in repository permission level handling

### DIFF
--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2266,13 +2266,13 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 		},
 		{
@@ -2289,14 +2289,14 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
-				{Name: "other-admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "other-admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 		},
 		{
@@ -2312,12 +2312,12 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true}},
 			}},
 		},
@@ -2333,11 +2333,11 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
-				{Name: "write", Permissions: github.RepoPermissions{Push: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true}},
 			}},
 		},

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -55,12 +55,12 @@ func ImageTooBig(url string) (bool, error) {
 // LevelFromPermissions adapts a repo permissions struct to the
 // appropriate permission level used elsewhere
 func LevelFromPermissions(permissions RepoPermissions) RepoPermissionLevel {
-	if permissions.Pull {
-		return Read
+	if permissions.Admin {
+		return Admin
 	} else if permissions.Push {
 		return Write
-	} else if permissions.Admin {
-		return Admin
+	} else if permissions.Pull {
+		return Read
 	} else {
 		return None
 	}
@@ -75,9 +75,9 @@ func PermissionsFromLevel(permission RepoPermissionLevel) RepoPermissions {
 	case Read:
 		return RepoPermissions{Pull: true}
 	case Write:
-		return RepoPermissions{Push: true}
+		return RepoPermissions{Pull: true, Push: true}
 	case Admin:
-		return RepoPermissions{Admin: true}
+		return RepoPermissions{Pull: true, Push: true, Admin: true}
 	default:
 		return RepoPermissions{}
 	}

--- a/prow/github/helpers_test.go
+++ b/prow/github/helpers_test.go
@@ -82,11 +82,11 @@ func TestLevelFromPermissions(t *testing.T) {
 			level:       Read,
 		},
 		{
-			permissions: RepoPermissions{Push: true},
+			permissions: RepoPermissions{Pull: true, Push: true},
 			level:       Write,
 		},
 		{
-			permissions: RepoPermissions{Admin: true},
+			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
 			level:       Admin,
 		},
 	}
@@ -117,11 +117,11 @@ func TestPermissionsFromLevel(t *testing.T) {
 		},
 		{
 			level:       Write,
-			permissions: RepoPermissions{Push: true},
+			permissions: RepoPermissions{Pull: true, Push: true},
 		},
 		{
 			level:       Admin,
-			permissions: RepoPermissions{Admin: true},
+			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Not super clear to me why the GitHub API has three fields when there are only three possible states, but ok. 

/assign @cjwagner @fejta @cblecker 