### PR TITLE
Allow --config in kubernetes_bazel scenario

### DIFF
--- a/scenarios/kubernetes_bazel_test.py
+++ b/scenarios/kubernetes_bazel_test.py
@@ -166,7 +166,6 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertIn('//b/...', call)
         self.assertIn('//c/...', call)
 
-
     def test_all_bazel(self):
         """Make sure all commands starts with bazel except for coarse."""
         args = kubernetes_bazel.parse_args([


### PR DESCRIPTION
Allow jobs to pass config options like `--config=ci` into the scenario

/assign @BenTheElder @krzyzacy @spiffxp 

