### PR TITLE
Fix validation of regex skip_branches

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1689,12 +1689,40 @@ func TestBrancher_Intersects(t *testing.T) {
 			},
 			result: true,
 		},
+		{
+			name: "NoIntersectionBecauseRegexSkip",
+			a: Brancher{
+				SkipBranches: []string{`release-\d+\.\d+`},
+			},
+			b: Brancher{
+				Branches: []string{`release-1.14`, `release-1.13`},
+			},
+			result: false,
+		},
+		{
+			name: "IntersectionDespiteRegexSkip",
+			a: Brancher{
+				SkipBranches: []string{`release-\d+\.\d+`},
+			},
+			b: Brancher{
+				Branches: []string{`release-1.14`, `master`},
+			},
+			result: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(st *testing.T) {
-			r1 := tc.a.Intersects(tc.b)
-			r2 := tc.b.Intersects(tc.a)
+			a, err := setBrancherRegexes(tc.a)
+			if err != nil {
+				st.Fatalf("Failed to set brancher A regexes: %v", err)
+			}
+			b, err := setBrancherRegexes(tc.b)
+			if err != nil {
+				st.Fatalf("Failed to set brancher B regexes: %v", err)
+			}
+			r1 := a.Intersects(b)
+			r2 := b.Intersects(a)
 			for _, result := range []bool{r1, r2} {
 				if result != tc.result {
 					st.Errorf("Expected %v got %v", tc.result, result)

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -249,8 +249,13 @@ func (br Brancher) Intersects(other Brancher) bool {
 			}
 			return false
 		}
-		if !baseBranches.Intersection(sets.NewString(other.SkipBranches...)).Equal(baseBranches) {
-			return true
+
+		// Actually test our branches against the other brancher - if there are regex skip lists, simple comparison
+		// is insufficient.
+		for _, b := range baseBranches.List() {
+			if other.ShouldRun(b) {
+				return true
+			}
 		}
 		return false
 	}


### PR DESCRIPTION
Currently if you have a presubmit with something like `skip_branches: ["release-\d+\.\d+"]` and another identically named presubmit with `branches: ["release-1.14"]`, validation fails because it thinks they are going to overlap. This is incorrect, but the current validation ignores the fact that `skip_branches` is a regex.

This PR is extracted from #12443.

/cc @cjwagner @stevekuznetsov 