### PR TITLE
Update docker in bootstrap image to 18.09

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -97,10 +97,8 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # We're already inside docker though so we can be sure these are already mounted.
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
-# TODO(benthelder): update docker version. This is pinned because of
-# https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce=18.06.* && \
+    apt-get install -y --no-install-recommends docker-ce=5:18.09.* && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 


### PR DESCRIPTION
Update docker in the bootstrap image to 18.09. This solves https://github.com/moby/moby/issues/37581.
#6187 solved, which per comment in the Dockerfile was the reason for pinning the older docker version.