### PR TITLE
Update lint and canary in k/ti and bazel-build in k/k

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2696,6 +2696,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - build
         - --config=remote
+        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
         - //...
         - //build/release-tars
         - --

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -53,6 +53,7 @@ presubmits:
         args:
         - build
         - --config=remote
+        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
         - //...
         - //build/release-tars
         - --

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/test-infra:
   - name: pull-test-infra-bazel-canary
+    decorate: true
     skip_report: true
     always_run: true
     labels:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -60,28 +60,6 @@ presubmits:
           value: "/workspace"
 
   - name: pull-test-infra-lint
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-experimental
-        command:
-        - runner.sh
-        - ./scenarios/kubernetes_bazel.py
-        args:
-        - "--install=gubernator/test_requirements.txt"
-        - "--test=//..."
-        - "--test-args=--config=lint"
-        volumeMounts:
-        resources:
-          requests:
-            memory: "2Gi"
-
-  - name: pull-test-infra-lint-rbe
     skip_report: true
     always_run: true
     decorate: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2771,9 +2771,6 @@ test_groups:
 - name: pull-test-infra-bazel-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
   num_columns_recent: 20
-- name: pull-test-infra-lint-rbe
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint-rbe
-  num_columns_recent: 20
 - name: pull-test-infra-lint
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
   num_columns_recent: 20
@@ -7790,9 +7787,6 @@ dashboards:
     base_options: width=10
   - name: lint
     test_group_name: pull-test-infra-lint
-    base_options: width=10
-  - name: lint-rbe
-    test_group_name: pull-test-infra-lint-rbe
     base_options: width=10
   - name: bazel-canary
     test_group_name: pull-test-infra-bazel-canary


### PR DESCRIPTION
* `pull-kubernetes-bazel-build` needs the instance name
* `pull-test-infra-bazel-canary` needs to turn on decoration
* Use rbe on `pull-test-infra-lint` now that we know its working:
  - https://prow.k8s.io/?job=pull-test-infra-lint-rbe
  - https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/12382/pull-test-infra-lint-rbe/1121921120077877249

/assign @krzyzacy @cjwagner @michelle192837 @Katharine 