### PR TITLE
Make plank aware of namespace set from prowjobs

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -174,14 +174,20 @@ func ProwJobToPod(pj prowapi.ProwJob, buildID string) (*coreapi.Pod, error) {
 	}
 
 	podLabels, annotations := LabelsAndAnnotationsForJob(pj)
-	return &coreapi.Pod{
+	pod := &coreapi.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pj.ObjectMeta.Name,
 			Labels:      podLabels,
 			Annotations: annotations,
 		},
 		Spec: *spec,
-	}, nil
+	}
+	// override if pj has a non-empty namespace
+	// otherwise will fallback to the default namespace of the pod client
+	if pj.Spec.Namespace != "" {
+		pod.ObjectMeta.Namespace = pj.Spec.Namespace
+	}
+	return pod, nil
 }
 
 const cloneLogPath = "clone.json"

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -1603,6 +1603,7 @@ func TestProwJobToPod(t *testing.T) {
 						},
 					},
 				},
+				Namespace: "test-pods",
 			},
 			expected: &coreapi.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1620,6 +1621,7 @@ func TestProwJobToPod(t *testing.T) {
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
 					},
+					Namespace: "test-pods",
 				},
 				Spec: coreapi.PodSpec{
 					AutomountServiceAccountToken: &falseth,


### PR DESCRIPTION
The field exists (https://github.com/kubernetes/test-infra/blob/master/prow/apis/prowjobs/v1/types.go#L112-L113) but seems we never respected it.

(This is assuming the pod client like https://github.com/kubernetes/test-infra/blob/64d9890dad8cd852038cba342b52d5283a950ecc/prow/cmd/plank/main.go#L131 uses the podnamespace as a default and the pod namespace is still over-writable.)

/assign @stevekuznetsov @cjwagner 