### PR TITLE
Fixing issues with project card move operation.

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -512,12 +512,13 @@ func (f *FakeClient) DeleteProjectCard(projectCardID int) error {
 	return nil
 }
 
-func (f *FakeClient) GetColumnProjectCard(columnID int, cardNumber int) (*github.ProjectCard, error) {
+// GetColumnProjectCard fetches project card if the content_url in the card matched the issue/pr
+func (f *FakeClient) GetColumnProjectCard(columnID int, contentURL string) (*github.ProjectCard, error) {
 	if f.ColumnCardsMap == nil {
 		f.ColumnCardsMap = make(map[int][]github.ProjectCard)
 	}
 	for _, existingCard := range f.ColumnCardsMap[columnID] {
-		if existingCard.ContentID == cardNumber {
+		if existingCard.ContentURL == contentURL {
 			return &existingCard, nil
 		}
 	}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -916,6 +916,8 @@ type ProjectColumn struct {
 
 // ProjectCard is a github project card
 type ProjectCard struct {
+	ID          int    `json:"id"`
 	ContentID   int    `json:"content_id"`
 	ContentType string `json:"content_type"`
+	ContentURL  string `json:"content_url"`
 }

--- a/prow/plugins/project/project_test.go
+++ b/prow/plugins/project/project_test.go
@@ -303,11 +303,12 @@ func TestProjectCommand(t *testing.T) {
 		fakeClient.Column = tc.previousColumn
 
 		e := &github.GenericCommentEvent{
-			Action: tc.action,
-			Body:   tc.body,
-			Number: 1,
-			Repo:   github.Repo{Owner: github.User{Login: tc.org}, Name: tc.repo},
-			User:   github.User{Login: tc.commenter},
+			Action:       tc.action,
+			Body:         tc.body,
+			Number:       1,
+			IssueHTMLURL: "1",
+			Repo:         github.Repo{Owner: github.User{Login: tc.org}, Name: tc.repo},
+			User:         github.User{Login: tc.commenter},
 		}
 		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, projectConfig); err != nil {
 			t.Errorf("(%s): Unexpected error from handle: %v.", tc.name, err)


### PR DESCRIPTION
Co-authored-by: Hippy Hacker <hh@ii.coop>

Currently project plugin fails to properly identify existence of the card as the card only contains the URL to work with and not the issue/pr number.
The Move operation reqParams require both the fields {Position, ColumnID}
Some optimization is done when searching for the project under the org. 