### PR TITLE
Drop double URL Encoding

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -21,7 +21,6 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"strings"
 	"time"
 
@@ -229,7 +228,7 @@ func (c *Client) GetBranchRevision(instance, project, branch string) (string, er
 		return "", fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	res, _, err := h.projectService.GetBranch(project, url.QueryEscape(branch))
+	res, _, err := h.projectService.GetBranch(project, branch)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The upstream change is already merged in https://github.com/andygrunwald/go-gerrit/pull/65

https://github.com/kubernetes/test-infra/blob/master/go.mod#L15 has up-to-date changes, and we should not encode slash twice.

/assign @amwat 