### PR TITLE
Fix branch name for ci-kubernetes-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -88,7 +88,7 @@ periodics:
     containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190509-ce5fe7e
         args:
-          - --repo=k8s.io/kubernetes=release
+          - --repo=k8s.io/kubernetes
           - --repo=k8s.io/release
           - --root=/go/src
           - --timeout=180


### PR DESCRIPTION
This should make https://testgrid.k8s.io/sig-release-master-blocking#build-master green.
Relevant slack message - https://kubernetes.slack.com/archives/C2C40FMNF/p1557837677253500

xref https://github.com/kubernetes/test-infra/pull/12516
/assign @Katharine 