### PR TITLE
Updating planter to use bazel 0.25

### DIFF
--- a/planter/cloudbuild.yaml
+++ b/planter/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
             '.' ]
     dir: planter/
 substitutions:
-  _BAZEL_VERSION: '0.20'
+  _BAZEL_VERSION: '0.25.2'
 options:
   substitution_option: ALLOW_LOOSE  # because _GIT_TAG is provided but not used.
 images:


### PR DESCRIPTION
Updating planter to install by default bazel 0.25.2.

I am using planter as a base image for one of my containers.  Looking to jump to 0.25.2.