### PR TITLE
Increase coredns memory limit to 300Mi

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -54,6 +54,9 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
+      # TODO(mborsz): Adjust or remove this change once we understand coredns
+      # memory usage regression.
+      - --env=DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale


### PR DESCRIPTION
The goal is to:
* check what is the real memory usage (right now it's capped at 170Mi)
* check if this is the only regression we have right now

The `DNS_MEMORY_LIMIT` is added in https://github.com/kubernetes/kubernetes/pull/77918 which hopefully will be merged soon.

/assign @wojtek-t 