### PR TITLE
Sweeping change to retire all the durationString fields

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -353,7 +353,7 @@ func (c *controller) buildID(pj prowjobv1.ProwJob) (string, string, error) {
 }
 
 func (c *controller) defaultBuildTimeout() time.Duration {
-	return c.config().DefaultJobTimeout
+	return c.config().DefaultJobTimeout.Duration
 }
 
 func (c *controller) allowCancellations() bool {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -321,7 +321,7 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 			log:  logrus.WithField("agent", "tide"),
 			path: o.tideURL,
 			updatePeriod: func() time.Duration {
-				return cfg().Deck.TideUpdatePeriod
+				return cfg().Deck.TideUpdatePeriod.Duration
 			},
 			hiddenRepos: cfg().Deck.HiddenRepos,
 			hiddenOnly:  o.hiddenOnly,

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -105,7 +105,7 @@ func main() {
 	logrus.Infof("Starting gerrit fetcher")
 
 	// TODO(fejta): refactor as timer, which we reset to the current TickInterval value each time
-	tick := time.Tick(cfg().Gerrit.TickInterval)
+	tick := time.Tick(cfg().Gerrit.TickInterval.Duration)
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -176,7 +176,7 @@ func main() {
 
 	// Expose prometheus metrics
 	pushGateway := configAgent.Config().PushGateway
-	metrics.ExposeMetrics("hook", pushGateway.Endpoint, pushGateway.Interval)
+	metrics.ExposeMetrics("hook", pushGateway.Endpoint, pushGateway.Interval.Duration)
 
 	server := &hook.Server{
 		ClientAgent:    clientAgent,

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -205,7 +205,7 @@ func main() {
 
 	// Expose prometheus metrics
 	pushGateway := cfg().PushGateway
-	m.ExposeMetrics("jenkins-operator", pushGateway.Endpoint, pushGateway.Interval)
+	m.ExposeMetrics("jenkins-operator", pushGateway.Endpoint, pushGateway.Interval.Duration)
 
 	// Serve Jenkins logs here and proxy deck to use this endpoint
 	// instead of baking agent-specific logic in deck

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -600,7 +600,7 @@ func configureTeams(client teamClient, orgName string, orgConfig org.Config, max
 			names[n] = t
 			older[n] = append(older[n], val)
 		default: // t does not have smallest id, add it to older set
-			logger.Debugf("Adding team to older set as a smaller ID is already recoded for it.", val.ID)
+			logger.Debugf("Adding team (%d) to older set as a smaller ID is already recoded for it.", val.ID)
 			older[n] = append(older[n], val)
 		}
 	}

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -146,7 +146,7 @@ func main() {
 
 	// Expose prometheus metrics
 	pushGateway := cfg().PushGateway
-	metrics.ExposeMetrics("plank", pushGateway.Endpoint, pushGateway.Interval)
+	metrics.ExposeMetrics("plank", pushGateway.Endpoint, pushGateway.Interval.Duration)
 	// gather metrics for the jobs handled by plank.
 	go gather(c)
 

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -144,7 +144,7 @@ func main() {
 		if o.runOnce {
 			break
 		}
-		time.Sleep(cfg().Sinker.ResyncPeriod)
+		time.Sleep(cfg().Sinker.ResyncPeriod.Duration)
 	}
 }
 
@@ -259,7 +259,7 @@ func (c *controller) clean() {
 	isExist := sets.NewString()
 	isFinished := sets.NewString()
 
-	maxProwJobAge := c.config().Sinker.MaxProwJobAge
+	maxProwJobAge := c.config().Sinker.MaxProwJobAge.Duration
 	for _, prowJob := range prowJobs.Items {
 		isExist.Insert(prowJob.ObjectMeta.Name)
 		// Handle periodics separately.
@@ -327,7 +327,7 @@ func (c *controller) clean() {
 			return
 		}
 		metrics.podsCreated += len(pods.Items)
-		maxPodAge := c.config().Sinker.MaxPodAge
+		maxPodAge := c.config().Sinker.MaxPodAge.Duration
 		for _, pod := range pods.Items {
 			clean := !pod.Status.StartTime.IsZero() && time.Since(pod.Status.StartTime.Time) > maxPodAge
 			reason := reasonPodAged

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -54,8 +54,8 @@ func newFakeConfigAgent() *fca {
 				ProwJobNamespace: "ns",
 				PodNamespace:     "ns",
 				Sinker: config.Sinker{
-					MaxProwJobAge: maxProwJobAge,
-					MaxPodAge:     maxPodAge,
+					MaxProwJobAge: &metav1.Duration{Duration: maxProwJobAge},
+					MaxPodAge:     &metav1.Duration{Duration: maxPodAge},
 				},
 			},
 			JobConfig: config.JobConfig{

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -122,7 +122,7 @@ func main() {
 
 	// Expose prometheus metrics
 	pushGateway := configAgent.Config().PushGateway
-	metrics.ExposeMetrics("sub", pushGateway.Endpoint, pushGateway.Interval)
+	metrics.ExposeMetrics("sub", pushGateway.Endpoint, pushGateway.Interval.Duration)
 
 	s := &subscriber.Subscriber{
 		ConfigAgent:   configAgent,

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -152,7 +152,7 @@ func main() {
 	// The sync loop should have a much lower burst allowance than the status
 	// loop which may need to update many statuses upon restarting Tide after
 	// changing the context format or starting Tide on a new repo.
-	githubSync.Throttle(o.syncThrottle, 3*tokensPerIteration(o.syncThrottle, cfg().Tide.SyncPeriod))
+	githubSync.Throttle(o.syncThrottle, 3*tokensPerIteration(o.syncThrottle, cfg().Tide.SyncPeriod.Duration))
 	githubStatus.Throttle(o.statusThrottle, o.statusThrottle/2)
 
 	gitClient, err := o.github.GitClient(secretAgent, o.dryRun)
@@ -177,7 +177,7 @@ func main() {
 
 	// Push metrics to the configured prometheus pushgateway endpoint or serve them
 	pushGateway := cfg().PushGateway
-	metrics.ExposeMetrics("tide", pushGateway.Endpoint, pushGateway.Interval)
+	metrics.ExposeMetrics("tide", pushGateway.Endpoint, pushGateway.Interval.Duration)
 
 	start := time.Now()
 	sync(c)
@@ -189,7 +189,7 @@ func main() {
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		for {
 			select {
-			case <-time.After(time.Until(start.Add(cfg().Tide.SyncPeriod))):
+			case <-time.After(time.Until(start.Add(cfg().Tide.SyncPeriod.Duration))):
 				start = time.Now()
 				sync(c)
 			case <-sig:

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"sync"
 	"text/template"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
 )
@@ -74,15 +74,11 @@ type TideMergeCommitTemplate struct {
 
 // Tide is config for the tide pool.
 type Tide struct {
-	// SyncPeriodString compiles into SyncPeriod at load time.
-	SyncPeriodString string `json:"sync_period,omitempty"`
 	// SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
-	SyncPeriod time.Duration `json:"-"`
-	// StatusUpdatePeriodString compiles into StatusUpdatePeriod at load time.
-	StatusUpdatePeriodString string `json:"status_update_period,omitempty"`
+	SyncPeriod *metav1.Duration `json:"sync_period,omitempty"`
 	// StatusUpdatePeriod specifies how often Tide will update GitHub status contexts.
 	// Defaults to the value of SyncPeriod.
-	StatusUpdatePeriod time.Duration `json:"-"`
+	StatusUpdatePeriod *metav1.Duration `json:"status_update_period,omitempty"`
 	// Queries represents a list of GitHub search queries that collectively
 	// specify the set of PRs that meet merge requirements.
 	Queries TideQueries `json:"queries,omitempty"`

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -396,7 +396,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			pj.Status.Description = "Job failed."
 
 		case coreapi.PodPending:
-			maxPodPending := c.config().Plank.PodPendingTimeout
+			maxPodPending := c.config().Plank.PodPendingTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodPending {
 				// Pod is running. Do nothing.
 				c.incrementNumPendingJobs(pj.Spec.Job)

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -84,7 +84,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 						MaxConcurrency: maxConcurrency,
 						MaxGoroutines:  20,
 					},
-					PodPendingTimeout: podPendingTimeout,
+					PodPendingTimeout: &metav1.Duration{Duration: podPendingTimeout},
 					PodRunningTimeout: &metav1.Duration{Duration: podRunningTimeout},
 				},
 			},

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -408,7 +408,7 @@ func (sc *statusController) run() {
 // this function returns immediately without syncing.
 func (sc *statusController) waitSync() {
 	// wait for the min sync period time to elapse if needed.
-	wait := time.After(time.Until(sc.lastSyncStart.Add(sc.config().Tide.StatusUpdatePeriod)))
+	wait := time.After(time.Until(sc.lastSyncStart.Add(sc.config().Tide.StatusUpdatePeriod.Duration)))
 	for {
 		select {
 		case <-wait:

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -31,6 +31,7 @@ import (
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	clienttesting "k8s.io/client-go/testing"
 
@@ -1553,8 +1554,9 @@ func TestSync(t *testing.T) {
 		ca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Tide: config.Tide{
-					Queries:       []config.TideQuery{{}},
-					MaxGoroutines: 4,
+					Queries:            []config.TideQuery{{}},
+					MaxGoroutines:      4,
+					StatusUpdatePeriod: &metav1.Duration{Duration: time.Second * 0},
 				},
 			},
 		})


### PR DESCRIPTION
following up https://github.com/kubernetes/test-infra/pull/12607 - doing this for all other duration dual fields in prow configs

/assign @cjwagner @stevekuznetsov 