### PR TITLE
Abort batch jobs as well

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -370,7 +370,7 @@ func (c *controller) terminateDupProwJobs(ctx string, namespace string) error {
 	if err != nil {
 		return err
 	}
-	return pjutil.TerminateOlderPresubmitJobs(pjClient, log, jobs, func(toCancel prowjobv1.ProwJob) error {
+	return pjutil.TerminateOlderJobs(pjClient, log, jobs, func(toCancel prowjobv1.ProwJob) error {
 		if c.allowCancellations() {
 			if err := c.deleteBuild(ctx, namespace, toCancel.GetName()); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting build: %v", err)

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -263,7 +263,7 @@ func (c *Controller) SyncMetrics() {
 // TODO: Dry this out - need to ensure we can abstract children cancellation first.
 func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]coreapi.Pod) error {
 	log := c.log.WithField("aborter", "pod")
-	return pjutil.TerminateOlderPresubmitJobs(c.kc, log, pjs, func(toCancel prowapi.ProwJob) error {
+	return pjutil.TerminateOlderJobs(c.kc, log, pjs, func(toCancel prowapi.ProwJob) error {
 		// Allow aborting presubmit jobs for commits that have been superseded by
 		// newer commits in GitHub pull requests.
 		if c.config().Plank.AllowCancellations {


### PR DESCRIPTION
When a batch job is running but another batch job with the same refs
has been triggered more recently, we should abort the older batch job
just as we do for presubmits.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 