### PR TITLE
Drop more pylint rules

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=fixme,locally-disabled,locally-enabled,relative-import,too-few-public-methods,missing-docstring,ungrouped-imports,too-many-lines,too-many-locals
+disable=fixme,locally-disabled,locally-enabled,relative-import,too-few-public-methods,missing-docstring,ungrouped-imports,too-many-lines,too-many-locals,invalid-name,superfluous-parens
 
 [REPORTS]
 reports=no


### PR DESCRIPTION
Being yelled at because `print` has "superfluous parens" is absurd.