### PR TITLE
Remove unused PREPULL_E2E_IMAGES flags

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -173,7 +173,6 @@ periodics:
       - --env=KUBELET_TEST_ARGS=--redirect-container-streaming
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
-      - --env=PREPULL_E2E_IMAGES=false
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest-1.11
       - --gcp-node-image=gci
@@ -202,7 +201,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
-      - --env=PREPULL_E2E_IMAGES=false
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest-1.12
       - --gcp-node-image=gci
@@ -1043,7 +1041,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
-      - --env=PREPULL_E2E_IMAGES=false
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest-1.13
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -103,9 +103,6 @@ presets:
     value: "--profiling --metrics-bind-address=0.0.0.0"
   - name: SCHEDULER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
-  # Switch off image puller to workaround #44701
-  - name: PREPULL_E2E_IMAGES
-    value: "false"
   # Reduce logs verbosity.
   - name: TEST_CLUSTER_LOG_LEVEL
     value: --v=2
@@ -169,9 +166,6 @@ presets:
     value: "--profiling"
   - name: SCHEDULER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
-  # Switch off image puller to workaround #44701
-  - name: PREPULL_E2E_IMAGES
-    value: "false"
   # Reduce logs verbosity.
   - name: TEST_CLUSTER_LOG_LEVEL
     value: --v=2


### PR DESCRIPTION
We removed `PREPULL_E2E_IMAGES` in the following PR:
https://github.com/kubernetes/kubernetes/pull/67950/files

So let's remove them from the CI jobs that somehow missed getting cleaned up.

Change-Id: Ib781d30ea368d66b7cf660b12dc86f9b2aa12476