### PR TITLE
bump kind ipv6 job to v20190516-576b68c-master

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -35,7 +35,7 @@ presubmits:
     optional: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190516-e3e3537-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190516-576b68c-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"


### PR DESCRIPTION
picks up actually using `cat` + heredocs correctly