### PR TITLE
Create bazel-krte with required additional toolchains

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -220,6 +220,31 @@ postsubmits:
         - name: creds
           secret:
             secretName: deployer-service-account
+  - name: post-test-infra-push-bazel-krte
+    cluster: test-infra-trusted
+    run_if_changed: '^images/bazel-krte/'
+    decorate: true
+    branches:
+      - master
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190402-v0.1-35-g8b2d62a
+          command:
+            - images/builder/ci-runner.sh
+          args:
+            - --scratch-bucket=gs://k8s-testimages-scratch
+            - --project=k8s-testimages
+            - images/bazel-krte/
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /creds/service-account.json
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: deployer-service-account
   - name: post-test-infra-push-bigquery
     cluster: test-infra-trusted
     run_if_changed: '^images/bigquery/'

--- a/images/bazel-krte/Dockerfile
+++ b/images/bazel-krte/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See rbe_autoconfig() in rbe_repo.bzl (digest comes from versions.bzl)
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/rules/rbe_repo.bzl
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/configs/ubuntu16_04_clang/versions.bzl
+FROM marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:677c1317f14c6fd5eba2fd8ec645bfdc5119f64b3e5e944e13c89e0525cc8ad1
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+   rpm

--- a/images/bazel-krte/Makefile
+++ b/images/bazel-krte/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+push-prod:
+	bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/bazel-krte
+
+push:
+	bazel run //images/builder -- --allow-dirty images/bazel-krte
+
+.PHONY: push push-prod

--- a/images/bazel-krte/cloudbuild.yaml
+++ b/images/bazel-krte/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/bazel-krte:$_GIT_TAG',
+            '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/bazel-krte:$_GIT_TAG',
+            '.' ]
+    dir: images/bazel-krte/
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/bazel-krte:$_GIT_TAG', 'gcr.io/$PROJECT_ID/bazel-krte:latest']
+substitutions:
+  _GIT_TAG: '12345'
+images:
+  - 'gcr.io/$PROJECT_ID/bazel-krte:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/bazel-krte:latest'

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2741,6 +2741,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-triage
 - name: post-test-infra-push-bazelbuild
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bazelbuild
+- name: post-test-infra-push-bazel-krte
+  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bazel-krte
 - name: post-test-infra-push-bigquery
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bigquery
 - name: post-test-infra-push-bootstrap
@@ -7273,6 +7275,8 @@ dashboards:
     test_group_name: post-test-infra-push-triage
   - name: bazelbuild
     test_group_name: post-test-infra-push-bazelbuild
+  - name: bazel-krte
+    test_group_name: post-test-infra-push-bazel-krte
   - name: bigquery
     test_group_name: post-test-infra-push-bigquery
   - name: bootstrap


### PR DESCRIPTION
/assign @Katharine @mikedanese @cjwagner @michelle192837 

Currently `pull-kubernetes-bazel-build` fails because `rpmbuild` does not exist in the default container image. I cannot find a rule to install this at runtime, so instead I'm extending the RBE image to install this utility.

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/76439/pull-kubernetes-bazel-build-rbe/1122351324285898753

Planning to find all the various ways remote execution fails because of missing toolchain utility and installing it in this image.

ref https://github.com/kubernetes/test-infra/issues/12282