### PR TITLE
kubeadm jobs: set frequency, alerts and move to a new sig-cluster-lifecycle-kubeadm dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -2,7 +2,7 @@
 
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-kind-1-12
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-bazel-scratch-dir: "true"
@@ -81,7 +81,7 @@ periodics:
         type: Directory
 
 - name: ci-kubernetes-e2e-kubeadm-kind-1-13
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-bazel-scratch-dir: "true"
@@ -160,7 +160,7 @@ periodics:
         type: Directory
 
 - name: ci-kubernetes-e2e-kubeadm-kind-1-14
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-bazel-scratch-dir: "true"
@@ -239,7 +239,7 @@ periodics:
         type: Directory
 
 - name: ci-kubernetes-e2e-kubeadm-kind-master
-  interval: 1h
+  interval: 2h
   decorate: true
   labels:
     preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -2,7 +2,7 @@
 
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
-  interval: 1h
+  interval: 2h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -33,7 +33,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -64,7 +64,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -95,7 +95,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -2,7 +2,7 @@
 
 periodics:
 - name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
-  interval: 1h
+  interval: 2h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -33,7 +33,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -64,7 +64,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -95,7 +95,7 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
-  interval: 1h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3820,48 +3820,6 @@ dashboards:
 
 - name: sig-cluster-lifecycle-all
   dashboard_tab:
-# kubeadm-kind tests
-  - name: kubeadm-kind-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 6 # Runs every 4h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 12 # Runs every 1h. Alert when it's been failing for 12 hours
-# kubeadm-kinder tests
-  - name: kubeadm-kinder-upgrade-stable-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
-  - name: kubeadm-kinder-upgrade-1.13-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
-  - name: kubeadm-kinder-upgrade-1.12-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
-  - name: kubeadm-kinder-upgrade-1.11-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
-  - name: kubeadm-kinder-master-on-stable
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
-  - name: kubeadm-kinder-1-14-on-1-13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
-  - name: kubeadm-kinder-1-13-on-1-12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
-  - name: kubeadm-kinder-1-12-on-1-11
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
 # packages tests
   - name: periodic-packages-pushed
     test_group_name: periodic-kubernetes-e2e-packages-pushed
@@ -3870,6 +3828,83 @@ dashboards:
 # manifest list tests
   - name: periodic-manifest-lists
     test_group_name: periodic-kubernetes-e2e-manifest-lists
+
+- name: sig-cluster-lifecycle-kubeadm
+  dashboard_tab:
+# kubeadm-kind tests
+  - name: kubeadm-kind-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kind-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kind-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kind-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 8
+    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
+# kubeadm-kinder tests
+  - name: kubeadm-kinder-upgrade-stable-master
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 8
+    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
+  - name: kubeadm-kinder-upgrade-1.13-1.14
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kinder-upgrade-1.12-1.13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kinder-upgrade-1.11-1.12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kinder-master-on-stable
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 8
+    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
+  - name: kubeadm-kinder-1-14-on-1-13
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kinder-1-13-on-1-12
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
+  - name: kubeadm-kinder-1-12-on-1-11
+    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    alert_stale_results_hours: 24
+    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
 
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:
@@ -6223,6 +6258,7 @@ dashboard_groups:
 - name: sig-cluster-lifecycle
   dashboard_names:
   - sig-cluster-lifecycle-all
+  - sig-cluster-lifecycle-kubeadm
   - sig-cluster-lifecycle-upgrade-skew
   - sig-cluster-lifecycle-multi-platform
   - sig-cluster-lifecycle-cluster-api


### PR DESCRIPTION
This PR harmonize kubeadm-kind(er)* jobs with
- run frequency for  jobs to 4h for jobs on master and to 12h for jobs on older branches
- notification after failing for 12h on master and 24 hours on older branches

then kubeadm-kind(er)* jobs are moved from `sig-cluster-lifecycle-all` into a new `sig-cluster-lifecycle-kubeadm` dashboard

/sig cluster-lifecycle
/kind cleanup
/priority important-longterm
/assign @neolit123