### PR TITLE
Make it possible not to delete kubemark master.

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -229,7 +229,7 @@ func run(deploy deployer, o options) error {
 
 	var kubemarkWg sync.WaitGroup
 	var kubemarkDownErr error
-	if o.kubemark {
+	if o.down && o.kubemark {
 		kubemarkWg.Add(1)
 		go kubemarkDown(&kubemarkDownErr, &kubemarkWg, dump)
 	}


### PR DESCRIPTION
Right now, using kubetest is the easiest (the only) way to create kubemark cluster.

Unfortunately, there is no easy way to prevent removing the cluster after the test has finished, which is important e.g. to debug the cluster after the test.

/cc @mm4tt @wojtek-t 