### PR TITLE
Revert fluentd-gcp version to 0.6-1.6.0-1 in gce-5000.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -54,6 +54,7 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
+      - --env=FLUENTD_GCP_VERSION=0.6-1.6.0-1
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale


### PR DESCRIPTION
This is essentially reverting https://github.com/kubernetes/kubernetes/pull/77224/ in our gce 5000 performance tests.

We believe it may be related to https://github.com/kubernetes/kubernetes/issues/76579