### PR TITLE
Remove duplicate pull-test-infra-verify-bazel job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -82,19 +82,6 @@ presubmits:
         - --config=lint
         - //...
 
-  - name: pull-test-infra-verify-bazel
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-experimental
-        command:
-        - ./hack/verify-bazel.sh
-
   - name: pull-test-infra-verify-config
     branches:
     - master

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2784,9 +2784,6 @@ test_groups:
 - name: pull-test-infra-gubernator
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-gubernator
   num_columns_recent: 20
-- name: pull-test-infra-verify-bazel
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-bazel
-  num_columns_recent: 20
 - name: pull-test-infra-verify-gofmt
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-gofmt
   num_columns_recent: 20
@@ -7900,9 +7897,6 @@ dashboards:
     base_options: width=10
   - name: gubernator
     test_group_name: pull-test-infra-gubernator
-    base_options: width=10
-  - name: verify-bazel
-    test_group_name: pull-test-infra-verify-bazel
     base_options: width=10
   - name: verify-gofmt
     test_group_name: pull-test-infra-verify-gofmt


### PR DESCRIPTION
/assign @alvaroaleman @krzyzacy 

This is now a bazel target (https://github.com/kubernetes/test-infra/pull/12439) and covered by the verify-lint job: https://testgrid.k8s.io/presubmits-test-infra#lint