### PR TITLE
Add email for sig-scheduling master-blocking alerts

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5283,6 +5283,8 @@ dashboards:
   - name: gce-device-plugin-gpu-master
     test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
     description: "OWNER: sig-scheduling; Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"
+    alert_options:
+      alert_mail_to_addresses: gke-kubernetes-accelerators-bugs@google.com
   - name: gce-cos-master-slow
     test_group_name: ci-kubernetes-e2e-gci-gce-slow
     description: "OWNER: sig-release (release-team); Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"


### PR DESCRIPTION
ref: https://github.com/kubernetes/sig-release/issues/441#issuecomment-490610114

This is the same e-mail used for https://testgrid.k8s.io/wg-resource-management#gce-device-plugin-gpu

/cc @bsalamat