### PR TITLE
Remove --job-config-path from start.yaml

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -461,7 +461,6 @@ spec:
         - --plugin-config=/etc/plugins/plugins.yaml
         - --config-path=/etc/config/config.yaml
         - --github-token-path=/etc/github/oauth
-        - --job-config-path=/etc/job-config
         volumeMounts:
         - name: oauth
           mountPath: /etc/github


### PR DESCRIPTION
/assign @krzyzacy @stevekuznetsov 

We do not use this by default, and there is no /etc/job-config mount in the starter yaml