### PR TITLE
Only build _binary targets

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2694,15 +2694,11 @@ presubmits:
       containers:
       - args:
         - --ssh=/etc/ssh-security/ssh-security
-        - build
-        - --config=remote
-        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
-        - //...
-        - //build/release-tars
-        - --
-        - -//vendor/...
+        - -c
+        - |
+          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
         command:
-        - ../test-infra/hack/bazel.sh
+        - bash
         image: launcher.gcr.io/google/bazel:0.24.1
         name: ""
         resources: {}

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -49,15 +49,11 @@ presubmits:
       containers:
       - image: launcher.gcr.io/google/bazel:0.24.1
         command:
-        - ../test-infra/hack/bazel.sh
+        - bash
         args:
-        - build
-        - --config=remote
-        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
-        - //...
-        - //build/release-tars
-        - --
-        - -//vendor/...
+        - -c
+        - |
+          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
 
   - name: pull-kubernetes-bazel-build
     always_run: true


### PR DESCRIPTION
/assign @cjwagner @michelle192837 @mikedanese 

This matches the behavior of the non-rbe job:
https://github.com/kubernetes/test-infra/blob/c1df80c41bc6afa854dd25ea3b02af3705dec349/scenarios/kubernetes_bazel.py#L172

This should drop the runtime from ~16m to ~9m : https://prow.k8s.io/?repo=kubernetes%2Fkubernetes&type=presubmit&state=success