### PR TITLE
Allow plank to terminate stale running pods

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,8 @@
 # Announcements
 
 New features added to each component:
+ - *May 13, 2019* New `plank` config `pod_running_timeout` is added and
+   defaulted to two days to allow plank abort pods stuck in running state.
  - *April 25, 2019* `--job-config` in `peribolos` has never been used; it is
    deprecated and will be removed in July 2019. Remove the flag from any calls
    to the tool.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -202,6 +202,11 @@ type Plank struct {
 	// PodPendingTimeout is after how long the controller will perform a garbage
 	// collection on pending pods. Defaults to one day.
 	PodPendingTimeout time.Duration `json:"-"`
+	// PodRunningTimeoutString compiles into PodRunningTimeout at load time.
+	PodRunningTimeoutString string `json:"pod_running_timeout,omitempty"`
+	// PodRunningTimeout is after how long the controller will abort a prowjob pod
+	// stuck in running state. Defaults to two days.
+	PodRunningTimeout time.Duration `json:"-"`
 	// DefaultDecorationConfig are defaults for shared fields for ProwJobs
 	// that request to have their PodSpecs decorated
 	DefaultDecorationConfig *prowapi.DecorationConfig `json:"default_decoration_config,omitempty"`
@@ -911,6 +916,16 @@ func parseProwConfig(c *Config) error {
 			return fmt.Errorf("cannot parse duration for plank.pod_pending_timeout: %v", err)
 		}
 		c.Plank.PodPendingTimeout = podPendingTimeout
+	}
+
+	if c.Plank.PodRunningTimeoutString == "" {
+		c.Plank.PodRunningTimeout = 48 * time.Hour
+	} else {
+		podRunningTimeout, err := time.ParseDuration(c.Plank.PodRunningTimeoutString)
+		if err != nil {
+			return fmt.Errorf("cannot parse duration for plank.pod_running_timeout: %v", err)
+		}
+		c.Plank.PodRunningTimeout = podRunningTimeout
 	}
 
 	if c.Gerrit.TickIntervalString == "" {


### PR DESCRIPTION
We still have a ton of bootstrap jobs doesn't timeout properly
We also see podutil jobs doesn't timeout properly (https://github.com/kubernetes/test-infra/issues/11631) for whatever reason...

Make plank able to abort pod stuck in running state so the next run can be scheduled.

/assign @cjwagner @stevekuznetsov @fejta 
cc @sebastienvas 