### PR TITLE
Add config-rotator

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -56,6 +56,7 @@ filegroup(
         "//experiment/aws-stockout:all-srcs",
         "//experiment/ci-janitor:all-srcs",
         "//experiment/config-forker:all-srcs",
+        "//experiment/config-rotator:all-srcs",
         "//experiment/coverage:all-srcs",
         "//experiment/dummybenchmarks:all-srcs",
         "//experiment/image-bumper:all-srcs",

--- a/experiment/config-rotator/BUILD.bazel
+++ b/experiment/config-rotator/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/config-rotator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "config-rotator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:private"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    visibility = ["//visibility:public"],
+    tags = ["automanaged"],
+)

--- a/experiment/config-rotator/BUILD.bazel
+++ b/experiment/config-rotator/BUILD.bazel
@@ -20,13 +20,13 @@ go_binary(
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
-    visibility = ["//visibility:private"],
     tags = ["automanaged"],
+    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
-    visibility = ["//visibility:public"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )

--- a/experiment/config-rotator/README.md
+++ b/experiment/config-rotator/README.md
@@ -1,0 +1,25 @@
+# config-rotator
+
+config-rotator rotated forked presubmit, periodic, and postsubmit job configs created by `config-forker`.
+
+## Usage
+
+* `--config-file`: Path to the job config to rotate
+* `--new`: Version to rotate to (one of stable1, stable2, stable3)
+* `--old`: Version to rotate from (one of beta, stable1, stable2)
+
+## Actions taken
+
+For the sake of clarity, all the below will assume we are rotating with `--old stable1 --new stable2`.
+
+For all jobs:
+
+- References to `stable1` in `args` will be replaced with `stable2`
+- References to `stable1` in `command` will be replaced with `stable2`
+- References to `stable1` in the job name will be replaced with `stable2`
+
+For periodics:
+
+- References to `stable1` in the job `tags` will replaced with `stable2`
+- If `fork-per-release-periodic-interval` or `fork-per-release-cron` has a non-empty list of values, the leftmost
+  value will be popped off and used to replace the current `interval` or `cron`, respectively.

--- a/experiment/config-rotator/main.go
+++ b/experiment/config-rotator/main.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"sigs.k8s.io/yaml"
+	"strings"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+type options struct {
+	configFile string
+	oldVersion string
+	newVersion string
+}
+
+func cdToRootDir() error {
+	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
+		if err := os.Chdir(bazelWorkspace); err != nil {
+			return fmt.Errorf("failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func parseFlags() options {
+	o := options{}
+	flag.StringVar(&o.configFile, "config-file", "", "Path to the job config")
+	flag.StringVar(&o.oldVersion, "old", "", "Old version (beta, stable1, or stable2)")
+	flag.StringVar(&o.newVersion, "new", "", "New version (stable1, stable2, or stable3)")
+	flag.Parse()
+	return o
+}
+
+func validateOptions(o options) error {
+	if o.configFile == "" {
+		return errors.New("--config-file must be specified")
+	}
+	if o.newVersion == "" {
+		return errors.New("--new must be specified")
+	}
+	if o.oldVersion == "" {
+		return errors.New("--old must be specified")
+	}
+	return nil
+}
+
+func updateString(s, old, new string) string {
+	return strings.ReplaceAll(s, old, new)
+}
+
+func updateJobBase(j *config.JobBase, old, new string) {
+	j.Name = updateString(j.Name, old, new)
+	for i := range j.Spec.Containers {
+		c := &j.Spec.Containers[i]
+		for j := range c.Args {
+			c.Args[j] = updateString(c.Args[j], old, new)
+		}
+		for j := range c.Command {
+			c.Command[j] = updateString(c.Command[j], old, new)
+		}
+	}
+}
+
+func updateEverything(c *config.JobConfig, old, new string) {
+	for _, presubmits := range c.Presubmits {
+		for i := range presubmits {
+			updateJobBase(&presubmits[i].JobBase, old, new)
+		}
+	}
+	for _, postsubmits := range c.Postsubmits {
+		for i := range postsubmits {
+			updateJobBase(&postsubmits[i].JobBase, old, new)
+		}
+	}
+	for i := range c.Periodics {
+		p := &c.Periodics[i]
+		updateJobBase(&p.JobBase, old, new)
+		for k, v := range p.Annotations {
+			if k == "fork-per-release-periodic-interval" {
+				f := strings.Fields(v)
+				if len(f) > 0 {
+					p.Interval = f[0]
+					p.Annotations[k] = strings.Join(f[1:], " ")
+				}
+			}
+		}
+		for k, v := range p.Annotations {
+			if k == "fork-per-release-cron" {
+				f := strings.Split(v, ", ")
+				if len(f) > 0 {
+					p.Cron = f[0]
+					p.Annotations[k] = strings.Join(f[1:], ", ")
+				}
+			}
+		}
+		for j := range p.Tags {
+			p.Tags[j] = updateString(p.Tags[j], old, new)
+		}
+	}
+}
+
+func main() {
+	if err := cdToRootDir(); err != nil {
+		log.Fatalln(err)
+	}
+	o := parseFlags()
+	if err := validateOptions(o); err != nil {
+		log.Fatalln(err)
+	}
+	c, err := config.ReadJobConfig(o.configFile)
+	if err != nil {
+		log.Fatalf("Failed to load job config: %v\n", err)
+	}
+	updateEverything(&c, o.oldVersion, o.newVersion)
+
+	output, err := yaml.Marshal(map[string]interface{}{
+		"presubmits":  c.Presubmits,
+		"postsubmits": c.Postsubmits,
+		"periodics":   c.Periodics,
+	})
+	if err != nil {
+		log.Fatalf("Failed to marshal new presubmits: %v\n", err)
+	}
+
+	if err := ioutil.WriteFile(o.configFile, output, 0666); err != nil {
+		log.Fatalf("Failed to write new presubmits: %v.\n", err)
+	}
+}


### PR DESCRIPTION
`config-rotator` is a simple tool to manage the config files previously produced by `config-forker`. 

Assuming we call ask it to rotate `stable1` to `stable` in a given file, it does the following:

For all jobs:

- References to `stable1` in `args` will be replaced with `stable2`
- References to `stable1` in `command` will be replaced with `stable2`
- References to `stable1` in the job name will be replaced with `stable2`

For periodics:

- References to `stable1` in the job `tags` will replaced with `stable2`
- If `fork-per-release-periodic-interval` or `fork-per-release-cron` has a non-empty list of values, the leftmost
  value will be popped off and used to replace the current `interval` or `cron`, respectively.

/cc @spiffxp 