### PR TITLE
Add bazel-build to sig-release dashboards for 1.11, 1.12

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.11.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.11.yaml
@@ -254,7 +254,7 @@ postsubmits:
         preset-bazel-scratch-dir: "true"
         preset-bazel-remote-cache-enabled: "true"
       annotations:
-        testgrid-dashboards: google-unit
+        testgrid-dashboards: sig-release-1.11-blocking, sig-release-1.11-all, google-unit
         testgrid-tab-name: bazel-build-1.11
       spec:
         containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -377,7 +377,7 @@ postsubmits:
         preset-bazel-scratch-dir: "true"
         preset-bazel-remote-cache-enabled: "true"
       annotations:
-        testgrid-dashboards: google-unit
+        testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, google-unit
         testgrid-tab-name: bazel-build-1.12
       spec:
         containers:


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/12610