### PR TITLE
update kind presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -5,6 +5,7 @@ presubmits:
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
+    preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
@@ -14,24 +15,12 @@ presubmits:
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
+    preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-experimental
         command:
         - "./hack/verify-all.sh"
-        env:
-        # skip dep verification in the main CI job, use verify-deps for that
-        - name: VERIFY_DEPS
-          value: "false"
-  - name: pull-kind-verify-deps
-    decorate: true
-    path_alias: sigs.k8s.io/kind
-    run_if_changed: ^(go\.mod)|(go\.sum)|(vendor/.*)$
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-experimental
-        command:
-        - "./hack/verify-deps.sh"
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   - name: pull-kind-conformance-parallel
@@ -177,47 +166,6 @@ presubmits:
         - "--root=/go/src"
         - "--repo=sigs.k8s.io/kind=$(PULL_REFS)"
         - "--repo=k8s.io/kubernetes=release-1.12"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        # the script must run from kubernetes, but we're checking out kind
-        - "bash"
-        - "--"
-        - "-c"
-        - "cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-  # conformance test against kubernetes release-1.11 branch with `kind`, skipping
-  # serial tests so it runs in ~20m
-  - name: pull-kind-conformance-parallel-1-11
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    always_run: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-1.11
-        env:
-        # skip serial tests and run with --ginkgo-parallel
-        - name: "PARALLEL"
-          value: "true"
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--root=/go/src"
-        - "--repo=sigs.k8s.io/kind=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes=release-1.11"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--scenario=execute"


### PR DESCRIPTION
- drop kubernetes 1.11 (it's out of support officially, and there's a bug in the e2e tests which we can't patch now)
- enable dind in build / verify so we can sanity check images
- drop verify-deps (we're removing vendor)

/cc @spiffxp @amwat 