### PR TITLE
Add go to path

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -46,6 +46,7 @@ else
 fi
 
 go=$(realpath "$1")
+export PATH=$(dirname "$go"):$PATH
 gazelle=$(realpath "$2")
 kazel=$(realpath "$3")
 update_bazel=(


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/12487

Otherwise we get `gazelle: error parsing "go.mod": exec: "go": executable file not found in $PATH` errors when we use an image that doesn't already have go on the path (and in this scenario it may be the wrong version): https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-autoupdate-patch/1125416539466502145

/assign @BenTheElder @krzyzacy 