### PR TITLE
Add a log message when checkconfig passes without error

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -234,7 +234,10 @@ func main() {
 	}
 	if len(errs) > 0 {
 		reportWarning(o.strict, errorutil.NewAggregate(errs...))
+		return
 	}
+
+	logrus.Info("checkconfig passes without any error!")
 }
 func policyIsStrict(p config.Policy) bool {
 	if p.Protect == nil || !*p.Protect {


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov 
/area bikeshed

ref https://prow.gflocks.com/view/gcs/oss-prow/pr-logs/pull/GoogleCloudPlatform_oss-test-infra/32/pull-prow-config-validate/1125863189448232960

A job with zero line of logs looks scary :-p 