### PR TITLE
Add more kinder upgrade jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -32,3 +32,96 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-1.13-1.14"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-1.12-1.13"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decoration_config:
+    timeout: 2400000000000 #40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-1.11-1.12"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2148,6 +2148,12 @@ test_groups:
 # kubeadm-kinder tests
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
 # kubeadm x-on-y tests
 - name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12
@@ -6250,6 +6256,12 @@ dashboards:
 # kubeadm-kinder tests
   - name: kubeadm-kinder-upgrade-stable-master
     test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
+  - name: kubeadm-kinder-upgrade-1.13-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
+  - name: kubeadm-kinder-upgrade-1.12-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
+  - name: kubeadm-kinder-upgrade-1.11-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
 # kubeadm x-on-y tests
   - name: kubeadm-gce-1.11-on-1.12
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-11-on-1-12


### PR DESCRIPTION
This PR adds more more kinder upgrade jobs; those jobs, once stabilized and evaluated reliable, are going to replace the failing kubeadm-gce-upgrade jobs based on kubernetes-anywhere (which is not maintained anymore) 

This PR will remain WIP until https://github.com/kubernetes/kubeadm/pull/1545 will merge

Rif. https://github.com/kubernetes/kubeadm/issues/1543

/sig cluster-lifecycle
/kind feature
/priority important-longterm
/assign @neolit123 