### PR TITLE
add prow jobs for cluster api provider ibmcloud

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- gyliu513
+- jichenjc
+- morvencao
+- xunpan

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -1,0 +1,56 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - name: pull-cluster-api-provider-ibmcloud-make
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        args:
+        - make
+        - images
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "6Gi"
+  - name: pull-cluster-api-provider-ibmcloud-test
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - make
+        - test
+  - name: pull-cluster-api-provider-ibmcloud-check
+    always_run: true
+    decorate: true
+    branches:
+    - master
+    path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - make
+        - check

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -438,6 +438,7 @@ tide:
     kubernetes-sigs/cluster-api-provider-azure: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-gcp: squash
+    kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-sigs/cluster-api-provider-vsphere: squash
     kubernetes-sigs/krew: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -592,6 +592,9 @@ plugins:
   - release-note
   - require-matching-label
   - welcome
+  
+  kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - milestone
 
   kubernetes-sigs/contributor-playground:
   - require-sig

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -355,6 +355,7 @@ func TestJobsTestgridEntryMatch(t *testing.T) {
 		"kubernetes-sigs/cluster-api-provider-azure",
 		"kubernetes-sigs/cluster-api-provider-digitalocean",
 		"kubernetes-sigs/cluster-api-provider-gcp",
+		"kubernetes-sigs/cluster-api-provider-ibmcloud",
 		"kubernetes-sigs/cluster-api-provider-vsphere",
 		"kubernetes-sigs/cluster-api-provider-openstack",
 		"kubernetes-sigs/poseidon",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2584,6 +2584,15 @@ test_groups:
 - name: pull-cluster-api-provider-gcp-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-gcp-test
   num_columns_recent: 20
+- name: pull-cluster-api-provider-ibmcloud-make
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-ibmcloud-make
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-ibmcloud-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-ibmcloud-test
+  num_columns_recent: 20
+- name: pull-cluster-api-provider-ibmcloud-check
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-ibmcloud-check
+  num_columns_recent: 20
 - name: pull-cluster-api-provider-vsphere-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-vsphere-test
   num_columns_recent: 20
@@ -6504,6 +6513,15 @@ dashboards:
     test_group_name: ci-gcp-compute-persistent-disk-csi-driver-0-4-0-k8s-integration-stable-1-13-5
     description: Kubernetes Integration tests for Kubernetes 1.13.5 and Driver Stable
 
+- name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+  dashboard_tab:
+  - name: pr-make
+    test_group_name: pull-cluster-api-provider-ibmcloud-make
+  - name: pr-check
+    test_group_name: pull-cluster-api-provider-ibmcloud-check
+  - name: pr-test
+    test_group_name: pull-cluster-api-provider-ibmcloud-test
+
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
   dashboard_tab:
   - name: pr-test
@@ -8626,6 +8644,7 @@ dashboard_groups:
   - sig-cluster-lifecycle-cluster-api-provider-digitalocean
   - sig-cluster-lifecycle-cluster-api-provider-vsphere
   - sig-cluster-lifecycle-cluster-api-provider-gcp
+  - sig-cluster-lifecycle-cluster-api-provider-ibmcloud
   - sig-cluster-lifecycle-cluster-api-provider-openstack
   - sig-cluster-lifecycle-kops
 


### PR DESCRIPTION
We have a new repo in kubernetes-sigs: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud

This repo is to add a new ibmcloud provider for cluster-api.

We need to support CI with prow jobs for this repo.

/cc @gyliu513 @jichenjc @xunpan