### PR TITLE
Add tooling to automate release-based job forking

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -53,6 +53,7 @@ filegroup(
         "//experiment/add-hook:all-srcs",
         "//experiment/aws-stockout:all-srcs",
         "//experiment/ci-janitor:all-srcs",
+        "//experiment/config-forker:all-srcs",
         "//experiment/coverage:all-srcs",
         "//experiment/dummybenchmarks:all-srcs",
         "//experiment/image-bumper:all-srcs",

--- a/experiment/config-forker/BUILD.bazel
+++ b/experiment/config-forker/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/config-forker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "config-forker",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
+)

--- a/experiment/config-forker/README.md
+++ b/experiment/config-forker/README.md
@@ -1,0 +1,64 @@
+# config-forker
+
+config-forker forks presubmit, periodic, and postsubmit job configs with the `fork-per-release` annotation.
+
+## Usage
+
+* `--job-config`: Path to the job config
+* `--output`: Path to the output yaml to create. If not specified, the process still runs but no file is generated
+  (potentially useful for presubmits)
+* `--version`: the version to generate a forked config for, e.g. `1.15`
+
+## Supported annotations
+
+- `fork-per-release`: only jobs with this set to `"true"` will be forked.
+- `fork-per-release-replacements`: allows replacing values in container `args` (see [Custom replacements](#custom-replacements)).
+- `fork-per-release-periodic-interval`: if set, forked jobs will use this value instead. If multiple space-separated values are provided, the first will be used.
+
+## Actions taken
+
+For the sake of clarity, all the below will assume we are forking with `--version 1.15`.
+
+Only jobs annotated with `fork-per-release` will be forked.
+
+For all jobs:
+
+- If `spec` includes a container with an `image` ending in `-master`, it is replaced with `-1.15`.
+- If `spec` includes a container with an `env` variable with `BRANCH` (case-insensitive) in the name and the value
+  `master`, the value will be changed to `release-1.15`.
+- If the `fork-per-release-replacements` annotation is specified, those replacements will be performed in the `args`
+  of all containers for that job.
+
+For presubmits and postsubmits:
+
+- `skip_branches` will be deleted
+- `branches` will be set to `release-1.15`
+
+For periodics and postsubmits:
+
+- If the job `name` ends in `-master`, it will be replaced with `-1-15`, otherwise `-1-15` will be appended
+
+For periodics only:
+
+- If `decorate` is `true`, and `extra_refs` contains a reference to `kubernetes/kubernetes` master, the `BaseRef`
+  will be updated to `release-1.15`
+- If `decorate` is not true, some bootstrap-related `args` will be replaced:
+  - `--repo=k8s.io/kubernetes` or `--repo=k8s.io/kubernetes=master` will be replaced with `--repo=k8s.io/kubernetes=release-1.15`
+  - `--branch=master` will be replaced with `--branch=release-1.15`
+- If the `fork-per-release-periodic-interval` annotation is set, the `interval` will be set to the first value it contains.
+ 
+## Custom replacements
+
+The `fork-per-release-replacements` annotation can be used for custom replacements in your `args`. It takes the form
+of a comma-separated list of replacements, like this:
+
+```
+fork-per-release-replacements: "original1 -> replacement1, original2 -> replacement2"
+```
+
+The replacements are interpreted as Go templates, with one value defined: `{{.Version}}`. `{{.Version}}` will be replaced
+by the version currently being forked (e.g. `1.15`). For example:
+
+```
+fork-per-release-replacements: "--version=stable -> --version={{.Version}"
+```

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"regexp"
+	"strings"
+	"text/template"
+
+	v1 "k8s.io/api/core/v1"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	forkAnnotation             = "fork-per-release"
+	periodicIntervalAnnotation = "fork-per-release-periodic-interval"
+	replacementAnnotation      = "fork-per-release-extra-arg-replacements"
+)
+
+func generatePostsubmits(c config.JobConfig, version string) (map[string][]config.Postsubmit, error) {
+	newPostsubmits := map[string][]config.Postsubmit{}
+	for repo, postsubmits := range c.Postsubmits {
+		for _, postsubmit := range postsubmits {
+			if postsubmit.Annotations[forkAnnotation] != "true" {
+				continue
+			}
+			p := postsubmit
+			p.Name = generateNameVariant(p.Name, version)
+			p.SkipBranches = nil
+			p.Branches = []string{"release-" + version}
+			if p.Spec != nil {
+				for i := range p.Spec.Containers {
+					c := &p.Spec.Containers[i]
+					c.Env = fixEnvVars(c.Env, version)
+					c.Image = fixImage(c.Image, version)
+					var err error
+					c.Args, err = performArgReplacements(c.Args, version, p.Annotations[replacementAnnotation])
+					if err != nil {
+						return nil, fmt.Errorf("%s: %v", postsubmit.Name, err)
+					}
+				}
+			}
+			p.Annotations = cleanAnnotations(p.Annotations)
+			newPostsubmits[repo] = append(newPostsubmits[repo], p)
+		}
+	}
+	return newPostsubmits, nil
+}
+
+func generatePresubmits(c config.JobConfig, version string) (map[string][]config.Presubmit, error) {
+	newPresubmits := map[string][]config.Presubmit{}
+	for repo, presubmits := range c.Presubmits {
+		for _, presubmit := range presubmits {
+			if presubmit.Annotations[forkAnnotation] != "true" {
+				continue
+			}
+			p := presubmit
+			p.SkipBranches = nil
+			p.Branches = []string{"release-" + version}
+			if p.Spec != nil {
+				for i := range p.Spec.Containers {
+					c := &p.Spec.Containers[i]
+					c.Env = fixEnvVars(c.Env, version)
+					c.Image = fixImage(c.Image, version)
+					var err error
+					c.Args, err = performArgReplacements(c.Args, version, p.Annotations[replacementAnnotation])
+					if err != nil {
+						return nil, fmt.Errorf("%s: %v", presubmit.Name, err)
+					}
+				}
+			}
+			p.Annotations = cleanAnnotations(p.Annotations)
+			newPresubmits[repo] = append(newPresubmits[repo], p)
+		}
+	}
+	return newPresubmits, nil
+}
+
+func generatePeriodics(c config.JobConfig, version string) ([]config.Periodic, error) {
+	var newPeriodics []config.Periodic
+	for _, periodic := range c.Periodics {
+		if periodic.Annotations[forkAnnotation] != "true" {
+			continue
+		}
+		p := periodic
+		p.Name = generateNameVariant(p.Name, version)
+		if p.Spec != nil {
+			for i := range p.Spec.Containers {
+				c := &p.Spec.Containers[i]
+				c.Image = fixImage(c.Image, version)
+				c.Env = fixEnvVars(c.Env, version)
+				if !p.Decorate {
+					c.Command = fixBootstrapArgs(c.Command, version)
+					c.Args = fixBootstrapArgs(c.Args, version)
+				}
+				var err error
+				c.Args, err = performArgReplacements(c.Args, version, p.Annotations[replacementAnnotation])
+				if err != nil {
+					return nil, fmt.Errorf("%s: %v", periodic.Name, err)
+				}
+			}
+		}
+		if p.Decorate {
+			p.ExtraRefs = fixExtraRefs(p.ExtraRefs, version)
+		}
+		if interval, ok := p.Annotations[periodicIntervalAnnotation]; ok {
+			f := strings.Fields(interval)
+			if len(f) > 0 {
+				p.Interval = f[0]
+			}
+		}
+		p.Annotations = cleanAnnotations(p.Annotations)
+		newPeriodics = append(newPeriodics, p)
+	}
+	return newPeriodics, nil
+}
+
+func cleanAnnotations(annotations map[string]string) map[string]string {
+	result := map[string]string{}
+	for k, v := range annotations {
+		if k != forkAnnotation && k != replacementAnnotation {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func evaluateTemplate(s string, c interface{}) (string, error) {
+	t, err := template.New("t").Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template %q: %v", s, err)
+	}
+	wr := bytes.Buffer{}
+	err = t.Execute(&wr, c)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute template: %v", err)
+	}
+	return wr.String(), nil
+}
+
+func performArgReplacements(args []string, version, replacements string) ([]string, error) {
+	if args == nil {
+		return nil, nil
+	}
+	if replacements == "" {
+		return args, nil
+	}
+
+	var rs []string
+	as := strings.Split(replacements, ", ")
+	for _, r := range as {
+		s := strings.Split(r, " -> ")
+		if len(s) != 2 {
+			return nil, fmt.Errorf("failed to parse replacement %q", r)
+		}
+		v, err := evaluateTemplate(s[1], struct{ Version string }{version})
+		if err != nil {
+			return nil, err
+		}
+		rs = append(rs, s[0], v)
+	}
+	replacer := strings.NewReplacer(rs...)
+
+	newArgs := make([]string, 0, len(args))
+	for _, a := range args {
+		newArgs = append(newArgs, replacer.Replace(a))
+	}
+
+	return newArgs, nil
+}
+
+func fixImage(image, version string) string {
+	return strings.ReplaceAll(image, "-master", "-"+version)
+}
+
+func fixBootstrapArgs(args []string, version string) []string {
+	if args == nil {
+		return nil
+	}
+	replacer := strings.NewReplacer(
+		"--repo=k8s.io/kubernetes=master", "--repo=k8s.io/kubernetes=release-"+version,
+		"--repo=k8s.io/kubernetes", "--repo=k8s.io/kubernetes=release-"+version,
+		"--branch=master", "--branch=release-"+version,
+	)
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, replacer.Replace(arg))
+	}
+	return newArgs
+}
+
+func fixExtraRefs(refs []prowapi.Refs, version string) []prowapi.Refs {
+	if refs == nil {
+		return nil
+	}
+	newRefs := make([]prowapi.Refs, 0, len(refs))
+	for _, r := range refs {
+		if r.Org == "kubernetes" && r.Repo == "kubernetes" && r.BaseRef == "master" {
+			r.BaseRef = "release-" + version
+		}
+		newRefs = append(newRefs, r)
+	}
+	return newRefs
+}
+
+func fixEnvVars(vars []v1.EnvVar, version string) []v1.EnvVar {
+	if vars == nil {
+		return nil
+	}
+	newVars := make([]v1.EnvVar, 0, len(vars))
+	for _, v := range vars {
+		if strings.Contains(strings.ToUpper(v.Name), "BRANCH") && v.Value == "master" {
+			v.Value = "release-" + version
+		}
+		newVars = append(newVars, v)
+	}
+	return newVars
+}
+
+func generateNameVariant(name, version string) string {
+	nameVersion := strings.ReplaceAll(version, ".", "-")
+	if !strings.HasSuffix(name, "-master") {
+		return name + "-" + nameVersion
+	}
+	return strings.ReplaceAll(name, "-master", "-"+nameVersion)
+}
+
+type options struct {
+	jobConfig  string
+	outputPath string
+	newVersion string
+}
+
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.jobConfig, "job-config", "", "Path to the job config")
+	flag.StringVar(&o.outputPath, "output", "", "Path to the output yaml. if not specified, just validate.")
+	flag.StringVar(&o.newVersion, "version", "", "Version number to generate jobs for")
+	flag.Parse()
+	return o
+}
+
+func validateOptions(o options) error {
+	if o.jobConfig == "" {
+		return errors.New("--job-config must be specified")
+	}
+	if o.newVersion == "" {
+		return errors.New("--version must be specified")
+	}
+	if match, err := regexp.MatchString(`^\d+\.\d+$`, o.newVersion); err != nil || !match {
+		return fmt.Errorf("%q doesn't look like a valid version number", o.newVersion)
+	}
+	return nil
+}
+
+func main() {
+	o := parseFlags()
+	if err := validateOptions(o); err != nil {
+		log.Fatalln(err)
+	}
+	c, err := config.ReadJobConfig(o.jobConfig)
+	if err != nil {
+		log.Fatalf("Failed to load job config: %v\n", err)
+	}
+
+	newPresubmits, err := generatePresubmits(c, o.newVersion)
+	if err != nil {
+		log.Fatalf("Failed to generate presubmits: %v.\n", err)
+	}
+	newPeriodics, err := generatePeriodics(c, o.newVersion)
+	if err != nil {
+		log.Fatalf("Failed to generate periodics: %v.\n", err)
+	}
+	newPostsubmits, err := generatePostsubmits(c, o.newVersion)
+	if err != nil {
+		log.Fatalf("Failed to generate postsubmits: %v.\n", err)
+	}
+
+	output, err := yaml.Marshal(map[string]interface{}{
+		"periodics":   newPeriodics,
+		"presubmits":  newPresubmits,
+		"postsubmits": newPostsubmits,
+	})
+	if err != nil {
+		log.Fatalf("Failed to marshal new presubmits: %v\n", err)
+	}
+
+	if o.outputPath != "" {
+		if err := ioutil.WriteFile(o.outputPath, output, 0666); err != nil {
+			log.Fatalf("Failed to write new presubmits: %v.\n", err)
+		}
+	} else {
+		log.Println("No output file specified, so not writing anything.")
+	}
+}

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -1,0 +1,630 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestCleanAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[string]string
+	}{
+		{
+			name:        "no annotations",
+			annotations: map[string]string{},
+			expected:    map[string]string{},
+		},
+		{
+			name: "only removable annotations",
+			annotations: map[string]string{
+				forkAnnotation:        "true",
+				replacementAnnotation: "foo -> bar",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "all our annotations",
+			annotations: map[string]string{
+				forkAnnotation:             "true",
+				replacementAnnotation:      "foo -> bar",
+				periodicIntervalAnnotation: "2h",
+			},
+			expected: map[string]string{
+				periodicIntervalAnnotation: "2h",
+			},
+		},
+		{
+			name: "foreign annotations",
+			annotations: map[string]string{
+				"someOtherAnnotation": "pony party",
+			},
+			expected: map[string]string{
+				"someOtherAnnotation": "pony party",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldAnnotations := map[string]string{}
+			for k, v := range tc.annotations {
+				oldAnnotations[k] = v
+			}
+			result := cleanAnnotations(tc.annotations)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected result %#v', got %#v", tc.expected, result)
+			}
+			if !reflect.DeepEqual(oldAnnotations, tc.annotations) {
+				t.Errorf("Input annotations map changed: used to be %#v, now %#v", oldAnnotations, tc.annotations)
+			}
+		})
+	}
+}
+
+func TestEvaluateTemplate(t *testing.T) {
+	const expected = "Foo Substitution! Baz"
+	result, err := evaluateTemplate("Foo {{.Bar}} Baz", map[string]string{"Bar": "Substitution!"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("Expected result %q, got %q", expected, result)
+	}
+}
+
+func TestPerformArgReplacements(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		replacements string
+		expected     []string
+		expectErr    bool
+	}{
+		{
+			name:         "nil arguments remain nil",
+			args:         nil,
+			replacements: "foo -> bar",
+			expected:     nil,
+		},
+		{
+			name:         "empty arguments remain empty",
+			args:         []string{},
+			replacements: "foo -> bar",
+			expected:     []string{},
+		},
+		{
+			name:         "empty replacements do nothing",
+			args:         []string{"foo", "bar"},
+			replacements: "",
+			expected:     []string{"foo", "bar"},
+		},
+		{
+			name:         "simple replacement works",
+			args:         []string{"foos", "bars", "bazzes"},
+			replacements: "foo -> bar",
+			expected:     []string{"bars", "bars", "bazzes"},
+		},
+		{
+			name:         "multiple replacements work",
+			args:         []string{"some foos", "bars", "bazzes"},
+			replacements: "foo -> bar, bars -> bazzes",
+			expected:     []string{"some bars", "bazzes", "bazzes"},
+		},
+		{
+			name:         "template expansion works",
+			args:         []string{"version: special one"},
+			replacements: "special one -> {{.Version}}",
+			expected:     []string{"version: 1.15"},
+		},
+		{
+			name:         "invalid template is an error",
+			args:         []string{"version: special one"},
+			replacements: "special one -> {{Version}}",
+			expectErr:    true,
+		},
+		{
+			name:         "unparseable replacements are an error",
+			args:         []string{"foo"},
+			replacements: "foo -> bar, baz",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := performArgReplacements(tc.args, "1.15", tc.replacements)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.expectErr {
+				t.Fatalf("Expected an error, but got %v", result)
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected result %v, but got %v instead", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFixImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{
+			name:     "replaces -master with -[version]",
+			image:    "kubekins-e2e-blahblahblah-master",
+			expected: "kubekins-e2e-blahblahblah-1.15",
+		},
+		{
+			name:     "does nothing with non-master images",
+			image:    "golang:1.12.2",
+			expected: "golang:1.12.2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := fixImage(tc.image, "1.15"); result != tc.expected {
+				t.Errorf("Expected %q, but got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFixBootstrapArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "replaces repo with no branch specified",
+			args:     []string{"--repo=k8s.io/kubernetes"},
+			expected: []string{"--repo=k8s.io/kubernetes=release-1.15"},
+		},
+		{
+			name:     "replaces repo with master branch specified",
+			args:     []string{"--repo=k8s.io/kubernetes=master"},
+			expected: []string{"--repo=k8s.io/kubernetes=release-1.15"},
+		},
+		{
+			name:     "replaces master branch with release branch",
+			args:     []string{"--branch=master"},
+			expected: []string{"--branch=release-1.15"},
+		},
+		{
+			name:     "replaces both repo and branch",
+			args:     []string{"--repo=k8s.io/kubernetes=master", "--branch=master"},
+			expected: []string{"--repo=k8s.io/kubernetes=release-1.15", "--branch=release-1.15"},
+		},
+		{
+			name:     "doesn't replace other repos",
+			args:     []string{"--repo=k8s.io/test-infra"},
+			expected: []string{"--repo=k8s.io/test-infra"},
+		},
+		{
+			name:     "doesn't touch other flags",
+			args:     []string{"--foo=bar", "--branch=master"},
+			expected: []string{"--foo=bar", "--branch=release-1.15"},
+		},
+		{
+			name:     "nil args are still nil",
+			args:     nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := fixBootstrapArgs(tc.args, "1.15"); !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected args %v, but got %v instead", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFixExtraRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		refs     []prowapi.Refs
+		expected []prowapi.Refs
+	}{
+		{
+			name:     "replaces kubernetes master with release branch",
+			refs:     []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "master"}},
+			expected: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "release-1.15"}},
+		},
+		{
+			name:     "ignores kubernetes repos other than kubernetes",
+			refs:     []prowapi.Refs{{Org: "kubernetes", Repo: "test-infra", BaseRef: "master"}},
+			expected: []prowapi.Refs{{Org: "kubernetes", Repo: "test-infra", BaseRef: "master"}},
+		},
+		{
+			name:     "ignores repos called kubernetes in other orgs",
+			refs:     []prowapi.Refs{{Org: "Katharine", Repo: "kubernetes", BaseRef: "master"}},
+			expected: []prowapi.Refs{{Org: "Katharine", Repo: "kubernetes", BaseRef: "master"}},
+		},
+		{
+			name:     "ignores non-master branches",
+			refs:     []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "other-branch"}},
+			expected: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "other-branch"}},
+		},
+		{
+			name:     "handles multiple refs",
+			refs:     []prowapi.Refs{{Org: "kubernetes", Repo: "test-infra", BaseRef: "master"}, {Org: "kubernetes", Repo: "kubernetes", BaseRef: "master"}},
+			expected: []prowapi.Refs{{Org: "kubernetes", Repo: "test-infra", BaseRef: "master"}, {Org: "kubernetes", Repo: "kubernetes", BaseRef: "release-1.15"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := fixExtraRefs(tc.refs, "1.15"); !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(tc.expected, result))
+			}
+		})
+	}
+}
+
+func TestFixEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     []v1.EnvVar
+		expected []v1.EnvVar
+	}{
+		{
+			name:     "replaces BRANCH-like jobs referencing master",
+			vars:     []v1.EnvVar{{Name: "KUBERNETES_BRANCH", Value: "master"}},
+			expected: []v1.EnvVar{{Name: "KUBERNETES_BRANCH", Value: "release-1.15"}},
+		},
+		{
+			name:     "ignores BRANCH-like jobs referencing something else",
+			vars:     []v1.EnvVar{{Name: "KUBERNETES_BRANCH", Value: "something-else"}},
+			expected: []v1.EnvVar{{Name: "KUBERNETES_BRANCH", Value: "something-else"}},
+		},
+		{
+			name:     "names are case-insensitive",
+			vars:     []v1.EnvVar{{Name: "branch", Value: "master"}},
+			expected: []v1.EnvVar{{Name: "branch", Value: "release-1.15"}},
+		},
+		{
+			name:     "other vars are not touched",
+			vars:     []v1.EnvVar{{Name: "foo", Value: "bar"}, {Name: "baz", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{Key: "baz-secret"}}}},
+			expected: []v1.EnvVar{{Name: "foo", Value: "bar"}, {Name: "baz", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{Key: "baz-secret"}}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := fixEnvVars(tc.vars, "1.15"); !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(tc.expected, result))
+			}
+		})
+	}
+}
+
+func TestGenerateNameVariant(t *testing.T) {
+	tests := []struct {
+		name     string
+		testName string
+		expected string
+	}{
+		{
+			name:     "jobs ending in -master have it replaced",
+			testName: "ci-party-master",
+			expected: "ci-party-1-15",
+		},
+		{
+			name:     "jobs not ending in in -master have a number appended",
+			testName: "ci-party",
+			expected: "ci-party-1-15",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := generateNameVariant(tc.testName, "1.15"); result != tc.expected {
+				t.Errorf("Expected name %q, but got name %q.", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGeneratePresubmits(t *testing.T) {
+	presubmits := map[string][]config.Presubmit{
+		"kubernetes/kubernetes": {
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e",
+					Annotations: map[string]string{forkAnnotation: "true"},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "pull-replace-some-things",
+					Annotations: map[string]string{
+						forkAnnotation:        "true",
+						replacementAnnotation: "foo -> {{.Version}}",
+						"some-annotation":     "yup",
+					},
+					Spec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-master",
+								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
+								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+							},
+						},
+					},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-not-forked",
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+		},
+	}
+
+	expected := map[string][]config.Presubmit{
+		"kubernetes/kubernetes": {
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e",
+					Annotations: map[string]string{},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "pull-replace-some-things",
+					Annotations: map[string]string{
+						"some-annotation": "yup",
+					},
+					Spec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-1.15",
+								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
+								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+							},
+						},
+					},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+			},
+		},
+	}
+
+	result, err := generatePresubmits(config.JobConfig{Presubmits: presubmits}, "1.15")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(expected, result))
+	}
+}
+
+func TestGeneratePeriodics(t *testing.T) {
+	periodics := []config.Periodic{
+		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name:        "some-forked-periodic-master",
+				Annotations: map[string]string{forkAnnotation: "true"},
+			},
+		},
+		{
+			Interval: "1h",
+			JobBase: config.JobBase{
+				Name: "periodic-with-replacements",
+				Annotations: map[string]string{
+					forkAnnotation:             "true",
+					periodicIntervalAnnotation: "6h 12h 24h 24h",
+					replacementAnnotation:      "stable -> {{.Version}}",
+				},
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-master",
+							Args:  []string{"--repo=k8s.io/kubernetes", "--version=stable"},
+							Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Interval: "2h",
+			JobBase: config.JobBase{
+				Name: "decorated-periodic",
+				Annotations: map[string]string{
+					forkAnnotation: "true",
+				},
+				UtilityConfig: config.UtilityConfig{
+					Decorate:  true,
+					ExtraRefs: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "master"}},
+				},
+			},
+		},
+		{
+			JobBase: config.JobBase{
+				Name: "not-forked",
+			},
+		},
+	}
+
+	expected := []config.Periodic{
+		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name:        "some-forked-periodic-1-15",
+				Annotations: map[string]string{},
+			},
+		},
+		{
+			Interval: "6h",
+			JobBase: config.JobBase{
+				Name: "periodic-with-replacements-1-15",
+				Annotations: map[string]string{
+					periodicIntervalAnnotation: "6h 12h 24h 24h",
+				},
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "gcr.io/k8s-testinfra/kubekins-e2e:blahblahblah-1.15",
+							Args:  []string{"--repo=k8s.io/kubernetes=release-1.15", "--version=1.15"},
+							Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Interval: "2h",
+			JobBase: config.JobBase{
+				Name:        "decorated-periodic-1-15",
+				Annotations: map[string]string{},
+				UtilityConfig: config.UtilityConfig{
+					Decorate:  true,
+					ExtraRefs: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "release-1.15"}},
+				},
+			},
+		},
+	}
+
+	result, err := generatePeriodics(config.JobConfig{Periodics: periodics}, "1.15")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(expected, result))
+	}
+}
+
+func TestGeneratePostsubmits(t *testing.T) {
+	postsubmits := map[string][]config.Postsubmit{
+		"kubernetes/kubernetes": {
+			{
+				JobBase: config.JobBase{
+					Name:        "post-kubernetes-e2e",
+					Annotations: map[string]string{forkAnnotation: "true"},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "post-replace-some-things-master",
+					Annotations: map[string]string{
+						forkAnnotation:        "true",
+						replacementAnnotation: "foo -> {{.Version}}",
+						"some-annotation":     "yup",
+					},
+					Spec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-master",
+								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
+								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
+							},
+						},
+					},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "post-not-forked",
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+		},
+	}
+
+	expected := map[string][]config.Postsubmit{
+		"kubernetes/kubernetes": {
+			{
+				JobBase: config.JobBase{
+					Name:        "post-kubernetes-e2e-1-15",
+					Annotations: map[string]string{},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "post-replace-some-things-1-15",
+					Annotations: map[string]string{
+						"some-annotation": "yup",
+					},
+					Spec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-1.15",
+								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
+								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
+							},
+						},
+					},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+			},
+		},
+	}
+
+	result, err := generatePostsubmits(config.JobConfig{Postsubmits: postsubmits}, "1.15")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(expected, result))
+	}
+}


### PR DESCRIPTION
Release job forking is currently a PITA and it really doesn't have to be. Also I couldn't sleep.

Assumptions:

- Jobs for a release branch don't change (much) once they're set
- Jobs for a release branch may differ in arbitrary ways from the master version of the job, and eachother

Solution:

- Use regexes for `skip_branches` instead of enumerating them
- Centralise all the forked jobs together in one or two files per release
- Add an annotation for jobs that need to be forked
- Write a tool to automatically generate the job config files for a given release, making appropriate substitutions
- Generate required testgrid config changes

Thus far, this is implemented for presubmits, but not postsubmits (because some of those are pretty complicated). In order to actually do this, I made the following concrete changes (so far):

- In #12463: added `omitempty` to some Presubmit fields that are generally omitted and empty (`Agent`, `AlwaysRun`, `Trigger`, `RerunCommand`, `Context`)
- Added an `Annotations` field to prowjobs for storing arbitrary key-value pairs that prow itself doesn't care about
- In #12462: fixed the config validation of `skip_branches` settings that contain regexes
- Refactored some of the prow config loading code so I could pull out a `ReadJobConfig` public function that would give me unmangled config data without me having to write my own loader
- Wrote a tool that can generate forked versions of presubmits, postsubmits, and periodics.

Still to do:

- Generate testgrid config for those CI jobs
  - I intend to achieve this by making the testgrid configurator read some information out of prow annotations
- Split out the config and actually use the tool

/assign @krzyzacy @fejta @stevekuznetsov @BenTheElder @spiffxp @cjwagner 