### PR TITLE
Use Pod Utilities for cloud-provider-alibaba-cloud jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
@@ -10,13 +10,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-6c3cafa-master
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
+        command:
         - make
+        args:
         - check
 
   - name: pull-cloud-provider-alibaba-cloud-unit-test
@@ -29,11 +25,7 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190514-6c3cafa-master
-        args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
+        command:
         - make
+        args:
         - unit-test


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/12678

The jobs use `decorate: true` right now but don't use pod utilities. I'm guessing that's why the logs don't show up in https://github.com/kubernetes/cloud-provider-alibaba-cloud/pull/53.

/assign @fejta @sunyuan3 
