### PR TITLE
Stop validating OWNERS files under vendor

### DIFF
--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -196,6 +196,24 @@ func TestHandle(t *testing.T) {
 			shouldLabel:  true,
 		},
 		{
+			name:         "forbidden labels in OWNERS file at top of vendor",
+			filesChanged: []string{"vendor/OWNERS", "b.go"},
+			ownersFile:   "invalidLabels",
+			shouldLabel:  true,
+		},
+		{
+			name:         "forbidden labels in OWNERS file somewhere under vendor",
+			filesChanged: []string{"vendor/github.com/oopsie/doopsie/OWNERS", "b.go"},
+			ownersFile:   "invalidLabels",
+			shouldLabel:  false,
+		},
+		{
+			name:         "forbidden labels in OWNERS file somewhere under vendor-like dir",
+			filesChanged: []string{"vendorability/github.com/oopsie/doopsie/OWNERS", "b.go"},
+			ownersFile:   "invalidLabels",
+			shouldLabel:  true,
+		},
+		{
 			name:         "forbidden labels in OWNERS file with filters",
 			filesChanged: []string{"OWNERS", "b.go"},
 			ownersFile:   "invalidLabelsFilters",


### PR DESCRIPTION
When someone vendors code, the code the are bringing is not under their
control and we should not be validating that the OWNERS files that they
pull in are valid in the context of the repository vendoring them.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @nikhita @fejta @cjwagner 