### PR TITLE
Publish tooling images

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -25,6 +25,8 @@ prow_push(
         "horologium",
         "initupload",
         "jenkins-operator",
+        "mkpj",
+        "mkpod",
         "peribolos",
         "plank",
         "sidecar",

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -6,6 +6,12 @@ load(
     "go_library",
     "go_test",
 )
+load("//prow:def.bzl", "prow_image")
+
+prow_image(
+    name = "image",
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/prow/cmd/mkpod/BUILD.bazel
+++ b/prow/cmd/mkpod/BUILD.bazel
@@ -1,4 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
+
+prow_image(
+    name = "image",
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",


### PR DESCRIPTION
Downstream developers working with Prow would like to be able to use
canonical verisons of tooling like `mkpj` and `mkpod` for their
deployments. Building and publishing images for these tools lets that
happen.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta @krzyzacy 