### PR TITLE
verify-owners: respect OwnersDirBlacklist while traversing

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -135,9 +135,13 @@ type ProwConfig struct {
 type OwnersDirBlacklist struct {
 	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`
-	// Default configures a default blacklist for repos (or orgs) not
-	// specifically configured
+	// Default configures a default blacklist for all repos (or orgs).
+	// By default, some directories like ".git", "_output" and "vendor/.*/OWNERS"
+	// are preconfigured to be blacklisted.
 	Default []string `json:"default"`
+	// By default, some directories are preconfigured to be blacklisted.
+	// If set, IgnorePreconfiguredDefaults will ignore these preconfigured directories.
+	IgnorePreconfiguredDefaults bool `json:"ignore_preconfigured_defaults,omitempty"`
 }
 
 // DirBlacklist returns regular expressions matching directories to ignore when
@@ -149,6 +153,11 @@ func (ownersDirBlacklist OwnersDirBlacklist) DirBlacklist(org, repo string) (bla
 	}
 	if bl, ok := ownersDirBlacklist.Repos[org+"/"+repo]; ok {
 		blacklist = append(blacklist, bl...)
+	}
+
+	preconfiguredDefaults := []string{"\\.git$", "_output$", "vendor/.*/.*"}
+	if !ownersDirBlacklist.IgnorePreconfiguredDefaults {
+		blacklist = append(blacklist, preconfiguredDefaults...)
 	}
 	return
 }

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -136,11 +136,13 @@ type OwnersDirBlacklist struct {
 	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`
 	// Default configures a default blacklist for all repos (or orgs).
+	// Some directories like ".git", "_output" and "vendor/.*/OWNERS"
+	// are already preconfigured to be blacklisted, and need not be included here.
+	Default []string `json:"default"`
 	// By default, some directories like ".git", "_output" and "vendor/.*/OWNERS"
 	// are preconfigured to be blacklisted.
-	Default []string `json:"default"`
-	// By default, some directories are preconfigured to be blacklisted.
-	// If set, IgnorePreconfiguredDefaults will ignore these preconfigured directories.
+	// If set, IgnorePreconfiguredDefaults will not add these preconfigured directories
+	// to the blacklist.
 	IgnorePreconfiguredDefaults bool `json:"ignore_preconfigured_defaults,omitempty"`
 }
 

--- a/prow/plugins/blunderbuss/BUILD.bazel
+++ b/prow/plugins/blunderbuss/BUILD.bazel
@@ -42,5 +42,6 @@ go_test(
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/prow/plugins/verify-owners/BUILD.bazel
+++ b/prow/plugins/verify-owners/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/golint:go_default_library",
+        "//prow/plugins/trigger:go_default_library",
         "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/plugins/verify-owners/BUILD.bazel
+++ b/prow/plugins/verify-owners/BUILD.bazel
@@ -29,7 +29,10 @@ go_test(
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -318,7 +318,7 @@ func markdownFriendlyComment(org string, nonTrustedUsers map[string][]string) st
 	commentLines = append(commentLines, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
 
 	for user, ownersFiles := range nonTrustedUsers {
-		commentLines = append(commentLines, fmt.Sprintf("- @%s", user))
+		commentLines = append(commentLines, fmt.Sprintf("- %s", user))
 		for _, filename := range ownersFiles {
 			commentLines = append(commentLines, fmt.Sprintf("  - %s", filename))
 		}

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -133,6 +133,7 @@ func handle(ghc githubClient, gc *git.Client, roc repoownersClient, log *logrus.
 		if change.Filename == ownersAliasesFileName {
 			modifiedOwnerAliasesFile = change
 			ownerAliasesModified = true
+			break
 		}
 	}
 

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -19,6 +19,7 @@ package verifyowners
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -33,13 +34,16 @@ import (
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/plugins/golint"
+	"k8s.io/test-infra/prow/plugins/trigger"
 	"k8s.io/test-infra/prow/repoowners"
 )
 
 const (
 	// PluginName defines this plugin's registered name.
-	PluginName     = "verify-owners"
-	ownersFileName = "OWNERS"
+	PluginName                    = "verify-owners"
+	ownersFileName                = "OWNERS"
+	ownersAliasesFileName         = "OWNERS_ALIASES"
+	nonCollaboratorResponseFormat = "The following users are mentioned in %s file(s) but are not members of the %s org."
 )
 
 func init() {
@@ -48,7 +52,7 @@ func init() {
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: fmt.Sprintf("The verify-owners plugin validates %s files if they are modified in a PR. On validation failure it automatically adds the '%s' label to the PR, and a review comment on the incriminating file(s).", ownersFileName, labels.InvalidOwners),
+		Description: fmt.Sprintf("The verify-owners plugin validates %s and %s files and ensures that they always contain collaborators of the org, if they are modified in a PR. On validation failure it automatically adds the '%s' label to the PR, and a review comment on the incriminating file(s).", ownersFileName, ownersAliasesFileName, labels.InvalidOwners),
 	}
 	if config.Owners.LabelsBlackList != nil {
 		pluginHelp.Config = map[string]string{
@@ -65,18 +69,30 @@ type ownersClient interface {
 }
 
 type githubClient interface {
+	IsCollaborator(owner, repo, login string) (bool, error)
+	IsMember(org, user string) (bool, error)
 	AddLabel(org, repo string, number int, label string) error
 	CreateComment(owner, repo string, number int, comment string) error
 	CreateReview(org, repo string, number int, r github.DraftReview) error
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
 		return nil
 	}
-	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, &pre, pc.PluginConfig.Owners.LabelsBlackList)
+
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, &pre, pc.PluginConfig.Owners.LabelsBlackList, pc.PluginConfig.TriggerFor(pre.Repo.Owner.Login, pre.Repo.Name), cp)
 }
 
 type messageWithLine struct {
@@ -84,9 +100,10 @@ type messageWithLine struct {
 	message string
 }
 
-func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.PullRequestEvent, labelsBlackList []string) error {
+func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.PullRequestEvent, labelsBlackList []string, triggerConfig plugins.Trigger, cp commentPruner) error {
 	org := pre.Repo.Owner.Login
 	repo := pre.Repo.Name
+	number := pre.Number
 	wrongOwnersFiles := map[string]messageWithLine{}
 
 	// Get changes.
@@ -102,7 +119,18 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 			modifiedOwnersFiles = append(modifiedOwnersFiles, change)
 		}
 	}
-	if len(modifiedOwnersFiles) == 0 {
+
+	// Check if the OWNERS_ALIASES file was modified.
+	var modifiedOwnerAliasesFile github.PullRequestChange
+	var ownerAliasesModified bool
+	for _, change := range changes {
+		if change.Filename == ownersAliasesFileName {
+			modifiedOwnerAliasesFile = change
+			ownerAliasesModified = true
+		}
+	}
+
+	if len(modifiedOwnersFiles) == 0 && !ownerAliasesModified {
 		return nil
 	}
 
@@ -126,27 +154,50 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 		}
 	}
 
-	// Check each OWNERS file.
+	// If OWNERS_ALIASES file exists, get all aliases.
+	// If the file was modified, check for non trusted users in the newly added owners.
+	nonTrustedUsers, repoAliases, err := nonTrustedUsersInOwnersAliases(ghc, log, triggerConfig, org, repo, r.Dir, modifiedOwnerAliasesFile.Patch, ownerAliasesModified)
+	if err != nil {
+		return err
+	}
+
+	// Check if OWNERS files have the correct config and if they do,
+	// check if all newly added owners are trusted users.
 	for _, c := range modifiedOwnersFiles {
-		// Try to load OWNERS file.
 		path := filepath.Join(r.Dir, c.Filename)
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to read %s.", path)
 			return nil
 		}
-		if msg := parseOwnersFile(b, c, log, labelsBlackList); msg != nil {
+		msg, owners := parseOwnersFile(b, c, log, labelsBlackList)
+		if msg != nil {
 			wrongOwnersFiles[c.Filename] = *msg
+			continue
+		}
+
+		nonTrustedUsers, err = nonTrustedUsersInOwners(ghc, log, triggerConfig, org, repo, c.Patch, c.Filename, owners, nonTrustedUsers, repoAliases)
+		if err != nil {
+			return err
 		}
 	}
-	// React if we saw something.
+
+	// React if there are files with incorrect configs or non-trusted users.
+	issueLabels, err := ghc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return err
+	}
+	hasInvalidOwnersLabel := github.HasLabel(labels.InvalidOwners, issueLabels)
+
 	if len(wrongOwnersFiles) > 0 {
 		s := "s"
 		if len(wrongOwnersFiles) == 1 {
 			s = ""
 		}
-		if err := ghc.AddLabel(org, repo, pre.Number, labels.InvalidOwners); err != nil {
-			return err
+		if !hasInvalidOwnersLabel {
+			if err := ghc.AddLabel(org, repo, number, labels.InvalidOwners); err != nil {
+				return err
+			}
 		}
 		log.Debugf("Creating a review for %d %s file%s.", len(wrongOwnersFiles), ownersFileName, s)
 		var comments []github.DraftReviewComment
@@ -171,17 +222,40 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, pre *github.Pul
 		if err != nil {
 			return fmt.Errorf("error creating a review for invalid %s file%s: %v", ownersFileName, s, err)
 		}
-	} else {
+	}
+
+	if len(nonTrustedUsers) > 0 {
+		if !hasInvalidOwnersLabel {
+			if err := ghc.AddLabel(org, repo, number, labels.InvalidOwners); err != nil {
+				return err
+			}
+		}
+
+		// prune old comments before adding a new one
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
+		})
+		if err := ghc.CreateComment(org, repo, number, markdownFriendlyComment(org, nonTrustedUsers)); err != nil {
+			log.WithError(err).Errorf("Could not create comment for listing non-collaborators in %s files", ownersFileName)
+		}
+	}
+
+	if len(wrongOwnersFiles) == 0 && len(nonTrustedUsers) == 0 {
 		// Don't bother checking if it has the label...it's a race, and we'll have
 		// to handle failure due to not being labeled anyway.
 		if err := ghc.RemoveLabel(org, repo, pre.Number, labels.InvalidOwners); err != nil {
 			return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
 		}
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
+		})
 	}
+
 	return nil
 }
 
-func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, labelsBlackList []string) *messageWithLine {
+func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, labelsBlackList []string) (*messageWithLine, []string) {
+	var reviewers []string
 	var approvers []string
 	var labels []string
 	// by default we bind errors to line 1
@@ -207,15 +281,17 @@ func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, la
 			return &messageWithLine{
 				lineNumber,
 				fmt.Sprintf("Cannot parse file: %v.", err),
-			}
+			}, nil
 		}
 		// it's a FullConfig
 		for _, config := range full.Filters {
+			reviewers = append(reviewers, config.Reviewers...)
 			approvers = append(approvers, config.Approvers...)
 			labels = append(labels, config.Labels...)
 		}
 	} else {
 		// it's a SimpleConfig
+		reviewers = simple.Config.Reviewers
 		approvers = simple.Config.Approvers
 		labels = simple.Config.Labels
 	}
@@ -224,14 +300,106 @@ func parseOwnersFile(b []byte, c github.PullRequestChange, log *logrus.Entry, la
 		return &messageWithLine{
 			lineNumber,
 			fmt.Sprintf("File contains blacklisted labels: %s.", sets.NewString(labels...).Intersection(sets.NewString(labelsBlackList...)).List()),
-		}
+		}, nil
 	}
 	// Check approvers isn't empty
 	if filepath.Dir(c.Filename) == "." && len(approvers) == 0 {
 		return &messageWithLine{
 			lineNumber,
 			fmt.Sprintf("No approvers defined in this root directory %s file.", ownersFileName),
+		}, nil
+	}
+	owners := append(reviewers, approvers...)
+	return nil, owners
+}
+
+func markdownFriendlyComment(org string, nonTrustedUsers map[string][]string) string {
+	var commentLines []string
+	commentLines = append(commentLines, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org))
+
+	for user, ownersFiles := range nonTrustedUsers {
+		commentLines = append(commentLines, fmt.Sprintf("- @%s", user))
+		for _, filename := range ownersFiles {
+			commentLines = append(commentLines, fmt.Sprintf("  - %s", filename))
 		}
 	}
-	return nil
+	return strings.Join(commentLines, "\n")
+}
+
+func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, dir, patch string, ownerAliasesModified bool) (map[string][]string, repoowners.RepoAliases, error) {
+	repoAliases := make(repoowners.RepoAliases)
+	// nonTrustedUsers is a map of non-trusted users to the list of files they are being added in
+	nonTrustedUsers := map[string][]string{}
+	var err error
+
+	// If OWNERS_ALIASES exists, get all aliases.
+	path := filepath.Join(dir, ownersAliasesFileName)
+	if _, err := os.Stat(path); err == nil {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nonTrustedUsers, repoAliases, fmt.Errorf("Failed to read %s: %v", path, err)
+		}
+		repoAliases, err = repoowners.ParseAliasesConfig(b)
+		if err != nil {
+			return nonTrustedUsers, repoAliases, fmt.Errorf("error parsing aliases config for %s file: %v", ownersAliasesFileName, err)
+		}
+	}
+
+	// If OWNERS_ALIASES file was modified, check if newly added owners are trusted.
+	if ownerAliasesModified {
+		allOwners := repoAliases.ExpandAllAliases().List()
+		for _, owner := range allOwners {
+			// cap the number of checks to avoid exhausting tokens in case of large OWNERS refactors.
+			if len(nonTrustedUsers) > 20 {
+				break
+			}
+			nonTrustedUsers, err = checkIfTrustedUser(ghc, log, triggerConfig, owner, patch, ownersAliasesFileName, org, repo, nonTrustedUsers, repoAliases)
+			if err != nil {
+				return nonTrustedUsers, repoAliases, err
+			}
+		}
+	}
+
+	return nonTrustedUsers, repoAliases, nil
+}
+
+func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, patch, fileName string, owners []string, nonTrustedUsers map[string][]string, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
+	var err error
+	for _, owner := range owners {
+		// cap the number of checks to avoid exhausting tokens in case of large OWNERS refactors.
+		if len(nonTrustedUsers) > 20 {
+			break
+		}
+
+		// ignore if owner is an alias
+		if _, ok := repoAliases[owner]; ok {
+			continue
+		}
+
+		nonTrustedUsers, err = checkIfTrustedUser(ghc, log, triggerConfig, owner, patch, fileName, org, repo, nonTrustedUsers, repoAliases)
+		if err != nil {
+			return nonTrustedUsers, err
+		}
+	}
+	return nonTrustedUsers, nil
+}
+
+// checkIfTrustedUser looks for newly addded owners by checking if they are in the patch
+// and then checks if the owner is a trusted user.
+func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, owner, patch, fileName, org, repo string, nonTrustedUsers map[string][]string, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
+	if strings.Contains(patch, owner) {
+		isTrustedUser, err := trigger.TrustedUser(ghc, triggerConfig, owner, org, repo)
+		if err != nil {
+			return nonTrustedUsers, err
+		}
+
+		if !isTrustedUser {
+			if ownersFiles, ok := nonTrustedUsers[owner]; ok {
+				nonTrustedUsers[owner] = append(ownersFiles, fileName)
+			} else {
+				nonTrustedUsers[owner] = []string{fileName}
+			}
+		}
+	}
+	return nonTrustedUsers, nil
 }

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -283,6 +283,9 @@ func parseOwnersFile(oc ownersClient, path string, c github.PullRequestChange, l
 	// by default we bind errors to line 1
 	lineNumber := 1
 	simple, err := oc.ParseSimpleConfig(path)
+	if err == filepath.SkipDir {
+		return nil, nil
+	}
 	if err != nil || simple.Empty() {
 		full, err := oc.ParseFullConfig(path)
 		if err == filepath.SkipDir {

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -19,16 +19,22 @@ package verifyowners
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/repoowners"
 )
 
 var ownerFiles = map[string][]byte{
@@ -145,6 +151,100 @@ func newFakeGitHubClient(files []string, pr int) *fakegithub.FakeClient {
 type fakePruner struct{}
 
 func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
+
+type fakeRepoownersClient struct {
+	foc *fakeOwnersClient
+}
+
+func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+	return froc.foc, nil
+}
+
+type fakeOwnersClient struct {
+	owners            map[string]string
+	approvers         map[string]sets.String
+	leafApprovers     map[string]sets.String
+	reviewers         map[string]sets.String
+	requiredReviewers map[string]sets.String
+	leafReviewers     map[string]sets.String
+	dirBlacklist      []*regexp.Regexp
+}
+
+func (foc *fakeOwnersClient) Approvers(path string) sets.String {
+	return foc.approvers[path]
+}
+
+func (foc *fakeOwnersClient) LeafApprovers(path string) sets.String {
+	return foc.leafApprovers[path]
+}
+
+func (foc *fakeOwnersClient) FindApproverOwnersForFile(path string) string {
+	return foc.owners[path]
+}
+
+func (foc *fakeOwnersClient) Reviewers(path string) sets.String {
+	return foc.reviewers[path]
+}
+
+func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.String {
+	return foc.requiredReviewers[path]
+}
+
+func (foc *fakeOwnersClient) LeafReviewers(path string) sets.String {
+	return foc.leafReviewers[path]
+}
+
+func (foc *fakeOwnersClient) FindReviewersOwnersForFile(path string) string {
+	return foc.owners[path]
+}
+
+func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
+	return sets.String{}
+}
+
+func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool {
+	return false
+}
+
+func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
+	dir := filepath.Dir(path)
+	for _, re := range foc.dirBlacklist {
+		if re.MatchString(dir) {
+			return repoowners.SimpleConfig{}, filepath.SkipDir
+		}
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return repoowners.SimpleConfig{}, err
+	}
+	full := new(repoowners.SimpleConfig)
+	err = yaml.Unmarshal(b, full)
+	return *full, err
+}
+
+func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig, error) {
+	dir := filepath.Dir(path)
+	for _, re := range foc.dirBlacklist {
+		if re.MatchString(dir) {
+			return repoowners.FullConfig{}, filepath.SkipDir
+		}
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return repoowners.FullConfig{}, err
+	}
+	full := new(repoowners.FullConfig)
+	err = yaml.Unmarshal(b, full)
+	return *full, err
+}
+
+func makeFakeRepoOwnersClient() fakeRepoownersClient {
+	return fakeRepoownersClient{
+		foc: &fakeOwnersClient{},
+	}
+}
 
 func TestHandle(t *testing.T) {
 	var tests = []struct {
@@ -288,7 +388,14 @@ func TestHandle(t *testing.T) {
 			Repo: github.Repo{FullName: "org/repo"},
 		}
 		fghc := newFakeGitHubClient(test.filesChanged, pr)
-		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
+		fghc.PullRequests = map[int]*github.PullRequest{}
+		fghc.PullRequests[pr] = &github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: fakegithub.TestRef,
+			},
+		}
+
+		if err := handle(fghc, c, makeFakeRepoOwnersClient(), logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}
 		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {
@@ -302,7 +409,7 @@ func TestHandle(t *testing.T) {
 }
 
 func TestParseOwnersFile(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name     string
 		document []byte
 		patch    string
@@ -360,25 +467,67 @@ func TestParseOwnersFile(t *testing.T) {
 			document: ownerFiles["validFilters"],
 		},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if c.patch == "" {
-				c.patch = makePatch(c.document)
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pr := i + 1
+			lg, c, err := localgit.New()
+			if err != nil {
+				t.Fatalf("Making localgit: %v", err)
+			}
+			defer func() {
+				if err := lg.Clean(); err != nil {
+					t.Errorf("Cleaning up localgit: %v", err)
+				}
+				if err := c.Clean(); err != nil {
+					t.Errorf("Cleaning up client: %v", err)
+				}
+			}()
+			if err := lg.MakeFakeRepo("org", "repo"); err != nil {
+				t.Fatalf("Making fake repo: %v", err)
+			}
+			// make sure we're on master before branching
+			if err := lg.Checkout("org", "repo", "master"); err != nil {
+				t.Fatalf("Switching to master branch: %v", err)
+			}
+			if err := lg.CheckoutNewBranch("org", "repo", fmt.Sprintf("pull/%d/head", pr)); err != nil {
+				t.Fatalf("Checking out pull branch: %v", err)
+			}
+			pullFiles := map[string][]byte{}
+			pullFiles["OWNERS"] = test.document
+			if err := lg.AddCommit("org", "repo", pullFiles); err != nil {
+				t.Fatalf("Adding PR commit: %v", err)
+			}
+
+			if test.patch == "" {
+				test.patch = makePatch(test.document)
 			}
 			change := github.PullRequestChange{
 				Filename: "OWNERS",
-				Patch:    c.patch,
+				Patch:    test.patch,
 			}
-			message, _ := parseOwnersFile(c.document, change, &logrus.Entry{}, []string{})
+
+			r, err := c.Clone("org/repo")
+			if err != nil {
+				t.Fatalf("error cloning the repo: %v", err)
+			}
+			defer func() {
+				if err := r.Clean(); err != nil {
+					t.Fatalf("error cleaning up repo: %v", err)
+				}
+			}()
+
+			path := filepath.Join(r.Dir, "OWNERS")
+			message, _ := parseOwnersFile(&fakeOwnersClient{}, path, change, &logrus.Entry{}, []string{})
 			if message != nil {
-				if c.errLine == 0 {
-					t.Errorf("%s: expected no error, got one: %s", c.name, message.message)
+				if test.errLine == 0 {
+					t.Errorf("%s: expected no error, got one: %s", test.name, message.message)
 				}
-				if message.line != c.errLine {
-					t.Errorf("%s: wrong line for message, expected %d, got %d", c.name, c.errLine, message.line)
+				if message.line != test.errLine {
+					t.Errorf("%s: wrong line for message, expected %d, got %d", test.name, test.errLine, message.line)
 				}
-			} else if c.errLine != 0 {
-				t.Errorf("%s: expected an error, got none", c.name)
+			} else if test.errLine != 0 {
+				t.Errorf("%s: expected an error, got none", test.name)
 			}
 		})
 	}
@@ -470,7 +619,7 @@ reviewers:
 - alice
 approvers:
 +- zee
-- bob   
+- bob
 `,
 	"nonCollaboratorsWithAliases": `@@ -1,4 +1,6 @@
 reviewers:
@@ -508,7 +657,7 @@ aliases:
   foo-reviewers:
   - alice
 + - phippy
-+ - zee   
++ - zee
 `,
 	"collaboratorAdditions": `@@ -0,0 +1,3 @@
 +aliases:
@@ -519,14 +668,15 @@ aliases:
 
 func TestNonCollaborators(t *testing.T) {
 	var tests = []struct {
-		name               string
-		filesChanged       []string
-		ownersFile         string
-		ownersPatch        string
-		ownersAliasesFile  string
-		ownersAliasesPatch string
-		shouldLabel        bool
-		shouldComment      bool
+		name                string
+		filesChanged        []string
+		ownersFile          string
+		ownersPatch         string
+		ownersAliasesFile   string
+		ownersAliasesPatch  string
+		includeVendorOwners bool
+		shouldLabel         bool
+		shouldComment       bool
 	}{
 		{
 			name:          "non-collaborators additions in OWNERS file",
@@ -565,6 +715,31 @@ func TestNonCollaborators(t *testing.T) {
 			shouldLabel:        false,
 			shouldComment:      false,
 		},
+		{
+			name:          "non-collaborators additions in OWNERS file in vendor subdir",
+			filesChanged:  []string{"vendor/k8s.io/client-go/OWNERS"},
+			ownersFile:    "nonCollaboratorAdditions",
+			ownersPatch:   "nonCollaboratorAdditions",
+			shouldLabel:   false,
+			shouldComment: false,
+		},
+		{
+			name:                "non-collaborators additions in OWNERS file in vendor subdir, but include it",
+			filesChanged:        []string{"vendor/k8s.io/client-go/OWNERS"},
+			ownersFile:          "nonCollaboratorAdditions",
+			ownersPatch:         "nonCollaboratorAdditions",
+			includeVendorOwners: true,
+			shouldLabel:         true,
+			shouldComment:       true,
+		},
+		{
+			name:          "non-collaborators additions in OWNERS file in vendor dir",
+			filesChanged:  []string{"vendor/OWNERS"},
+			ownersFile:    "nonCollaboratorAdditions",
+			ownersPatch:   "nonCollaboratorAdditions",
+			shouldLabel:   true,
+			shouldComment: true,
+		},
 	}
 	lg, c, err := localgit.New()
 	if err != nil {
@@ -594,23 +769,21 @@ func TestNonCollaborators(t *testing.T) {
 		changes := []github.PullRequestChange{}
 
 		for _, file := range test.filesChanged {
-			if file == "OWNERS" {
+			if strings.Contains(file, "OWNERS_ALIASES") {
+				pullFiles[file] = ownersAliases[test.ownersAliasesFile]
+				changes = append(changes, github.PullRequestChange{
+					Filename: file,
+					Patch:    ownersAliasesPatch[test.ownersAliasesPatch],
+				})
+			} else if strings.Contains(file, "OWNERS") {
 				pullFiles[file] = ownersFiles[test.ownersFile]
 				changes = append(changes, github.PullRequestChange{
-					Filename: "OWNERS",
+					Filename: file,
 					Patch:    ownersPatch[test.ownersPatch],
 				})
 			}
-
-			if file == "OWNERS_ALIASES" {
-				pullFiles[file] = ownersAliases[test.ownersAliasesFile]
-				changes = append(changes, github.PullRequestChange{
-					Filename: "OWNERS_ALIASES",
-					Patch:    ownersAliasesPatch[test.ownersAliasesPatch],
-				})
-			}
-
 		}
+
 		if err := lg.AddCommit("org", "repo", pullFiles); err != nil {
 			t.Fatalf("Adding PR commit: %v", err)
 		}
@@ -631,7 +804,25 @@ func TestNonCollaborators(t *testing.T) {
 		fghc := newFakeGitHubClient(test.filesChanged, pr)
 		fghc.PullRequestChanges[pr] = changes
 
-		if err := handle(fghc, c, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
+		fghc.PullRequests = map[int]*github.PullRequest{}
+		fghc.PullRequests[pr] = &github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: fakegithub.TestRef,
+			},
+		}
+
+		froc := makeFakeRepoOwnersClient()
+		if !test.includeVendorOwners {
+			var blacklist []*regexp.Regexp
+			re, err := regexp.Compile("vendor/.*/.*$")
+			if err != nil {
+				t.Fatalf("error compiling regex: %v", err)
+			}
+			blacklist = append(blacklist, re)
+			froc.foc.dirBlacklist = blacklist
+		}
+
+		if err := handle(fghc, c, froc, logrus.WithField("plugin", PluginName), pre, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, &fakePruner{}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}
 		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -319,6 +319,20 @@ func (a RepoAliases) ExpandAliases(logins sets.String) sets.String {
 	return logins
 }
 
+// ExpandAllAliases returns members of all aliases mentioned, duplicates are pruned
+func (a RepoAliases) ExpandAllAliases() sets.String {
+	if a == nil {
+		return nil
+	}
+
+	var result, users sets.String
+	for alias := range a {
+		users = a.ExpandAlias(alias)
+		result = result.Union(users)
+	}
+	return result
+}
+
 func loadAliasesFrom(baseDir string, log *logrus.Entry) RepoAliases {
 	path := filepath.Join(baseDir, aliasesFileName)
 	b, err := ioutil.ReadFile(path)
@@ -466,6 +480,24 @@ func ParseSimpleConfig(b []byte) (SimpleConfig, error) {
 	simple := new(SimpleConfig)
 	err := yaml.Unmarshal(b, simple)
 	return *simple, err
+}
+
+// ParseAliasesConfig will unmarshal an OWNERS_ALIASES file's content into RepoAliases.
+// Returns an error if the content cannot be unmarshalled.
+func ParseAliasesConfig(b []byte) (RepoAliases, error) {
+	result := make(RepoAliases)
+
+	config := &struct {
+		Data map[string][]string `json:"aliases,omitempty"`
+	}{}
+	if err := yaml.Unmarshal(b, config); err != nil {
+		return result, err
+	}
+
+	for alias, expanded := range config.Data {
+		result[github.NormLogin(alias)] = normLogins(expanded)
+	}
+	return result, nil
 }
 
 var mdStructuredHeaderRegex = regexp.MustCompile("^---\n(.|\n)*\n---")

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -434,8 +434,14 @@ func (o *RepoOwners) walkFunc(path string, info os.FileInfo, err error) error {
 	}
 
 	simple, err := o.ParseSimpleConfig(path)
+	if err == filepath.SkipDir {
+		return err
+	}
 	if err != nil || simple.Empty() {
 		c, err := o.ParseFullConfig(path)
+		if err == filepath.SkipDir {
+			return err
+		}
 		if err != nil {
 			log.WithError(err).Errorf("Failed to unmarshal %s into either Simple or FullConfig.", path)
 		} else {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -42,8 +42,6 @@ const (
 	baseDirConvention = ""
 )
 
-var commonDirBlacklist = []string{"^\\.git$", "^_output$"}
-
 type dirOptions struct {
 	NoParentOwners bool `json:"no_parent_owners,omitempty"`
 }
@@ -257,7 +255,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 				entry.aliases = loadAliasesFrom(gitRepo.Dir, log)
 			}
 
-			dirBlacklistPatterns := append(c.ownersDirBlacklist().DirBlacklist(org, repo), commonDirBlacklist...)
+			dirBlacklistPatterns := c.ownersDirBlacklist().DirBlacklist(org, repo)
 			var dirBlacklist []*regexp.Regexp
 			for _, pattern := range dirBlacklistPatterns {
 				re, err := regexp.Compile(pattern)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/12407, fixes https://github.com/kubernetes/test-infra/issues/10553

This PR adds the following changes:

- Reverts https://github.com/kubernetes/test-infra/pull/12402, essentially adding https://github.com/kubernetes/test-infra/pull/12297.
- Updates `verify-owners` to avoid at-mentioning folks who are not part of the org.
- Adds `vendor/.*/.*` to the list of preconfigured default blacklist dirs. It also adds a new field `IgnorePreconfiguredDefaults` to `OwnersDirBlacklist`, so that a prow admin can override these preconfigured defaults. Ref: https://github.com/kubernetes/test-infra/pull/12374#issuecomment-487224670
- Updates `verify-owners` (and as a consequence `repoowners`) to respect the list of blacklisted directories while traversing. 

/cc @fejta @stevekuznetsov @cjwagner @cblecker @matthyx @danwinship