### PR TITLE
Stick to generic suffixes for forked jobs for now

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -4,6 +4,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 1h 2h 6h 24h
+    fork-per-release-generic-suffix: "true"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -82,7 +82,7 @@ periodics:
     preset-dind-enabled: "true"
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-{{.Version}}"
+    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
     testgrid-dashboards: sig-release-master-informing
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -83,6 +83,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
+    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-informing
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -67,6 +67,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
+    fork-per-release-generic-suffix: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20190509-ce5fe7e

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -109,6 +109,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
+    fork-per-release-generic-suffix: "true"
   decorate: true
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
For forked jobs that currently have generic suffixes (`beta`, `stable1`, `stable2`, `stable3`), keep using them for now.

/cc @imkin @taragu @mariantalla 