### PR TITLE
Add testgrid annotation support to config-forker

### DIFF
--- a/experiment/config-forker/README.md
+++ b/experiment/config-forker/README.md
@@ -29,6 +29,10 @@ For all jobs:
   `master`, the value will be changed to `release-1.15`.
 - If the `fork-per-release-replacements` annotation is specified, those replacements will be performed in the `args`
   of all containers for that job.
+- If the `testgrid-dashboards` annotation is specified, references to `master-blocking` and `master-informing` are
+  changed to `1.15-blocking` and `1.15-informing`.
+- If the `testgrid-tab-name` annotation is specified, references to `master` are changed to `1.15`.
+- If the `description` annotation is specified, it is removed (for now).
 
 For presubmits and postsubmits:
 
@@ -38,6 +42,7 @@ For presubmits and postsubmits:
 For periodics and postsubmits:
 
 - If the job `name` ends in `-master`, it will be replaced with `-1-15`, otherwise `-1-15` will be appended
+- `sig-release-1.15-all` is added to the job's `testgrid-dashboards` annotation (creating the annotation if necessary)
 
 For periodics only:
 

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -34,11 +34,14 @@ import (
 )
 
 const (
-	forkAnnotation             = "fork-per-release"
-	suffixAnnotation           = "fork-per-release-generic-suffix"
-	periodicIntervalAnnotation = "fork-per-release-periodic-interval"
-	cronAnnotation             = "fork-per-release-cron"
-	replacementAnnotation      = "fork-per-release-replacements"
+	forkAnnotation               = "fork-per-release"
+	suffixAnnotation             = "fork-per-release-generic-suffix"
+	periodicIntervalAnnotation   = "fork-per-release-periodic-interval"
+	cronAnnotation               = "fork-per-release-cron"
+	replacementAnnotation        = "fork-per-release-replacements"
+	testgridDashboardsAnnotation = "testgrid-dashboards"
+	testgridTabNameAnnotation    = "testgrid-tab-name"
+	descriptionAnnotation        = "description"
 )
 
 func generatePostsubmits(c config.JobConfig, version string) (map[string][]config.Postsubmit, error) {
@@ -271,23 +274,23 @@ func fixTestgridAnnotations(annotations map[string]string, version string, isPre
 annotations:
 	for k, v := range annotations {
 		switch k {
-		case "testgrid-dashboards":
+		case testgridDashboardsAnnotation:
 			v = r.Replace(v)
 			if !isPresubmit {
 				v += ", " + "sig-release-" + version + "-all"
 			}
 			didDashboards = true
 			break
-		case "testgrid-tab-name":
+		case testgridTabNameAnnotation:
 			v = strings.ReplaceAll(v, "master", version)
 			break
-		case "description":
+		case descriptionAnnotation:
 			continue annotations
 		}
 		a[k] = v
 	}
 	if !didDashboards && !isPresubmit {
-		a["testgrid-dashboards"] = "sig-release-" + version + "-all"
+		a[testgridDashboardsAnnotation] = "sig-release-" + version + "-all"
 	}
 	return a
 

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -64,7 +64,7 @@ func generatePostsubmits(c config.JobConfig, version string) (map[string][]confi
 					}
 				}
 			}
-			p.Annotations = cleanAnnotations(p.Annotations)
+			p.Annotations = cleanAnnotations(fixTestgridAnnotations(p.Annotations, version, false))
 			newPostsubmits[repo] = append(newPostsubmits[repo], p)
 		}
 	}
@@ -93,7 +93,7 @@ func generatePresubmits(c config.JobConfig, version string) (map[string][]config
 					}
 				}
 			}
-			p.Annotations = cleanAnnotations(p.Annotations)
+			p.Annotations = cleanAnnotations(fixTestgridAnnotations(p.Annotations, version, true))
 			newPresubmits[repo] = append(newPresubmits[repo], p)
 		}
 	}
@@ -146,7 +146,7 @@ func generatePeriodics(c config.JobConfig, version string) ([]config.Periodic, e
 				p.Annotations[cronAnnotation] = strings.Join(c[1:], ", ")
 			}
 		}
-		p.Annotations = cleanAnnotations(p.Annotations)
+		p.Annotations = cleanAnnotations(fixTestgridAnnotations(p.Annotations, version, false))
 		newPeriodics = append(newPeriodics, p)
 	}
 	return newPeriodics, nil
@@ -259,6 +259,38 @@ func fixEnvVars(vars []v1.EnvVar, version string) []v1.EnvVar {
 		newVars = append(newVars, v)
 	}
 	return newVars
+}
+
+func fixTestgridAnnotations(annotations map[string]string, version string, isPresubmit bool) map[string]string {
+	r := strings.NewReplacer(
+		"master-blocking", version+"-blocking",
+		"master-informing", version+"-informing",
+	)
+	a := map[string]string{}
+	didDashboards := false
+annotations:
+	for k, v := range annotations {
+		switch k {
+		case "testgrid-dashboards":
+			v = r.Replace(v)
+			if !isPresubmit {
+				v += ", " + "sig-release-" + version + "-all"
+			}
+			didDashboards = true
+			break
+		case "testgrid-tab-name":
+			v = strings.ReplaceAll(v, "master", version)
+			break
+		case "description":
+			continue annotations
+		}
+		a[k] = v
+	}
+	if !didDashboards && !isPresubmit {
+		a["testgrid-dashboards"] = "sig-release-" + version + "-all"
+	}
+	return a
+
 }
 
 func generateNameVariant(name, version string, generic bool) string {

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -338,6 +338,61 @@ func TestFixEnvVars(t *testing.T) {
 	}
 }
 
+func TestFixTestgridAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[string]string
+		isPresubmit bool
+	}{
+		{
+			name:        "update master-blocking to point at 1.15-blocking",
+			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking"},
+			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking"},
+			isPresubmit: true,
+		},
+		{
+			name:        "update master-informing to point at 1.15-informing",
+			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-informing"},
+			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-informing"},
+			isPresubmit: true,
+		},
+		{
+			name:        "periodic updates master-blocking to point at 1.15-blocking and adds 1.15-all",
+			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking"},
+			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking, sig-release-1.15-all"},
+			isPresubmit: false,
+		},
+		{
+			name:        "update master-blocking to point at 1.15-blocking and leave other entries alone",
+			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking, google-unit"},
+			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking, google-unit"},
+			isPresubmit: true,
+		},
+		{
+			name:        "drop 'description'",
+			annotations: map[string]string{"description": "some description"},
+			expected:    map[string]string{},
+			isPresubmit: true,
+		},
+		{
+			name:        "update tab names",
+			annotations: map[string]string{"testgrid-tab-name": "foo master"},
+			expected:    map[string]string{"testgrid-tab-name": "foo 1.15"},
+			isPresubmit: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := fixTestgridAnnotations(tc.annotations, "1.15", tc.isPresubmit)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(tc.expected, result))
+			}
+		})
+	}
+}
+
 func TestGenerateNameVariant(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -526,14 +581,14 @@ func TestGeneratePeriodics(t *testing.T) {
 			Cron: "0 * * * *",
 			JobBase: config.JobBase{
 				Name:        "some-forked-periodic-1-15",
-				Annotations: map[string]string{},
+				Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
 			},
 		},
 		{
 			Cron: "0 * * * *",
 			JobBase: config.JobBase{
 				Name:        "some-generic-periodic-beta",
-				Annotations: map[string]string{suffixAnnotation: "true"},
+				Annotations: map[string]string{suffixAnnotation: "true", "testgrid-dashboards": "sig-release-1.15-all"},
 			},
 		},
 		{
@@ -542,6 +597,7 @@ func TestGeneratePeriodics(t *testing.T) {
 				Name: "periodic-with-replacements-1-15",
 				Annotations: map[string]string{
 					periodicIntervalAnnotation: "12h 24h 24h",
+					"testgrid-dashboards":      "sig-release-1.15-all",
 				},
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{
@@ -558,7 +614,7 @@ func TestGeneratePeriodics(t *testing.T) {
 			Interval: "2h",
 			JobBase: config.JobBase{
 				Name:        "decorated-periodic-1-15",
-				Annotations: map[string]string{},
+				Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
 				UtilityConfig: config.UtilityConfig{
 					Decorate:  true,
 					ExtraRefs: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "release-1.15"}},
@@ -591,8 +647,12 @@ func TestGeneratePostsubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name:        "post-kubernetes-generic",
-					Annotations: map[string]string{forkAnnotation: "true", suffixAnnotation: "true"},
+					Name: "post-kubernetes-generic",
+					Annotations: map[string]string{
+						forkAnnotation:        "true",
+						suffixAnnotation:      "true",
+						"testgrid-dashboards": "sig-release-master-blocking, google-unit",
+					},
 				},
 				Brancher: config.Brancher{
 					SkipBranches: []string{`release-\d\.\d`},
@@ -634,7 +694,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 			{
 				JobBase: config.JobBase{
 					Name:        "post-kubernetes-e2e-1-15",
-					Annotations: map[string]string{},
+					Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
 				},
 				Brancher: config.Brancher{
 					Branches: []string{"release-1.15"},
@@ -642,8 +702,11 @@ func TestGeneratePostsubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
-					Name:        "post-kubernetes-generic-beta",
-					Annotations: map[string]string{suffixAnnotation: "true"},
+					Name: "post-kubernetes-generic-beta",
+					Annotations: map[string]string{
+						suffixAnnotation:      "true",
+						"testgrid-dashboards": "sig-release-1.15-blocking, google-unit, sig-release-1.15-all",
+					},
 				},
 				Brancher: config.Brancher{
 					Branches: []string{"release-1.15"},
@@ -653,7 +716,8 @@ func TestGeneratePostsubmits(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "post-replace-some-things-1-15",
 					Annotations: map[string]string{
-						"some-annotation": "yup",
+						"some-annotation":     "yup",
+						"testgrid-dashboards": "sig-release-1.15-all",
 					},
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -347,38 +347,38 @@ func TestFixTestgridAnnotations(t *testing.T) {
 	}{
 		{
 			name:        "update master-blocking to point at 1.15-blocking",
-			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking"},
-			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking"},
+			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking"},
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking"},
 			isPresubmit: true,
 		},
 		{
 			name:        "update master-informing to point at 1.15-informing",
-			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-informing"},
-			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-informing"},
+			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-informing"},
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-informing"},
 			isPresubmit: true,
 		},
 		{
 			name:        "periodic updates master-blocking to point at 1.15-blocking and adds 1.15-all",
-			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking"},
-			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking, sig-release-1.15-all"},
+			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking"},
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking, sig-release-1.15-all"},
 			isPresubmit: false,
 		},
 		{
 			name:        "update master-blocking to point at 1.15-blocking and leave other entries alone",
-			annotations: map[string]string{"testgrid-dashboards": "sig-release-master-blocking, google-unit"},
-			expected:    map[string]string{"testgrid-dashboards": "sig-release-1.15-blocking, google-unit"},
+			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking, google-unit"},
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit"},
 			isPresubmit: true,
 		},
 		{
 			name:        "drop 'description'",
-			annotations: map[string]string{"description": "some description"},
+			annotations: map[string]string{descriptionAnnotation: "some description"},
 			expected:    map[string]string{},
 			isPresubmit: true,
 		},
 		{
 			name:        "update tab names",
-			annotations: map[string]string{"testgrid-tab-name": "foo master"},
-			expected:    map[string]string{"testgrid-tab-name": "foo 1.15"},
+			annotations: map[string]string{testgridTabNameAnnotation: "foo master"},
+			expected:    map[string]string{testgridTabNameAnnotation: "foo 1.15"},
 			isPresubmit: true,
 		},
 	}
@@ -581,14 +581,14 @@ func TestGeneratePeriodics(t *testing.T) {
 			Cron: "0 * * * *",
 			JobBase: config.JobBase{
 				Name:        "some-forked-periodic-1-15",
-				Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
+				Annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-all"},
 			},
 		},
 		{
 			Cron: "0 * * * *",
 			JobBase: config.JobBase{
 				Name:        "some-generic-periodic-beta",
-				Annotations: map[string]string{suffixAnnotation: "true", "testgrid-dashboards": "sig-release-1.15-all"},
+				Annotations: map[string]string{suffixAnnotation: "true", testgridDashboardsAnnotation: "sig-release-1.15-all"},
 			},
 		},
 		{
@@ -596,8 +596,8 @@ func TestGeneratePeriodics(t *testing.T) {
 			JobBase: config.JobBase{
 				Name: "periodic-with-replacements-1-15",
 				Annotations: map[string]string{
-					periodicIntervalAnnotation: "12h 24h 24h",
-					"testgrid-dashboards":      "sig-release-1.15-all",
+					periodicIntervalAnnotation:   "12h 24h 24h",
+					testgridDashboardsAnnotation: "sig-release-1.15-all",
 				},
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{
@@ -614,7 +614,7 @@ func TestGeneratePeriodics(t *testing.T) {
 			Interval: "2h",
 			JobBase: config.JobBase{
 				Name:        "decorated-periodic-1-15",
-				Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
+				Annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-all"},
 				UtilityConfig: config.UtilityConfig{
 					Decorate:  true,
 					ExtraRefs: []prowapi.Refs{{Org: "kubernetes", Repo: "kubernetes", BaseRef: "release-1.15"}},
@@ -649,9 +649,9 @@ func TestGeneratePostsubmits(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "post-kubernetes-generic",
 					Annotations: map[string]string{
-						forkAnnotation:        "true",
-						suffixAnnotation:      "true",
-						"testgrid-dashboards": "sig-release-master-blocking, google-unit",
+						forkAnnotation:               "true",
+						suffixAnnotation:             "true",
+						testgridDashboardsAnnotation: "sig-release-master-blocking, google-unit",
 					},
 				},
 				Brancher: config.Brancher{
@@ -694,7 +694,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 			{
 				JobBase: config.JobBase{
 					Name:        "post-kubernetes-e2e-1-15",
-					Annotations: map[string]string{"testgrid-dashboards": "sig-release-1.15-all"},
+					Annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-all"},
 				},
 				Brancher: config.Brancher{
 					Branches: []string{"release-1.15"},
@@ -704,8 +704,8 @@ func TestGeneratePostsubmits(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "post-kubernetes-generic-beta",
 					Annotations: map[string]string{
-						suffixAnnotation:      "true",
-						"testgrid-dashboards": "sig-release-1.15-blocking, google-unit, sig-release-1.15-all",
+						suffixAnnotation:             "true",
+						testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit, sig-release-1.15-all",
 					},
 				},
 				Brancher: config.Brancher{
@@ -716,8 +716,8 @@ func TestGeneratePostsubmits(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "post-replace-some-things-1-15",
 					Annotations: map[string]string{
-						"some-annotation":     "yup",
-						"testgrid-dashboards": "sig-release-1.15-all",
+						"some-annotation":            "yup",
+						testgridDashboardsAnnotation: "sig-release-1.15-all",
 					},
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{


### PR DESCRIPTION
Teach config-forker how it's supposed to mangle testgrid-related annotations:

* `master-blocking` -> `<version>-blocking`
* `master-informing` -> `<version>-informing`
* Add `sig-release-<version>-all` for non-presubmit jobs
* Remove `description` (until I come up with something smarter to do).
* Replace `master` in tab names with `<version>`

/cc @spiffxp 