### PR TITLE
prow: clonerefs: speed up cloning of large repos through shallow cloning

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -517,6 +517,10 @@ type Refs struct {
 	// SkipSubmodules determines if submodules should be
 	// cloned when the job is run. Defaults to true.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
+	// CloneDepth is the depth of the clone that will be used. 
+	// A depth of zero will do a full clone.
+	CloneDepth int `json:"clone_depth,omitempty"`
+
 }
 
 func (r Refs) String() string {

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -517,10 +517,9 @@ type Refs struct {
 	// SkipSubmodules determines if submodules should be
 	// cloned when the job is run. Defaults to true.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
-	// CloneDepth is the depth of the clone that will be used. 
+	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.
 	CloneDepth int `json:"clone_depth,omitempty"`
-
 }
 
 func (r Refs) String() string {

--- a/prow/cmd/clonerefs/README.md
+++ b/prow/cmd/clonerefs/README.md
@@ -60,7 +60,8 @@ as JSON in the `$CLONEREFS_OPTIONS` environment variable, which has the form:
                     "sha": "2b58234a8aee0d55918b158a3b38c292d6a95ef7"
                 }
             ],
-            "skip_submodules": true
+            "skip_submodules": true,
+            "clone_depth": 0
         }
     ]
 }

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -404,6 +404,9 @@ type UtilityConfig struct {
 	// SkipSubmodules determines if submodules should be
 	// cloned when the job is run. Defaults to true.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
+	// CloneDepth is the depth of the clone that will be used. 
+	// A depth of zero will do a full clone.
+	CloneDepth int `json:"clone_depth,omitempty"`
 
 	// ExtraRefs are auxiliary repositories that
 	// need to be cloned, determined from config

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -404,7 +404,7 @@ type UtilityConfig struct {
 	// SkipSubmodules determines if submodules should be
 	// cloned when the job is run. Defaults to true.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
-	// CloneDepth is the depth of the clone that will be used. 
+	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.
 	CloneDepth int `json:"clone_depth,omitempty"`
 

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -185,6 +185,7 @@ func completePrimaryRefs(refs prowapi.Refs, jb config.JobBase) *prowapi.Refs {
 		refs.CloneURI = jb.CloneURI
 	}
 	refs.SkipSubmodules = jb.SkipSubmodules
+	refs.CloneDepth = jb.CloneDepth
 	return &refs
 }
 

--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -82,6 +82,7 @@ to clone the repo to different go import path than the default of `/home/prow/go
 - Jobs that require additional repos to be checked out can arrange for that with
 the `exta_refs` field.
 - Jobs that do not want submodules to be cloned should set `skip_submodules` to `true`
+- Jobs that want to perform shallow cloning can use `clone_depth` field. It can be set to desired clone depth. By default, clone_depth get set to 0 which results in full clone of repo.
 
 ```yaml
 - name: post-job
@@ -95,6 +96,7 @@ the `exta_refs` field.
     repo: other-repo
     base_ref: master
   skip_submodules: true
+  clone_depth: 0
   spec:
     containers:
     - image: alpine

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -128,9 +128,14 @@ func (g *gitCtx) commandsForBaseRef(refs prowapi.Refs, gitUserName, gitUserEmail
 	if cookiePath != "" {
 		commands = append(commands, g.gitCommand("config", "http.cookiefile", cookiePath))
 	}
-	commands = append(commands, g.gitCommand("fetch", g.repositoryURI, "--tags", "--prune"))
-	commands = append(commands, g.gitCommand("fetch", g.repositoryURI, refs.BaseRef))
 
+	if refs.CloneDepth > 0 {
+		commands = append(commands, g.gitCommand("fetch", g.repositoryURI, "--tags", "--prune", "--depth", strconv.Itoa(refs.CloneDepth)))
+		commands = append(commands, g.gitCommand("fetch", "--depth", strconv.Itoa(refs.CloneDepth), g.repositoryURI, refs.BaseRef))
+	} else {
+		commands = append(commands, g.gitCommand("fetch", g.repositoryURI, "--tags", "--prune"))
+		commands = append(commands, g.gitCommand("fetch", g.repositoryURI, refs.BaseRef))
+	}
 	var target string
 	if refs.BaseSHA != "" {
 		target = refs.BaseSHA


### PR DESCRIPTION
#10388

Issue:
Cloning of large repos (>1 gb) for prow jobs takes a significant amount of time.

Resolution:
Add a knob in clonerefs structure to allow providing git fetch/clone command's depth argument to allow shallow cloning of large repos.