### PR TITLE
Update bazel jobs to 0.25.2

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3215,7 +3215,7 @@ presubmits:
           ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
         volumeMounts:
@@ -3257,7 +3257,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
         volumeMounts:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -16,7 +16,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.25.2
         command:
         - bash
         args:
@@ -39,7 +39,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.25.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -133,7 +133,7 @@ postsubmits:
     - release-\d+.\d+ # per-release job
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.25.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -162,7 +162,7 @@ postsubmits:
     - release-\d+.\d+ # per-release job
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.25.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -229,7 +229,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+    - image: launcher.gcr.io/google/bazel
       imagePullPolicy: Always
       command:
       - bash
@@ -265,7 +265,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.24.1
+    - image: launcher.gcr.io/google/bazel:0.25.2
       command:
       - ../test-infra/hack/bazel.sh
       args:


### PR DESCRIPTION
/assign @mikedanese @cjwagner @michelle192837 

* Passing with https://github.com/kubernetes/kubernetes/pull/77853 -- https://testgrid.k8s.io/sig-testing-canaries#bazel-test
* Includes a stability fix around pulling images concurrently
* Also switch `periodic-kubernetes-bazel-build-canary` over to use the official bazel image


