### PR TITLE
Update more test-infra jobs to use RBE

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -1,28 +1,23 @@
-presubmits:  
+presubmits:
   kubernetes/test-infra:
   - name: pull-test-infra-bazel-canary
-    always_run: false
+    skip_report: true
+    always_run: true
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      - image: launcher.gcr.io/google/bazel
         imagePullPolicy: Always
+        command:
+        - hack/bazel.sh
         args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=kubernetes_execute_bazel"
-        - "--timeout=15"
-        - "--" # end bootstrap args, scenario args below
-        - "hack/build-then-unit.sh"
-        volumeMounts:
-        resources:
-          requests:
-            memory: "2Gi"
+        - test
+        - --config=ci
+        - --config=unit
+        - --nobuild_tests_only
+        - //...
 
 # Testing to make sure things still update.
 periodics:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -15,28 +15,23 @@ postsubmits:
         image: busybox
         args: ["cat", "config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml"]
 
-  - name: ci-test-infra-bazel
+  - name: post-test-infra-bazel
     branches:
     - master
     decorate: true
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-experimental
+      - image: launcher.gcr.io/google/bazel:0.24.1
         command:
-        - runner.sh
-        - ./scenarios/kubernetes_bazel.py
+        - hack/bazel.sh
         args:
-        - --build=//...
-        - --install=gubernator/test_requirements.txt
-        - --test=//...
-        - --test-args=--test_output=errors
-        resources:
-          requests:
-            memory: "2Gi"
+        - test
+        - --config=ci
+        - --nobuild_tests_only
+        - //...
 
   - name: maintenance-boskos-config-upload
     branches:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -81,6 +81,24 @@ presubmits:
           requests:
             memory: "2Gi"
 
+  - name: pull-test-infra-lint-rbe
+    skip_report: true
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: launcher.gcr.io/google/bazel:0.24.1
+        command:
+        - hack/bazel.sh
+        args:
+        - test
+        - --config=ci
+        - --config=lint
+        - //...
+
   - name: pull-test-infra-verify-tslint
     branches:
       - master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -786,6 +786,8 @@ test_groups:
   num_columns_recent: 20
 - name: post-test-infra-build-smoke
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-build-smoke
+- name: post-test-infra-bazel
+  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-bazel
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
 - name: ci-test-infra-canary-echo-test
@@ -2763,6 +2765,9 @@ test_groups:
   num_columns_recent: 20
 - name: pull-test-infra-bazel-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
+  num_columns_recent: 20
+- name: pull-test-infra-lint-rbe
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint-rbe
   num_columns_recent: 20
 - name: pull-test-infra-lint
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
@@ -7284,9 +7289,14 @@ dashboards:
     test_group_name: post-test-infra-push-test-gubernator
 - name: sig-testing-misc
   dashboard_tab:
-  - name: bazel
-    description: Runs bazel test //... on the test-infra repo.
+  - name: ci-bazel
+    description: Runs bazel test //... on the test-infra repo every hour
     test_group_name: ci-test-infra-bazel
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: post-bazel
+    description: Runs bazel test //... on the test-infra repo on each commit
+    test_group_name: post-test-infra-bazel
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: triage
@@ -7772,6 +7782,9 @@ dashboards:
     base_options: width=10
   - name: lint
     test_group_name: pull-test-infra-lint
+    base_options: width=10
+  - name: lint-rbe
+    test_group_name: pull-test-infra-lint-rbe
     base_options: width=10
   - name: bazel-canary
     test_group_name: pull-test-infra-bazel-canary


### PR DESCRIPTION
* Update `pull-test-infra-bazel-canary` to use a bazel image instead of kubetest
  - Make it call bazel directly instead of in a script (will update blocking job when this passes)
* Update `post-test-infra-bazel` postsubmit to use the same pattern as the presubmit (and have the right prefix)
* Create a silent `pull-test-infra-lint-rbe` job that uses rbe

/assign @krzyzacy @cjwagner @michelle192837 @amwat 