### PR TITLE
Slack reporting

### DIFF
--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pubsub/reporter:go_default_library",
+        "//prow/slack/reporter:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -4,7 +4,7 @@ Crier reports your prowjobs on their status changes.
 
 ## Usage / How to enable existing available reporters
 
-For any reporter you want to use, you need to mount your prow configs and specify `--config-path` and `job-config-path` 
+For any reporter you want to use, you need to mount your prow configs and specify `--config-path` and `job-config-path`
 flag as most of other prow controllers do.
 
 ### [Gerrit reporter](/prow/gerrit/reporter)
@@ -32,7 +32,7 @@ You need to specify following labels in order for pubsub reporter to report your
 
 Pubsub reporter will report whenever prowjob has a state transition.
 
-You can check the reported result by [list the pubsub topic](https://cloud.google.com/sdk/gcloud/reference/pubsub/topics/list). 
+You can check the reported result by [list the pubsub topic](https://cloud.google.com/sdk/gcloud/reference/pubsub/topics/list).
 
 ### [GitHub reporter](/prow/github/reporter)
 
@@ -44,12 +44,39 @@ If you have a [ghproxy](/ghproxy) deployed, also remember to point `--github-end
 
 The actual report logic is in the [github report library](/prow/github/report) for your reference.
 
+### [Slack reporter](/prow/slack/reporter)
+
+You can enable the Slack reporter in crier by specifying the `--slack-workers=n` and `--slack-token-file=path-to-tokenfile` flags.
+
+In order for it to work, you must add the following to your `config.yaml`:
+
+```
+slack_reporter:
+  # Default: None
+  job_types_to_report:
+  - presubmit
+  - postsubmit
+  - periodic
+  - batch
+  # Default: None
+  job_states_to_report:
+  - triggered
+  - pending
+  - success
+  - failure
+  - aborted
+  - error
+  channel: my-slack-channel
+  # The template shown below is the default
+  report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>'
+```
+
 ## Implementation details
 
 Crier supports multiple reporters, each reporter will become a crier controller. Controllers
 will get prowjob change notifications from a [shared informer](https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go), and you can specify `--num-workers` to change parallelism.
 
-If you are interested in how client-go works under the hood, the details are explained 
+If you are interested in how client-go works under the hood, the details are explained
 [in this doc](https://github.com/kubernetes/sample-controller/blob/master/docs/controller-client-go.md)
 
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2021,3 +2021,44 @@ func TestValidateComponentConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestSlackReporterValidation(t *testing.T) {
+	testCases := []struct {
+		name            string
+		channel         string
+		reportTemplate  string
+		successExpected bool
+	}{
+		{
+			name:            "Valid config - no error",
+			channel:         "my-channel",
+			successExpected: true,
+		},
+		{
+			name: "No channel - error",
+		},
+		{
+			name:           "Invalid template - error",
+			channel:        "my-channel",
+			reportTemplate: "{{ if .Spec.Name}}",
+		},
+		{
+			name:           "Template accessed invalid property - error",
+			channel:        "my-channel",
+			reportTemplate: "{{ .Undef}}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &SlackReporter{
+				Channel:        tc.channel,
+				ReportTemplate: tc.reportTemplate,
+			}
+
+			if err := cfg.DefaultAndValidate(); (err == nil) != tc.successExpected {
+				t.Errorf("Expected success=%t but got err=%v", tc.successExpected, err)
+			}
+		})
+	}
+}

--- a/prow/slack/BUILD.bazel
+++ b/prow/slack/BUILD.bazel
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -21,6 +22,15 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/slack/reporter:all-srcs",
+    ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
 )

--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -104,10 +104,20 @@ func (sl *Client) WriteMessage(text, channel string) error {
 	if sl.fake {
 		return nil
 	}
+
+	text = escapeText(text)
+
 	var uv = sl.urlValues()
 	uv.Add("channel", channel)
 	uv.Add("text", text)
 
 	_, err := sl.postMessage(chatPostMessage, uv)
 	return err
+}
+
+func escapeText(s string) string {
+	// See https://api.slack.com/docs/message-formatting#how_to_escape_characters
+	s = strings.Replace(s, "&", "&amp;", -1)
+	s = strings.Replace(s, "<", "&lt;", -1)
+	return strings.Replace(s, ">", "&gt;", -1)
 }

--- a/prow/slack/client_test.go
+++ b/prow/slack/client_test.go
@@ -1,0 +1,35 @@
+package slack
+
+import (
+	"testing"
+)
+
+func TestEscapeText(t *testing.T) {
+	testCases := []struct {
+		in       string
+		expected string
+	}{
+		{
+			in:       "&",
+			expected: "&amp;",
+		},
+		{
+			in:       ">",
+			expected: "&gt;",
+		},
+		{
+			in:       "<",
+			expected: "&lt;",
+		},
+		{
+			in:       "<>&",
+			expected: "&lt;&gt;&amp;",
+		},
+	}
+
+	for _, tc := range testCases {
+		if result := escapeText(tc.in); result != tc.expected {
+			t.Errorf("Expected result to be %q but was %q", result, tc.expected)
+		}
+	}
+}

--- a/prow/slack/reporter/BUILD.bazel
+++ b/prow/slack/reporter/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["reporter.go"],
+    importpath = "k8s.io/test-infra/prow/slack/reporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/slack:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["reporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/slack/reporter/reporter.go
+++ b/prow/slack/reporter/reporter.go
@@ -1,0 +1,89 @@
+package reporter
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	slackclient "k8s.io/test-infra/prow/slack"
+)
+
+const reporterName = "slackreporter"
+
+type slackReporter struct {
+	client *slackclient.Client
+	config config.SlackReporter
+	logger *logrus.Entry
+	dryRun bool
+}
+
+func (sr *slackReporter) Report(pj *v1.ProwJob) ([]*v1.ProwJob, error) {
+	b := &bytes.Buffer{}
+	tmpl, err := template.New("").Parse(sr.config.ReportTemplate)
+	if err != nil {
+		sr.logger.WithField("prowjob", pj.Name).Errorf("failed to parse template: %v", err)
+		return nil, fmt.Errorf("failed to parse template: %v", err)
+	}
+	if err := tmpl.Execute(b, pj); err != nil {
+		sr.logger.WithField("prowjob", pj.Name).WithError(err).Error("failed to execute report template")
+		return nil, fmt.Errorf("failed to execute report template: %v", err)
+	}
+	if sr.dryRun {
+		sr.logger.
+			WithField("prowjob", pj.Name).
+			WithField("messagetext", b.String()).
+			Debug("Skipping reporting because dry-run is enabled")
+		return []*v1.ProwJob{pj}, nil
+	}
+	if err := sr.client.WriteMessage(b.String(), sr.config.Channel); err != nil {
+		sr.logger.WithError(err).Error("failed to write Slack message")
+		return nil, fmt.Errorf("failed to write Slack message: %v", err)
+	}
+	return []*v1.ProwJob{pj}, nil
+}
+
+func (sr *slackReporter) GetName() string {
+	return reporterName
+}
+
+func (sr *slackReporter) ShouldReport(pj *v1.ProwJob) bool {
+
+	stateShouldReport := false
+	for _, stateToReport := range sr.config.JobStatesToReport {
+		if pj.Status.State == stateToReport {
+			stateShouldReport = true
+			break
+		}
+	}
+
+	typeShouldReport := false
+	for _, typeToReport := range sr.config.JobTypesToReport {
+		if typeToReport == pj.Spec.Type {
+			typeShouldReport = true
+			break
+		}
+	}
+
+	sr.logger.WithField("prowjob", pj.Name).
+		Debugf("reporting=%t", stateShouldReport && typeShouldReport)
+	return stateShouldReport && typeShouldReport
+}
+
+func New(cfg config.SlackReporter, dryRun bool, tokenFile string) (*slackReporter, error) {
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read -token-file: %v", err)
+	}
+
+	return &slackReporter{
+		client: slackclient.NewClient(func() []byte { return token }),
+		config: cfg,
+		logger: logrus.WithField("component", reporterName),
+		dryRun: dryRun,
+	}, nil
+}

--- a/prow/slack/reporter/reporter_test.go
+++ b/prow/slack/reporter/reporter_test.go
@@ -1,0 +1,96 @@
+package reporter
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestShouldReport(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   config.SlackReporter
+		pj       *v1.ProwJob
+		expected bool
+	}{
+		{
+			name: "Presubmit Job should report",
+			config: config.SlackReporter{
+				JobTypesToReport:  []v1.ProwJobType{v1.PresubmitJob},
+				JobStatesToReport: []v1.ProwJobState{v1.SuccessState},
+			},
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type: v1.PresubmitJob,
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Presubmit Job should not report",
+			config: config.SlackReporter{
+				JobTypesToReport:  []v1.ProwJobType{v1.PostsubmitJob},
+				JobStatesToReport: []v1.ProwJobState{v1.SuccessState},
+			},
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type: v1.PresubmitJob,
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Successful Job should report",
+			config: config.SlackReporter{
+				JobTypesToReport:  []v1.ProwJobType{v1.PostsubmitJob},
+				JobStatesToReport: []v1.ProwJobState{v1.SuccessState},
+			},
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type: v1.PostsubmitJob,
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Successful Job should not report",
+			config: config.SlackReporter{
+				JobTypesToReport:  []v1.ProwJobType{v1.PostsubmitJob},
+				JobStatesToReport: []v1.ProwJobState{v1.PendingState},
+			},
+			pj: &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type: v1.PostsubmitJob,
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reporter := &slackReporter{
+				config: tc.config,
+				logger: logrus.NewEntry(&logrus.Logger{}),
+			}
+
+			if result := reporter.ShouldReport(tc.pj); result != tc.expected {
+				t.Errorf("expected result to be %t but was %t", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a Slack reporter to crier.

Fixes #12393 

Open question: Right now this uses the Slack client I found in this repo. That slack client however uses [legacy tokens](https://api.slack.com/custom-integrations/legacy-tokens) which are personalized and I don't feel exactly comfortable using a personalized token for this. Hence I'd like to use the new API. Is it okay to look out for a Slack lib and vendoring it?