### PR TITLE
Turn off AWS resource sweeping for now

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -95,3 +95,5 @@ spec:
         image: gcr.io/k8s-testimages/janitor-aws:v20190326-5dd3da15c
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
+        # Turn off sweeping until https://github.com/kubernetes/test-infra/issues/12527 is resolved
+        - --sweep-count=0


### PR DESCRIPTION
Until #12527 is resolved.  It appears that the boskos users are logins
to the same AWS account, instead of logins to separate accounts, so
the deletions are not correctly scoped.

We should be able to fall back to the time-based aws-janitor, so we
have some cleanup.