### PR TITLE
Enable /project for the website repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -269,6 +269,13 @@ project_config:
               To do
             Workloads:
               Backlog
+        website:
+          repo_maintainers_team_id: 3175912 # website-milestone-maintainers
+          repo_default_column_map:
+            component-base:
+              To do
+            Doc Writing and Editing:
+              To do
     kubeflow:
       org_maintainers_team_id: 3198542 # kubeflow-project-maintainers
 
@@ -482,6 +489,7 @@ plugins:
 
   kubernetes/website:
   - milestone
+  - project
 
   kubernetes-client:
   - approve


### PR DESCRIPTION
This PR enables the `/project` command for the specified k/website team.

/assign @fejta
/assign @taragu 
/area prow
/sig docs