### PR TITLE
Add more logs to config-bootstrapper

### DIFF
--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -113,6 +113,7 @@ func main() {
 				Filename: relPath,
 				Status:   github.PullRequestFileAdded,
 			})
+			logrus.Infof("added to mock change: %s", relPath)
 		} else {
 			logrus.WithError(err).Warn("unexpected error determining relative path to file")
 		}
@@ -126,6 +127,8 @@ func main() {
 		logger := logrus.WithFields(logrus.Fields{"configmap": map[string]string{"name": cm.Name, "namespace": cm.Namespace}})
 		if err := updateconfig.Update(&osFileGetter{root: o.sourcePath}, client.CoreV1().ConfigMaps(cm.Namespace), cm.Name, cm.Namespace, data, logger); err != nil {
 			logger.WithError(err).Error("failed to update config on cluster")
+		} else {
+			logger.Infof("Successfully processed configmap")
 		}
 	}
 }


### PR DESCRIPTION
Was a bit confused when the only message it printed out was https://github.com/kubernetes/test-infra/blob/34eed5413a77c094a20e74ae9eb70daf7fa177ba/prow/kube/config.go#L147 while the bootstrapper is actually running

/area bikeshed
/assign @cjwagner @stevekuznetsov 