### PR TITLE
gce-5000-performance - disable load & run density more often

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -34,7 +34,9 @@ periodics:
           memory: "16Gi"
 
 # This is a sig-release-master-blocking job.
-- cron: '1 8 * * 1,2,3,4,5' # Run at 00:01PST (8:01 UTC) on Mon, Thu, Wed, Thu and Fri
+# TODO(#76579): Switch the cron settings once the density passes.
+#- cron: '1 8 * * 1,2,3,4,5' # Run at 00:01PST (8:01 UTC) on Mon, Thu, Wed, Thu and Fri
+- cron: '30 7,11,15,19,23 * * 1,2,3,4,5' # Run (7:30,11:30,15:30,19:30,23:30 UTC) on Mon-Fri
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -46,7 +48,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=1080
+      - --timeout=240 # TODO(#76579): Change back to 1080.
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -66,12 +68,13 @@ periodics:
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      # TODO(#76579): Uncomment once density passes.
+      #- --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
       # TODO(https://github.com/kubernetes/kubernetes/issues/75294): Enable when fixed
       - --test-cmd-args=--enable-prometheus-server=false
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=1050m
+      - --timeout=210m # TODO(#76579): Change back to 1050m.
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190509-e418529-master
       resources:


### PR DESCRIPTION
Ref. https://github.com/kubernetes/kubernetes/issues/76579

As the regression is cleary visible in the density tests, we'll disable the long taking (~10h) load tests and run the density tests more frequently until we figure out what is going on. 