### PR TITLE
DRY out prometheus metrics server and pushgateway

### DIFF
--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -129,12 +129,10 @@ func main() {
 		cache = ghcache.NewMemCache(http.DefaultTransport, o.maxConcurrency)
 	} else {
 		cache = ghcache.NewDiskCache(http.DefaultTransport, o.dir, o.sizeGB, o.maxConcurrency)
-	}
-
-	if o.pushGateway != "" {
-		go metrics.PushMetrics("ghproxy", o.pushGateway, o.pushGatewayInterval)
 		go diskMonitor(o.pushGatewayInterval, o.dir)
 	}
+
+	metrics.ExposeMetrics("ghproxy", o.pushGateway, o.pushGatewayInterval)
 
 	proxy := newReverseProxy(o.upstreamParsed, cache, 30*time.Second)
 	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(o.port), proxy))

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -61,6 +61,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *May 2, 2019* All components exposing Prometheus metrics will now either push them
+   to the Prometheus PushGateway, if configured, or serve them locally on port 9090 at
+   `/metrics`, if not configured (the default).
  - *April 26, 2019* `blunderbuss`, `approve`, and other plugins that read OWNERS
    now treat `owners_dir_blacklist` as a list of regular expressions matched
    against the entire (repository-relative) directory path of the OWNERS file rather

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",
         "//vendor/github.com/NYTimes/gziphandler:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/test-infra/prow/pjutil"
@@ -204,14 +203,12 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to instantiate Jenkins controller.")
 	}
 
-	// Push metrics to the configured prometheus pushgateway endpoint.
+	// Expose prometheus metrics
 	pushGateway := cfg().PushGateway
-	if pushGateway.Endpoint != "" {
-		go m.PushMetrics("jenkins-operator", pushGateway.Endpoint, pushGateway.Interval)
-	}
+	m.ExposeMetrics("jenkins-operator", pushGateway.Endpoint, pushGateway.Interval)
+
 	// Serve Jenkins logs here and proxy deck to use this endpoint
-	// instead of baking agent-specific logic in deck. This func also
-	// serves prometheus metrics.
+	// instead of baking agent-specific logic in deck
 	go serve(jc)
 	// gather metrics for the jobs handled by the jenkins controller.
 	go gather(c)
@@ -262,11 +259,9 @@ func loadCerts(certFile, keyFile, caCertFile string) (*tls.Config, error) {
 }
 
 // serve starts a http server and serves Jenkins logs
-// and prometheus metrics. Meant to be called inside
-// a goroutine.
+// and. Meant to be called inside a goroutine.
 func serve(jc *jenkins.Client) {
 	http.Handle("/", gziphandler.GzipHandler(handleLog(jc)))
-	http.Handle("/metrics", promhttp.Handler())
 	logrus.WithError(http.ListenAndServe(":8080", nil)).Fatal("ListenAndServe returned.")
 }
 

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/plank:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],

--- a/prow/cmd/sub/BUILD.bazel
+++ b/prow/cmd/sub/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pubsub/reporter:go_default_library",
         "//prow/pubsub/subscriber:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/golang.org/x/sync/errgroup:go_default_library",
     ],

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -27,7 +27,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
@@ -121,11 +120,9 @@ func main() {
 
 	promMetrics := subscriber.NewMetrics()
 
-	// Push metrics to the configured prometheus pushgateway endpoint.
+	// Expose prometheus metrics
 	pushGateway := configAgent.Config().PushGateway
-	if pushGateway.Endpoint != "" {
-		go metrics.PushMetrics("sub", pushGateway.Endpoint, pushGateway.Interval)
-	}
+	metrics.ExposeMetrics("sub", pushGateway.Endpoint, pushGateway.Interval)
 
 	s := &subscriber.Subscriber{
 		ConfigAgent:   configAgent,
@@ -136,7 +133,6 @@ func main() {
 
 	// Return 200 on / for health checks.
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
-	http.Handle("/metrics", promhttp.Handler())
 
 	// Will call shutdown which will stop the errGroup
 	shutdownCtx, shutdown := context.WithCancel(context.Background())

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -175,11 +175,9 @@ func main() {
 	http.Handle("/history", c.History)
 	server := &http.Server{Addr: ":" + strconv.Itoa(o.port)}
 
-	// Push metrics to the configured prometheus pushgateway endpoint.
+	// Push metrics to the configured prometheus pushgateway endpoint or serve them
 	pushGateway := cfg().PushGateway
-	if pushGateway.Endpoint != "" {
-		go metrics.PushMetrics("tide", pushGateway.Endpoint, pushGateway.Interval)
-	}
+	metrics.ExposeMetrics("tide", pushGateway.Endpoint, pushGateway.Interval)
 
 	start := time.Now()
 	sync(c)

--- a/prow/metrics/BUILD.bazel
+++ b/prow/metrics/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/push:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],


### PR DESCRIPTION
When an admin is deploying Prow they either want metrics on the services
themselves or through a pushgateway. This patch makes that clear and
shares the startup code between components as has been done for pprof
and health/readiness servers.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 

this also makes sure we are not serving metrics externally to the cluster if the service is exposed since it's on a different port