### PR TITLE
Use gcr.io/cloud-provider-vsphere/csi-ci for CI

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -12,7 +12,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+      - image: gcr.io/cloud-provider-vsphere/csi-ci:b23178d9
         command:
         - "make"
         args:
@@ -29,7 +29,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+      - image: gcr.io/cloud-provider-vsphere/csi-ci:b23178d9
         command:
         - "make"
         args:
@@ -46,7 +46,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+      - image: gcr.io/cloud-provider-vsphere/csi-ci:b23178d9
         command:
         - "make"
         args:
@@ -69,7 +69,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:caae939f
+      - image: gcr.io/cloud-provider-vsphere/csi-ci:b23178d9
         command:
         - "make"
         args:


### PR DESCRIPTION
This patch changes the csi-vsphere Prow jobs to use the CI image of
gcr.io/cloud-provider-vsphere/csi-ci instead of
gcr.io/cloud-provider-vsphere/ci.