### PR TITLE
Removing trailing comma from email address.

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -7461,7 +7461,7 @@ dashboards:
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
     alert_options:
-      alert_mail_to_addresses: kubernetes-sig-testing-alerts@googlegroups.com,
+      alert_mail_to_addresses: kubernetes-sig-testing-alerts@googlegroups.com
   - name: ci-kubernetes-local-e2e
     description: Runs conformance tests using kubetest with local-up-cluster
     test_group_name: ci-kubernetes-local-e2e


### PR DESCRIPTION
Something in TestGrid code (will track it down after) is treating a trailing comma as an empty email address. :D