### PR TITLE
Enforce release-master-blocking jobs must have alerts

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
@@ -23,7 +23,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: gce-device-plugin-gpu-master
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
-    description: "OWNER: sig-scheduling; Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -8,7 +8,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-master
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
-    description: "OWNER: sig-node; Uses kubetest to run a subset of node-e2e tests (+NodeConformance, -Flaky|Serial)"
+    description: "Uses kubetest to run a subset of node-e2e tests (+NodeConformance, -Flaky|Serial)"
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -86,7 +86,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: build-master
-    description: "OWNER: sig-release (rel-engineering)"
+    testgrid-alert-email: "kuberentes-release-team@googlegroups.com"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190509-ce5fe7e

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -100,7 +100,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com
-    description: "OWNER: sig-scalability;  Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-d37ef86-master

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -62,7 +62,7 @@ postsubmits:
       testgrid-dashboards: sig-release-master-blocking, google-unit
       testgrid-tab-name: bazel-build-master
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
-      description: "OWNER: sig-testing; Builds kubernetes using bazel"
+      description: "Builds kubernetes using bazel"
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -71,7 +71,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: integration-master
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    description: "OWNER: sig-release (release-team); Ends up running: make test-cmd test-integration"
+    description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20190509-ce5fe7e

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -113,7 +113,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: verify-master
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
-    description: "OWNER: sig-testing; Ends up running: make verify"
+    description: "Ends up running: make verify"
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -476,16 +476,20 @@ func TestReleaseBlockingJobsMustHaveTestgridDescriptions(t *testing.T) {
 				t.Errorf("%v: - Must have a description", intro)
 			}
 			// TODO(spiffxp): enforce for informing as well
-			if suffix == "blocking" {
-				// TODO(spiffxp): remove this check when alert_options are populated
+			if suffix == "informing" {
 				if !strings.HasPrefix(dashboardtab.Description, "OWNER: ") {
-					t.Errorf("%v: - Must have a description that starts with OWNER: ", intro)
+					t.Logf("NOTICE: %v: - Must have a description that starts with OWNER: ", intro)
 				}
-				// TODO(spiffxp): convert these from a warn to failure once alert_options are populated
 				if dashboardtab.AlertOptions == nil {
 					t.Logf("NOTICE: %v: - Must have alert_options", intro)
 				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
 					t.Logf("NOTICE: %v: - Must have alert_options.alert_mail_to_addresses", intro)
+				}
+			} else {
+				if dashboardtab.AlertOptions == nil {
+					t.Errorf("%v: - Must have alert_options", intro)
+				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
+					t.Errorf("%v: - Must have alert_options.alert_mail_to_addresses", intro)
 				}
 			}
 		}

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2525,47 +2525,49 @@ dashboards:
   dashboard_tab:
   - name: build-master-fast
     test_group_name: ci-kubernetes-build-fast
-    description: "OWNER: sig-release (release-engineering); Ends up running: make quick-release"
+    description: "Ends up running: make quick-release"
     alert_options:
       alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
   - name: gce-cos-master-default
     test_group_name: ci-kubernetes-e2e-gci-gce
-    description: "OWNER: sig-release (release-team); Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
     alert_options:
       alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
   - name: gce-cos-master-slow
     test_group_name: ci-kubernetes-e2e-gci-gce-slow
-    description: "OWNER: sig-release (release-team); Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
     alert_options:
       alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
   - name: gce-cos-master-serial
     test_group_name: ci-kubernetes-e2e-gci-gce-serial
-    description: "OWNER: sig-release (release-team); Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
+    alert_options:
+      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
   - name: gce-cos-master-alpha-features
     test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-    description: "OWNER: sig-release (release-team); Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh"
     alert_options:
       alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
   - name: gce-cos-master-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-    description: "OWNER: sig-networking (ingress); Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh"
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
 - name: sig-release-master-informing
   dashboard_tab:
   - name: bazel-build-master
-    description: Builds kubernetes at each bommit using bazel with RBE
     test_group_name: post-kubernetes-bazel-build
+    description: "OWNER: sig-testing; Builds kubernetes at each bommit using bazel with RBE"
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-    description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
+    description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
   - name: Conformance - vSphere-cloud-provider
     test_group_name: ci-cloud-provider-vsphere-conformance-latest
-    description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere
+    description: "OWNER: sig-vmware; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere"
   - name: Conformance - vSphere
     test_group_name: ci-vsphere-conformance-latest
-    description: Runs conformance tests using e2e.test against latest kubernetes master with in-tree vSphere
+    description: "OWNER: sig-vmware; Runs conformance tests using e2e.test against latest kubernetes master with in-tree vSphere"
   - name: gce-master-scale-correctness
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
     description: "OWNER: sig-scalability; Runs 1000-node performance test once a week and checks that operational results are still all correct at that scale"
@@ -2586,10 +2588,10 @@ dashboards:
     description: "OWNER: sig-testing; Runs kubernetes unit tests using bazel"
   - name: gce-new-master-upgrade-master
     test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-master
-    description: Upgrade master only, in gce(gci), from 1.14 to master, run non-parallel-safe tests only
+    description: "OWNER: kube-up-owners; Upgrade master only, in gce(gci), from 1.14 to master, run non-parallel-safe tests only"
   - name: gce-new-master-upgrade-master-parallel
     test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-master-parallel
-    description: Upgrade master only, in gce(gci), from 1.14 to master, run parallel tests only
+    description: "OWNER: kube-upowners; Upgrade master only, in gce(gci), from 1.14 to master, run parallel tests only"
   - name: gce-new-master-upgrade-cluster-parallel
     test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-parallel
     description: Upgrade master and node, in gce(gci), from 1.14 to master, run parallel tests only


### PR DESCRIPTION
Drop the OWNERS: in description requirement, and drop the OWNERS
entry from descriptions; it's stringly typed data, and the e-mail
address is more representative of owner, less likely to fall
out of date.

Start down the same path for -informing jobs

touchup: build-master was missing an alert e-mail

This basically wraps up https://github.com/kubernetes/sig-release/issues/441