### PR TITLE
tide: add optional commit message template

### DIFF
--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -17,15 +17,16 @@ The following configuration fields are available:
 * `merge_method`: A key/value pair of an `org/repo` as the key and merge method to override
    the default method of merge as value. Valid options are `squash`, `rebase`, and `merge`.
    Defaults to `merge`.
+* `merge_commit_template`: A mapping from `org/repo` or `org` to a set of Go templates to use when creating the title and body of merge commits. Go templates are evaluated with a `PullRequest`  (see [`PullRequest`](https://godoc.org/k8s.io/test-infra/prow/tide#PullRequest) type). This field and map keys are optional.
 * `target_url`: URL for tide status contexts.
 * `pr_status_base_url`: The base URL for the PR status page. If specified, this URL is used to construct
    a link that will be used for the tide status context. It is mutually exclusive with the `target_url` field.
 * `max_goroutines`: The maximum number of goroutines spawned inside the component to
    handle org/repo:branch pools. Defaults to 20. Needs to be a positive number.
 * `blocker_label`: The label used to identify issues which block merges to repository branches.
-* `squash_label`: The label used to ask Tide to use the squash method when merging the labeled PR. 
-* `rebase_label`: The label used to ask Tide to use the rebase method when merging the labeled PR. 
-* `merge_label`: The label used to ask Tide to use the merge method when merging the labeled PR. 
+* `squash_label`: The label used to ask Tide to use the squash method when merging the labeled PR.
+* `rebase_label`: The label used to ask Tide to use the rebase method when merging the labeled PR.
+* `merge_label`: The label used to ask Tide to use the merge method when merging the labeled PR.
 
 ### Merge Blocker Issues
 
@@ -34,7 +35,7 @@ In order to use this option, set the `blocker_label` configuration option for th
 Then, when blocking merges is required, if an issue is found with the label it will block merges to
 all branches for the repo. In order to scope the branches which are blocked, add a `branch:name` token
 to the issue title. These tokens can be repeated to select multiple branches and the tokens also support
-quoting, so `branch:"name"` will block the `name` branch just as `branch:name` would. 
+quoting, so `branch:"name"` will block the `name` branch just as `branch:name` would.
 
 ### Queries
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1020,6 +1020,30 @@ func parseProwConfig(c *Config) error {
 		}
 	}
 
+	for name, templates := range c.Tide.MergeTemplate {
+		if templates.TitleTemplate != "" {
+			titleTemplate, err := template.New("CommitTitle").Parse(templates.TitleTemplate)
+
+			if err != nil {
+				return fmt.Errorf("parsing template for commit title: %v", err)
+			}
+
+			templates.Title = titleTemplate
+		}
+
+		if templates.BodyTemplate != "" {
+			bodyTemplate, err := template.New("CommitBody").Parse(templates.BodyTemplate)
+
+			if err != nil {
+				return fmt.Errorf("parsing template for commit body: %v", err)
+			}
+
+			templates.Body = bodyTemplate
+		}
+
+		c.Tide.MergeTemplate[name] = templates
+	}
+
 	for i, tq := range c.Tide.Queries {
 		if err := tq.Validate(); err != nil {
 			return fmt.Errorf("tide query (index %d) is invalid: %v", i, err)

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"text/template"
 	"time"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
@@ -1839,6 +1840,134 @@ github_reporter:
 		if err == nil {
 			if !reflect.DeepEqual(cfg.GitHubReporter.JobTypesToReport, tc.expectTypes) {
 				t.Errorf("tc %s: expected %#v\n!=\nactual %#v", tc.name, tc.expectTypes, cfg.GitHubReporter.JobTypesToReport)
+			}
+		}
+	}
+}
+
+func TestMergeCommitTemplateLoading(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		prowConfig  string
+		expectError bool
+		expect      map[string]TideMergeCommitTemplate
+	}{
+		{
+			name: "no template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+`,
+			expect: nil,
+		},
+		{
+			name: "empty template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+`,
+			expect: map[string]TideMergeCommitTemplate{
+				"kubernetes/ingress": {},
+			},
+		},
+		{
+			name: "two proper templates",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+      title: "{{ .Title }}"
+      body: "{{ .Body }}"
+`,
+			expect: map[string]TideMergeCommitTemplate{
+				"kubernetes/ingress": {
+					TitleTemplate: "{{ .Title }}",
+					BodyTemplate:  "{{ .Body }}",
+					Title:         template.Must(template.New("CommitTitle").Parse("{{ .Title }}")),
+					Body:          template.Must(template.New("CommitBody").Parse("{{ .Body }}")),
+				},
+			},
+		},
+		{
+			name: "only title template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+      title: "{{ .Title }}"
+`,
+			expect: map[string]TideMergeCommitTemplate{
+				"kubernetes/ingress": {
+					TitleTemplate: "{{ .Title }}",
+					BodyTemplate:  "",
+					Title:         template.Must(template.New("CommitTitle").Parse("{{ .Title }}")),
+					Body:          nil,
+				},
+			},
+		},
+		{
+			name: "only body template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+      body: "{{ .Body }}"
+`,
+			expect: map[string]TideMergeCommitTemplate{
+				"kubernetes/ingress": {
+					TitleTemplate: "",
+					BodyTemplate:  "{{ .Body }}",
+					Title:         nil,
+					Body:          template.Must(template.New("CommitBody").Parse("{{ .Body }}")),
+				},
+			},
+		},
+		{
+			name: "malformed title template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+      title: "{{ .Title"
+`,
+			expectError: true,
+		},
+		{
+			name: "malformed body template",
+			prowConfig: `
+tide:
+  merge_commit_template:
+    kubernetes/ingress:
+      body: "{{ .Body"
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		// save the config
+		prowConfigDir, err := ioutil.TempDir("", "prowConfig")
+		if err != nil {
+			t.Fatalf("fail to make tempdir: %v", err)
+		}
+		defer os.RemoveAll(prowConfigDir)
+
+		prowConfig := filepath.Join(prowConfigDir, "config.yaml")
+		if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
+			t.Fatalf("fail to write prow config: %v", err)
+		}
+
+		cfg, err := Load(prowConfig, "")
+		if tc.expectError && err == nil {
+			t.Errorf("tc %s: Expect error, but got nil", tc.name)
+		} else if !tc.expectError && err != nil {
+			t.Errorf("tc %s: Expect no error, but got error %v", tc.name, err)
+		}
+
+		if err == nil {
+			if !reflect.DeepEqual(cfg.Tide.MergeTemplate, tc.expect) {
+				t.Errorf("tc %s: expected %#v\n!=\nactual %#v", tc.name, tc.expect, cfg.Tide.MergeTemplate)
 			}
 		}
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -148,6 +148,80 @@ func TestMergeMethod(t *testing.T) {
 		}
 	}
 }
+func TestMergeTemplate(t *testing.T) {
+	ti := &Tide{
+		MergeTemplate: map[string]TideMergeCommitTemplate{
+			"kubernetes/kops": {
+				TitleTemplate: "",
+				BodyTemplate:  "",
+			},
+			"kubernetes/charts": {
+				TitleTemplate: "{{ .Number }}",
+				BodyTemplate:  "",
+			},
+			"helm/charts": {
+				TitleTemplate: "",
+				BodyTemplate:  "{{ .Body }}",
+			},
+			"kubernetes-helm": {
+				TitleTemplate: "{{ .Title }}",
+				BodyTemplate:  "{{ .Body }}",
+			},
+		},
+	}
+
+	var testcases = []struct {
+		org      string
+		repo     string
+		expected TideMergeCommitTemplate
+	}{
+		{
+			org:      "kubernetes",
+			repo:     "kubernetes",
+			expected: TideMergeCommitTemplate{},
+		},
+		{
+			org:  "kubernetes",
+			repo: "kops",
+			expected: TideMergeCommitTemplate{
+				TitleTemplate: "",
+				BodyTemplate:  "",
+			},
+		},
+		{
+			org:  "kubernetes",
+			repo: "charts",
+			expected: TideMergeCommitTemplate{
+				TitleTemplate: "{{ .Number }}",
+				BodyTemplate:  "",
+			},
+		},
+		{
+			org:  "helm",
+			repo: "charts",
+			expected: TideMergeCommitTemplate{
+				TitleTemplate: "",
+				BodyTemplate:  "{{ .Body }}",
+			},
+		},
+		{
+			org:  "kubernetes-helm",
+			repo: "monocular",
+			expected: TideMergeCommitTemplate{
+				TitleTemplate: "{{ .Title }}",
+				BodyTemplate:  "{{ .Body }}",
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		actual := ti.MergeCommitTemplate(test.org, test.repo)
+
+		if actual.TitleTemplate != test.expected.TitleTemplate || actual.BodyTemplate != test.expected.BodyTemplate {
+			t.Errorf("Expected title \"%v\", body \"%v\", but got title \"%v\", body \"%v\" for %v/%v", test.expected.TitleTemplate, test.expected.BodyTemplate, actual.TitleTemplate, actual.BodyTemplate, test.org, test.repo)
+		}
+	}
+}
 
 func TestParseTideContextPolicyOptions(t *testing.T) {
 	yes := true


### PR DESCRIPTION
New Tide config field `merge_commit_template` allows customizing merge commit title and/or body using PullRequest data. The field is optional, as are the title/body keys.