### PR TITLE
kubernetes-csi: test 1.14 deployment periodically

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -356,6 +356,111 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
+  name: ci-kubernetes-csi-1-14-on-kubernetes-1-13
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.13"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.14"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-14-on-kubernetes-1-14
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.14"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.14"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-14-on-kubernetes-master
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.14"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
   name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
   decorate: true
   extra_refs:
@@ -382,6 +487,41 @@ periodics:
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
         value: "kubernetes-1.13"
+      - name: CSI_PROW_TESTS
+        value: "serial-alpha parallel-alpha"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.14"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.14"
       - name: CSI_PROW_TESTS
         value: "serial-alpha parallel-alpha"
       # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -558,7 +558,9 @@ periodics:
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"
-      # ... but not the RBAC rules.
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
       - name: UPDATE_RBAC_RULES
         value: "false"
       - name: CSI_PROW_TESTS
@@ -597,7 +599,9 @@ periodics:
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"
-      # ... but not the RBAC rules.
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
       - name: UPDATE_RBAC_RULES
         value: "false"
       - name: CSI_PROW_TESTS
@@ -636,9 +640,11 @@ periodics:
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"
-      # ... but not the RBAC rules.
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
       - name: UPDATE_RBAC_RULES
-        value: "false"
+        value: "true"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -675,9 +681,11 @@ periodics:
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"
-      # ... but not the RBAC rules.
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
       - name: UPDATE_RBAC_RULES
-        value: "false"
+        value: "true"
       - name: CSI_PROW_TESTS
         value: "serial-alpha parallel-alpha"
       # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -20,6 +20,9 @@
 
 base="$(dirname $0)"
 
+# We need this image because it has Docker in Docker and go.
+dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master"
+
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix.
 hostpath_example_repos="
@@ -192,7 +195,7 @@ EOF
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: ${dind_image}
         command:
         - runner.sh
         args:
@@ -238,7 +241,7 @@ EOF
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: ${dind_image}
         command:
         - runner.sh
         args:
@@ -270,7 +273,7 @@ EOF
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: ${dind_image}
         command:
         - runner.sh
         args:
@@ -308,7 +311,7 @@ EOF
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: ${dind_image}
         command:
         - runner.sh
         args:
@@ -347,7 +350,7 @@ EOF
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: ${dind_image}
         command:
         - runner.sh
         args:
@@ -402,7 +405,7 @@ for tests in non-alpha alpha; do
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: ${dind_image}
       command:
       - runner.sh
       args:
@@ -451,7 +454,7 @@ for kubernetes in 1.13.3 1.14.0 master; do
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+    - image: ${dind_image}
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -380,9 +380,8 @@ cat >>"$base/csi-driver-host-path/csi-driver-host-path-config.yaml" <<EOF
 periodics:
 EOF
 
-# TODO: decide how we want to test the kubernetes-1.14 deployment
 for tests in non-alpha alpha; do
-    for deployment in 1.13; do
+    for deployment in 1.13 1.14; do
         for kubernetes in 1.13 1.14 master; do
             # No version skew testing of alpha features, deployment has to match Kubernetes.
             if [ "$tests" = "alpha" ] && ! echo "$kubernetes" | grep -q "^$deployment"; then

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -466,9 +466,11 @@ for kubernetes in 1.13.3 1.14.0 master; do
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"
-      # ... but not the RBAC rules.
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
       - name: UPDATE_RBAC_RULES
-        value: "false"
+        value: "$([ "$kubernetes" = "master" ] && echo "true" || echo "false")"
       - name: CSI_PROW_TESTS
         value: "$(expand_tests "$tests")"
       # docker-in-docker needs privileged mode

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3693,8 +3693,16 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-1-13-on-kubernetes-1-14
 - name: ci-kubernetes-csi-1-13-on-kubernetes-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-1-13-on-kubernetes-master
+- name: ci-kubernetes-csi-1-14-on-kubernetes-1-13
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-1-14-on-kubernetes-1-13
+- name: ci-kubernetes-csi-1-14-on-kubernetes-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-1-14-on-kubernetes-1-14
+- name: ci-kubernetes-csi-1-14-on-kubernetes-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-1-14-on-kubernetes-master
 - name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
+- name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
 - name: ci-kubernetes-csi-canary-on-kubernetes-1-13
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-csi-canary-on-kubernetes-1-13
 - name: ci-kubernetes-csi-canary-on-kubernetes-1-14
@@ -7250,9 +7258,21 @@ dashboards:
   - name: 1-13-on-master
     test_group_name: ci-kubernetes-csi-1-13-on-kubernetes-master
     description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.13 sidecars
+  - name: 1-14-on-1-13
+    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-1-13
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars
+  - name: 1-14-on-1-14
+    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-1-14
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.14 sidecars
+  - name: 1-14-on-master
+    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-master
+    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.14 sidecars
   - name: alpha-1-13-on-1-13
     test_group_name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
     description: Kubernetes-CSI alpha tests with Kubernetes 1.13.x and 1.13 sidecars
+  - name: alpha-1-14-on-1-14
+    test_group_name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
+    description: Kubernetes-CSI alpha tests with Kubernetes 1.14.x and 1.14 sidecars
   - name: canary-on-1-13
     test_group_name: ci-kubernetes-csi-canary-on-kubernetes-1-13
     description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars


### PR DESCRIPTION
With the kubernetes-1.14 deployment finalized in the
csi-driver-host-path master branch (no more canary images!) we can
start testing it periodically against all Kubernetes versions for
which it works. As for kubernetes-1.13, alpha testing is limited to
the matching Kubernetes release.

Also tweaks the on-master periodic jobs such that the snapshotter alpha tests
work again.

Fixes: https://github.com/kubernetes-csi/external-snapshotter/issues/120