### PR TITLE
Add missing periodic annotations

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -123,6 +123,9 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-generic-suffix: "true"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190510-1285909-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -459,6 +459,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
+      fork-per-release-periodic-interval: 24h
       testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, sig-node-kubelet
       testgrid-tab-name: node-kubelet-1.12
     spec:
@@ -517,6 +518,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 24h
       testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, google-unit
       testgrid-tab-name: verify-1.12
     spec:
@@ -609,6 +611,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 24h
       testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, google-unit
       testgrid-tab-name: integration-1.12
     spec:
@@ -635,6 +638,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-ci-gce-device-plugin-gpu: "true"
     annotations:
+      fork-per-release-cron: 0 8-23/24 * * *
       testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
       testgrid-tab-name: gce-device-gpu-plugin-1.12
     spec:
@@ -663,6 +667,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-e2e-scalability-common: "true"
     annotations:
+      fork-per-release-cron: 0 8-20/12 * * *
       testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, sig-scalability-gce, google-gce
       testgrid-tab-name: gce-cos-1.12-scalability-100
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -459,6 +459,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
+      fork-per-release-periodic-interval: 6h 24h
       testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, sig-node-kubelet
       testgrid-tab-name: node-kubelet-1.13
     spec:
@@ -517,6 +518,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 6h 24h
       testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
       testgrid-tab-name: verify-1.13
     spec:
@@ -609,6 +611,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 6h 24h
       testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
       testgrid-tab-name: integration-1.13
     spec:
@@ -635,6 +638,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-ci-gce-device-plugin-gpu: "true"
     annotations:
+      fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *
       testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
       testgrid-tab-name: gce-device-gpu-plugin-1.13
     spec:
@@ -664,6 +668,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-e2e-scalability-common: "true"
     annotations:
+      fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
       testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, sig-scalability-gce, google-gce
       testgrid-tab-name: gce-cos-1.13-scalability-100
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -459,6 +459,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
+      fork-per-release-periodic-interval: 2h 6h 24h
       testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-node-kubelet, sig-node-cri-1.12
       testgrid-tab-name: node-kubelet-1.14
     spec:
@@ -543,6 +544,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 2h 6h 24h
       testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
       testgrid-tab-name: verify-1.14
     decorate: true
@@ -644,6 +646,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
+      fork-per-release-periodic-interval: 2h 6h 24h
       testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
       testgrid-tab-name: integration-1.14
     spec:
@@ -670,6 +673,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-ci-gce-device-plugin-gpu: "true"
     annotations:
+      fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
       testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
       testgrid-tab-name: gce-device-gpu-plugin-1.14
     spec:
@@ -700,6 +704,7 @@ periodics:
       preset-k8s-ssh: "true"
       preset-e2e-scalability-common: "true"
     annotations:
+      fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
       testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-scalability-gce, google-gce
       testgrid-tab-name: gce-cos-1.14-scalability-100
     spec:

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -135,6 +135,7 @@ func generatePeriodics(c config.JobConfig, version string) ([]config.Periodic, e
 			if len(f) > 0 {
 				p.Interval = f[0]
 				p.Cron = ""
+				p.Annotations[periodicIntervalAnnotation] = strings.Join(f[1:], " ")
 			}
 		}
 		if cron, ok := p.Annotations[cronAnnotation]; ok {
@@ -142,6 +143,7 @@ func generatePeriodics(c config.JobConfig, version string) ([]config.Periodic, e
 			if len(c) > 0 {
 				p.Cron = c[0]
 				p.Interval = ""
+				p.Annotations[cronAnnotation] = strings.Join(c[1:], ", ")
 			}
 		}
 		p.Annotations = cleanAnnotations(p.Annotations)
@@ -153,9 +155,16 @@ func generatePeriodics(c config.JobConfig, version string) ([]config.Periodic, e
 func cleanAnnotations(annotations map[string]string) map[string]string {
 	result := map[string]string{}
 	for k, v := range annotations {
-		if k != forkAnnotation && k != replacementAnnotation {
-			result[k] = v
+		if k == forkAnnotation || k == replacementAnnotation {
+			continue
 		}
+		if k == periodicIntervalAnnotation && v == "" {
+			continue
+		}
+		if k == cronAnnotation && v == "" {
+			continue
+		}
+		result[k] = v
 	}
 	return result
 }

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -65,6 +65,14 @@ func TestCleanAnnotations(t *testing.T) {
 				"someOtherAnnotation": "pony party",
 			},
 		},
+		{
+			name: "blank periodic annotations",
+			annotations: map[string]string{
+				periodicIntervalAnnotation: "",
+				cronAnnotation:             "",
+			},
+			expected: map[string]string{},
+		},
 	}
 
 	for _, tc := range tests {
@@ -533,7 +541,7 @@ func TestGeneratePeriodics(t *testing.T) {
 			JobBase: config.JobBase{
 				Name: "periodic-with-replacements-1-15",
 				Annotations: map[string]string{
-					periodicIntervalAnnotation: "6h 12h 24h 24h",
+					periodicIntervalAnnotation: "12h 24h 24h",
 				},
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{


### PR DESCRIPTION
The forked release branch jobs didn't have periodic annotations (because they weren't ever actually forked, just cut/pasted from the old ones). Add the periodic annotations so the config-rotator (coming in a later PR) knows what to do with them.

Also add `fork-per-release` to `ci-kubernetes-node-kubelet-features` (which already has existing forked versions in the right places but lacked the annotation).

Also add some mangling to `config-forker` to make life easier for `config-rotator`.

/cc @spiffxp 