### PR TITLE
kubeadm-upgrade: track k/kubernetes commits instead of k/kubeadm

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -11,19 +11,19 @@ periodics:
     timeout: 2400000000000 #40m
   extra_refs:
   - org: kubernetes
-    repo: kubeadm
-    base_ref: master
-    path_alias: k8s.io/kubeadm
-  - org: kubernetes
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
       command:
       - runner.sh
-      - "./kinder/ci/kinder-run.sh"
+      - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
       - "upgrade-stable-master"
       securityContext:


### PR DESCRIPTION
Swap the extra_refs for k/kubernetes and k/kubeadm. This results in:
- testgrid commits are now for k/kubernetes and "search for changes"
can be used.
- The command has to be changed to "../kubeadm/..." because
now the home path is k/kubernetes.

/assign @fabriziopandini 
/kind cleanup
/sig cluster-lifecycle
