### PR TITLE
Add kubernetes-sigs/release-notes jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/OWNERS
+++ b/config/jobs/kubernetes-sigs/release-notes/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - jeefy
+  - marpaia
+  - onyiny-ang
+  - sig-release-leads

--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -1,0 +1,93 @@
+---
+presubmits:
+  kubernetes-sigs/release-notes:
+    - name: pull-release-notes-build-dev
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run build-dev
+
+    - name: pull-release-notes-build-prod
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run build-prod
+
+    - name: pull-release-notes-check-prettier
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run check-prettier
+
+    - name: pull-release-notes-doc
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run doc
+
+    - name: pull-release-notes-e2e
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: cypress/base:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run e2e-cy-ci
+
+    - name: pull-release-notes-lint
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run lint
+
+    - name: pull-release-notes-test
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: node:11
+            command:
+              - /bin/bash
+              - -c
+              - >
+                npm ci &&
+                npm run test

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1935,6 +1935,29 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/ci-ingress-nginx-e2e
   num_columns_recent: 20
 
+# kubernetes-sigs/release-notes
+- name: pull-release-notes-build-dev
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-build-dev
+  num_columns_recent: 30
+- name: pull-release-notes-build-prod
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-build-prod
+  num_columns_recent: 30
+- name: pull-release-notes-check-prettier
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-check-prettier
+  num_columns_recent: 30
+- name: pull-release-notes-doc
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-doc
+  num_columns_recent: 30
+- name: pull-release-notes-e2e
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-e2e
+  num_columns_recent: 30
+- name: pull-release-notes-lint
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-lint
+  num_columns_recent: 30
+- name: pull-release-notes-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-notes-test
+  num_columns_recent: 30
+
 #
 # Start dashboards
 #
@@ -6158,6 +6181,30 @@ dashboards:
     description: k8s1.14.x node conformance test results for ee-19.03 on ubuntu16.04
 #
 
+- name: presubmits-release-notes-master
+  dashboard_tab:
+  - name: build-dev
+    test_group_name: pull-release-notes-build-dev
+    base_options: width=10
+  - name: build-prod
+    test_group_name: pull-release-notes-build-prod
+    base_options: width=10
+  - name: check-prettier
+    test_group_name: pull-release-notes-check-prettier
+    base_options: width=10
+  - name: doc
+    test_group_name: pull-release-notes-doc
+    base_options: width=10
+  - name: e2e
+    test_group_name: pull-release-notes-e2e
+    base_options: width=10
+  - name: lint
+    test_group_name: pull-release-notes-lint
+    base_options: width=10
+  - name: test
+    test_group_name: pull-release-notes-test
+    base_options: width=10
+
 #
 # Start dashboard groups
 #
@@ -6387,3 +6434,7 @@ dashboard_groups:
 - name: presubmits-cloud-provider
   dashboard_names:
   - presubmits-cloud-provider-alibaba
+
+- name: presubmits-release-notes
+  dashboard_names:
+  - presubmits-release-notes-master


### PR DESCRIPTION
This PR adds the release notes jobs including the owner file for [kubernetes-sigs/release-notes](https://github.com/kubernetes-sigs/release-notes). On my local tests with phaino the `$JOB_NAME` environment variable was not exposed, which is hopefully only related to the tooling.

A good-to-test PR would be https://github.com/kubernetes-sigs/release-notes/pull/26