### PR TITLE
Remove ixdy from SIG Release job owners

### DIFF
--- a/config/jobs/kubernetes/sig-release/OWNERS
+++ b/config/jobs/kubernetes/sig-release/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
 - calebamiles
-- ixdy
 - justaugustus
 - tpepper
 


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/pull/12247#discussion_r276862762 (@cblecker)
> I think @ixdy should probably be pulled back from this.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @tpepper 
/cc @ixdy 