### PR TITLE
Revert "verify-owners: ensure all users are org collaborators"

### DIFF
--- a/prow/plugins/verify-owners/BUILD.bazel
+++ b/prow/plugins/verify-owners/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/golint:go_default_library",
-        "//prow/plugins/trigger:go_default_library",
         "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -19,7 +19,6 @@ package verifyowners
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -34,16 +33,13 @@ import (
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/plugins/golint"
-	"k8s.io/test-infra/prow/plugins/trigger"
 	"k8s.io/test-infra/prow/repoowners"
 )
 
 const (
 	// PluginName defines this plugin's registered name.
-	PluginName                    = "verify-owners"
-	ownersFileName                = "OWNERS"
-	ownersAliasesFileName         = "OWNERS_ALIASES"
-	nonCollaboratorResponseFormat = "The following users are mentioned in %s file(s) but are not members of the %s org."
+	PluginName     = "verify-owners"
+	ownersFileName = "OWNERS"
 )
 
 func init() {
@@ -52,7 +48,7 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: fmt.Sprintf("The verify-owners plugin validates %s and %s files and ensures that they always contain collaborators of the org, if they are modified in a PR. On validation failure it automatically adds the '%s' label to the PR, and a review comment on the incriminating file(s).", ownersFileName, ownersAliasesFileName, labels.InvalidOwners),
+		Description: fmt.Sprintf("The verify-owners plugin validates %s files if they are modified in a PR. On validation failure it automatically adds the '%s' label to the PR, and a review comment on the incriminating file(s).", ownersFileName, labels.InvalidOwners),
 	}
 	if config.Owners.LabelsBlackList != nil {
 		pluginHelp.Config = map[string]string{
@@ -69,30 +65,18 @@ type ownersClient interface {
 }
 
 type githubClient interface {
-	IsCollaborator(owner, repo, login string) (bool, error)
-	IsMember(org, user string) (bool, error)
 	AddLabel(org, repo string, number int, label string) error
 	CreateComment(owner, repo string, number int, comment string) error
 	CreateReview(org, repo string, number int, r github.DraftReview) error
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 	RemoveLabel(owner, repo string, number int, label string) error
-	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
-}
-
-type commentPruner interface {
-	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
 		return nil
 	}
-
-	cp, err := pc.CommentPruner()
-	if err != nil {
-		return err
-	}
-	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, &pre, pc.PluginConfig.Owners.LabelsBlackList, pc.PluginConfig.TriggerFor(pre.Repo.Owner.Login, pre.Repo.Name), cp)
+	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, &pre, pc.PluginConfig.Owners.LabelsBlackList)
 }
 
 type messageWithLine struct {
@@ -100,10 +84,9 @@ type messageWithLine struct {
 	message string
 }
 
-func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.PullRequestEvent, labelsBlackList []string, triggerConfig plugins.Trigger, cp commentPruner) error {
+func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.PullRequestEvent, labelsBlackList []string) error {
 	org := pre.Repo.Owner.Login
 	repo := pre.Repo.Name
-	number := pre.Number
 	wrongOwnersFiles := map[string]messageWithLine{}
 
 	// Get changes.
@@ -119,18 +102,7 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 			modifiedOwnersFiles = append(modifiedOwnersFiles, change)
 		}
 	}
-
-	// Check if the OWNERS_ALIASES file was modified.
-	var modifiedOwnerAliasesFile github.PullRequestChange
-	var ownerAliasesModified bool
-	for _, change := range changes {
-		if change.Filename == ownersAliasesFileName {
-			modifiedOwnerAliasesFile = change
-			ownerAliasesModified = true
-		}
-	}
-
-	if len(modifiedOwnersFiles) == 0 && !ownerAliasesModified {
+	if len(modifiedOwnersFiles) == 0 {
 		return nil
 	}
 
@@ -154,50 +126,27 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 		}
 	}
 
-	// If OWNERS_ALIASES file exists, get all aliases.
-	// If the file was modified, check for non trusted users in the newly added owners.
-	nonTrustedUsers, repoAliases, err := nonTrustedUsersInOwnersAliases(ghc, log, triggerConfig, org, repo, r.Dir, modifiedOwnerAliasesFile.Patch, ownerAliasesModified)
-	if err != nil {
-		return err
-	}
-
-	// Check if OWNERS files have the correct config and if they do,
-	// check if all newly added owners are trusted users.
+	// Check each OWNERS file.
 	for _, c := range modifiedOwnersFiles {
+		// Try to load OWNERS file.
 		path := filepath.Join(r.Dir, c.Filename)
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to read %s.", path)
 			return nil
 		}
-		msg, owners := parseOwnersFile(b, c, log, labelsBlackList)
-		if msg != nil {
+		if msg := parseOwnersFile(b, c, log, labelsBlackList); msg != nil {
 			wrongOwnersFiles[c.Filename] = *msg
-			continue
-		}
-
-		nonTrustedUsers, err = nonTrustedUsersInOwners(ghc, log, triggerConfig, org, repo, c.Patch, c.Filename, owners, nonTrustedUsers, repoAliases)
-		if err != nil {
-			return err
 		}
 	}
-
-	// React if there are files with incorrect configs or non-trusted users.
-	issueLabels, err := ghc.GetIssueLabels(org, repo, number)
-	if err != nil {
-		return err
-	}
-	hasInvalidOwnersLabel := github.HasLabel(labels.InvalidOwners, issueLabels)
-
+	// React if we saw something.
 	if len(wrongOwnersFiles) > 0 {
 		s := "s"
 		if len(wrongOwnersFiles) == 1 {
 			s = ""
 		}
-		if !hasInvalidOwnersLabel {
-			if err := ghc.AddLabel(org, repo, number, labels.InvalidOwners); err != nil {
-				return err
-			}
+		if err := ghc.AddLabel(org, repo, pre.Number, labels.InvalidOwners); err != nil {
+			return err
 		}
 		log.Debugf("Creating a review for %d %s file%s.", len(wrongOwnersFiles), ownersFileName, s)
 		var comments []github.DraftReviewComment
@@ -222,40 +171,17 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 		if err != nil {
 			return fmt.Errorf("error creating a review for invalid %s file%s: %v", ownersFileName, s, err)
 		}
-	}
-
-	if len(nonTrustedUsers) > 0 {
-		if !hasInvalidOwnersLabel {
-			if err := ghc.AddLabel(org, repo, number, labels.InvalidOwners); err != nil {
-				return err
-			}
-		}
-
-		// prune old comments before adding a new one
-		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
-		})
-		if err := ghc.CreateComment(org, repo, number, markdownFriendlyComment(org, nonTrustedUsers)); err != nil {
-			log.WithError(err).Errorf("Could not create comment for listing non-collaborators in %s files", ownersFileName)
-		}
-	}
-
-	if len(wrongOwnersFiles) == 0 && len(nonTrustedUsers) == 0 {
+	} else {
 		// Don't bother checking if it has the label...it's a race, and we'll have
 		// to handle failure due to not being labeled anyway.
 		if err := ghc.RemoveLabel(org, repo, pre.Number, labels.InvalidOwners); err != nil {
 			return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
 		}
-		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
-		})
 	}
-
 	return nil
 }
 
-func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, labelsBlackList []string) (*messageWithLine, []string) {
-	var reviewers []string
+func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, labelsBlackList []string) *messageWithLine {
 	var approvers []string
 	var labels []string
 	// by default we bind errors to line 1
@@ -281,17 +207,15 @@ func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, la
 			return &messageWithLine{
 				lineNumber,
 				fmt.Sprintf("Cannot parse file: %v.", err),
-			}, nil
+			}
 		}
 		// it's a FullConfig
 		for _, config := range full.Filters {
-			reviewers = append(reviewers, config.Reviewers...)
 			approvers = append(approvers, config.Approvers...)
 			labels = append(labels, config.Labels...)
 		}
 	} else {
 		// it's a SimpleConfig
-		reviewers = simple.Config.Reviewers
 		approvers = simple.Config.Approvers
 		labels = simple.Config.Labels
 	}
@@ -300,106 +224,14 @@ func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, la
 		return &messageWithLine{
 			lineNumber,
 			fmt.Sprintf("File contains blacklisted labels: %s.", sets.NewString(labels...).Intersection(sets.NewString(labelsBlackList...)).List()),
-		}, nil
+		}
 	}
 	// Check approvers isn't empty
 	if filepath.Dir(c.Filename) == "." && len(approvers) == 0 {
 		return &messageWithLine{
 			lineNumber,
 			fmt.Sprintf("No approvers defined in this root directory %s file.", ownersFileName),
-		}, nil
-	}
-	owners := append(reviewers, approvers...)
-	return nil, owners
-}
-
-func markdownFriendlyComment(org string, nonTrustedUsers map[string][]string) string {
-	var commentLines []string
-	commentLines = append(commentLines, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
-
-	for user, ownersFiles := range nonTrustedUsers {
-		commentLines = append(commentLines, fmt.Sprintf("- @%s", user))
-		for _, filename := range ownersFiles {
-			commentLines = append(commentLines, fmt.Sprintf("  - %s", filename))
 		}
 	}
-	return strings.Join(commentLines, "\n")
-}
-
-func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, dir, patch string, ownerAliasesModified bool) (map[string][]string, repoowners.RepoAliases, error) {
-	repoAliases := make(repoowners.RepoAliases)
-	// nonTrustedUsers is a map of non-trusted users to the list of files they are being added in
-	nonTrustedUsers := map[string][]string{}
-	var err error
-
-	// If OWNERS_ALIASES exists, get all aliases.
-	path := filepath.Join(dir, ownersAliasesFileName)
-	if _, err := os.Stat(path); err == nil {
-		b, err := ioutil.ReadFile(path)
-		if err != nil {
-			return nonTrustedUsers, repoAliases, fmt.Errorf("Failed to read %s: %v", path, err)
-		}
-		repoAliases, err = repoowners.ParseAliasesConfig(b)
-		if err != nil {
-			return nonTrustedUsers, repoAliases, fmt.Errorf("error parsing aliases config for %s file: %v", ownersAliasesFileName, err)
-		}
-	}
-
-	// If OWNERS_ALIASES file was modified, check if newly added owners are trusted.
-	if ownerAliasesModified {
-		allOwners := repoAliases.ExpandAllAliases().List()
-		for _, owner := range allOwners {
-			// cap the number of checks to avoid exhausting tokens in case of large OWNERS refactors.
-			if len(nonTrustedUsers) > 20 {
-				break
-			}
-			nonTrustedUsers, err = checkIfTrustedUser(ghc, log, triggerConfig, owner, patch, ownersAliasesFileName, org, repo, nonTrustedUsers, repoAliases)
-			if err != nil {
-				return nonTrustedUsers, repoAliases, err
-			}
-		}
-	}
-
-	return nonTrustedUsers, repoAliases, nil
-}
-
-func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, patch, fileName string, owners []string, nonTrustedUsers map[string][]string, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
-	var err error
-	for _, owner := range owners {
-		// cap the number of checks to avoid exhausting tokens in case of large OWNERS refactors.
-		if len(nonTrustedUsers) > 20 {
-			break
-		}
-
-		// ignore if owner is an alias
-		if _, ok := repoAliases[owner]; ok {
-			continue
-		}
-
-		nonTrustedUsers, err = checkIfTrustedUser(ghc, log, triggerConfig, owner, patch, fileName, org, repo, nonTrustedUsers, repoAliases)
-		if err != nil {
-			return nonTrustedUsers, err
-		}
-	}
-	return nonTrustedUsers, nil
-}
-
-// checkIfTrustedUser looks for newly addded owners by checking if they are in the patch
-// and then checks if the owner is a trusted user.
-func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, owner, patch, fileName, org, repo string, nonTrustedUsers map[string][]string, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
-	if strings.Contains(patch, owner) {
-		isTrustedUser, err := trigger.TrustedUser(ghc, triggerConfig, owner, org, repo)
-		if err != nil {
-			return nonTrustedUsers, err
-		}
-
-		if !isTrustedUser {
-			if ownersFiles, ok := nonTrustedUsers[owner]; ok {
-				nonTrustedUsers[owner] = append(ownersFiles, fileName)
-			} else {
-				nonTrustedUsers[owner] = []string{fileName}
-			}
-		}
-	}
-	return nonTrustedUsers, nil
+	return nil
 }

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -137,14 +137,8 @@ func newFakeGitHubClient(files []string, pr int) *fakegithub.FakeClient {
 	return &fakegithub.FakeClient{
 		PullRequestChanges: map[int][]github.PullRequestChange{pr: changes},
 		Reviews:            map[int][]github.Review{},
-		Collaborators:      []string{"alice", "bob", "jdoe"},
-		IssueComments:      map[int][]github.IssueComment{},
 	}
 }
-
-type fakePruner struct{}
-
-func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
 
 func TestHandle(t *testing.T) {
 	var tests = []struct {
@@ -288,7 +282,7 @@ func TestHandle(t *testing.T) {
 			Repo: github.Repo{FullName: "org/repo"},
 		}
 		fghc := newFakeGitHubClient(test.filesChanged, pr)
-		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
+		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}
 		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {
@@ -369,7 +363,7 @@ func TestParseOwnersFile(t *testing.T) {
 				Filename: "OWNERS",
 				Patch:    c.patch,
 			}
-			message, _ := parseOwnersFile(c.document, change, &logrus.Entry{}, []string{})
+			message := parseOwnersFile(c.document, change, &logrus.Entry{}, []string{})
 			if message != nil {
 				if c.errLine == 0 {
 					t.Errorf("%s: expected no error, got one: %s", c.name, message.message)
@@ -437,214 +431,5 @@ func TestHelpProvider(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-var ownersFiles = map[string][]byte{
-	"nonCollaboratorAdditions": []byte(`reviewers:
-- phippy
-- alice
-approvers:
-- zee
-- bob
-`),
-	"collaboratorsWithAliases": []byte(`reviewers:
-- foo-reviewers
-- alice
-approvers:
-- bob
-`),
-	"nonCollaboratorsWithAliases": []byte(`reviewers:
-- foo-reviewers
-- alice
-- goldie
-approvers:
-- bob
-`),
-}
-
-var ownersPatch = map[string]string{
-	"nonCollaboratorAdditions": `@@ -1,4 +1,6 @@
-reviewers:
-+- phippy
-- alice
-approvers:
-+- zee
-- bob   
-`,
-	"nonCollaboratorsWithAliases": `@@ -1,4 +1,6 @@
-reviewers:
-+- foo-reviewers
-- alice
-+- goldie
-approvers:
-- bob
-`,
-	"collaboratorsWtihAliases": `@@ -1,2 +1,5 @@
-+reviewers:
-+- foo-reviewers
-+- alice
-approvers:
-- bob
-`,
-}
-
-var ownersAliases = map[string][]byte{
-	"nonCollaboratorAdditions": []byte(`aliases:
-  foo-reviewers:
-  - alice
-  - phippy
-  - zee
-`),
-	"collaboratorAdditions": []byte(`aliases:
-  foo-reviewers:
-  - alice
-`),
-}
-
-var ownersAliasesPatch = map[string]string{
-	"nonCollaboratorAdditions": `@@ -1,3 +1,5 @@
-aliases:
-  foo-reviewers:
-  - alice
-+ - phippy
-+ - zee   
-`,
-	"collaboratorAdditions": `@@ -0,0 +1,3 @@
-+aliases:
-+ foo-reviewers:
-+ - alice
-`,
-}
-
-func TestNonCollaborators(t *testing.T) {
-	var tests = []struct {
-		name               string
-		filesChanged       []string
-		ownersFile         string
-		ownersPatch        string
-		ownersAliasesFile  string
-		ownersAliasesPatch string
-		shouldLabel        bool
-		shouldComment      bool
-	}{
-		{
-			name:          "non-collaborators additions in OWNERS file",
-			filesChanged:  []string{"OWNERS"},
-			ownersFile:    "nonCollaboratorAdditions",
-			ownersPatch:   "nonCollaboratorAdditions",
-			shouldLabel:   true,
-			shouldComment: true,
-		},
-		{
-			name:               "non-collaborators additions in OWNERS_ALIASES file",
-			filesChanged:       []string{"OWNERS_ALIASES"},
-			ownersFile:         "collaboratorsWithAliases",
-			ownersAliasesFile:  "nonCollaboratorAdditions",
-			ownersAliasesPatch: "nonCollaboratorAdditions",
-			shouldLabel:        true,
-			shouldComment:      true,
-		},
-		{
-			name:               "non-collaborators additions in both OWNERS and OWNERS_ALIASES file",
-			filesChanged:       []string{"OWNERS", "OWNERS_ALIASES"},
-			ownersFile:         "nonCollaboratorsWithAliases",
-			ownersPatch:        "nonCollaboratorsWithAliases",
-			ownersAliasesFile:  "nonCollaboratorAdditions",
-			ownersAliasesPatch: "nonCollaboratorAdditions",
-			shouldLabel:        true,
-			shouldComment:      true,
-		},
-		{
-			name:               "collaborator additions in both OWNERS and OWNERS_ALIASES file",
-			filesChanged:       []string{"OWNERS", "OWNERS_ALIASES"},
-			ownersFile:         "collaboratorsWithAliases",
-			ownersPatch:        "collaboratorsWtihAliases",
-			ownersAliasesFile:  "collaboratorAdditions",
-			ownersAliasesPatch: "collaboratorAdditions",
-			shouldLabel:        false,
-			shouldComment:      false,
-		},
-	}
-	lg, c, err := localgit.New()
-	if err != nil {
-		t.Fatalf("Making localgit: %v", err)
-	}
-	defer func() {
-		if err := lg.Clean(); err != nil {
-			t.Errorf("Cleaning up localgit: %v", err)
-		}
-		if err := c.Clean(); err != nil {
-			t.Errorf("Cleaning up client: %v", err)
-		}
-	}()
-	if err := lg.MakeFakeRepo("org", "repo"); err != nil {
-		t.Fatalf("Making fake repo: %v", err)
-	}
-	for i, test := range tests {
-		pr := i + 1
-		// make sure we're on master before branching
-		if err := lg.Checkout("org", "repo", "master"); err != nil {
-			t.Fatalf("Switching to master branch: %v", err)
-		}
-		if err := lg.CheckoutNewBranch("org", "repo", fmt.Sprintf("pull/%d/head", pr)); err != nil {
-			t.Fatalf("Checking out pull branch: %v", err)
-		}
-		pullFiles := map[string][]byte{}
-		changes := []github.PullRequestChange{}
-
-		for _, file := range test.filesChanged {
-			if file == "OWNERS" {
-				pullFiles[file] = ownersFiles[test.ownersFile]
-				changes = append(changes, github.PullRequestChange{
-					Filename: "OWNERS",
-					Patch:    ownersPatch[test.ownersPatch],
-				})
-			}
-
-			if file == "OWNERS_ALIASES" {
-				pullFiles[file] = ownersAliases[test.ownersAliasesFile]
-				changes = append(changes, github.PullRequestChange{
-					Filename: "OWNERS_ALIASES",
-					Patch:    ownersAliasesPatch[test.ownersAliasesPatch],
-				})
-			}
-
-		}
-		if err := lg.AddCommit("org", "repo", pullFiles); err != nil {
-			t.Fatalf("Adding PR commit: %v", err)
-		}
-		sha, err := lg.RevParse("org", "repo", "HEAD")
-		if err != nil {
-			t.Fatalf("Getting commit SHA: %v", err)
-		}
-		pre := &github.PullRequestEvent{
-			Number: pr,
-			PullRequest: github.PullRequest{
-				User: github.User{Login: "author"},
-				Head: github.PullRequestBranch{
-					SHA: sha,
-				},
-			},
-			Repo: github.Repo{FullName: "org/repo"},
-		}
-		fghc := newFakeGitHubClient(test.filesChanged, pr)
-		fghc.PullRequestChanges[pr] = changes
-
-		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
-			t.Fatalf("Handle PR: %v", err)
-		}
-		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {
-			t.Errorf("%s: didn't expect label %s in %s", test.name, labels.InvalidOwners, fghc.IssueLabelsAdded)
-		}
-		if test.shouldLabel && !IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {
-			t.Errorf("%s: expected label %s in %s", test.name, labels.InvalidOwners, fghc.IssueLabelsAdded)
-		}
-		if !test.shouldComment && len(fghc.IssueComments[pr]) > 0 {
-			t.Errorf("%s: didn't expect comment", test.name)
-		}
-		if test.shouldComment && len(fghc.IssueComments[pr]) == 0 {
-			t.Errorf("%s: expected comment but didn't receive", test.name)
-		}
 	}
 }

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -319,20 +319,6 @@ func (a RepoAliases) ExpandAliases(logins sets.String) sets.String {
 	return logins
 }
 
-// ExpandAllAliases returns members of all aliases mentioned, duplicates are pruned
-func (a RepoAliases) ExpandAllAliases() sets.String {
-	if a == nil {
-		return nil
-	}
-
-	var result, users sets.String
-	for alias := range a {
-		users = a.ExpandAlias(alias)
-		result = result.Union(users)
-	}
-	return result
-}
-
 func loadAliasesFrom(baseDir string, log *logrus.Entry) RepoAliases {
 	path := filepath.Join(baseDir, aliasesFileName)
 	b, err := ioutil.ReadFile(path)
@@ -480,24 +466,6 @@ func ParseSimpleConfig(b []byte) (SimpleConfig, error) {
 	simple := new(SimpleConfig)
 	err := yaml.Unmarshal(b, simple)
 	return *simple, err
-}
-
-// ParseAliasesConfig will unmarshal an OWNERS_ALIASES file's content into RepoAliases.
-// Returns an error if the content cannot be unmarshalled.
-func ParseAliasesConfig(b []byte) (RepoAliases, error) {
-	result := make(RepoAliases)
-
-	config := &struct {
-		Data map[string][]string `json:"aliases,omitempty"`
-	}{}
-	if err := yaml.Unmarshal(b, config); err != nil {
-		return result, err
-	}
-
-	for alias, expanded := range config.Data {
-		result[github.NormLogin(alias)] = normLogins(expanded)
-	}
-	return result, nil
 }
 
 var mdStructuredHeaderRegex = regexp.MustCompile("^---\n(.|\n)*\n---")


### PR DESCRIPTION
This reverts commit a9a8621f6d19958989564626e4f230d89b624936.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @nikhita @cblecker 
