### PR TITLE
Use regex to skip release branches

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2643,10 +2643,7 @@ presubmits:
     name: pull-security-kubernetes-bazel-build
     rerun_command: /test pull-security-kubernetes-bazel-build
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+
     spec:
       containers:
       - args:
@@ -2843,10 +2840,7 @@ presubmits:
     name: pull-security-kubernetes-bazel-test
     rerun_command: /test pull-security-kubernetes-bazel-test
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+
     spec:
       containers:
       - args:
@@ -3111,10 +3105,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-dependencies
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+
     spec:
       containers:
       - args:
@@ -3142,8 +3133,6 @@ presubmits:
     trigger: (?m)^/test( | .* )pull-security-kubernetes-dependencies,?($|\s.*)
   - agent: kubernetes
     always_run: true
-    branches:
-    - master
     cluster: security
     context: pull-security-kubernetes-dependencies-canary
     decorate: true
@@ -3153,6 +3142,8 @@ presubmits:
     name: pull-security-kubernetes-dependencies-canary
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-dependencies-canary
+    skip_branches:
+    - release-\d+.\d+
     skip_report: true
     spec:
       containers:
@@ -3481,10 +3472,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-typecheck
     skip_branches:
-    - release-1.11
-    - release-1.12
-    - release-1.13
-    - release-1.14
+    - release-\d+.\d+
     spec:
       containers:
       - args:
@@ -3647,10 +3635,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-verify
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -5,10 +5,7 @@ presubmits:
     decorate: true
     always_run: true
     skip_branches:
-    - release-1.14 # per-release job
-    - release-1.13 # per-release job
-    - release-1.12 # per-release job
-    - release-1.11 # per-release job
+    - release-\d+.\d+ # per-release job
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -131,10 +128,7 @@ presubmits:
     decorate: true
     always_run: true
     skip_branches:
-    - release-1.14 # per-release job
-    - release-1.13 # per-release job
-    - release-1.12 # per-release job
-    - release-1.11 # per-release job
+    - release-\d+.\d+ # per-release job
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -313,10 +307,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
     skip_branches:
-    - release-1.14 # per-release job
-    - release-1.13 # per-release job
-    - release-1.12 # per-release job
-    - release-1.11 # per-release job
+    - release-\d+.\d+ # per-release job
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
@@ -347,10 +338,7 @@ postsubmits:
       org: kubernetes
       repo: test-infra
     skip_branches:
-    - release-1.14 # per-release job
-    - release-1.13 # per-release job
-    - release-1.12 # per-release job
-    - release-1.11 # per-release job
+    - release-\d+.\d+ # per-release job
     spec:
       containers:
       - image: launcher.gcr.io/google/bazel:0.24.1

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -4,10 +4,7 @@ presubmits:
     path_alias: "k8s.io/kubernetes"
     decorate: true
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+ # per-release job
     always_run: true
     skip_report: false
     labels:
@@ -33,8 +30,8 @@ presubmits:
   - name: pull-kubernetes-dependencies-canary
     path_alias: "k8s.io/kubernetes"
     decorate: true
-    branches:
-    - master
+    skip_branches:
+    - release-\d+.\d+ # per-release job
     always_run: true
     skip_report: true
     labels:

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -8,10 +8,7 @@ presubmits:
     skip_report: false
     # branched per release (older go versions)
     skip_branches:
-    - release-1.11
-    - release-1.12
-    - release-1.13
-    - release-1.14
+    - release-\d+.\d+ # per-release job
     spec:
       containers:
       - name: main

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -1,15 +1,11 @@
 presubmits:
   kubernetes/kubernetes:
-  # TODO(krzyzacy): add branches once this works
   # TODO(krzyzacy): Consider combine kubekins-e2e and kubekins-test
   - name: pull-kubernetes-verify
     always_run: true
     decorate: true
     skip_branches:
-    - release-1.14
-    - release-1.13
-    - release-1.12
-    - release-1.11
+    - release-\d+.\d+ # per-release job
     path_alias: k8s.io/kubernetes
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
/assign @Katharine @krzyzacy 

Follow-up to https://github.com/kubernetes/test-infra/pull/12495

fixes all the sig-testing skip_branches lines