### PR TITLE
Add CRD verification to kops jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -247,6 +247,26 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: verify-packages
+  - name: pull-kops-verify-crds
+    branches:
+    - master
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - --scenario=execute
+        - --
+        - ./hack/verify-generate.sh
+
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      testgrid-tab-name: verify-crds
 periodics:
 - interval: 30m
   name: ci-kops-build


### PR DESCRIPTION
Builds on https://github.com/kubernetes/kops/pull/6996 to run verify generate on PRs.

Fixes https://github.com/kubernetes/kops/issues/6892