### PR TITLE
Make benchmarkjunit exit non-zero if a benchmark fails unless `--pass-on-error` is set.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -34,9 +34,9 @@ periodics:
     interval: 20m
     decorate: true
     extra_refs:
-    - org: cjwagner
+    - org: kubernetes
       repo: test-infra
-      base_ref: microbe-nchmarks
+      base_ref: master
       path_alias: k8s.io/test-infra
     spec:
       containers:
@@ -48,4 +48,5 @@ periodics:
         - ./pkg/benchmarkjunit
         - --log-file=$(ARTIFACTS)/benchmark-log.txt
         - --output=$(ARTIFACTS)/junit_benchmarks.xml
+        - --pass-on-error
         - ./experiment/dummybenchmarks/...

--- a/pkg/benchmarkjunit/README.md
+++ b/pkg/benchmarkjunit/README.md
@@ -8,10 +8,13 @@ Run `go run ./pkg/benchmarkjunit --help` to see all the available flags.
 go run ./pkg/benchmarkjunit k8s.io/test-infra/experiment/dummybenchmarks
 ```
 ```shell
-go run ./pkg/benchmarkjunit ./experiment/dummybenchmarks
+go run ./pkg/benchmarkjunit ./experiment/dummybenchmarks/...
 ```
 ```shell
-go run ./pkg/benchmarkjunit -o junit_benchmark.xml -l testlog.txt --test-arg=-benchmem --bench=Core ./experiment/dummybenchmarks
+go run ./pkg/benchmarkjunit \
+-o junit_benchmark.xml -l testlog.txt \
+--test-arg=-benchmem --bench=Core --pass-on-error \
+./experiment/dummybenchmarks/...
 ```
 With bazel:
 ```shell

--- a/pkg/benchmarkjunit/integration_test.go
+++ b/pkg/benchmarkjunit/integration_test.go
@@ -72,6 +72,7 @@ func TestDummybenchmarksIntegration(t *testing.T) {
 		outputFile:   outFile,
 		logFile:      logFile,
 		goBinaryPath: *goBinaryPath,
+		passOnError:  true,
 		// Omit benchmarks that aren't in the core group to keep test time reasonable.
 		benchRegexp: "Core",
 	}

--- a/pkg/benchmarkjunit/main.go
+++ b/pkg/benchmarkjunit/main.go
@@ -80,11 +80,10 @@ func run(opts *options, args []string) {
 	// Now parse output to JUnit, marshal to XML, and output.
 	junit, err := parse(testOutput)
 	if err != nil {
-		fmt.Printf("Error parsing go test output: %v.\nOutput:\n%s\n\n", err, string(testOutput))
-		logrus.WithError(err).Fatal("Error parsing 'go test' output.")
+		logrus.WithField("output", string(testOutput)).WithError(err).Fatal("Error parsing 'go test' output.")
 	}
 	if len(junit.Suites) == 0 {
-		logrus.Warn("Warning: no test suites were found in the 'go test' output.")
+		logrus.WithField("output", string(testOutput)).Fatal("Error: no test suites were found in the 'go test' output.")
 	}
 	junitBytes, err := xml.Marshal(junit)
 	if err != nil {

--- a/pkg/benchmarkjunit/main.go
+++ b/pkg/benchmarkjunit/main.go
@@ -32,6 +32,7 @@ type options struct {
 	benchRegexp   string
 	extraTestArgs []string
 	goBinaryPath  string
+	passOnError   bool
 }
 
 func main() {
@@ -49,6 +50,7 @@ func main() {
 	cmd.Flags().StringVar(&opts.benchRegexp, "bench", ".", "The regexp to pass to the -bench 'go test' flag to select benchmarks to run.")
 	cmd.Flags().StringSliceVar(&opts.extraTestArgs, "test-arg", nil, "additional args for go test")
 	cmd.Flags().StringVar(&opts.goBinaryPath, "go", "go", "The location of the go binary. This flag is primarily intended for use with bazel.")
+	cmd.Flags().BoolVar(&opts.passOnError, "pass-on-error", false, "Indicates that benchmarkjunit should exit zero if junit is properly generated, even if benchmarks fail.")
 
 	if err := cmd.Execute(); err != nil {
 		logrus.WithError(err).Fatal("Command failed.")
@@ -64,9 +66,9 @@ func run(opts *options, args []string) {
 	testCmd := exec.Command(opts.goBinaryPath, testArgs...)
 
 	logrus.Infof("Running command %q...", append([]string{opts.goBinaryPath}, testArgs...))
-	testOutput, err := testCmd.CombinedOutput()
-	if err != nil {
-		logrus.WithError(err).Error("Error(s) executing benchmarks.")
+	testOutput, testErr := testCmd.CombinedOutput()
+	if testErr != nil {
+		logrus.WithError(testErr).Error("Error(s) executing benchmarks.")
 	}
 	if len(opts.logFile) > 0 {
 		if err := ioutil.WriteFile(opts.logFile, testOutput, 0666); err != nil {
@@ -96,4 +98,8 @@ func run(opts *options, args []string) {
 		}
 	}
 	logrus.Info("Successfully generated JUnit XML for Benchmarks.")
+
+	if !opts.passOnError && testErr != nil {
+		logrus.WithError(testErr).Fatal("Exiting non-zero due to benchmark error.")
+	}
 }

--- a/pkg/benchmarkjunit/prowjob_example.yaml
+++ b/pkg/benchmarkjunit/prowjob_example.yaml
@@ -3,9 +3,9 @@ periodics:
   interval: 10m
   decorate: true
   extra_refs:
-  - org: cjwagner
+  - org: kubernetes
     repo: test-infra
-    base_ref: microbe-nchmarks
+    base_ref: master
     path_alias: k8s.io/test-infra
   spec:
     containers:
@@ -17,4 +17,5 @@ periodics:
       - ./pkg/benchmarkjunit
       - --log-file=$(ARTIFACTS)/benchmark-log.txt
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
+      - --pass-on-error
       - ./experiment/dummybenchmarks/...


### PR DESCRIPTION
Currently `benchmarkjunit` exits successfully so long as there are no errors generating the junit output. This is probably not the expected behavior so I switched the default to error if a benchmark fails and added a flag to optionally use the existing behavior (useful for jobs like `ci-test-infra-benchmark-demo`).
Also makes the `no test suites found` case result in a non-zero exit since this will almost always be an error.

/assign @fejta 