### PR TITLE
Add the required path_alias to the ci-test-infra-benchmark-demo job.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -37,6 +37,7 @@ periodics:
     - org: cjwagner
       repo: test-infra
       base_ref: microbe-nchmarks
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - image: golang:latest


### PR DESCRIPTION
I tried to use phaino to validate this, but the refs are ignored so I didn't catch this bug. I also couldn't successfully run the job (as is) to completion with phaino because pod utility decoration is ignored so the `ARTIFACTS` environment variable is not specified.

I validated this fix works by using mkpj to run the modified job in the cluster: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-benchmark-demo/1124126766311411712

/assign @Katharine @stevekuznetsov 