### PR TITLE
Make the build, pipeline and crier controllers to watch the configured namespaces instead of the entire cluster

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -169,7 +169,8 @@ func main() {
 		logrus.WithError(err).Fatal("unable to create prow job client")
 	}
 
-	prowjobInformerFactory := prowjobinformer.NewSharedInformerFactory(prowjobClientset, resync)
+	prowjobInformerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(prowjobClientset,
+		resync, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
 
 	var controllers []*crier.Controller
 

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -169,8 +169,13 @@ func main() {
 		logrus.WithError(err).Fatal("unable to create prow job client")
 	}
 
-	prowjobInformerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(prowjobClientset,
-		resync, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
+	var prowjobInformerFactory prowjobinformer.SharedInformerFactory
+	if cfg().WatchNamespace {
+		prowjobInformerFactory = prowjobinformer.NewSharedInformerFactoryWithOptions(prowjobClientset,
+			resync, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
+	} else {
+		prowjobInformerFactory = prowjobinformer.NewSharedInformerFactory(prowjobClientset, resync)
+	}
 
 	var controllers []*crier.Controller
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -96,6 +96,12 @@ type ProwConfig struct {
 	// Defaults to "default".
 	PodNamespace string `json:"pod_namespace,omitempty"`
 
+	// WatchNamespace will make the prow's controllers to watch
+	// only the configured ProwJobNamespace and PodNamespace namespaces.
+	// Defaults to "false" (indicating that the prow's controllers will
+	// watch the entire cluster)
+	WatchNamespace bool `json:"watch_namespace,omitempty"`
+
 	// LogLevel enables dynamically updating the log level of the
 	// standard logger that is used by all prow components.
 	//


### PR DESCRIPTION
This change ensures that the build, pipeline and crier controllers only watch the configured prow job and pod namespaces instead of the entire cluster as of today. 


Signed-off-by: Cosmin Cojocar <cosmin.cojocar@gmx.ch>