### PR TITLE
Convert {update,verify}-config.sh into bazel targets

### DIFF
--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -209,6 +209,45 @@ py_binary(
     ],
 )
 
+genrule(
+    name = "generate-security-jobs",
+    srcs = [
+        "//config:all-srcs",
+        "//prow:config.yaml",
+    ],
+    outs = ["zz.security-jobs.yaml"],
+    cmd = "./$(location //config/jobs/kubernetes-security:genjobs) --config=prow/config.yaml --jobs=config/jobs --output=\"$@\"",
+    tools = ["//config/jobs/kubernetes-security:genjobs"],
+)
+
+sh_binary(
+    name = "update-config",
+    srcs = ["update-config.sh"],
+    data = [
+        ":zz.security-jobs.yaml",
+    ],
+)
+
+sh_test(
+    name = "verify-config",
+    srcs = ["verify-config.sh"],
+    args = [
+        "$(location //prow/cmd/checkconfig)",
+        "--config-path=prow/config.yaml",
+        "--job-config-path=config/jobs",
+        "--plugin-config=prow/plugins.yaml",
+    ],
+    data = [
+        ":zz.security-jobs.yaml",
+        "//config:all-srcs",
+        "//config/jobs/kubernetes-security:all-srcs",
+        "//prow:config.yaml",
+        "//prow:plugins.yaml",
+        "//prow/cmd/checkconfig",
+    ],
+    tags = ["lint"],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/hack/update-config.sh
+++ b/hack/update-config.sh
@@ -17,13 +17,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
+if [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+  echo "Updating job configs..." >&2
+elif ! command -v bazel &>/dev/null; then
+  echo "Install bazel at https://bazel.build" >&2
+  exit 1
+else
+  (
+    set -o xtrace
+    bazel run //hack:update-config
+  )
+  exit 0
+fi
 
-GENERATED_SECURITY_CONFIG="${TESTINFRA_ROOT}/config/jobs/kubernetes-security/generated-security-jobs.yaml"
+in=hack/zz.security-jobs.yaml
+out=$BUILD_WORKSPACE_DIRECTORY/config/jobs/kubernetes-security/generated-security-jobs.yaml
 
-rm "${GENERATED_SECURITY_CONFIG}"
-
-bazel run //config/jobs/kubernetes-security:genjobs -- \
-"--config=${TESTINFRA_ROOT}/prow/config.yaml" \
-"--jobs=${TESTINFRA_ROOT}/config/jobs" \
-"--output=${GENERATED_SECURITY_CONFIG}"
+cp "$in" "$out"
+chmod 644 "$out"

--- a/hack/verify-config.sh
+++ b/hack/verify-config.sh
@@ -17,37 +17,39 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
-
-PROW_CONFIG="${TESTINFRA_ROOT}/prow/config.yaml"
-PLUGIN_CONFIG="${TESTINFRA_ROOT}/prow/plugins.yaml"
-JOBS_DIR="${TESTINFRA_ROOT}/config/jobs"
-TMP_CONFIG=$(mktemp)
-TMP_GENERATED_JOBS=$(mktemp)
-
-trap 'rm ${TMP_CONFIG} && rm ${TMP_GENERATED_JOBS}' EXIT
-cp "${PROW_CONFIG}" "${TMP_CONFIG}"
-
-bazel run //config/jobs/kubernetes-security:genjobs -- \
-"--config=${PROW_CONFIG}" \
-"--jobs=${JOBS_DIR}" \
-"--output=${TMP_GENERATED_JOBS}"
-
-DIFF=$(diff "${TMP_GENERATED_JOBS}" "${JOBS_DIR}/kubernetes-security/generated-security-jobs.yaml" || true)
-if [ ! -z "$DIFF" ]; then
-    echo "${DIFF}"
-    echo ""
-    echo "FAILED: config is not correct, please run 'hack/update-config.sh'"
-    exit 1
+if [[ -n "${TEST_WORKSPACE:-}" ]]; then
+  echo "Validating job configs..." >&2
+elif ! command -v bazel &> /dev/null; then
+  echo "Install bazel at https://bazel.build" >&2
+  exit 1
+else
+  (
+    set -o xtrace
+    bazel test --test_output=streamed //hack:verify-config
+  )
+  exit 0
 fi
 
-# Run checkconfig with strict warnings.
-bazel run //prow/cmd/checkconfig -- \
---config-path="${PROW_CONFIG}" --job-config-path="${JOBS_DIR}" --plugin-config="${PLUGIN_CONFIG}" --strict \
---warnings=mismatched-tide-lenient \
---warnings=tide-strict-branch \
---warnings=needs-ok-to-test \
---warnings=validate-owners \
---warnings=missing-trigger \
---warnings=validate-urls \
---warnings=unknown-fields
+trap 'echo ERROR: security jobs changed, run hack/update-config.sh >&2' ERR
+
+echo -n "Running checkconfig with strict warnings..." >&2
+"$@" \
+    --strict \
+    --warnings=mismatched-tide-lenient \
+    --warnings=tide-strict-branch \
+    --warnings=needs-ok-to-test \
+    --warnings=validate-owners \
+    --warnings=missing-trigger \
+    --warnings=validate-urls \
+    --warnings=unknown-fields
+echo PASS
+
+echo -n "Checking generated security jobs..." >&2
+d=$(diff config/jobs/kubernetes-security/generated-security-jobs.yaml hack/zz.security-jobs.yaml || true)
+if [[ -n "$d" ]]; then
+  echo "FAIL" >&2
+  echo "< unexpected" >&2
+  echo "> missing" >&2
+  echo "$d" >&2
+  false
+fi


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov @krzyzacy 

This will first fail, then will fix

Example verify-config failure: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/12452/pull-test-infra-lint/1123858626411237378