### PR TITLE
Add support for prowjob annotations to the testgrid configurator

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -73,6 +73,9 @@ postsubmits:
   - name: post-test-infra-push-velodrome
     cluster: test-infra-trusted
     run_if_changed: '^velodrome/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "velodrome"
     decorate: true
     branches:
       - master
@@ -98,6 +101,9 @@ postsubmits:
   - name: post-test-infra-push-boskos
     cluster: test-infra-trusted
     run_if_changed: '^boskos/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "boskos"
     decorate: true
     branches:
       - master
@@ -122,6 +128,9 @@ postsubmits:
             secretName: deployer-service-account
   - name: post-test-infra-push-kettle
     cluster: test-infra-trusted
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "kettle"
     run_if_changed: '^kettle/'
     decorate: true
     branches:
@@ -147,6 +156,9 @@ postsubmits:
             secretName: deployer-service-account
   - name: post-test-infra-push-planter
     cluster: test-infra-trusted
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "planter"
     run_if_changed: '^planter/'
     decorate: true
     branches:
@@ -173,6 +185,9 @@ postsubmits:
   - name: post-test-infra-push-triage
     cluster: test-infra-trusted
     run_if_changed: '^triage/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "triage"
     decorate: true
     branches:
       - master
@@ -198,6 +213,9 @@ postsubmits:
   - name: post-test-infra-push-bazelbuild
     cluster: test-infra-trusted
     run_if_changed: '^images/bazelbuild/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "bazelbuild"
     decorate: true
     branches:
       - master
@@ -223,6 +241,9 @@ postsubmits:
   - name: post-test-infra-push-bazel-krte
     cluster: test-infra-trusted
     run_if_changed: '^images/bazel-krte/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "bazel-krte"
     decorate: true
     branches:
       - master
@@ -248,6 +269,9 @@ postsubmits:
   - name: post-test-infra-push-bigquery
     cluster: test-infra-trusted
     run_if_changed: '^images/bigquery/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "bigquery"
     decorate: true
     branches:
       - master
@@ -273,6 +297,9 @@ postsubmits:
   - name: post-test-infra-push-bootstrap
     cluster: test-infra-trusted
     run_if_changed: '^(images/bootstrap|scenarios)/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "bootstrap"
     decorate: true
     branches:
       - master
@@ -298,6 +325,9 @@ postsubmits:
   - name: post-test-infra-push-cluster-api
     cluster: test-infra-trusted
     run_if_changed: '^images/cluster-api/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "cluster-api"
     decorate: true
     branches:
       - master
@@ -323,6 +353,9 @@ postsubmits:
   - name: post-test-infra-push-gcloud
     cluster: test-infra-trusted
     run_if_changed: '^images/gcloud/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "gcloud"
     decorate: true
     branches:
       - master
@@ -348,6 +381,9 @@ postsubmits:
   - name: post-test-infra-push-kubekins-e2e
     cluster: test-infra-trusted
     run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "kubekins-e2e"
     decorate: true
     branches:
       - master
@@ -373,6 +409,9 @@ postsubmits:
   - name: post-test-infra-push-kubekins-test
     cluster: test-infra-trusted
     run_if_changed: '^images/kubekins-test/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "kubekins-test"
     decorate: true
     branches:
       - master
@@ -398,6 +437,9 @@ postsubmits:
   - name: post-test-infra-push-kubemci
     cluster: test-infra-trusted
     run_if_changed: '^images/kubemci/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "kubemci"
     decorate: true
     branches:
       - master
@@ -423,6 +465,9 @@ postsubmits:
   - name: post-test-infra-push-test-gubernator
     cluster: test-infra-trusted
     run_if_changed: '^images/pull-test-infra-gubernator/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "gubernator"
     decorate: true
     branches:
       - master
@@ -448,6 +493,9 @@ postsubmits:
   - name: post-test-infra-push-image-builder
     cluster: test-infra-trusted
     run_if_changed: '^images/builder/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "image-builder"
     decorate: true
     branches:
       - master

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -104,6 +104,8 @@ type JobBase struct {
 	Spec *v1.PodSpec `json:"spec,omitempty"`
 	// BuildSpec is the Knative build spec used if Agent is knative-build.
 	BuildSpec *buildv1alpha1.BuildSpec `json:"build_spec,omitempty"`
+	// Annotations are unused by prow itself, but provide a space to configure other automation.
+	Annotations map[string]string `json:"annotations,omitempty"`
 
 	UtilityConfig
 }

--- a/testgrid/README.md
+++ b/testgrid/README.md
@@ -31,6 +31,22 @@ The video demos power features of testgrid, including:
 
 Please have a look!
 
+# Minimal Configuration
+
+If you just have a prowjob you want to appear in an existing dashboard and don't care about anything
+else, you can add annotations to that prowjob instead of making changes here.
+
+Add something like this to your prowjob:
+
+```yaml
+annotations:
+  testgrid-dashboards: dashboard-name  # a dashboard defined in config.yaml
+  tab-name: some-short-name            # optionally, a shorter name for the tab. If omitted, just uses the job name.
+  description: Words about your job.   # optionally, a description of your job. If omitted, just uses the job name.
+```
+
+If you need to create a new dashboard, or do anything more advanced, read on.
+
 ## Configuration
 Open [`config.yaml`] in your favorite editor and:
 1. Configure the test groups

--- a/testgrid/cmd/configurator/BUILD.bazel
+++ b/testgrid/cmd/configurator/BUILD.bazel
@@ -34,10 +34,15 @@ go_library(
     name = "go_default_library",
     srcs = [
         "main.go",
+        "prow.go",
         "yaml2proto.go",
     ],
     importpath = "k8s.io/test-infra/testgrid/cmd/configurator",
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
+        "//prow/pod-utils/gcs:go_default_library",
         "//testgrid/config:go_default_library",
         "//testgrid/util/gcs:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"k8s.io/test-infra/testgrid/config"
+	"path"
+	"strings"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowConfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	prowGCS "k8s.io/test-infra/prow/pod-utils/gcs"
+)
+
+const testgridCreateTestGroupAnnotation = "testgrid-create-test-group"
+const testgridDashboardsAnnotation = "testgrid-dashboards"
+const testgridTabNameAnnotation = "testgrid-tab-name"
+const descriptionAnnotation = "description"
+
+// Talk to @michelle192837 if you're thinking about adding more of these!
+
+func applySingleProwjobAnnotations(c *Config, pc *prowConfig.Config, j prowConfig.JobBase, jobType prowapi.ProwJobType) error {
+	tabName := j.Name
+	testGroupName := j.Name
+	description := j.Name
+
+	mustMakeGroup := j.Annotations[testgridCreateTestGroupAnnotation] == "true"
+	dashboards, addToDashboards := j.Annotations[testgridDashboardsAnnotation]
+	mightMakeGroup := mustMakeGroup || addToDashboards
+
+	if mightMakeGroup {
+		if c.config.FindTestGroup(testGroupName) != nil {
+			if mustMakeGroup {
+				return fmt.Errorf("test group %q already exists", testGroupName)
+			}
+		} else {
+			var prefix string
+			if j.DecorationConfig != nil && j.DecorationConfig.GCSConfiguration != nil {
+				prefix = path.Join(j.DecorationConfig.GCSConfiguration.Bucket, j.DecorationConfig.GCSConfiguration.PathPrefix)
+			} else if pc.Plank.DefaultDecorationConfig != nil && pc.Plank.DefaultDecorationConfig.GCSConfiguration != nil {
+				prefix = path.Join(pc.Plank.DefaultDecorationConfig.GCSConfiguration.Bucket, j.DecorationConfig.GCSConfiguration.PathPrefix)
+			} else {
+				return fmt.Errorf("job %s: couldn't figure out a default decoration config", j.Name)
+			}
+
+			g := &config.TestGroup{
+				Name:      testGroupName,
+				GcsPrefix: path.Join(prefix, prowGCS.RootForSpec(&downwardapi.JobSpec{Job: j.Name, Type: jobType})),
+			}
+			ReconcileTestGroup(g, c.defaultConfig.DefaultTestGroup)
+			c.config.TestGroups = append(c.config.TestGroups, g)
+		}
+	}
+
+	if tn, ok := j.Annotations[testgridTabNameAnnotation]; ok {
+		tabName = tn
+	}
+	if d := j.Annotations[descriptionAnnotation]; d != "" {
+		description = d
+	}
+
+	if addToDashboards {
+		for _, dashboardName := range strings.Split(dashboards, ",") {
+			dashboardName = strings.TrimSpace(dashboardName)
+			d := c.config.FindDashboard(dashboardName)
+			if d == nil {
+				return fmt.Errorf("couldn't find dashboard %q for job %q", dashboardName, j.Name)
+			}
+			dt := &config.DashboardTab{
+				Name:          tabName,
+				TestGroupName: testGroupName,
+				Description:   description,
+			}
+			ReconcileDashboardTab(dt, c.defaultConfig.DefaultDashboardTab)
+			d.DashboardTab = append(d.DashboardTab, dt)
+		}
+	}
+
+	return nil
+}
+
+func applyProwjobAnnotations(c *Config, prowConfigAgent *prowConfig.Agent) error {
+	pc := prowConfigAgent.Config()
+	if pc == nil {
+		return nil
+	}
+	jobs := prowConfigAgent.Config().JobConfig
+	for _, j := range jobs.AllPeriodics() {
+		if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PeriodicJob); err != nil {
+			return err
+		}
+	}
+	for _, j := range jobs.AllPostsubmits(nil) {
+		if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PostsubmitJob); err != nil {
+			return err
+		}
+	}
+	for _, j := range jobs.AllPresubmits(nil) {
+		if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PresubmitJob); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2748,38 +2748,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-deploy-prow
 - name: post-test-infra-push-prow
   gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-prow
-- name: post-test-infra-push-velodrome
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-velodrome
-- name: post-test-infra-push-boskos
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-boskos
-- name: post-test-infra-push-kettle
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-kettle
-- name: post-test-infra-push-planter
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-planter
-- name: post-test-infra-push-triage
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-triage
-- name: post-test-infra-push-bazelbuild
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bazelbuild
-- name: post-test-infra-push-bazel-krte
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bazel-krte
-- name: post-test-infra-push-bigquery
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bigquery
-- name: post-test-infra-push-bootstrap
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-bootstrap
-- name: post-test-infra-push-cluster-api
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-cluster-api
-- name: post-test-infra-push-gcloud
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-gcloud
-- name: post-test-infra-push-kubekins-e2e
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e
-- name: post-test-infra-push-kubekins-test
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-kubekins-test
-- name: post-test-infra-push-kubemci
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-kubemci
-- name: post-test-infra-push-test-gubernator
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-test-gubernator
-- name: post-test-infra-push-image-builder
-  gcs_prefix: kubernetes-jenkins/logs/post-test-infra-push-image-builder
 - name: ci-test-infra-autoupdate-minor
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-autoupdate-minor
 - name: ci-test-infra-autoupdate-patch
@@ -7392,39 +7360,6 @@ dashboards:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 
 - name: sig-testing-images
-  dashboard_tab:
-  - name: velodrome
-    test_group_name: post-test-infra-push-velodrome
-  - name: boskos
-    test_group_name: post-test-infra-push-boskos
-  - name: kettle
-    test_group_name: post-test-infra-push-kettle
-  - name: planter
-    test_group_name: post-test-infra-push-planter
-  - name: triage
-    test_group_name: post-test-infra-push-triage
-  - name: bazelbuild
-    test_group_name: post-test-infra-push-bazelbuild
-  - name: bazel-krte
-    test_group_name: post-test-infra-push-bazel-krte
-  - name: bigquery
-    test_group_name: post-test-infra-push-bigquery
-  - name: bootstrap
-    test_group_name: post-test-infra-push-bootstrap
-  - name: cluster-api
-    test_group_name: post-test-infra-push-cluster-api
-  - name: gcloud-in-go
-    test_group_name: post-test-infra-push-gcloud
-  - name: kubekins-e2e
-    test_group_name: post-test-infra-push-kubekins-e2e
-  - name: kubekins-test
-    test_group_name: post-test-infra-push-kubekins-test
-  - name: kubemci
-    test_group_name: post-test-infra-push-kubemci
-  - name: test-gubernator
-    test_group_name: post-test-infra-push-test-gubernator
-  - name: image-builder
-    test_group_name: post-test-infra-push-image-builder
 - name: sig-testing-misc
   dashboard_tab:
   - name: ci-bazel

--- a/testgrid/config/config.go
+++ b/testgrid/config/config.go
@@ -84,3 +84,12 @@ func (cfg Configuration) FindTestGroup(name string) *TestGroup {
 	}
 	return nil
 }
+
+func (cfg Configuration) FindDashboard(name string) *Dashboard {
+	for _, d := range cfg.Dashboards {
+		if d.Name == name {
+			return d
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds support for reading certain prowjob annotations to the testgrid configurator. In particular, the following annotations are supported:

- `testgrid-test-group`: if specified, generate a test group using the given name. If explicitly specified as an empty string, use the job name.
- `testgrid-dashboards`: if specified, add this test group to the given comma-separated list of dashboards. If `testgrid-test-group` was not specified, and no test group with the same name as the job is specified, creates a test group.
- `testgrid-tab-name`: the name to use when adding this test to the dashboards specified in `testgrid-dashboards`. If omitted, uses the job name.

It also updates the configuration test to include these prowjob entries.

If you want something more sophisticated than the default options, you need to move back to adding entries to `config.yaml`. I do wonder if it would make sense to encode some more options here, though.

I also migrated all the test-infra image-pusher jobs from config.yaml to prowjob annotations as an example.

This PR depends on #12475 (which is the first commit here), and is related to #12443.

/cc @michelle192837 @fejta 