### PR TITLE
Add job for iSCSI storage tests

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3252,6 +3252,119 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-gce-csi-serial,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce-iscsi
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-gce-iscsi
+    optional: true
+    rerun_command: /test pull-security-kubernetes-e2e-gce-iscsi
+    run_if_changed: (pkg\/volume\/iscsi)
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=150
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --gcp-node-image=ubuntu
+        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-project=ubuntu-os-gke-cloud
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --ginkgo-parallel=30
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
+        - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]
+          --minStartupPods=8
+        - --timeout=120m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-iscsi
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-gce-iscsi,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    cluster: security
+    context: pull-security-kubernetes-e2e-gce-iscsi-serial
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-gce-iscsi-serial
+    optional: true
+    rerun_command: /test pull-security-kubernetes-e2e-gce-iscsi-serial
+    run_if_changed: (pkg\/volume\/iscsi)
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=150
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --gcp-node-image=ubuntu
+        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-project=ubuntu-os-gke-cloud
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
+        - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]
+          --minStartupPods=8
+        - --timeout=120m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-iscsi-serial
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-gce-iscsi-serial,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     cluster: security
     context: pull-security-kubernetes-bazel-build

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -145,3 +145,151 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+  - name: pull-kubernetes-e2e-gce-iscsi
+    always_run: false
+    optional: true
+    run_if_changed: '(pkg\/volume\/iscsi)'
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=150
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --gcp-node-image=ubuntu
+        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-project=ubuntu-os-gke-cloud
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --ginkgo-parallel=30
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
+        - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+        resources:
+          requests:
+            memory: "6Gi"
+  - name: pull-kubernetes-e2e-gce-iscsi-serial
+    always_run: false
+    optional: true
+    run_if_changed: '(pkg\/volume\/iscsi)'
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=150
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --gcp-node-image=ubuntu
+        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-project=ubuntu-os-gke-cloud
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
+        - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
+        - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+        resources:
+          requests:
+            memory: "6Gi"
+
+periodics:
+- interval: 24h
+  name: ci-kubernetes-e2e-gce-iscsi
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  spec:
+    containers:
+    - args:
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes=$(PULL_REFS)
+      - --repo=k8s.io/release
+      - --upload=gs://kubernetes-jenkins/pr-logs
+      - --timeout=150
+      - --scenario=kubernetes_e2e
+      - --
+      - --build=bazel
+      - --cluster=
+      - --extract=local
+      - --gcp-node-image=ubuntu
+      - --image-family=ubuntu-gke-1804-lts-1
+      - --image-project=ubuntu-os-gke-cloud
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --ginkgo-parallel=30
+      - --runtime-config=batch/v2alpha1=true
+      - --stage=gs://kubernetes-release-pull/ci/ci-kubernetes-e2e-gce-iscsi
+      - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+      resources:
+        requests:
+          memory: "6Gi"
+- interval: 24h
+  name: ci-kubernetes-e2e-gce-iscsi-serial
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  spec:
+    containers:
+    - args:
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes=$(PULL_REFS)
+      - --repo=k8s.io/release
+      - --upload=gs://kubernetes-jenkins/pr-logs
+      - --timeout=150
+      - --scenario=kubernetes_e2e
+      - --
+      - --build=bazel
+      - --cluster=
+      - --extract=local
+      - --gcp-node-image=ubuntu
+      - --image-family=ubuntu-gke-1804-lts-1
+      - --image-project=ubuntu-os-gke-cloud
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --runtime-config=batch/v2alpha1=true
+      - --stage=gs://kubernetes-release-pull/ci/ci-kubernetes-e2e-gce-iscsi-serial
+      - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-b03896b-master
+      resources:
+        requests:
+          memory: "6Gi"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -976,6 +976,18 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-scalability-stable3
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-stable3
   num_failures_to_alert: 1
+- name: pull-kubernetes-e2e-gce-iscsi
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-iscsi
+  num_columns_recent: 20
+- name: pull-kubernetes-e2e-gce-iscsi-serial
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-iscsi-serial
+  num_columns_recent: 20
+- name: ci-kubernetes-e2e-gce-iscsi
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-iscsi
+  num_columns_recent: 20
+- name: ci-kubernetes-e2e-gce-iscsi-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-iscsi-serial
+  num_columns_recent: 20
 # GCE Guest compute-image-tools
 - name: ci-daisy-e2e
   gcs_prefix: compute-image-tools-test/logs/ci-daisy-e2e
@@ -4594,6 +4606,19 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-regional-slow
     base_options: include-filter-by-regex=Volume%7Cstorage
     description: storage gke regional slow e2e tests for master branch
+  - name: gce-iscsi
+    test_group_name: ci-kubernetes-e2e-gce-iscsi
+    base_options: include-filter-by-regex=Volume%7Cstorage
+    description: storage iSCSI e2e tests for master branch
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
+  - name: gce-iscsi-serial
+    test_group_name: ci-kubernetes-e2e-gce-iscsi-serial
+    base_options: include-filter-by-regex=Volume%7Cstorage
+    description: storage iSCSI serial e2e tests for master branch
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
+
 
 - name: sig-storage-local-static-provisioner
   dashboard_tab:
@@ -5198,6 +5223,12 @@ dashboards:
     base_options: width=10
   - name: pull-canaries
     test_group_name: pull-kubernetes-dependencies-canary
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-iscsi
+    test_group_name: pull-kubernetes-e2e-gce-iscsi
+    base_options: width=10
+  - name: pull-kubernetes-e2e-gce-iscsi-serial
+    test_group_name: pull-kubernetes-e2e-gce-iscsi-serial
     base_options: width=10
 
 - name: presubmits-cloud-provider-vsphere-blocking


### PR DESCRIPTION
Goal: run iSCSI tests regularly + every time iscsi code is changed.
The iSCSI code changes only rarely, so running once per day should be enough to catch regressions in the other parts of Kubernetes that may affect iscsi.

Prerequisite: Distro with iscsiadm installed on all nodes. That's why it can't run in regular storage jobs that use GCI. `ubuntu-gke-1804-bionic-20180921` works fine without any changes.

Tested with following commands, I tried to translate it into proper prow config fields:

`$ KUBE_GCE_NODE_IMAGE=ubuntu-gke-1804-bionic-20180921 KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud KUBE_NODE_OS_DISTRIBUTION=ubuntu  cluster/kube-up.sh`

```
$ go run hack/e2e.go  -- --test  --test_args="--ginkgo.focus=\[Driver:.iscsi\]"
Ran 48 of 3966 Specs in 3442.416 seconds
SUCCESS! -- 48 Passed | 0 Failed | 0 Pending | 3918 Skipped
```

Edit: reworked to two jobs - one parallel (completes within ~5 minutes), one serial (~10 minutes).
