### PR TITLE
    Fixing issues with project card create operation.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -214,6 +214,7 @@ type PullRequestEvent struct {
 
 // PullRequest contains information about a PullRequest.
 type PullRequest struct {
+	ID                 int               `json:"id"`
 	Number             int               `json:"number"`
 	HTMLURL            string            `json:"html_url"`
 	User               User              `json:"user"`
@@ -510,6 +511,7 @@ type IssueCommentEvent struct {
 
 // Issue represents general info about an issue.
 type Issue struct {
+	ID        int       `json:"id"`
 	User      User      `json:"user"`
 	Number    int       `json:"number"`
 	Title     string    `json:"title"`
@@ -861,6 +863,7 @@ const (
 // Issue and PR "closed" events are not coerced to the "deleted" Action and do not trigger
 // a GenericCommentEvent because these events don't actually remove the comment content from GH.
 type GenericCommentEvent struct {
+	ID           int `json:"id"`
 	IsPR         bool
 	Action       GenericCommentEventAction
 	Body         string

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -189,6 +189,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 	s.handleGenericComment(
 		l,
 		&github.GenericCommentEvent{
+			ID:           pr.PullRequest.ID,
 			GUID:         pr.GUID,
 			IsPR:         true,
 			Action:       action,
@@ -262,6 +263,7 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 	s.handleGenericComment(
 		l,
 		&github.GenericCommentEvent{
+			ID:           i.Issue.ID,
 			GUID:         i.GUID,
 			IsPR:         i.Issue.IsPullRequest(),
 			Action:       action,
@@ -312,6 +314,7 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 	s.handleGenericComment(
 		l,
 		&github.GenericCommentEvent{
+			ID:           ic.Issue.ID,
 			GUID:         ic.GUID,
 			IsPR:         ic.Issue.IsPullRequest(),
 			Action:       action,

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -325,7 +325,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	}
 
 	projectCard := github.ProjectCard{}
-	projectCard.ContentID = e.Number
+	projectCard.ContentID = e.ID
 	if e.IsPR {
 		projectCard.ContentType = "PullRequest"
 	} else {


### PR DESCRIPTION
    Co-authored-by: Hippy Hacker <hh@ii.coop>

/kind bug
/release-note-none

Create card requires the object id of the PR or issue.  Code is added to address the bug and fetch the GitHub objectid into the contented of the card to satisfy the api requirement.
