### PR TITLE
use the pouchcontainer/pouchlinter:v0.1.2 image

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-alibaba-cloud
     spec:
       containers:
-      - image: quay.io/kubermatic/gometalinter:latest
+      - image: pouchcontainer/pouchlinter:v0.1.2
         command:
         - make
         args:


### PR DESCRIPTION
Since ineffassign is not included in quay.io/kubermatic/gometalinter:latest, use pouchcontainer/pouchlinter:v0.1.2.

Signed-off-by: Yuan Sun <yile.sy@alibaba-inc.com>