### PR TITLE
Use bazel 0.25.2 for test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
       - name: third
         image: busybox
         args: ["cat", "config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml"]
+
   - name: pull-test-infra-build-smoke-fail
     agent: knative-build
     decorate: true
@@ -39,13 +40,12 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.25.2
         command:
         - hack/bazel.sh
         args:
         - test
         - --config=ci
-        - --config=unit
         - --nobuild_tests_only
         - //...
 
@@ -64,85 +64,6 @@ presubmits:
         env:
         - name: WORKSPACE
           value: "/workspace"
-
-  - name: pull-test-infra-lint
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
-        command:
-        - hack/bazel.sh
-        args:
-        - test
-        - --config=ci
-        - --config=lint
-        - //...
-
-  - name: pull-test-infra-verify-config
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-d37ef86-experimental
-        command:
-        - runner.sh
-        args:
-        - ./hack/verify-config.sh
-        resources:
-          requests:
-            memory: "2Gi"
-
-  - name: pull-test-infra-verify-config-canary
-    branches:
-    - master
-    path_alias: "k8s.io/test-infra"
-    decorate: true
-    spec:
-      containers:
-      - name: test
-        command:
-        - ./hack/verify-config.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-d37ef86-experimental
-        env:
-        - name: TEST_TMPDIR
-          value: /bazel-scratch/.cache/bazel
-        resources:
-          requests:
-            memory: "2Gi"
-        volumeMounts:
-        - name: bazel-scratch
-          mountPath: /bazel-scratch/.cache
-      volumes:
-      - name: bazel-scratch
-        emptyDir: {}
-
-  - name: pull-test-infra-verify-deps
-    branches:
-    - master
-    run_if_changed: '^(go\.mod|go\.sum|WORKSPACE|BUILD\.bazel|hack/verify-deps\.sh|hack/update-deps\.sh|vendor/.*)$'
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-d37ef86-experimental
-        command:
-        - runner.sh
-        args:
-        - ./hack/verify-deps.sh
-        resources:
-          requests:
-            memory: "2Gi"
 
   - name: pull-test-infra-verify-codegen
     branches:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -866,21 +866,8 @@ test_groups:
 - name: pull-test-infra-bazel-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-bazel-canary
   num_columns_recent: 20
-- name: pull-test-infra-lint
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-lint
-  num_columns_recent: 20
 - name: pull-test-infra-gubernator
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-gubernator
-  num_columns_recent: 20
-- name: pull-test-infra-verify-config
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-config
-  num_columns_recent: 20
-- name: pull-test-infra-verify-config-canary
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-config-canary
-  days_of_results: 1
-  num_columns_recent: 20
-- name: pull-test-infra-verify-deps
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-deps
   num_columns_recent: 20
 - name: pull-test-infra-verify-file-perms
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-file-perms
@@ -5024,9 +5011,6 @@ dashboards:
   - name: bazel
     test_group_name: pull-test-infra-bazel
     base_options: width=10
-  - name: lint
-    test_group_name: pull-test-infra-lint
-    base_options: width=10
   - name: bazel-canary
     test_group_name: pull-test-infra-bazel-canary
     base_options: width=10
@@ -5035,15 +5019,6 @@ dashboards:
     base_options: width=10
   - name: verify-file-perms
     test_group_name: pull-test-infra-verify-file-perms
-    base_options: width=10
-  - name: verify-config
-    test_group_name: pull-test-infra-verify-config
-    base_options: width=10
-  - name: verify-config-canary
-    test_group_name: pull-test-infra-verify-config-canary
-    base_options: width=10
-  - name: verify-deps
-    test_group_name: pull-test-infra-verify-deps
     base_options: width=10
   - name: verify-codegen
     test_group_name: pull-test-infra-verify-codegen


### PR DESCRIPTION
* Also retire jobs now covered by bazel


* Canary on 0.25.2 - https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/12632/pull-test-infra-bazel-canary/1128375155878268935
  - Note also the 11 extra lint targets, including:
  - `//hack:verify-config`, `//hack:verify-deps`, `//hack:verify-pylint`, etc
* 0.24.1 - https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/test-infra/12632/pull-test-infra-bazel/1128375155878268930


/assign @krzyzacy @michelle192837 