### PR TITLE
add more logging when mergepatch is empty

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -175,6 +175,10 @@ func (c *Controller) updateReportState(pj *v1.ProwJob) error {
 		return fmt.Errorf("error CreateMergePatch: %v", err)
 	}
 
+	if len(patch) == 0 {
+		logrus.Warnf("Empty merge patch: pjData: %s, newpjData: %s", string(pjData), string(newpjData))
+	}
+
 	logrus.Infof("Created merge patch: %v", string(patch))
 
 	_, err = c.pjclientset.Prow().ProwJobs(pj.Namespace).Patch(pj.Name, types.MergePatchType, patch)


### PR DESCRIPTION
```
{"component":"crier","level":"info","msg":"Updated job, now will update pj","prowjob":"default/e422ddc8-66e3-11e9-88ba-ceb9efd1da19","time":"2019-04-26T20:43:54Z"}
{"component":"crier","level":"info","msg":"Created merge patch: {}","time":"2019-04-26T20:43:54Z"}
```

Which should not happen and we lost the report state on the prowjob (which leads to reporting again when crier is restarted). Want to inspect the pj and see why the mergepatch would be empty.

/assign @amwat @fejta 