### PR TITLE
Override cos version used by nodes in scalability tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -120,8 +120,11 @@ presets:
   # Keep all logrotated files (not just 5 latest which is a default)
   - name: LOGROTATE_FILES_MAX_COUNT
     value: 1000
-  # Experimentally use cos-69-10895-138-0 to test fs-related fixes there.
+  # TODO(mborsz): Remove overrides when we understand if new cos
+  # causes performance regression.
   - name: KUBE_GCE_MASTER_IMAGE
+    value: cos-69-10895-138-0
+  - name: KUBE_GCE_NODE_IMAGE
     value: cos-69-10895-138-0
   - name: ENABLE_PROMETHEUS_SERVER
     value: "true"


### PR DESCRIPTION
The goal is to understand if changing cos version causes performance regression.