### PR TITLE
Add apiserver audit-log support to experiment/kind-e2e.sh

### DIFF
--- a/experiment/audit-policy.yaml
+++ b/experiment/audit-policy.yaml
@@ -1,0 +1,164 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # The following requests were manually identified as high-volume and low-risk,
+  # so drop them.
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints", "services", "services/status"]
+  - level: None
+    # Ingress controller reads 'configmaps/ingress-uid' through the unsecured port.
+    # TODO(#46983): Change this to the ingress controller service account.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics.k8s.io"
+
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+      - /swagger*
+
+  # Don't log events requests.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+
+  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+  - level: Request
+    users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  - level: Request
+    userGroups: ["system:nodes"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+
+  # deletecollection calls can be large, don't log responses for expected namespace deletions
+  - level: Request
+    users: ["system:serviceaccount:kube-system:namespace-controller"]
+    verbs: ["deletecollection"]
+    omitStages:
+      - "RequestReceived"
+
+  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
+    omitStages:
+      - "RequestReceived"
+  # Get repsonses can be large; skip them.
+  - level: Request
+    verbs: ["get", "list", "watch"]
+    resources: 
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for known APIs
+  - level: RequestResponse
+    resources: 
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for all other requests.
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -87,18 +87,79 @@ build() {
 
 # up a cluster with kind
 create_cluster() {
+    # create the audit-policy necessary for API Coverage
+    # https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
+    cp $(dirname $0)/audit-policy.yaml /tmp/audit-policy.yaml
     # create the config file
     cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
 # config for 1 control plane node and 2 workers
 # necessary for conformance
-kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 # the control plane node
 - role: control-plane
+  extraMounts:
+  - hostPath: "${ARTIFACTS}/logs/apiserver-audit.log"
+    containerPath: /var/log/apiserver-audit.log
+  - hostPath: /tmp/audit-policy.yaml
+    containerPath: /etc/kubernetes/audit-policy.yaml
 - role: worker
-  replicas: 2
+- role: worker
 EOF
+    KUBEADM_MINOR=$(kubectl version --client=true 2>&1 | perl -pe 's/(^.*Minor:")([0-9]+)(.*$)/\2/')
+    if echo $KUBEADM_MINOR | grep 11\\\|12\\\|13
+    then
+        echo Patching for kubeadm.k8s.io/v1alpha3
+        cat <<ALPHA3_CONFIG > "${ARTIFACTS}/kind-config.yaml"
+# v1alpha2 works for 1.11, 1.12 and 1.13
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1alpha3
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      audit-log-path: /var/log/apiserver-audit.log
+      audit-policy-file: /etc/kubernetes/audit-policy.yaml
+  apiServerExtraVolumes:
+  - name: auditpolicy
+    pathType: FileOrCreate
+    readOnly: true
+    hostPath: /etc/kubernetes/audit-policy.yaml
+    mountPath: /etc/kubernetes/audit-policy.yaml
+  - name: auditlog
+    pathType: FileOrCreate
+    readOnly: false
+    hostPath: /var/log/apiserver-audit.log
+    mountPath: /var/log/apiserver-audit.log
+ALPHA3_CONFIG
+    else
+        echo Patching for kubeadm.k8s.io/v1beta1
+        cat <<BETA1_CONFIG > "${ARTIFACTS}/kind-config.yaml"
+# v1beta1 works for 1.14 and 1.15
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      audit-log-path: /var/log/apiserver-audit.log
+      audit-policy-file: /etc/kubernetes/audit-policy.yaml
+    extraVolumes:
+    - hostPath: /etc/kubernetes/audit-policy.yaml
+      mountPath: /etc/kubernetes/audit-policy.yaml
+      name: auditpolicy
+      readOnly: true
+    - hostPath: /var/log/apiserver-audit.log
+      mountPath: /var/log/apiserver-audit.log
+      name: auditlog
+      readOnly: false
+BETA1_CONFIG
+    fi
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it
     KIND_IS_UP=true


### PR DESCRIPTION
> Adds support for auditlog generation.
> Log is created at **$ARTIFACTS/logs/apiserver-audit.log**
> 
> After merging, this should update and make conformance audit logs available via testgrid.
> 
> https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
> 
> ```yaml
>             # the script must run from kubernetes, but we're checking out kind
>             - "bash"
>             - "--"
>             - "-c"
>             - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh"
> ```

It should be noted that @BenTheElder suggested we stop using this script.
#12378 moves from using this script to kind/hack/ci/e2e.sh.
