### PR TITLE
Add new release branches to testgrid dashboard for OpenShift

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1666,12 +1666,20 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
 - name: release-openshift-origin-installer-e2e-aws-serial-4.1
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
+- name: release-openshift-origin-installer-e2e-aws-4.2
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
+- name: release-openshift-origin-installer-e2e-aws-serial-4.2
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
 - name: release-openshift-origin-installer-e2e-aws-upgrade
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade
 - name: release-openshift-ocp-installer-e2e-aws-4.1
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.1
 - name: release-openshift-ocp-installer-e2e-aws-serial-4.1
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.1
+- name: release-openshift-ocp-installer-e2e-aws-4.2
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
+- name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
 - name: release-openshift-osd-e2e-4.0
   gcs_prefix: redhat-openshift-osd-e2e/logs/release-openshift-osd-e2e-4.0
 
@@ -5738,6 +5746,14 @@ dashboards:
     description: Runs Kubernetes serial e2e tests against an OpenShift 4.1 cluster.
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
     base_options: width=10
+  - name: redhat-release-openshift-origin-installer-e2e-aws-4.2
+    description: Runs Kubernetes e2e tests against an OpenShift 4.2 cluster.
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.2
+    base_options: width=10
+  - name: redhat-release-openshift-origin-installer-e2e-aws-serial-4.2
+    description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 cluster.
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
+    base_options: width=10
   - name: redhat-release-openshift-origin-installer-e2e-aws-upgrade
     description: Runs Kubernetes upgrade e2e tests against an OpenShift 4.x cluster.
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade
@@ -5749,6 +5765,14 @@ dashboards:
   - name: redhat-release-openshift-ocp-installer-e2e-aws-serial-4.1
     description: Runs Kubernetes serial e2e tests against an OpenShift 4.1 OCP cluster.
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.1
+    base_options: width=10
+  - name: redhat-release-openshift-ocp-installer-e2e-aws-4.2
+    description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster.
+    test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
+    base_options: width=10
+  - name: redhat-release-openshift-ocp-installer-e2e-aws-serial-4.2
+    description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster.
+    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
     base_options: width=10
   - name: redhat-release-openshift-osd-e2e-4.0
     description: Runs cluster acceptance tests on a OpenShift 4.X cluster created with UHC.


### PR DESCRIPTION
Adds 4 new variants of the release branches to testgrid of the 4.2 (1.14)
release.