### PR TITLE
prow/gcsupload: Set Content-Type and Content-Encoding

### DIFF
--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -37,6 +37,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "metadata_test.go",
         "target_test.go",
         "upload_test.go",
     ],

--- a/prow/pod-utils/gcs/metadata_test.go
+++ b/prow/pod-utils/gcs/metadata_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcs
+
+import (
+	"mime"
+	"reflect"
+	"testing"
+)
+
+func TestMetadataFromFileName(t *testing.T) {
+	mime.AddExtensionType(".log", "text/plain")
+
+	testCases := []struct {
+		name             string
+		filename         string
+		expectedFileName string
+		expectedMetadata map[string]string
+	}{
+		{
+			name:             "txt",
+			filename:         "build-log.txt",
+			expectedFileName: "build-log.txt",
+			expectedMetadata: map[string]string{
+				"Content-Type": "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:             "txt.gz",
+			filename:         "build-log.txt.gz",
+			expectedFileName: "build-log.txt",
+			expectedMetadata: map[string]string{
+				"Content-Encoding": "gzip",
+				"Content-Type":     "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:             "txt.gzip",
+			filename:         "build-log.txt.gzip",
+			expectedFileName: "build-log.txt",
+			expectedMetadata: map[string]string{
+				"Content-Encoding": "gzip",
+				"Content-Type":     "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:             "bare gz",
+			filename:         "gz",
+			expectedFileName: "gz",
+			expectedMetadata: map[string]string{
+				"Content-Type": "application/gzip",
+			},
+		},
+		{
+			name:             "gz",
+			filename:         "build-log.gz",
+			expectedFileName: "build-log",
+			expectedMetadata: map[string]string{
+				"Content-Type": "application/gzip",
+			},
+		},
+		{
+			name:             "gzip",
+			filename:         "build-log.gzip",
+			expectedFileName: "build-log",
+			expectedMetadata: map[string]string{
+				"Content-Type": "application/gzip",
+			},
+		},
+		{
+			name:             "json",
+			filename:         "events.json",
+			expectedFileName: "events.json",
+			expectedMetadata: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			name:             "json.gz",
+			filename:         "events.json.gz",
+			expectedFileName: "events.json",
+			expectedMetadata: map[string]string{
+				"Content-Encoding": "gzip",
+				"Content-Type":     "application/json",
+			},
+		},
+		{
+			name:             "log",
+			filename:         "journal.log",
+			expectedFileName: "journal.log",
+			expectedMetadata: map[string]string{
+				"Content-Type": "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:             "empty",
+			filename:         "",
+			expectedFileName: "",
+			expectedMetadata: map[string]string{},
+		},
+		{
+			name:             "dot",
+			filename:         ".",
+			expectedFileName: ".",
+			expectedMetadata: map[string]string{},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualFileName, actualMetadata := MetadataFromFileName(test.filename)
+
+			if actualFileName != test.expectedFileName {
+				t.Errorf("expected file name %q but got %q", test.expectedFileName, actualFileName)
+			}
+
+			if !reflect.DeepEqual(actualMetadata, test.expectedMetadata) {
+				t.Errorf("expected metadata %#+v but got %#+v", test.expectedMetadata, actualMetadata)
+			}
+		})
+	}
+}

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -66,13 +66,20 @@ func Upload(bucket *storage.BucketHandle, uploadTargets map[string]UploadFunc) e
 // FileUpload returns an UploadFunc which copies all
 // data from the file on disk to the GCS object
 func FileUpload(file string) UploadFunc {
+	return FileUploadWithMetadata(file, nil)
+}
+
+// FileUploadWithMetadata returns an UploadFunc which copies all
+// data from the file on disk into GCS object and also sets the provided
+// metadata fields on the object.
+func FileUploadWithMetadata(file string, metadata map[string]string) UploadFunc {
 	return func(obj *storage.ObjectHandle) error {
 		reader, err := os.Open(file)
 		if err != nil {
 			return err
 		}
 
-		uploadErr := DataUpload(reader)(obj)
+		uploadErr := DataUploadWithMetadata(reader, metadata)(obj)
 		closeErr := reader.Close()
 
 		return errorutil.NewAggregate(uploadErr, closeErr)
@@ -80,15 +87,9 @@ func FileUpload(file string) UploadFunc {
 }
 
 // DataUpload returns an UploadFunc which copies all
-// data from src reader into GCS
+// data from src reader into GCS.
 func DataUpload(src io.Reader) UploadFunc {
-	return func(obj *storage.ObjectHandle) error {
-		writer := obj.NewWriter(context.Background())
-		_, copyErr := io.Copy(writer, src)
-		closeErr := writer.Close()
-
-		return errorutil.NewAggregate(copyErr, closeErr)
-	}
+	return DataUploadWithMetadata(src, nil)
 }
 
 // DataUploadWithMetadata returns an UploadFunc which copies all


### PR DESCRIPTION
[`Content-Type is recommended][1].  And from [the docs][1]:

> If you do not specify a content type, Cloud Storage defaults to [`application/octet-stream`](https://tools.ietf.org/html/rfc2046#section-4.5.1) when it serves the object.

although there seems to be some (minimal) autodetection in place at the moment:

```console
$ curl -sI https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1/317/build-log.txt | grep Content
Content-Type: text/plain; charset=utf-8
Content-Length: 2175
$ curl -sI https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1/317/finished.json | grep Content
Content-Type: text/plain; charset=utf-8
Content-Length: 226
$ curl -sI https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1/317/artifacts/junit_operator.xml | grep Content
Content-Type: text/plain; charset=utf-8
Content-Length: 672
$ curl -sI https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1/317/artifacts/e2e-aws/openapi.json.gz | grep Content
Content-Type: application/x-gzip
Content-Length: 278997
```

With this change, clients will get better `Content-Type` (e.g. `application/json` instead of `text/plain`), and `.gz` and `.gzip` extensions are being shifted out of `Content-Type` and into `Content-Encoding`.  That will allow clients to opt-in to over-the-wire compression, via `Accept-Encoding` headers (on the client side) and [decompressive transcoding][2] (on the server side).

In support of this change, I've added a new `FileUploadWithMetadata`.  I've also removed some redundant code from `DataUpload` and made that function just syntactic sugar for `DataUploadWithMetadata` to DRY things up a bit.

Also interesting, [`TypeByExtension`'s docs][3] say:

> The built-in table is small but on unix it is augmented by the local system's `mime.types` file(s) if available under one or more of these names:
>
>     /etc/mime.types
>     /etc/apache2/mime.types
>     /etc/apache/mime.types
>
> On Windows, MIME types are extracted from the registry.
>
> Text types have the charset parameter set to "utf-8" by default.

So the current implementation is somewhat host-dependent for type detection.  If assuming UTF-8 is considered too risky, [`DetectContentType`][4] uses peak-inside magic, which presumably includes detecting charsets.

One potential downside is that, now that compression is part of the encoding negotiation, it's not a fundamental part of the resource, so I've removed it from uploaded filenames.  Scripts and users who are used to finding `whatever.txt.gz` will now want to request `whatever.txt` with `Accept-Encoding: gzip`.  But copying the content up twice to provide a gentler transition seemed wasteful of GCS storage space.  We could add a new flag to allow callers to opt-in to a graceful transition (`--gzip-copies`?), but I'm punting on that until we have a demonstrated use-case where my current hard cut-over will be too painful.

Untested, because I don't have GCS creds yet, so don't assume I know what I'm doing ;).

CC @smarterclayton

[1]: https://cloud.google.com/storage/docs/xml-api/put-object#request-headers
[2]: https://cloud.google.com/storage/docs/transcoding
[3]: https://golang.org/pkg/mime/#TypeByExtension
[4]: https://golang.org/pkg/net/http/#DetectContentType