### PR TITLE
build kind with modules

### DIFF
--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -204,7 +204,7 @@ func (d *Deployer) prepareKindBinary() error {
 	case kindBinaryBuild:
 		log.Println("Building a kind binary from source.")
 		// Build the kind binary.
-		cmd := exec.Command("go", "build", "-o", d.kindBinaryPath)
+		cmd := exec.Command("make", "install", "INSTALL_DIR="+d.kindBinaryDir)
 		cmd.Dir = d.importPathKind
 		if err := d.control.FinishRunning(cmd); err != nil {
 			return err


### PR DESCRIPTION
/cc @neolit123 @amwat @krzyzacy 

this should unbreak the kubeadm CI, we should consider switching to tagged releases.
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-all#kubeadm-kind-master

NOTE: I did not just flip on modules mode, as we have to deal with old kubernetes versions, using the kind reproducible build instead.