### PR TITLE
Add jobs for kubernetes/ingress-nginx

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
@@ -1,0 +1,206 @@
+presubmits:
+
+  kubernetes/ingress-nginx:
+  - name: pull-ingress-nginx-boilerplate
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - ./hack/verify-boilerplate.sh
+
+  - name: pull-ingress-nginx-codegen
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - ./hack/verify-codegen.sh
+
+  - name: pull-ingress-nginx-gofmt
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - ./hack/verify-gofmt.sh
+
+  - name: pull-ingress-nginx-golint
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - ./hack/verify-golint.sh
+
+  - name: pull-ingress-nginx-test-lua
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - make
+        - lua-test
+
+  - name: pull-ingress-nginx-test
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e:v05132019-4a7d93287
+        command:
+        - /bin/bash
+        - -c
+        - "GIT_COMMIT=${PULL_PULL_SHA} make cover"
+        env:
+        - name: CODECOV_TOKEN
+          value: 9d09c10d-af0f-446e-94a2-e534c604d235
+
+  - name: pull-ingress-nginx-e2e-1-12
+    always_run: true
+    decorate: true
+    max_concurrency: 5
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e-prow:v05152019-a4eaa09a5
+        command:
+        - /usr/local/bin/runner.sh
+        args:
+        - make
+        - kind-e2e-test
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: REPO_INFO
+          value: https://github.com/kubernetes/ingress-nginx
+        - name: E2E_NODES
+          value: "15"
+        - name: K8S_VERSION
+          value: v1.12.8
+        resources:
+          requests:
+            cpu: 2
+
+  - name: pull-ingress-nginx-e2e-1-13
+    always_run: true
+    decorate: true
+    max_concurrency: 5
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e-prow:v05152019-a4eaa09a5
+        command:
+        - /usr/local/bin/runner.sh
+        args:
+        - make
+        - kind-e2e-test
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: REPO_INFO
+          value: https://github.com/kubernetes/ingress-nginx
+        - name: E2E_NODES
+          value: "15"
+        - name: K8S_VERSION
+          value: v1.13.6
+        resources:
+          requests:
+            cpu: 2
+
+  - name: pull-ingress-nginx-e2e-1-14
+    always_run: true
+    decorate: true
+    max_concurrency: 5
+    path_alias: k8s.io/ingress-nginx
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/e2e-prow:v05152019-a4eaa09a5
+        command:
+        - /usr/local/bin/runner.sh
+        args:
+        - make
+        - kind-e2e-test
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: REPO_INFO
+          value: https://github.com/kubernetes/ingress-nginx
+        - name: E2E_NODES
+          value: "15"
+        - name: K8S_VERSION
+          value: v1.14.1
+        resources:
+          requests:
+            cpu: 2
+
+periodics:
+
+- name: ci-ingress-nginx-e2e
+  interval: 12h
+  max_concurrency: 1
+  decorate: true
+  path_alias: k8s.io/ingress-nginx
+  labels:
+    preset-kind-volume-mounts: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: quay.io/kubernetes-ingress-controller/e2e-prow:v05152019-a4eaa09a5
+      command:
+      - /usr/local/bin/runner.sh
+      args:
+      - make
+      - kind-e2e-test
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      env:
+      - name: REPO_INFO
+        value: https://github.com/kubernetes/ingress-nginx
+      - name: E2E_NODES
+        value: "15"
+      resources:
+        requests:
+          cpu: 2

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1746,6 +1746,38 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-community-verify
   num_columns_recent: 20
 
+# ingress-nginx
+- name: pull-ingress-nginx-boilerplate
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-boilerplate
+  num_columns_recent: 20
+- name: pull-ingress-nginx-codegen
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-codegen
+  num_columns_recent: 20
+- name: pull-ingress-nginx-gofmt
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-gofmt
+  num_columns_recent: 20
+- name: pull-ingress-nginx-golint
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-golint
+  num_columns_recent: 20
+- name: pull-ingress-nginx-test-lua
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-test-lua
+  num_columns_recent: 20
+- name: pull-ingress-nginx-test
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-test
+  num_columns_recent: 20
+- name: pull-ingress-nginx-e2e-1-12
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-e2e-1-12
+  num_columns_recent: 20
+- name: pull-ingress-nginx-e2e-1-13
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-e2e-1-13
+  num_columns_recent: 20
+- name: pull-ingress-nginx-e2e-1-14
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-ingress-nginx-e2e-1-14
+  num_columns_recent: 20
+- name: ci-ingress-nginx-e2e
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/ci-ingress-nginx-e2e
+  num_columns_recent: 20
+
 #
 # Start dashboards
 #
@@ -3931,6 +3963,29 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
+- name: sig-network-ingress-nginx
+  dashboard_tab:
+  - name: boilerplate
+    test_group_name: pull-ingress-nginx-boilerplate
+  - name: codegen
+    test_group_name: pull-ingress-nginx-codegen
+  - name: gofmt
+    test_group_name: pull-ingress-nginx-gofmt
+  - name: golint
+    test_group_name: pull-ingress-nginx-golint
+  - name: test-lua
+    test_group_name: pull-ingress-nginx-test-lua
+  - name: test
+    test_group_name: pull-ingress-nginx-test
+  - name: e2e-1-12
+    test_group_name: pull-ingress-nginx-e2e-1-12
+  - name: e2e-1-13
+    test_group_name: pull-ingress-nginx-e2e-1-13
+  - name: e2e-1-14
+    test_group_name: pull-ingress-nginx-e2e-1-14
+  - name: ci-e2e
+    test_group_name: ci-ingress-nginx-e2e
+
 - name: sig-network-netd
   dashboard_tab:
   - name: e2e-gci-gce-netd
@@ -5884,6 +5939,7 @@ dashboard_groups:
   - sig-network-gce
   - sig-network-gke
   - sig-network-ingress-gce-e2e
+  - sig-network-ingress-nginx
   - sig-network-netd
 
 - name: sig-node


### PR DESCRIPTION
to migrate the project from travis-ci to Prow.
I've been testing these jobs with a custom prow installation http://prow.rocket-science.io/ using my ingress fork to test the prow integration https://github.com/aledbf/ingress-nginx/pull/7
