### PR TITLE
Back off triage job from 20m to 40m

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -41,7 +41,7 @@ periodics:
 
 - name: ci-test-infra-triage
   decorate: true
-  interval: 20m
+  interval: 40m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/triage:latest


### PR DESCRIPTION
Its average duration has gone from under 20m to 35m in the past two weeks

No point in scheduling something faster than we can run it

ref: https://github.com/kubernetes/test-infra/issues/12508