### PR TITLE
Use RBE on periodic-kubernetes-bazel-test-master

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -240,42 +240,6 @@ periodics:
 # periodic bazel test jobs
 - interval: 5m
   name: periodic-kubernetes-bazel-test-master
-  labels:
-    preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-periodic-interval: 6h
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master
-      args:
-      - --repo=k8s.io/kubernetes
-      - --root=/go/src
-      - "--service-account=/etc/service-account/service-account.json"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--timeout=60"
-      - "--scenario=kubernetes_bazel"
-      - "--" # end bootstrap args, scenario args below
-      - "--test=//... -//build/... -//vendor/..."
-      - "--manual-test=//hack:verify-all"
-      - "--test-args=--config=unit"
-      - "--test-args=--build_tag_filters=-e2e,-integration"
-      - "--test-args=--test_tag_filters=-e2e,-integration"
-      - "--test-args=--flaky_test_attempts=3"
-      env:
-      # TODO(bentheelder): switch to kubernetes_execute_bazel and consider dropping this
-      - name: REPO_OWNER
-        value: kubernetes
-      - name: REPO_NAME
-        value: kubernetes
-      resources:
-        requests:
-          memory: "6Gi"
-
-- interval: 5m
-  name: periodic-kubernetes-bazel-test-rbe-master
   decorate: true
   labels:
     preset-service-account: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2237,8 +2237,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-enhancements-unfreeze
 - name: periodic-kubernetes-bazel-test-master
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-master
-- name: periodic-kubernetes-bazel-test-rbe-master
-  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-rbe-master
 - name: periodic-kubernetes-bazel-test-1-11
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-11
 - name: periodic-kubernetes-bazel-test-1-12
@@ -5067,8 +5065,6 @@ dashboards:
     test_group_name: ci-kubernetes-bazel-test
   - name: periodic-bazel-test-master
     test_group_name: periodic-kubernetes-bazel-test-master
-  - name: periodic-bazel-test-rbe-master
-    test_group_name: periodic-kubernetes-bazel-test-rbe-master
   - name: bazel-test-1.11
     test_group_name: ci-kubernetes-bazel-test-1-11
   - name: bazel-test-1.12


### PR DESCRIPTION
/assign @michelle192837 @spiffxp 

* rbe - https://testgrid.k8s.io/google-unit#periodic-bazel-test-rbe-master&width=20
* local - https://testgrid.k8s.io/google-unit#periodic-bazel-test-master&width=20 (the periodic non-rbe job has the same issue as the presubmit and postsubmit: https://github.com/kubernetes/kubernetes/issues/77392)

