### PR TITLE
Use "make install" for building kind

### DIFF
--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -48,7 +48,9 @@ install_kind() {
     mkdir -p "${TMP_DIR}/bin"
     # if we have a kind checkout, install that to the tmpdir, otherwise go get it
     if [[ $(go list sigs.k8s.io/kind) = "sigs.k8s.io/kind" ]]; then
-        env "GOBIN=${TMP_DIR}/bin" go install sigs.k8s.io/kind
+        pushd $GOPATH/src/sigs.k8s.io/kind
+        make install
+        popd
     else
         env "GOPATH=${TMP_DIR}" go get -u sigs.k8s.io/kind
     fi


### PR DESCRIPTION
`go install` no longer works (see example below), we should use `make install` instead.

Needed for https://github.com/kubernetes/test-infra/issues/12603

Change-Id: I10f9b542105a033cf7a0bf76592be2a600251e43