### PR TITLE
trusted promoter jobs: use secret for k8s-artifacts-prod

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -488,20 +488,20 @@ postsubmits:
         - multirun.sh
         args:
         - /app/cip-docker-image.binary
-        - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-        - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-        - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
         env:
         - name: CIP_OPTS
           value: "-dry-run=false"
         volumeMounts:
-        - name: k8s-gcr-prod-service-account-creds
-          mountPath: /etc/k8s-gcr-prod-service-account
+        - name: k8s-artifacts-prod-service-account-creds
+          mountPath: /etc/k8s-artifacts-prod-service-account
           readOnly: true
       volumes:
-      - name: k8s-gcr-prod-service-account-creds
+      - name: k8s-artifacts-prod-service-account-creds
         secret:
-          secretName: k8s-gcr-prod-service-account
+          secretName: k8s-artifacts-prod-service-account
   kubernetes/community:
   - name: post-community-tempelis-apply
     cluster: test-infra-trusted
@@ -814,9 +814,9 @@ periodics:
       # If you run mkpj for this postsubmit, the job will query you for the base
       # ref to fetch (name of a branch, not a SHA, e.g. "master").
       - /app/cip-docker-image.binary
-      - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-      - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
-      - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-gcr-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
+      - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
       env:
       - name: CIP_OPTS
         value: "-dry-run=false"
@@ -827,19 +827,10 @@ periodics:
       #  # Be aggressive about keeping the prod registry clean.
       #  value: "-delete-extra-tags"
       volumeMounts:
-      - name: k8s-gcr-prod-service-account-creds
-        mountPath: /etc/k8s-gcr-prod-service-account
+      - name: k8s-artifacts-prod-service-account-creds
+        mountPath: /etc/k8s-artifacts-prod-service-account
         readOnly: true
-    # Create a volume from a Kubernetes Secret. The Secret can be created as
-    # per: https://kubernetes.io/docs/concepts/configuration/secret/.
-    #
-    # In our case we downloaded a service account secret key file from GCP, then ran
-    #
-    #   kubectl create secret generic k8s-gcr-prod-service-account \
-    #     --from-file=service-account.json=PATH/TO/cip-demo-staging-e881274d0046.json
-    #
-    # and so our secretName is k8s-gcr-prod-service-account.
     volumes:
-    - name: k8s-gcr-prod-service-account-creds
+    - name: k8s-artifacts-prod-service-account-creds
       secret:
-        secretName: k8s-gcr-prod-service-account
+        secretName: k8s-artifacts-prod-service-account


### PR DESCRIPTION
This is to match the pending upstream change
https://github.com/kubernetes/k8s.io/pull/247 which opts for a
differently-named destination GCP project.

    Old GCP project name: k8s-gcr-prod
    New GCP project name: k8s-artifacts-prod

As part of this we will also have to create the new
`k8s-artifacts-prod-service-account` secret as well as retire the old
`k8s-gcr-prod-service-account` secret.

/hold
/cc @thockin