### PR TITLE
Temporarily serialize decoration durations to ns for compatibility w/ Openshift downstream tools.

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -456,8 +456,8 @@ presubmits:
         default_repo: kubernetes
         path_strategy: legacy
       gcs_credentials_secret: service-account
-      grace_period: 15s
-      timeout: 40m0s
+      grace_period: 15000000000
+      timeout: 2400000000000
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -539,8 +539,8 @@ presubmits:
         default_repo: kubernetes
         path_strategy: legacy
       gcs_credentials_secret: service-account
-      grace_period: 15s
-      timeout: 40m0s
+      grace_period: 15000000000
+      timeout: 2400000000000
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -622,8 +622,8 @@ presubmits:
         default_repo: kubernetes
         path_strategy: legacy
       gcs_credentials_secret: service-account
-      grace_period: 15s
-      timeout: 40m0s
+      grace_period: 15000000000
+      timeout: 2400000000000
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -703,8 +703,8 @@ presubmits:
         default_repo: kubernetes
         path_strategy: legacy
       gcs_credentials_secret: service-account
-      grace_period: 15s
-      timeout: 40m0s
+      grace_period: 15000000000
+      timeout: 2400000000000
     extra_refs:
     - base_ref: master
       org: kubernetes

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -161,7 +161,9 @@ type ProwJobSpec struct {
 
 // Duration is a wrapper around time.Duration that parses times in either
 // 'integer number of nanoseconds' or 'duration string' formats and serializes
-// to 'duration string' format.
+// to 'integer number of nanoseconds' format.
+// TODO(cjwagner): Switch to serializing to 'duration string' format after
+// October 2019.
 type Duration struct {
 	time.Duration
 }
@@ -188,7 +190,10 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 func (d *Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Duration.String())
+	// TODO(cjwagner): Switch to serializing to 'duration string' format after
+	// October 2019.
+	// return json.Marshal(d.Duration.String())
+	return json.Marshal(d.Duration)
 }
 
 // DecorationConfig specifies how to augment pods.

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -23,8 +23,8 @@ spec:
       default_repo: kubernetes
       path_strategy: legacy
     gcs_credentials_secret: default-service-account
-    grace_period: 15s
-    timeout: 2h0m0s
+    grace_period: 15000000000
+    timeout: 7200000000000
     utility_images:
       clonerefs: clonerefs:default
       entrypoint: entrypoint:default

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -23,8 +23,8 @@ spec:
       default_repo: kubernetes
       path_strategy: explicit
     gcs_credentials_secret: explicit-service-account
-    grace_period: 1ns
-    timeout: 1ns
+    grace_period: 1
+    timeout: 1
     utility_images:
       clonerefs: clonerefs:explicit
       entrypoint: entrypoint:explicit

--- a/prow/test/data/test-config.yaml
+++ b/prow/test/data/test-config.yaml
@@ -1,7 +1,7 @@
 plank:
   default_decoration_config:
     timeout: 7200000000000 # 2h
-    grace_period: 15s
+    grace_period: 15000000000 # 15s
     utility_images:
       clonerefs: "clonerefs:default"
       initupload: "initupload:default"


### PR DESCRIPTION
I'll revert this sometime after October 2019.

This will also ensure that other deployments have smooth migrations to
the new duration type even if all components are not updated atomically.

/assign @stevekuznetsov 