### PR TITLE
Use the image builder to build itself

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -445,6 +445,31 @@ postsubmits:
         - name: creds
           secret:
             secretName: deployer-service-account
+  - name: post-test-infra-push-image-builder
+    cluster: test-infra-trusted
+    run_if_changed: '^images/builder/'
+    decorate: true
+    branches:
+      - master
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190402-v0.1-35-g8b2d62a
+          command:
+            - images/builder/ci-runner.sh
+          args:
+            - --scratch-bucket=gs://k8s-testimages-scratch
+            - --project=k8s-testimages
+            - images/builder/
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /creds/service-account.json
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: deployer-service-account
   kubernetes/k8s.io:
   - name: post-k8sio-cip
     cluster: test-infra-trusted

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM google/cloud-sdk:244.0.0-alpine
+COPY builder run.sh /
+CMD ["/run.sh"]

--- a/images/builder/cloudbuild.yaml
+++ b/images/builder/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: gcr.io/cloud-builders/go
+    args: ['build', '-o', './images/builder/builder', './images/builder']
+    env: ['PROJECT_ROOT=k8s.io/test-infra', 'CGO_ENABLED=0', 'GOOS=linux', 'GOARCH=amd64']
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build',
+            '-t', 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG',
+            '-t', 'gcr.io/$PROJECT_ID/image-builder:latest',
+            '.' ]
+    dir: images/builder
+substitutions:
+  _GIT_TAG: '12345'
+images:
+  - 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/image-builder:latest'

--- a/images/builder/run.sh
+++ b/images/builder/run.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used by gcr.io/k8s-testimages/image-builder.
+# See ci-runner.sh for the version prow uses to build and run on the fly.
+
+set -e
+
+echo "Activating service account..."
+gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+echo "Running..."
+if [[ ! -z "${ARTIFACTS}" ]]; then
+  echo "\$ARTIFACTS is set, sending logs to ${ARTIFACTS}"
+  ./builder --log-dir="${ARTIFACTS}" "$@"
+else
+  ./builder "$@"
+fi

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2759,6 +2759,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-kubemci
 - name: post-test-infra-push-test-gubernator
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-test-gubernator
+- name: post-test-infra-push-image-builder
+  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-image-builder
 - name: ci-test-infra-autoupdate-minor
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-autoupdate-minor
 - name: ci-test-infra-autoupdate-patch
@@ -7372,6 +7374,8 @@ dashboards:
     test_group_name: post-test-infra-push-kubemci
   - name: test-gubernator
     test_group_name: post-test-infra-push-test-gubernator
+  - name: image-builder
+    test_group_name: post-test-infra-push-image-builder
 - name: sig-testing-misc
   dashboard_tab:
   - name: ci-bazel


### PR DESCRIPTION
I want to use this for slack-infra, and preferably not have to clone test-infra to do so.

Since this makes no sense without authentication, defaults to assuming a setup similar to the one we use in prow, but without using bazel to build on the fly.