### PR TITLE
prow/pod-utils/gcs: Add *UploadWithAttributes()

### DIFF
--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -78,8 +78,8 @@ func (o Options) assembleTargets(spec *downwardapi.JobSpec, extra map[string]gcs
 	if latestBuilds := gcs.LatestBuildForSpec(spec, builder); len(latestBuilds) > 0 {
 		for _, latestBuild := range latestBuilds {
 			dir, filename := path.Split(latestBuild)
-			metadataFromFileName, metadata := gcs.MetadataFromFileName(filename)
-			uploadTargets[path.Join(dir, metadataFromFileName)] = gcs.DataUploadWithMetadata(strings.NewReader(spec.BuildID), metadata)
+			metadataFromFileName, attrs := gcs.AttributesFromFileName(filename)
+			uploadTargets[path.Join(dir, metadataFromFileName)] = gcs.DataUploadWithAttributes(strings.NewReader(spec.BuildID), attrs)
 		}
 	}
 
@@ -92,13 +92,13 @@ func (o Options) assembleTargets(spec *downwardapi.JobSpec, extra map[string]gcs
 		if info.IsDir() {
 			gatherArtifacts(item, gcsPath, info.Name(), uploadTargets)
 		} else {
-			metadataFromFileName, metadata := gcs.MetadataFromFileName(info.Name())
+			metadataFromFileName, attrs := gcs.AttributesFromFileName(info.Name())
 			destination := path.Join(gcsPath, metadataFromFileName)
 			if _, exists := uploadTargets[destination]; exists {
 				logrus.Warnf("Encountered duplicate upload of %s, skipping...", destination)
 				continue
 			}
-			uploadTargets[destination] = gcs.FileUploadWithMetadata(item, metadata)
+			uploadTargets[destination] = gcs.FileUploadWithAttributes(item, attrs)
 		}
 	}
 
@@ -157,14 +157,14 @@ func gatherArtifacts(artifactDir, gcsPath, subDir string, uploadTargets map[stri
 		// effort upload is OK in any case
 		if relPath, err := filepath.Rel(artifactDir, fspath); err == nil {
 			dir, filename := path.Split(path.Join(gcsPath, subDir, relPath))
-			metadataFromFileName, metadata := gcs.MetadataFromFileName(filename)
+			metadataFromFileName, attrs := gcs.AttributesFromFileName(filename)
 			destination := path.Join(dir, metadataFromFileName)
 			if _, exists := uploadTargets[destination]; exists {
 				logrus.Warnf("Encountered duplicate upload of %s, skipping...", destination)
 				return nil
 			}
 			logrus.Printf("Found %s in artifact directory. Uploading as %s\n", fspath, destination)
-			uploadTargets[destination] = gcs.FileUploadWithMetadata(fspath, metadata)
+			uploadTargets[destination] = gcs.FileUploadWithAttributes(fspath, attrs)
 		} else {
 			logrus.Warnf("Encountered error in relative path calculation for %s under %s: %v", fspath, artifactDir, err)
 		}

--- a/prow/pod-utils/gcs/metadata_test.go
+++ b/prow/pod-utils/gcs/metadata_test.go
@@ -20,116 +20,118 @@ import (
 	"mime"
 	"reflect"
 	"testing"
+
+	"cloud.google.com/go/storage"
 )
 
-func TestMetadataFromFileName(t *testing.T) {
+func TestAttrsFromFileName(t *testing.T) {
 	mime.AddExtensionType(".log", "text/plain")
 
 	testCases := []struct {
 		name             string
 		filename         string
 		expectedFileName string
-		expectedMetadata map[string]string
+		expectedAttrs    *storage.ObjectAttrs
 	}{
 		{
 			name:             "txt",
 			filename:         "build-log.txt",
 			expectedFileName: "build-log.txt",
-			expectedMetadata: map[string]string{
-				"Content-Type": "text/plain; charset=utf-8",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "text/plain; charset=utf-8",
 			},
 		},
 		{
 			name:             "txt.gz",
 			filename:         "build-log.txt.gz",
 			expectedFileName: "build-log.txt",
-			expectedMetadata: map[string]string{
-				"Content-Encoding": "gzip",
-				"Content-Type":     "text/plain; charset=utf-8",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentEncoding: "gzip",
+				ContentType:     "text/plain; charset=utf-8",
 			},
 		},
 		{
 			name:             "txt.gzip",
 			filename:         "build-log.txt.gzip",
 			expectedFileName: "build-log.txt",
-			expectedMetadata: map[string]string{
-				"Content-Encoding": "gzip",
-				"Content-Type":     "text/plain; charset=utf-8",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentEncoding: "gzip",
+				ContentType:     "text/plain; charset=utf-8",
 			},
 		},
 		{
 			name:             "bare gz",
 			filename:         "gz",
 			expectedFileName: "gz",
-			expectedMetadata: map[string]string{
-				"Content-Type": "application/gzip",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "application/gzip",
 			},
 		},
 		{
 			name:             "gz",
 			filename:         "build-log.gz",
 			expectedFileName: "build-log",
-			expectedMetadata: map[string]string{
-				"Content-Type": "application/gzip",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "application/gzip",
 			},
 		},
 		{
 			name:             "gzip",
 			filename:         "build-log.gzip",
 			expectedFileName: "build-log",
-			expectedMetadata: map[string]string{
-				"Content-Type": "application/gzip",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "application/gzip",
 			},
 		},
 		{
 			name:             "json",
 			filename:         "events.json",
 			expectedFileName: "events.json",
-			expectedMetadata: map[string]string{
-				"Content-Type": "application/json",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "application/json",
 			},
 		},
 		{
 			name:             "json.gz",
 			filename:         "events.json.gz",
 			expectedFileName: "events.json",
-			expectedMetadata: map[string]string{
-				"Content-Encoding": "gzip",
-				"Content-Type":     "application/json",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentEncoding: "gzip",
+				ContentType:     "application/json",
 			},
 		},
 		{
 			name:             "log",
 			filename:         "journal.log",
 			expectedFileName: "journal.log",
-			expectedMetadata: map[string]string{
-				"Content-Type": "text/plain; charset=utf-8",
+			expectedAttrs: &storage.ObjectAttrs{
+				ContentType: "text/plain; charset=utf-8",
 			},
 		},
 		{
 			name:             "empty",
 			filename:         "",
 			expectedFileName: "",
-			expectedMetadata: map[string]string{},
+			expectedAttrs:    &storage.ObjectAttrs{},
 		},
 		{
 			name:             "dot",
 			filename:         ".",
 			expectedFileName: ".",
-			expectedMetadata: map[string]string{},
+			expectedAttrs:    &storage.ObjectAttrs{},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			actualFileName, actualMetadata := MetadataFromFileName(test.filename)
+			actualFileName, actualAttrs := AttributesFromFileName(test.filename)
 
 			if actualFileName != test.expectedFileName {
 				t.Errorf("expected file name %q but got %q", test.expectedFileName, actualFileName)
 			}
 
-			if !reflect.DeepEqual(actualMetadata, test.expectedMetadata) {
-				t.Errorf("expected metadata %#+v but got %#+v", test.expectedMetadata, actualMetadata)
+			if !reflect.DeepEqual(actualAttrs, test.expectedAttrs) {
+				t.Errorf("expected attributes %#+v but got %#+v", test.expectedAttrs, actualAttrs)
 			}
 		})
 	}

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -66,20 +66,27 @@ func Upload(bucket *storage.BucketHandle, uploadTargets map[string]UploadFunc) e
 // FileUpload returns an UploadFunc which copies all
 // data from the file on disk to the GCS object
 func FileUpload(file string) UploadFunc {
-	return FileUploadWithMetadata(file, nil)
+	return FileUploadWithAttributes(file, nil)
 }
 
 // FileUploadWithMetadata returns an UploadFunc which copies all
 // data from the file on disk into GCS object and also sets the provided
 // metadata fields on the object.
 func FileUploadWithMetadata(file string, metadata map[string]string) UploadFunc {
+	return FileUploadWithAttributes(file, &storage.ObjectAttrs{Metadata: metadata})
+}
+
+// FileUploadWithAttributes returns an UploadFunc which copies all data
+// from the file on disk into GCS object and also sets the provided
+// attributes on the object.
+func FileUploadWithAttributes(file string, attrs *storage.ObjectAttrs) UploadFunc {
 	return func(obj *storage.ObjectHandle) error {
 		reader, err := os.Open(file)
 		if err != nil {
 			return err
 		}
 
-		uploadErr := DataUploadWithMetadata(reader, metadata)(obj)
+		uploadErr := DataUploadWithAttributes(reader, attrs)(obj)
 		closeErr := reader.Close()
 
 		return errorutil.NewAggregate(uploadErr, closeErr)
@@ -89,16 +96,29 @@ func FileUploadWithMetadata(file string, metadata map[string]string) UploadFunc 
 // DataUpload returns an UploadFunc which copies all
 // data from src reader into GCS.
 func DataUpload(src io.Reader) UploadFunc {
-	return DataUploadWithMetadata(src, nil)
+	return DataUploadWithAttributes(src, nil)
 }
 
 // DataUploadWithMetadata returns an UploadFunc which copies all
 // data from src reader into GCS and also sets the provided metadata
 // fields onto the object.
 func DataUploadWithMetadata(src io.Reader, metadata map[string]string) UploadFunc {
+	return DataUploadWithAttributes(src, &storage.ObjectAttrs{Metadata: metadata})
+}
+
+// DataUploadWithAttributes returns an UploadFunc which copies all data
+// from src reader into GCS and also sets the provided attributes on
+// the object.
+func DataUploadWithAttributes(src io.Reader, attrs *storage.ObjectAttrs) UploadFunc {
 	return func(obj *storage.ObjectHandle) error {
 		writer := obj.NewWriter(context.Background())
-		writer.Metadata = metadata
+
+		if attrs != nil {
+			name := writer.ObjectAttrs.Name
+			writer.ObjectAttrs = *attrs
+			writer.ObjectAttrs.Name = name
+		}
+
 		_, copyErr := io.Copy(writer, src)
 		closeErr := writer.Close()
 


### PR DESCRIPTION
0b7effa0f7 (#12391) was broken because these `Content-*` properties have explicit fields on [the parent][1], leading to resources like:

```console
$ curl -sI https://storage.googleapis.com/origin-ci-test/wking/logs/job-name/1/wking-test/zip.log | grep Content
x-goog-meta-Content-Encoding: gzip
x-goog-meta-Content-Type: text/plain; charset=utf-8
Content-Type: application/x-gzip
Content-Length: 23
$ curl -sI --compressed https://storage.googleapis.com/origin-ci-test/wking/logs/job-name/1/wking-test/zip.log | grep Content
x-goog-meta-Content-Encoding: gzip
x-goog-meta-Content-Type: text/plain; charset=utf-8
Content-Type: application/x-gzip
Content-Length: 23
```

With this commit, we fix that to get:

```console
$ curl -sI --compressed https://storage.googleapis.com/origin-ci-test/wking/logs/job-name/3/wking-test/zip.log | grep Content
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
$ curl -sI https://storage.googleapis.com/origin-ci-test/wking/logs/job-name/3/wking-test/zip.log | grep Content
Content-Type: text/plain; charset=utf-8
```

by giving folks access to additional attributes like [`ObjectAttrs.ContentType`][1].  The `Name` preservation avoids:

```
{"component":"gcsupload","error":"failed to upload to GCS: encountered errors during upload: [[storage: Writer.Name \"\" does not match object name \"logs/job-name/latest-build.txt\", storage: Writer.Name \"\" does not match object name \"logs/job-name/latest-build.txt\"] ...]","level":"fatal","msg":"Failed to upload to GCS","time":"2019-05-03T10:08:39-07:00"}
```

Checking the incoming object, `Name` was the only property that was set.

This is the long-form version of #12468.

[1]: https://godoc.org/cloud.google.com/go/storage#ObjectAttrs