### PR TITLE
Add email for sig-network master-blocking alerts

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5302,6 +5302,8 @@ dashboards:
   - name: gce-cos-master-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
     description: "OWNER: sig-networking (ingress); Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh"
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
 - name: sig-release-master-informing
   dashboard_tab:


### PR DESCRIPTION
ref: https://github.com/kubernetes/sig-release/issues/441#issuecomment-490657159

This is the same alert e-mail address used for https://testgrid.k8s.io/sig-network-gce#gci-gce-ingress which is an identical copy of the job