### PR TITLE
Extract an interface from existing GitHub client and use it throughout the code

### DIFF
--- a/experiment/add-hook/main.go
+++ b/experiment/add-hook/main.go
@@ -41,7 +41,7 @@ type options struct {
 	events   flagutil.Strings
 }
 
-func (o options) githubClient() (*github.Client, error) {
+func (o options) githubClient() (github.Client, error) {
 	agent := &secret.Agent{}
 	if err := agent.Start([]string{o.TokenPath}); err != nil {
 		return nil, fmt.Errorf("start %s: %v", o.TokenPath, err)
@@ -97,7 +97,7 @@ type changer struct {
 	creator func(org string, req github.HookRequest) (int, error)
 }
 
-func orgChanger(client *github.Client) changer {
+func orgChanger(client github.Client) changer {
 	return changer{
 		lister:  client.ListOrgHooks,
 		editor:  client.EditOrgHook,
@@ -105,7 +105,7 @@ func orgChanger(client *github.Client) changer {
 	}
 }
 
-func repoChanger(client *github.Client, repo string) changer {
+func repoChanger(client github.Client, repo string) changer {
 	return changer{
 		lister: func(org string) ([]github.Hook, error) {
 			return client.ListRepoHooks(org, repo)

--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -104,7 +104,7 @@ func call(cmd string, args ...string) error {
 	return c.Run()
 }
 
-func updatePR(gc *github.Client, org, repo, title, body, matchTitle, source, branch string) error {
+func updatePR(gc github.Client, org, repo, title, body, matchTitle, source, branch string) error {
 	logrus.Info("Creating PR...")
 	n, err := updater.UpdatePR(org, repo, title, body, matchTitle, gc)
 	if err != nil {

--- a/maintenance/migratestatus/migrator/migrator.go
+++ b/maintenance/migratestatus/migrator/migrator.go
@@ -218,7 +218,7 @@ type Migrator struct {
 }
 
 // New creates a new migrator with specified options and client.
-func New(mode Mode, client *github.Client, org, repo string, targetBranchFilter func(string) bool, continueOnError bool) *Migrator {
+func New(mode Mode, client github.Client, org, repo string, targetBranchFilter func(string) bool, continueOnError bool) *Migrator {
 	return &Migrator{
 		org:                org,
 		repo:               repo,

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -765,7 +765,7 @@ func orgInvitations(opt options, client inviteClient, orgName string) (sets.Stri
 	return invitees, nil
 }
 
-func configureOrg(opt options, client *github.Client, orgName string, orgConfig org.Config) error {
+func configureOrg(opt options, client github.Client, orgName string, orgConfig org.Config) error {
 	// Ensure that metadata is configured correctly.
 	if !opt.fixOrg {
 		logrus.Infof("Skipping org metadata configuration")
@@ -813,7 +813,7 @@ func configureOrg(opt options, client *github.Client, orgName string, orgConfig 
 	return nil
 }
 
-func configureTeamAndMembers(opt options, client *github.Client, githubTeams map[string]github.Team, name, orgName string, team org.Team, parent *int) error {
+func configureTeamAndMembers(opt options, client github.Client, githubTeams map[string]github.Team, name, orgName string, team org.Team, parent *int) error {
 	gt, ok := githubTeams[name]
 	if !ok { // configureTeams is buggy if this is the case
 		return fmt.Errorf("%s not found in id list", name)

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -446,7 +446,7 @@ func githubToken(choice string) (string, error) {
 	return path, nil
 }
 
-func githubClient(tokenPath string, dry bool) (*github.Client, error) {
+func githubClient(tokenPath string, dry bool) (github.Client, error) {
 	secretAgent := &secret.Agent{}
 	if err := secretAgent.Start([]string{tokenPath}); err != nil {
 		return nil, fmt.Errorf("start agent: %v", err)
@@ -596,7 +596,7 @@ func hmacSecret() string {
 	return fmt.Sprintf("%x", buf)
 }
 
-func findHook(client *github.Client, org, repo string, loc url.URL) (*github.Hook, error) {
+func findHook(client github.Client, org, repo string, loc url.URL) (*github.Hook, error) {
 	loc.Scheme = ""
 	goal := loc.String()
 	var hooks []github.Hook
@@ -665,7 +665,7 @@ func ensureHmac(kc *kubernetes.Clientset, ns string) (string, error) {
 	return hmac, nil
 }
 
-func enableHooks(client *github.Client, loc url.URL, secret string, repos ...string) ([]string, error) {
+func enableHooks(client github.Client, loc url.URL, secret string, repos ...string) ([]string, error) {
 	var enabled []string
 	locStr := loc.String()
 	hasFlagValues := len(repos) > 0

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -130,7 +130,7 @@ func main() {
 // then dispatches them to the appropriate plugins.
 type Server struct {
 	tokenGenerator func() []byte
-	ghc            *github.Client
+	ghc            github.Client
 	log            *logrus.Entry
 }
 
@@ -173,7 +173,7 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 	return nil
 }
 
-func periodicUpdate(log *logrus.Entry, pa *plugins.ConfigAgent, ghc *github.Client, period time.Duration) {
+func periodicUpdate(log *logrus.Entry, pa *plugins.ConfigAgent, ghc github.Client, period time.Duration) {
 	update := func() {
 		start := time.Now()
 		if err := plugin.HandleAll(log, ghc, pa.Config()); err != nil {

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -56,7 +56,7 @@ type server struct {
 	tokenGenerator func() []byte
 	prowURL        string
 	configAgent    *config.Agent
-	ghc            *github.Client
+	ghc            github.Client
 	log            *logrus.Entry
 }
 

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -89,7 +89,7 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 }
 
 // GitHubClientWithLogFields returns a GitHub client with extra logging fields
-func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dryRun bool, fields logrus.Fields) (client *github.Client, err error) {
+func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dryRun bool, fields logrus.Fields) (client github.Client, err error) {
 	var generator *func() []byte
 	if o.TokenPath == "" {
 		generatorFunc := func() []byte {
@@ -111,7 +111,7 @@ func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dry
 }
 
 // GitHubClient returns a GitHub client.
-func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (client *github.Client, err error) {
+func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (client github.Client, err error) {
 	return o.GitHubClientWithLogFields(secretAgent, dryRun, logrus.Fields{})
 }
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -55,8 +55,160 @@ func (s *standardTime) Until(t time.Time) time.Duration {
 	return time.Until(t)
 }
 
-// Client interacts with the github api.
-type Client struct {
+// OrganizationClient interface for organisation related API actions
+type OrganizationClient interface {
+	IsMember(org, user string) (bool, error)
+	GetOrg(name string) (*Organization, error)
+	EditOrg(name string, config Organization) (*Organization, error)
+	ListOrgInvitations(org string) ([]OrgInvitation, error)
+	ListOrgMembers(org, role string) ([]TeamMember, error)
+	HasPermission(org, repo, user string, roles ...string) (bool, error)
+	GetUserPermission(org, repo, user string) (string, error)
+	UpdateOrgMembership(org, user string, admin bool) (*OrgMembership, error)
+	RemoveOrgMembership(org, user string) error
+}
+
+// HookClient interface for hook related API actions
+type HookClient interface {
+	ListOrgHooks(org string) ([]Hook, error)
+	ListRepoHooks(org, repo string) ([]Hook, error)
+	EditRepoHook(org, repo string, id int, req HookRequest) error
+	EditOrgHook(org string, id int, req HookRequest) error
+	CreateOrgHook(org string, req HookRequest) (int, error)
+	CreateRepoHook(org, repo string, req HookRequest) (int, error)
+}
+
+// CommentClient interface for comment related API actions
+type CommentClient interface {
+	CreateComment(org, repo string, number int, comment string) error
+	DeleteComment(org, repo string, id int) error
+	EditComment(org, repo string, id int, comment string) error
+	CreateCommentReaction(org, repo string, id int, reaction string) error
+	DeleteStaleComments(org, repo string, number int, comments []IssueComment, isStale func(IssueComment) bool) error
+}
+
+// IssueClient interface for issue related API actions
+type IssueClient interface {
+	CreateIssueReaction(org, repo string, id int, reaction string) error
+	ListIssueComments(org, repo string, number int) ([]IssueComment, error)
+	GetIssueLabels(org, repo string, number int) ([]Label, error)
+	ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent, error)
+	AssignIssue(org, repo string, number int, logins []string) error
+	UnassignIssue(org, repo string, number int, logins []string) error
+	CloseIssue(org, repo string, number int) error
+	ReopenIssue(org, repo string, number int) error
+	FindIssues(query, sort string, asc bool) ([]Issue, error)
+}
+
+// PullRequestClient interface for pull request related API actions
+type PullRequestClient interface {
+	GetPullRequests(org, repo string) ([]PullRequest, error)
+	GetPullRequest(org, repo string, number int) (*PullRequest, error)
+	GetPullRequestPatch(org, repo string, number int) ([]byte, error)
+	CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error)
+	UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error
+	GetPullRequestChanges(org, repo string, number int) ([]PullRequestChange, error)
+	ListPullRequestComments(org, repo string, number int) ([]ReviewComment, error)
+	ListReviews(org, repo string, number int) ([]Review, error)
+	ClosePR(org, repo string, number int) error
+	ReopenPR(org, repo string, number int) error
+	CreateReview(org, repo string, number int, r DraftReview) error
+	RequestReview(org, repo string, number int, logins []string) error
+	UnrequestReview(org, repo string, number int, logins []string) error
+	Merge(org, repo string, pr int, details MergeDetails) error
+	IsMergeable(org, repo string, number int, SHA string) (bool, error)
+	ListPRCommits(org, repo string, number int) ([]RepositoryCommit, error)
+}
+
+// CommitClient interface for commit related API actions
+type CommitClient interface {
+	CreateStatus(org, repo, SHA string, s Status) error
+	ListStatuses(org, repo, ref string) ([]Status, error)
+	GetSingleCommit(org, repo, SHA string) (SingleCommit, error)
+	GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error)
+	GetRef(org, repo, ref string) (string, error)
+	DeleteRef(org, repo, ref string) error
+}
+
+// RepositoryClient interface for repository related API actions
+type RepositoryClient interface {
+	GetRepo(owner, name string) (Repo, error)
+	GetRepos(org string, isUser bool) ([]Repo, error)
+	GetBranches(org, repo string, onlyProtected bool) ([]Branch, error)
+	RemoveBranchProtection(org, repo, branch string) error
+	UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error
+	AddRepoLabel(org, repo, label, description, color string) error
+	UpdateRepoLabel(org, repo, label, newName, description, color string) error
+	DeleteRepoLabel(org, repo, label string) error
+	GetRepoLabels(org, repo string) ([]Label, error)
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+	GetFile(org, repo, filepath, commit string) ([]byte, error)
+	IsCollaborator(org, repo, user string) (bool, error)
+	ListCollaborators(org, repo string) ([]User, error)
+	CreateFork(owner, repo string) error
+}
+
+// TeamClient interface for team related API actions
+type TeamClient interface {
+	CreateTeam(org string, team Team) (*Team, error)
+	EditTeam(t Team) (*Team, error)
+	DeleteTeam(id int) error
+	ListTeams(org string) ([]Team, error)
+	UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error)
+	RemoveTeamMembership(id int, user string) error
+	ListTeamMembers(id int, role string) ([]TeamMember, error)
+	ListTeamRepos(id int) ([]Repo, error)
+	UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error
+	RemoveTeamRepo(id int, org, repo string) error
+	ListTeamInvitations(id int) ([]OrgInvitation, error)
+	TeamHasMember(teamID int, memberLogin string) (bool, error)
+}
+
+// UserClient interface for user related API actions
+type UserClient interface {
+	BotName() (string, error)
+	Email() (string, error)
+}
+
+// ProjectClient interface for project related API actions
+type ProjectClient interface {
+	GetRepoProjects(owner, repo string) ([]Project, error)
+	GetOrgProjects(org string) ([]Project, error)
+	GetProjectColumns(projectID int) ([]ProjectColumn, error)
+	CreateProjectCard(columnID int, projectCard ProjectCard) (*ProjectCard, error)
+	GetColumnProjectCard(columnID int, issueURL string) (*ProjectCard, error)
+	MoveProjectCard(projectCardID int, newColumnID int) error
+	DeleteProjectCard(projectCardID int) error
+}
+
+// MilestoneClient interface for milestone related API actions
+type MilestoneClient interface {
+	ClearMilestone(org, repo string, num int) error
+	SetMilestone(org, repo string, issueNum, milestoneNum int) error
+	ListMilestones(org, repo string) ([]Milestone, error)
+}
+
+// Client interface for GitHub API
+type Client interface {
+	PullRequestClient
+	RepositoryClient
+	CommitClient
+	IssueClient
+	CommentClient
+	OrganizationClient
+	TeamClient
+	ProjectClient
+	MilestoneClient
+	UserClient
+	HookClient
+
+	Throttle(hourlyTokens, burst int)
+	Query(ctx context.Context, q interface{}, vars map[string]interface{}) error
+}
+
+// client interacts with the github api.
+type client struct {
 	// If logger is non-nil, log all method calls with it.
 	logger *logrus.Entry
 	time   timeClient
@@ -184,7 +336,7 @@ func (t *throttler) Query(ctx context.Context, q interface{}, vars map[string]in
 
 // Throttle client to a rate of at most hourlyTokens requests per hour,
 // allowing burst tokens.
-func (c *Client) Throttle(hourlyTokens, burst int) {
+func (c *client) Throttle(hourlyTokens, burst int) {
 	c.log("Throttle", hourlyTokens, burst)
 	c.throttle.lock.Lock()
 	defer c.throttle.lock.Unlock()
@@ -230,8 +382,8 @@ func (c *Client) Throttle(hourlyTokens, burst int) {
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
-	return &Client{
+func NewClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) Client {
+	return &client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		time:   &standardTime{},
 		gqlc: githubql.NewEnterpriseClient(
@@ -248,7 +400,7 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEn
 }
 
 // NewClient creates a new fully operational GitHub client.
-func NewClient(getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
+func NewClient(getToken func() []byte, graphqlEndpoint string, bases ...string) Client {
 	return NewClientWithFields(logrus.Fields{}, getToken, graphqlEndpoint, bases...)
 }
 
@@ -260,8 +412,8 @@ func NewClient(getToken func() []byte, graphqlEndpoint string, bases ...string) 
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
-	return &Client{
+func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, graphqlEndpoint string, bases ...string) Client {
+	return &client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		time:   &standardTime{},
 		gqlc: githubql.NewEnterpriseClient(
@@ -285,13 +437,13 @@ func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, gra
 //   An endpoint is used when all preceding endpoints have returned a conn err.
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
-func NewDryRunClient(getToken func() []byte, graphqlEndpoint string, bases ...string) *Client {
+func NewDryRunClient(getToken func() []byte, graphqlEndpoint string, bases ...string) Client {
 	return NewDryRunClientWithFields(logrus.Fields{}, getToken, graphqlEndpoint, bases...)
 }
 
 // NewFakeClient creates a new client that will not perform any actions at all.
-func NewFakeClient() *Client {
-	return &Client{
+func NewFakeClient() Client {
+	return &client{
 		logger: logrus.WithField("client", "github"),
 		time:   &standardTime{},
 		fake:   true,
@@ -299,7 +451,7 @@ func NewFakeClient() *Client {
 	}
 }
 
-func (c *Client) log(methodName string, args ...interface{}) {
+func (c *client) log(methodName string, args ...interface{}) {
 	if c.logger == nil {
 		return
 	}
@@ -345,7 +497,7 @@ func (r requestError) ErrorMessages() []string {
 
 // Make a request with retries. If ret is not nil, unmarshal the response body
 // into it. Returns an error if the exit code is not one of the provided codes.
-func (c *Client) request(r *request, ret interface{}) (int, error) {
+func (c *client) request(r *request, ret interface{}) (int, error) {
 	statusCode, b, err := c.requestRaw(r)
 	if err != nil {
 		return statusCode, err
@@ -360,7 +512,7 @@ func (c *Client) request(r *request, ret interface{}) (int, error) {
 
 // requestRaw makes a request with retries and returns the response body.
 // Returns an error if the exit code is not one of the provided codes.
-func (c *Client) requestRaw(r *request) (int, []byte, error) {
+func (c *client) requestRaw(r *request) (int, []byte, error) {
 	if c.fake || (c.dry && r.method != http.MethodGet) {
 		return r.exitCodes[0], nil, nil
 	}
@@ -393,7 +545,7 @@ func (c *Client) requestRaw(r *request) (int, []byte, error) {
 // Retry on transport failures. Retries on 500s, retries after sleep on
 // ratelimit exceeded, and retries 404s a couple times.
 // This function closes the response body iff it also returns an error.
-func (c *Client) requestRetry(method, path, accept string, body interface{}) (*http.Response, error) {
+func (c *client) requestRetry(method, path, accept string, body interface{}) (*http.Response, error) {
 	var hostIndex int
 	var resp *http.Response
 	var err error
@@ -481,7 +633,7 @@ func (c *Client) requestRetry(method, path, accept string, body interface{}) (*h
 	return resp, err
 }
 
-func (c *Client) doRequest(method, path, accept string, body interface{}) (*http.Response, error) {
+func (c *client) doRequest(method, path, accept string, body interface{}) (*http.Response, error) {
 	var buf io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -511,7 +663,7 @@ func (c *Client) doRequest(method, path, accept string, body interface{}) (*http
 }
 
 // Not thread-safe - callers need to hold c.mut.
-func (c *Client) getUserData() error {
+func (c *client) getUserData() error {
 	c.log("User")
 	var u User
 	_, err := c.request(&request{
@@ -533,7 +685,7 @@ func (c *Client) getUserData() error {
 // BotName returns the login of the authenticated identity.
 //
 // See https://developer.github.com/v3/users/#get-the-authenticated-user
-func (c *Client) BotName() (string, error) {
+func (c *client) BotName() (string, error) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 	if c.botName == "" {
@@ -547,7 +699,7 @@ func (c *Client) BotName() (string, error) {
 // Email returns the user-configured email for the authenticated identity.
 //
 // See https://developer.github.com/v3/users/#get-the-authenticated-user
-func (c *Client) Email() (string, error) {
+func (c *client) Email() (string, error) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 	if c.email == "" {
@@ -561,7 +713,7 @@ func (c *Client) Email() (string, error) {
 // IsMember returns whether or not the user is a member of the org.
 //
 // See https://developer.github.com/v3/orgs/members/#check-membership
-func (c *Client) IsMember(org, user string) (bool, error) {
+func (c *client) IsMember(org, user string) (bool, error) {
 	c.log("IsMember", org, user)
 	if org == user {
 		// Make it possible to run a couple of plugins on personal repos.
@@ -586,7 +738,7 @@ func (c *Client) IsMember(org, user string) (bool, error) {
 	return false, fmt.Errorf("unexpected status: %d", code)
 }
 
-func (c *Client) listHooks(org string, repo *string) ([]Hook, error) {
+func (c *client) listHooks(org string, repo *string) ([]Hook, error) {
 	var ret []Hook
 	var path string
 	if repo != nil {
@@ -612,19 +764,19 @@ func (c *Client) listHooks(org string, repo *string) ([]Hook, error) {
 
 // ListOrgHooks returns a list of hooks for the org.
 // https://developer.github.com/v3/orgs/hooks/#list-hooks
-func (c *Client) ListOrgHooks(org string) ([]Hook, error) {
+func (c *client) ListOrgHooks(org string) ([]Hook, error) {
 	c.log("ListOrgHooks", org)
 	return c.listHooks(org, nil)
 }
 
 // ListRepoHooks returns a list of hooks for the repo.
 // https://developer.github.com/v3/repos/hooks/#list-hooks
-func (c *Client) ListRepoHooks(org, repo string) ([]Hook, error) {
+func (c *client) ListRepoHooks(org, repo string) ([]Hook, error) {
 	c.log("ListRepoHooks", org, repo)
 	return c.listHooks(org, &repo)
 }
 
-func (c *Client) editHook(org string, repo *string, id int, req HookRequest) error {
+func (c *client) editHook(org string, repo *string, id int, req HookRequest) error {
 	if c.dry {
 		return nil
 	}
@@ -646,19 +798,19 @@ func (c *Client) editHook(org string, repo *string, id int, req HookRequest) err
 
 // EditRepoHook updates an existing hook with new info (events/url/secret)
 // https://developer.github.com/v3/repos/hooks/#edit-a-hook
-func (c *Client) EditRepoHook(org, repo string, id int, req HookRequest) error {
+func (c *client) EditRepoHook(org, repo string, id int, req HookRequest) error {
 	c.log("EditRepoHook", org, repo, id)
 	return c.editHook(org, &repo, id, req)
 }
 
 // EditOrgHook updates an existing hook with new info (events/url/secret)
 // https://developer.github.com/v3/orgs/hooks/#edit-a-hook
-func (c *Client) EditOrgHook(org string, id int, req HookRequest) error {
+func (c *client) EditOrgHook(org string, id int, req HookRequest) error {
 	c.log("EditOrgHook", org, id)
 	return c.editHook(org, nil, id, req)
 }
 
-func (c *Client) createHook(org string, repo *string, req HookRequest) (int, error) {
+func (c *client) createHook(org string, repo *string, req HookRequest) (int, error) {
 	if c.dry {
 		return -1, nil
 	}
@@ -683,14 +835,14 @@ func (c *Client) createHook(org string, repo *string, req HookRequest) (int, err
 
 // CreateOrgHook creates a new hook for the org
 // https://developer.github.com/v3/orgs/hooks/#create-a-hook
-func (c *Client) CreateOrgHook(org string, req HookRequest) (int, error) {
+func (c *client) CreateOrgHook(org string, req HookRequest) (int, error) {
 	c.log("CreateOrgHook", org)
 	return c.createHook(org, nil, req)
 }
 
 // CreateRepoHook creates a new hook for the repo
 // https://developer.github.com/v3/repos/hooks/#create-a-hook
-func (c *Client) CreateRepoHook(org, repo string, req HookRequest) (int, error) {
+func (c *client) CreateRepoHook(org, repo string, req HookRequest) (int, error) {
 	c.log("CreateRepoHook", org, repo)
 	return c.createHook(org, &repo, req)
 }
@@ -698,7 +850,7 @@ func (c *Client) CreateRepoHook(org, repo string, req HookRequest) (int, error) 
 // GetOrg returns current metadata for the org
 //
 // https://developer.github.com/v3/orgs/#get-an-organization
-func (c *Client) GetOrg(name string) (*Organization, error) {
+func (c *client) GetOrg(name string) (*Organization, error) {
 	c.log("GetOrg", name)
 	var retOrg Organization
 	_, err := c.request(&request{
@@ -715,7 +867,7 @@ func (c *Client) GetOrg(name string) (*Organization, error) {
 // EditOrg will update the metadata for this org.
 //
 // https://developer.github.com/v3/orgs/#edit-an-organization
-func (c *Client) EditOrg(name string, config Organization) (*Organization, error) {
+func (c *client) EditOrg(name string, config Organization) (*Organization, error) {
 	c.log("EditOrg", name, config)
 	if c.dry {
 		return &config, nil
@@ -736,7 +888,7 @@ func (c *Client) EditOrg(name string, config Organization) (*Organization, error
 // ListOrgInvitations lists pending invitations to th org.
 //
 // https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-func (c *Client) ListOrgInvitations(org string) ([]OrgInvitation, error) {
+func (c *client) ListOrgInvitations(org string) ([]OrgInvitation, error) {
 	c.log("ListOrgInvitations", org)
 	if c.fake {
 		return nil, nil
@@ -766,7 +918,7 @@ func (c *Client) ListOrgInvitations(org string) ([]OrgInvitation, error) {
 // Role options are "all", "admin" and "member"
 //
 // https://developer.github.com/v3/orgs/members/#members-list
-func (c *Client) ListOrgMembers(org, role string) ([]TeamMember, error) {
+func (c *client) ListOrgMembers(org, role string) ([]TeamMember, error) {
 	c.log("ListOrgMembers", org, role)
 	if c.fake {
 		return nil, nil
@@ -794,7 +946,7 @@ func (c *Client) ListOrgMembers(org, role string) ([]TeamMember, error) {
 }
 
 // HasPermission returns true if GetUserPermission() returns any of the roles.
-func (c *Client) HasPermission(org, repo, user string, roles ...string) (bool, error) {
+func (c *client) HasPermission(org, repo, user string, roles ...string) (bool, error) {
 	perm, err := c.GetUserPermission(org, repo, user)
 	if err != nil {
 		return false, err
@@ -810,7 +962,7 @@ func (c *Client) HasPermission(org, repo, user string, roles ...string) (bool, e
 // GetUserPermission returns the user's permission level for a repo
 //
 // https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
-func (c *Client) GetUserPermission(org, repo, user string) (string, error) {
+func (c *client) GetUserPermission(org, repo, user string) (string, error) {
 	c.log("GetUserPermission", org, repo, user)
 
 	var perm struct {
@@ -833,7 +985,7 @@ func (c *Client) GetUserPermission(org, repo, user string) (string, error) {
 // This will also change the role to/from admin, on either the invitation or membership setting.
 //
 // https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
-func (c *Client) UpdateOrgMembership(org, user string, admin bool) (*OrgMembership, error) {
+func (c *client) UpdateOrgMembership(org, user string, admin bool) (*OrgMembership, error) {
 	c.log("UpdateOrgMembership", org, user, admin)
 	om := OrgMembership{}
 	if admin {
@@ -857,7 +1009,7 @@ func (c *Client) UpdateOrgMembership(org, user string, admin bool) (*OrgMembersh
 // RemoveOrgMembership removes the user from the org.
 //
 // https://developer.github.com/v3/orgs/members/#remove-organization-membership
-func (c *Client) RemoveOrgMembership(org, user string) error {
+func (c *client) RemoveOrgMembership(org, user string) error {
 	c.log("RemoveOrgMembership", org, user)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
@@ -870,7 +1022,7 @@ func (c *Client) RemoveOrgMembership(org, user string) error {
 // CreateComment creates a comment on the issue.
 //
 // See https://developer.github.com/v3/issues/comments/#create-a-comment
-func (c *Client) CreateComment(org, repo string, number int, comment string) error {
+func (c *client) CreateComment(org, repo string, number int, comment string) error {
 	c.log("CreateComment", org, repo, number, comment)
 	ic := IssueComment{
 		Body: comment,
@@ -887,7 +1039,7 @@ func (c *Client) CreateComment(org, repo string, number int, comment string) err
 // DeleteComment deletes the comment.
 //
 // See https://developer.github.com/v3/issues/comments/#delete-a-comment
-func (c *Client) DeleteComment(org, repo string, id int) error {
+func (c *client) DeleteComment(org, repo string, id int) error {
 	c.log("DeleteComment", org, repo, id)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
@@ -900,7 +1052,7 @@ func (c *Client) DeleteComment(org, repo string, id int) error {
 // EditComment changes the body of comment id in org/repo.
 //
 // See https://developer.github.com/v3/issues/comments/#edit-a-comment
-func (c *Client) EditComment(org, repo string, id int, comment string) error {
+func (c *client) EditComment(org, repo string, id int, comment string) error {
 	c.log("EditComment", org, repo, id, comment)
 	ic := IssueComment{
 		Body: comment,
@@ -917,7 +1069,7 @@ func (c *Client) EditComment(org, repo string, id int, comment string) error {
 // CreateCommentReaction responds emotionally to comment id in org/repo.
 //
 // See https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
-func (c *Client) CreateCommentReaction(org, repo string, id int, reaction string) error {
+func (c *client) CreateCommentReaction(org, repo string, id int, reaction string) error {
 	c.log("CreateCommentReaction", org, repo, id, reaction)
 	r := Reaction{Content: reaction}
 	_, err := c.request(&request{
@@ -933,7 +1085,7 @@ func (c *Client) CreateCommentReaction(org, repo string, id int, reaction string
 // CreateIssueReaction responds emotionally to org/repo#id
 //
 // See https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
-func (c *Client) CreateIssueReaction(org, repo string, id int, reaction string) error {
+func (c *client) CreateIssueReaction(org, repo string, id int, reaction string) error {
 	c.log("CreateIssueReaction", org, repo, id, reaction)
 	r := Reaction{Content: reaction}
 	_, err := c.request(&request{
@@ -948,7 +1100,7 @@ func (c *Client) CreateIssueReaction(org, repo string, id int, reaction string) 
 
 // DeleteStaleComments iterates over comments on an issue/PR, deleting those which the 'isStale'
 // function identifies as stale. If 'comments' is nil, the comments will be fetched from GitHub.
-func (c *Client) DeleteStaleComments(org, repo string, number int, comments []IssueComment, isStale func(IssueComment) bool) error {
+func (c *client) DeleteStaleComments(org, repo string, number int, comments []IssueComment, isStale func(IssueComment) bool) error {
 	var err error
 	if comments == nil {
 		comments, err = c.ListIssueComments(org, repo, number)
@@ -972,7 +1124,7 @@ func (c *Client) DeleteStaleComments(org, repo string, number int, comments []Is
 // accumulate() should accept that populated slice for each page of results.
 //
 // Returns an error any call to GitHub or object marshalling fails.
-func (c *Client) readPaginatedResults(path, accept string, newObj func() interface{}, accumulate func(interface{})) error {
+func (c *client) readPaginatedResults(path, accept string, newObj func() interface{}, accumulate func(interface{})) error {
 	values := url.Values{
 		"per_page": []string{"100"},
 	}
@@ -980,7 +1132,7 @@ func (c *Client) readPaginatedResults(path, accept string, newObj func() interfa
 }
 
 // readPaginatedResultsWithValues is an override that allows control over the query string.
-func (c *Client) readPaginatedResultsWithValues(path string, values url.Values, accept string, newObj func() interface{}, accumulate func(interface{})) error {
+func (c *client) readPaginatedResultsWithValues(path string, values url.Values, accept string, newObj func() interface{}, accumulate func(interface{})) error {
 	pagedPath := path
 	if len(values) > 0 {
 		pagedPath += "?" + values.Encode()
@@ -1025,7 +1177,7 @@ func (c *Client) readPaginatedResultsWithValues(path string, values url.Values, 
 // Each page of results consumes one API token.
 //
 // See https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
-func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment, error) {
+func (c *client) ListIssueComments(org, repo string, number int) ([]IssueComment, error) {
 	c.log("ListIssueComments", org, repo, number)
 	if c.fake {
 		return nil, nil
@@ -1051,7 +1203,7 @@ func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment
 // GetPullRequests get all open pull requests for a repo.
 //
 // See https://developer.github.com/v3/pulls/#list-pull-requests
-func (c *Client) GetPullRequests(org, repo string) ([]PullRequest, error) {
+func (c *client) GetPullRequests(org, repo string) ([]PullRequest, error) {
 	c.log("GetPullRequests", org, repo)
 	var prs []PullRequest
 	if c.fake {
@@ -1080,7 +1232,7 @@ func (c *Client) GetPullRequests(org, repo string) ([]PullRequest, error) {
 // GetPullRequest gets a pull request.
 //
 // See https://developer.github.com/v3/pulls/#get-a-single-pull-request
-func (c *Client) GetPullRequest(org, repo string, number int) (*PullRequest, error) {
+func (c *client) GetPullRequest(org, repo string, number int) (*PullRequest, error) {
 	c.log("GetPullRequest", org, repo, number)
 	var pr PullRequest
 	_, err := c.request(&request{
@@ -1098,7 +1250,7 @@ func (c *Client) GetPullRequest(org, repo string, number int) (*PullRequest, err
 // GetPullRequestPatch gets the patch version of a pull request.
 //
 // See https://developer.github.com/v3/media/#commits-commit-comparison-and-pull-requests
-func (c *Client) GetPullRequestPatch(org, repo string, number int) ([]byte, error) {
+func (c *client) GetPullRequestPatch(org, repo string, number int) ([]byte, error) {
 	c.log("GetPullRequestPatch", org, repo, number)
 	_, patch, err := c.requestRaw(&request{
 		accept:    "application/vnd.github.VERSION.patch",
@@ -1113,7 +1265,7 @@ func (c *Client) GetPullRequestPatch(org, repo string, number int) ([]byte, erro
 // the creation is successful, otherwise any error that is encountered.
 //
 // See https://developer.github.com/v3/pulls/#create-a-pull-request
-func (c *Client) CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error) {
+func (c *client) CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error) {
 	c.log("CreatePullRequest", org, repo, title)
 	data := struct {
 		Title string `json:"title"`
@@ -1151,7 +1303,7 @@ func (c *Client) CreatePullRequest(org, repo, title, body, head, base string, ca
 }
 
 // UpdatePullRequest modifies the title, body, open state
-func (c *Client) UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error {
+func (c *client) UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error {
 	c.log("UpdatePullRequest", org, repo, title)
 	data := struct {
 		State *string `json:"state,omitempty"`
@@ -1190,7 +1342,7 @@ func (c *Client) UpdatePullRequest(org, repo string, number int, title, body *st
 // GetPullRequestChanges gets a list of files modified in a pull request.
 //
 // See https://developer.github.com/v3/pulls/#list-pull-requests-files
-func (c *Client) GetPullRequestChanges(org, repo string, number int) ([]PullRequestChange, error) {
+func (c *client) GetPullRequestChanges(org, repo string, number int) ([]PullRequestChange, error) {
 	c.log("GetPullRequestChanges", org, repo, number)
 	if c.fake {
 		return []PullRequestChange{}, nil
@@ -1218,7 +1370,7 @@ func (c *Client) GetPullRequestChanges(org, repo string, number int) ([]PullRequ
 // Multiple-pages of comments consumes multiple API tokens.
 //
 // See https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
-func (c *Client) ListPullRequestComments(org, repo string, number int) ([]ReviewComment, error) {
+func (c *client) ListPullRequestComments(org, repo string, number int) ([]ReviewComment, error) {
 	c.log("ListPullRequestComments", org, repo, number)
 	if c.fake {
 		return nil, nil
@@ -1246,7 +1398,7 @@ func (c *Client) ListPullRequestComments(org, repo string, number int) ([]Review
 // Multiple-pages of results consumes multiple API tokens.
 //
 // See https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
-func (c *Client) ListReviews(org, repo string, number int) ([]Review, error) {
+func (c *client) ListReviews(org, repo string, number int) ([]Review, error) {
 	c.log("ListReviews", org, repo, number)
 	if c.fake {
 		return nil, nil
@@ -1272,7 +1424,7 @@ func (c *Client) ListReviews(org, repo string, number int) ([]Review, error) {
 // CreateStatus creates or updates the status of a commit.
 //
 // See https://developer.github.com/v3/repos/statuses/#create-a-status
-func (c *Client) CreateStatus(org, repo, SHA string, s Status) error {
+func (c *client) CreateStatus(org, repo, SHA string, s Status) error {
 	c.log("CreateStatus", org, repo, SHA, s)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
@@ -1286,7 +1438,7 @@ func (c *Client) CreateStatus(org, repo, SHA string, s Status) error {
 // ListStatuses gets commit statuses for a given ref.
 //
 // See https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-func (c *Client) ListStatuses(org, repo, ref string) ([]Status, error) {
+func (c *client) ListStatuses(org, repo, ref string) ([]Status, error) {
 	c.log("ListStatuses", org, repo, ref)
 	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, ref)
 	var statuses []Status
@@ -1306,7 +1458,7 @@ func (c *Client) ListStatuses(org, repo, ref string) ([]Status, error) {
 // GetRepo returns the repo for the provided owner/name combination.
 //
 // See https://developer.github.com/v3/repos/#get
-func (c *Client) GetRepo(owner, name string) (Repo, error) {
+func (c *client) GetRepo(owner, name string) (Repo, error) {
 	c.log("GetRepo", owner, name)
 
 	var repo Repo
@@ -1323,7 +1475,7 @@ func (c *Client) GetRepo(owner, name string) (Repo, error) {
 // This call uses multiple API tokens when results are paginated.
 //
 // See https://developer.github.com/v3/repos/#list-organization-repositories
-func (c *Client) GetRepos(org string, isUser bool) ([]Repo, error) {
+func (c *client) GetRepos(org string, isUser bool) ([]Repo, error) {
 	c.log("GetRepos", org, isUser)
 	var (
 		repos   []Repo
@@ -1356,7 +1508,7 @@ func (c *Client) GetRepos(org string, isUser bool) ([]Repo, error) {
 // GetSingleCommit returns a single commit.
 //
 // See https://developer.github.com/v3/repos/#get
-func (c *Client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
+func (c *client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
 	c.log("GetSingleCommit", org, repo, SHA)
 	var commit SingleCommit
 	_, err := c.request(&request{
@@ -1375,7 +1527,7 @@ func (c *Client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
 // This call uses multiple API tokens when results are paginated.
 //
 // See https://developer.github.com/v3/repos/branches/#list-branches
-func (c *Client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, error) {
+func (c *client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, error) {
 	c.log("GetBranches", org, repo)
 	var branches []Branch
 	err := c.readPaginatedResultsWithValues(
@@ -1401,7 +1553,7 @@ func (c *Client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, er
 // RemoveBranchProtection unprotects org/repo=branch.
 //
 // See https://developer.github.com/v3/repos/branches/#remove-branch-protection
-func (c *Client) RemoveBranchProtection(org, repo, branch string) error {
+func (c *client) RemoveBranchProtection(org, repo, branch string) error {
 	c.log("RemoveBranchProtection", org, repo, branch)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
@@ -1414,7 +1566,7 @@ func (c *Client) RemoveBranchProtection(org, repo, branch string) error {
 // UpdateBranchProtection configures org/repo=branch.
 //
 // See https://developer.github.com/v3/repos/branches/#update-branch-protection
-func (c *Client) UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error {
+func (c *client) UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error {
 	c.log("UpdateBranchProtection", org, repo, branch, config)
 	_, err := c.request(&request{
 		accept:      "application/vnd.github.luke-cage-preview+json", // for required_approving_review_count
@@ -1429,7 +1581,7 @@ func (c *Client) UpdateBranchProtection(org, repo, branch string, config BranchP
 // AddRepoLabel adds a defined label given org/repo
 //
 // See https://developer.github.com/v3/issues/labels/#create-a-label
-func (c *Client) AddRepoLabel(org, repo, label, description, color string) error {
+func (c *client) AddRepoLabel(org, repo, label, description, color string) error {
 	c.log("AddRepoLabel", org, repo, label, description, color)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
@@ -1444,7 +1596,7 @@ func (c *Client) AddRepoLabel(org, repo, label, description, color string) error
 // UpdateRepoLabel updates a org/repo label to new name, description, and color
 //
 // See https://developer.github.com/v3/issues/labels/#update-a-label
-func (c *Client) UpdateRepoLabel(org, repo, label, newName, description, color string) error {
+func (c *client) UpdateRepoLabel(org, repo, label, newName, description, color string) error {
 	c.log("UpdateRepoLabel", org, repo, label, newName, color)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
@@ -1459,7 +1611,7 @@ func (c *Client) UpdateRepoLabel(org, repo, label, newName, description, color s
 // DeleteRepoLabel deletes a label in org/repo
 //
 // See https://developer.github.com/v3/issues/labels/#delete-a-label
-func (c *Client) DeleteRepoLabel(org, repo, label string) error {
+func (c *client) DeleteRepoLabel(org, repo, label string) error {
 	c.log("DeleteRepoLabel", org, repo, label)
 	_, err := c.request(&request{
 		method:      http.MethodDelete,
@@ -1474,7 +1626,7 @@ func (c *Client) DeleteRepoLabel(org, repo, label string) error {
 // GetCombinedStatus returns the latest statuses for a given ref.
 //
 // See https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
-func (c *Client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error) {
+func (c *client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error) {
 	c.log("GetCombinedStatus", org, repo, ref)
 	var combinedStatus CombinedStatus
 	err := c.readPaginatedResults(
@@ -1493,7 +1645,7 @@ func (c *Client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, erro
 }
 
 // getLabels is a helper function that retrieves a paginated list of labels from a github URI path.
-func (c *Client) getLabels(path string) ([]Label, error) {
+func (c *client) getLabels(path string) ([]Label, error) {
 	var labels []Label
 	if c.fake {
 		return labels, nil
@@ -1517,7 +1669,7 @@ func (c *Client) getLabels(path string) ([]Label, error) {
 // GetRepoLabels returns the list of labels accessible to org/repo.
 //
 // See https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
-func (c *Client) GetRepoLabels(org, repo string) ([]Label, error) {
+func (c *client) GetRepoLabels(org, repo string) ([]Label, error) {
 	c.log("GetRepoLabels", org, repo)
 	return c.getLabels(fmt.Sprintf("/repos/%s/%s/labels", org, repo))
 }
@@ -1525,7 +1677,7 @@ func (c *Client) GetRepoLabels(org, repo string) ([]Label, error) {
 // GetIssueLabels returns the list of labels currently on issue org/repo#number.
 //
 // See https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
-func (c *Client) GetIssueLabels(org, repo string, number int) ([]Label, error) {
+func (c *client) GetIssueLabels(org, repo string, number int) ([]Label, error) {
 	c.log("GetIssueLabels", org, repo, number)
 	return c.getLabels(fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number))
 }
@@ -1533,7 +1685,7 @@ func (c *Client) GetIssueLabels(org, repo string, number int) ([]Label, error) {
 // AddLabel adds label to org/repo#number, returning an error on a bad response code.
 //
 // See https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
-func (c *Client) AddLabel(org, repo string, number int, label string) error {
+func (c *client) AddLabel(org, repo string, number int, label string) error {
 	c.log("AddLabel", org, repo, number, label)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
@@ -1551,7 +1703,7 @@ type githubError struct {
 // RemoveLabel removes label from org/repo#number, returning an error on any failure.
 //
 // See https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
-func (c *Client) RemoveLabel(org, repo string, number int, label string) error {
+func (c *client) RemoveLabel(org, repo string, number int, label string) error {
 	c.log("RemoveLabel", org, repo, number, label)
 	code, body, err := c.requestRaw(&request{
 		method: http.MethodDelete,
@@ -1602,7 +1754,7 @@ func (m MissingUsers) Error() string {
 // AssignIssue adds logins to org/repo#number, returning an error if any login is missing after making the call.
 //
 // See https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
-func (c *Client) AssignIssue(org, repo string, number int, logins []string) error {
+func (c *client) AssignIssue(org, repo string, number int, logins []string) error {
 	c.log("AssignIssue", org, repo, number, logins)
 	assigned := make(map[string]bool)
 	var i Issue
@@ -1643,7 +1795,7 @@ func (e ExtraUsers) Error() string {
 // UnassignIssue removes logins from org/repo#number, returns an error if any login remains assigned.
 //
 // See https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
-func (c *Client) UnassignIssue(org, repo string, number int, logins []string) error {
+func (c *client) UnassignIssue(org, repo string, number int, logins []string) error {
 	c.log("UnassignIssue", org, repo, number, logins)
 	assigned := make(map[string]bool)
 	var i Issue
@@ -1674,7 +1826,7 @@ func (c *Client) UnassignIssue(org, repo string, number int, logins []string) er
 // CreateReview creates a review using the draft.
 //
 // https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
-func (c *Client) CreateReview(org, repo string, number int, r DraftReview) error {
+func (c *client) CreateReview(org, repo string, number int, r DraftReview) error {
 	c.log("CreateReview", org, repo, number, r)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
@@ -1721,7 +1873,7 @@ func prepareReviewersBody(logins []string, org string) (map[string][]string, err
 	return body, errorutil.NewAggregate(errors...)
 }
 
-func (c *Client) tryRequestReview(org, repo string, number int, logins []string) (int, error) {
+func (c *client) tryRequestReview(org, repo string, number int, logins []string) (int, error) {
 	c.log("RequestReview", org, repo, number, logins)
 	var pr PullRequest
 	body, err := prepareReviewersBody(logins, org)
@@ -1746,7 +1898,7 @@ func (c *Client) tryRequestReview(org, repo string, number int, logins []string)
 // each member individually. We try first with all users in 'logins' for efficiency in the common case.
 //
 // See https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
-func (c *Client) RequestReview(org, repo string, number int, logins []string) error {
+func (c *client) RequestReview(org, repo string, number int, logins []string) error {
 	statusCode, err := c.tryRequestReview(org, repo, number, logins)
 	if err != nil && statusCode == http.StatusUnprocessableEntity /*422*/ {
 		// Failed to set all members of 'logins' as reviewers, try individually.
@@ -1776,7 +1928,7 @@ func (c *Client) RequestReview(org, repo string, number int, logins []string) er
 // The API responds with http status code 200 no matter what the content of 'logins' is.
 //
 // See https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request
-func (c *Client) UnrequestReview(org, repo string, number int, logins []string) error {
+func (c *client) UnrequestReview(org, repo string, number int, logins []string) error {
 	c.log("UnrequestReview", org, repo, number, logins)
 	var pr PullRequest
 	body, err := prepareReviewersBody(logins, org)
@@ -1817,7 +1969,7 @@ func (c *Client) UnrequestReview(org, repo string, number int, logins []string) 
 // CloseIssue closes the existing, open issue provided
 //
 // See https://developer.github.com/v3/issues/#edit-an-issue
-func (c *Client) CloseIssue(org, repo string, number int) error {
+func (c *client) CloseIssue(org, repo string, number int) error {
 	c.log("CloseIssue", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
@@ -1859,7 +2011,7 @@ func stateCannotBeChangedOrOriginalError(err error) error {
 // ReopenIssue re-opens the existing, closed issue provided
 //
 // See https://developer.github.com/v3/issues/#edit-an-issue
-func (c *Client) ReopenIssue(org, repo string, number int) error {
+func (c *client) ReopenIssue(org, repo string, number int) error {
 	c.log("ReopenIssue", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
@@ -1874,7 +2026,7 @@ func (c *Client) ReopenIssue(org, repo string, number int) error {
 // TODO: Rename to ClosePullRequest
 //
 // See https://developer.github.com/v3/pulls/#update-a-pull-request
-func (c *Client) ClosePR(org, repo string, number int) error {
+func (c *client) ClosePR(org, repo string, number int) error {
 	c.log("ClosePR", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
@@ -1889,7 +2041,7 @@ func (c *Client) ClosePR(org, repo string, number int) error {
 // TODO: Rename to ReopenPullRequest
 //
 // See https://developer.github.com/v3/pulls/#update-a-pull-request
-func (c *Client) ReopenPR(org, repo string, number int) error {
+func (c *client) ReopenPR(org, repo string, number int) error {
 	c.log("ReopenPR", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
@@ -1903,7 +2055,7 @@ func (c *Client) ReopenPR(org, repo string, number int) error {
 // GetRef returns the SHA of the given ref, such as "heads/master".
 //
 // See https://developer.github.com/v3/git/refs/#get-a-reference
-func (c *Client) GetRef(org, repo, ref string) (string, error) {
+func (c *client) GetRef(org, repo, ref string) (string, error) {
 	c.log("GetRef", org, repo, ref)
 	var res struct {
 		Object map[string]string `json:"object"`
@@ -1919,7 +2071,7 @@ func (c *Client) GetRef(org, repo, ref string) (string, error) {
 // DeleteRef deletes the given ref
 //
 // See https://developer.github.com/v3/git/refs/#delete-a-reference
-func (c *Client) DeleteRef(org, repo, ref string) error {
+func (c *client) DeleteRef(org, repo, ref string) error {
 	c.log("DeleteRef", org, repo, ref)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
@@ -1936,7 +2088,7 @@ func (c *Client) DeleteRef(org, repo, ref string) error {
 // Control whether oldest/newest is first with asc.
 //
 // See https://help.github.com/articles/searching-issues-and-pull-requests/ for details.
-func (c *Client) FindIssues(query, sort string, asc bool) ([]Issue, error) {
+func (c *client) FindIssues(query, sort string, asc bool) ([]Issue, error) {
 	c.log("FindIssues", query)
 	path := fmt.Sprintf("/search/issues?q=%s", url.QueryEscape(query))
 	if sort != "" {
@@ -1968,7 +2120,7 @@ func (e *FileNotFound) Error() string {
 // TODO(krzyzacy): Support retrieve a directory
 //
 // See https://developer.github.com/v3/repos/contents/#get-contents
-func (c *Client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
+func (c *client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 	c.log("GetFile", org, repo, filepath, commit)
 
 	url := fmt.Sprintf("/repos/%s/%s/contents/%s", org, repo, filepath)
@@ -2005,7 +2157,7 @@ func (c *Client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 }
 
 // Query runs a GraphQL query using shurcooL/githubql's client.
-func (c *Client) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
+func (c *client) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
 	// Don't log query here because Query is typically called multiple times to get all pages.
 	// Instead log once per search and include total search cost.
 	return c.gqlc.Query(ctx, q, vars)
@@ -2014,7 +2166,7 @@ func (c *Client) Query(ctx context.Context, q interface{}, vars map[string]inter
 // CreateTeam adds a team with name to the org, returning a struct with the new ID.
 //
 // See https://developer.github.com/v3/teams/#create-team
-func (c *Client) CreateTeam(org string, team Team) (*Team, error) {
+func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 	c.log("CreateTeam", org, team)
 	if team.Name == "" {
 		return nil, errors.New("team.Name must be non-empty")
@@ -2041,7 +2193,7 @@ func (c *Client) CreateTeam(org string, team Team) (*Team, error) {
 // EditTeam patches team.ID to contain the specified other values.
 //
 // See https://developer.github.com/v3/teams/#edit-team
-func (c *Client) EditTeam(t Team) (*Team, error) {
+func (c *client) EditTeam(t Team) (*Team, error) {
 	c.log("EditTeam", t)
 	if t.ID == 0 {
 		return nil, errors.New("team.ID must be non-zero")
@@ -2076,7 +2228,7 @@ func (c *Client) EditTeam(t Team) (*Team, error) {
 // DeleteTeam removes team.ID from GitHub.
 //
 // See https://developer.github.com/v3/teams/#delete-team
-func (c *Client) DeleteTeam(id int) error {
+func (c *client) DeleteTeam(id int) error {
 	c.log("DeleteTeam", id)
 	path := fmt.Sprintf("/teams/%d", id)
 	_, err := c.request(&request{
@@ -2090,7 +2242,7 @@ func (c *Client) DeleteTeam(id int) error {
 // ListTeams gets a list of teams for the given org
 //
 // See https://developer.github.com/v3/teams/#list-teams
-func (c *Client) ListTeams(org string) ([]Team, error) {
+func (c *client) ListTeams(org string) ([]Team, error) {
 	c.log("ListTeams", org)
 	if c.fake {
 		return nil, nil
@@ -2120,7 +2272,7 @@ func (c *Client) ListTeams(org string) ([]Team, error) {
 // If the user is not a member of the org, GitHub will invite them to become an outside collaborator, setting their status to pending.
 //
 // https://developer.github.com/v3/teams/members/#add-or-update-team-membership
-func (c *Client) UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error) {
+func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error) {
 	c.log("UpdateTeamMembership", id, user, maintainer)
 	if c.fake {
 		return nil, nil
@@ -2148,7 +2300,7 @@ func (c *Client) UpdateTeamMembership(id int, user string, maintainer bool) (*Te
 // RemoveTeamMembership removes the user from the team (but not the org).
 //
 // https://developer.github.com/v3/teams/members/#remove-team-member
-func (c *Client) RemoveTeamMembership(id int, user string) error {
+func (c *client) RemoveTeamMembership(id int, user string) error {
 	c.log("RemoveTeamMembership", id, user)
 	if c.fake {
 		return nil
@@ -2166,7 +2318,7 @@ func (c *Client) RemoveTeamMembership(id int, user string) error {
 // Role options are "all", "maintainer" and "member"
 //
 // https://developer.github.com/v3/teams/members/#list-team-members
-func (c *Client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
+func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 	c.log("ListTeamMembers", id, role)
 	if c.fake {
 		return nil, nil
@@ -2198,7 +2350,7 @@ func (c *Client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 // ListTeamRepos gets a list of team repos for the given team id
 //
 // https://developer.github.com/v3/teams/#list-team-repos
-func (c *Client) ListTeamRepos(id int) ([]Repo, error) {
+func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 	c.log("ListTeamRepos", id)
 	if c.fake {
 		return nil, nil
@@ -2229,7 +2381,7 @@ func (c *Client) ListTeamRepos(id int) ([]Repo, error) {
 // UpdateTeamRepo adds the repo to the team with the provided role.
 //
 // https://developer.github.com/v3/teams/#add-or-update-team-repository
-func (c *Client) UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error {
+func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error {
 	c.log("UpdateTeamRepo", id, org, repo, permission)
 	if c.fake || c.dry {
 		return nil
@@ -2253,7 +2405,7 @@ func (c *Client) UpdateTeamRepo(id int, org, repo string, permission RepoPermiss
 // RemoveTeamRepo removes the team from the repo.
 //
 // https://developer.github.com/v3/teams/#add-or-update-team-repository
-func (c *Client) RemoveTeamRepo(id int, org, repo string) error {
+func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 	c.log("RemoveTeamRepo", id, org, repo)
 	if c.fake || c.dry {
 		return nil
@@ -2271,7 +2423,7 @@ func (c *Client) RemoveTeamRepo(id int, org, repo string) error {
 // given team id
 //
 // https://developer.github.com/v3/teams/members/#list-pending-team-invitations
-func (c *Client) ListTeamInvitations(id int) ([]OrgInvitation, error) {
+func (c *client) ListTeamInvitations(id int) ([]OrgInvitation, error) {
 	c.log("ListTeamInvites", id)
 	if c.fake {
 		return nil, nil
@@ -2336,7 +2488,7 @@ func (e MergeCommitsForbiddenError) Error() string { return string(e) }
 // Merge merges a PR.
 //
 // See https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
-func (c *Client) Merge(org, repo string, pr int, details MergeDetails) error {
+func (c *client) Merge(org, repo string, pr int, details MergeDetails) error {
 	c.log("Merge", org, repo, pr, details)
 	ge := githubError{}
 	ec, err := c.request(&request{
@@ -2375,7 +2527,7 @@ func (c *Client) Merge(org, repo string, pr int, details MergeDetails) error {
 // organization owners.
 //
 // See https://developer.github.com/v3/repos/collaborators/
-func (c *Client) IsCollaborator(org, repo, user string) (bool, error) {
+func (c *client) IsCollaborator(org, repo, user string) (bool, error) {
 	c.log("IsCollaborator", org, user)
 	if org == user {
 		// Make it possible to run a couple of plugins on personal repos.
@@ -2405,7 +2557,7 @@ func (c *Client) IsCollaborator(org, repo, user string) (bool, error) {
 //
 // See 'IsCollaborator' for more details.
 // See https://developer.github.com/v3/repos/collaborators/
-func (c *Client) ListCollaborators(org, repo string) ([]User, error) {
+func (c *client) ListCollaborators(org, repo string) ([]User, error) {
 	c.log("ListCollaborators", org, repo)
 	if c.fake {
 		return nil, nil
@@ -2436,7 +2588,7 @@ func (c *Client) ListCollaborators(org, repo string) ([]User, error) {
 // recommends contacting their support.
 //
 // See https://developer.github.com/v3/repos/forks/#create-a-fork
-func (c *Client) CreateFork(owner, repo string) error {
+func (c *client) CreateFork(owner, repo string) error {
 	c.log("CreateFork", owner, repo)
 	_, err := c.request(&request{
 		method:    http.MethodPost,
@@ -2451,7 +2603,7 @@ func (c *Client) CreateFork(owner, repo string) error {
 // are excluded.
 //
 // See https://developer.github.com/v3/issues/events/
-func (c *Client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent, error) {
+func (c *client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent, error) {
 	c.log("ListIssueEvents", org, repo, num)
 	if c.fake {
 		return nil, nil
@@ -2477,7 +2629,7 @@ func (c *Client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent,
 // IsMergeable determines if a PR can be merged.
 // Mergeability is calculated by a background job on GitHub and is not immediately available when
 // new commits are added so the PR must be polled until the background job completes.
-func (c *Client) IsMergeable(org, repo string, number int, SHA string) (bool, error) {
+func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, error) {
 	backoff := time.Second * 3
 	maxTries := 3
 	for try := 0; try < maxTries; try++ {
@@ -2505,7 +2657,7 @@ func (c *Client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 // ClearMilestone clears the milestone from the specified issue
 //
 // See https://developer.github.com/v3/issues/#edit-an-issue
-func (c *Client) ClearMilestone(org, repo string, num int) error {
+func (c *client) ClearMilestone(org, repo string, num int) error {
 	c.log("ClearMilestone", org, repo, num)
 
 	issue := &struct {
@@ -2525,7 +2677,7 @@ func (c *Client) ClearMilestone(org, repo string, num int) error {
 // SetMilestone sets the milestone from the specified issue (if it is a valid milestone)
 //
 // See https://developer.github.com/v3/issues/#edit-an-issue
-func (c *Client) SetMilestone(org, repo string, issueNum, milestoneNum int) error {
+func (c *client) SetMilestone(org, repo string, issueNum, milestoneNum int) error {
 	c.log("SetMilestone", org, repo, issueNum, milestoneNum)
 
 	issue := &struct {
@@ -2544,7 +2696,7 @@ func (c *Client) SetMilestone(org, repo string, issueNum, milestoneNum int) erro
 // ListMilestones list all milestones in a repo
 //
 // See https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository/
-func (c *Client) ListMilestones(org, repo string) ([]Milestone, error) {
+func (c *client) ListMilestones(org, repo string) ([]Milestone, error) {
 	c.log("ListMilestones", org)
 	if c.fake {
 		return nil, nil
@@ -2570,7 +2722,7 @@ func (c *Client) ListMilestones(org, repo string) ([]Milestone, error) {
 // ListPRCommits lists the commits in a pull request.
 //
 // GitHub API docs: https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
-func (c *Client) ListPRCommits(org, repo string, number int) ([]RepositoryCommit, error) {
+func (c *client) ListPRCommits(org, repo string, number int) ([]RepositoryCommit, error) {
 	c.log("ListPRCommits", org, repo, number)
 	if c.fake {
 		return nil, nil
@@ -2609,7 +2761,7 @@ func (s *reloadingTokenSource) Token() (*oauth2.Token, error) {
 // GetRepoProjects returns the list of projects in this repo.
 //
 // See https://developer.github.com/v3/projects/#list-repository-projects
-func (c *Client) GetRepoProjects(owner, repo string) ([]Project, error) {
+func (c *client) GetRepoProjects(owner, repo string) ([]Project, error) {
 	c.log("GetOrgProjects", owner, repo)
 	path := (fmt.Sprintf("/repos/%s/%s/projects", owner, repo))
 	var projects []Project
@@ -2632,7 +2784,7 @@ func (c *Client) GetRepoProjects(owner, repo string) ([]Project, error) {
 // GetOrgProjects returns the list of projects in this org.
 //
 // See https://developer.github.com/v3/projects/#list-organization-projects
-func (c *Client) GetOrgProjects(org string) ([]Project, error) {
+func (c *client) GetOrgProjects(org string) ([]Project, error) {
 	c.log("GetOrgProjects", org)
 	path := (fmt.Sprintf("/orgs/%s/projects", org))
 	var projects []Project
@@ -2655,7 +2807,7 @@ func (c *Client) GetOrgProjects(org string) ([]Project, error) {
 // GetProjectColumns returns the list of columns in a project.
 //
 // See https://developer.github.com/v3/projects/columns/#list-project-columns
-func (c *Client) GetProjectColumns(projectID int) ([]ProjectColumn, error) {
+func (c *client) GetProjectColumns(projectID int) ([]ProjectColumn, error) {
 	c.log("GetProjectColumns", projectID)
 	path := (fmt.Sprintf("/projects/%d/columns", projectID))
 	var projectColumns []ProjectColumn
@@ -2678,7 +2830,7 @@ func (c *Client) GetProjectColumns(projectID int) ([]ProjectColumn, error) {
 // CreateProjectCard adds a project card to the specified project column.
 //
 // See https://developer.github.com/v3/projects/cards/#create-a-project-card
-func (c *Client) CreateProjectCard(columnID int, projectCard ProjectCard) (*ProjectCard, error) {
+func (c *client) CreateProjectCard(columnID int, projectCard ProjectCard) (*ProjectCard, error) {
 	c.log("CreateProjectCard", columnID, projectCard)
 	if (projectCard.ContentType != "Issue") && (projectCard.ContentType != "PullRequest") {
 		return nil, errors.New("projectCard.ContentType must be either Issue or PullRequest")
@@ -2701,7 +2853,7 @@ func (c *Client) CreateProjectCard(columnID int, projectCard ProjectCard) (*Proj
 // GetColumnProjectCard of a specific issue or PR for a specific column in a board/project
 // This method requires the URL of the issue/pr to compare the issue with the content_url
 // field of the card.  See https://developer.github.com/v3/projects/cards/#list-project-cards
-func (c *Client) GetColumnProjectCard(columnID int, issueURL string) (*ProjectCard, error) {
+func (c *client) GetColumnProjectCard(columnID int, issueURL string) (*ProjectCard, error) {
 	c.log("GetColumnProjectCard", columnID, issueURL)
 	if c.fake {
 		return nil, nil
@@ -2734,7 +2886,7 @@ func (c *Client) GetColumnProjectCard(columnID int, issueURL string) (*ProjectCa
 // MoveProjectCard moves a specific project card to a specified column in the same project
 //
 // See https://developer.github.com/v3/projects/cards/#move-a-project-card
-func (c *Client) MoveProjectCard(projectCardID int, newColumnID int) error {
+func (c *client) MoveProjectCard(projectCardID int, newColumnID int) error {
 	c.log("MoveProjectCard", projectCardID, newColumnID)
 	reqParams := struct {
 		Position string `json:"position"`
@@ -2754,7 +2906,7 @@ func (c *Client) MoveProjectCard(projectCardID int, newColumnID int) error {
 // DeleteProjectCard deletes the project card of a specific issue or PR
 //
 // See https://developer.github.com/v3/projects/cards/#delete-a-project-card
-func (c *Client) DeleteProjectCard(projectCardID int) error {
+func (c *client) DeleteProjectCard(projectCardID int) error {
 	c.log("DeleteProjectCard", projectCardID)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
@@ -2766,7 +2918,7 @@ func (c *Client) DeleteProjectCard(projectCardID int) error {
 }
 
 // TeamHasMember checks if a user belongs to a team
-func (c *Client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
+func (c *client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
 	c.log("TeamHasMember", teamID, memberLogin)
 	projectMaintainers, err := c.ListTeamMembers(teamID, RoleAll)
 	if err != nil {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -48,12 +48,12 @@ func (tt *testTime) Until(t time.Time) time.Duration {
 	return t.Sub(tt.now)
 }
 
-func getClient(url string) *Client {
+func getClient(url string) *client {
 	getToken := func() []byte {
 		return []byte("")
 	}
 
-	return &Client{
+	return &client{
 		time:     &testTime{},
 		getToken: getToken,
 		client: &http.Client{

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -82,7 +82,7 @@ type Controller struct {
 }
 
 // NewController creates a new Controller from the provided clients.
-func NewController(prowJobClient prowv1.ProwJobInterface, jc *Client, ghc *github.Client, logger *logrus.Entry, cfg config.Getter, totURL, selector string) (*Controller, error) {
+func NewController(prowJobClient prowv1.ProwJobInterface, jc *Client, ghc github.Client, logger *logrus.Entry, cfg config.Getter, totURL, selector string) (*Controller, error) {
 	n, err := snowflake.NewNode(1)
 	if err != nil {
 		return nil, err

--- a/prow/life_of_a_prow_job.md
+++ b/prow/life_of_a_prow_job.md
@@ -8,7 +8,7 @@ To each plugin, hook passes two objects: a [plugin client](https://github.com/ku
 
 ```go
 type PluginClient struct {
-	GitHubClient *github.Client
+	GitHubClient github.Client
 	KubeClient   *kube.Client
 	Config       *config.Config
 	Logger       *logrus.Entry

--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -61,7 +61,7 @@ func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, pe)
 }
 
-// Strict subset of *github.Client methods.
+// Strict subset of github.Client methods.
 type githubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -132,7 +132,7 @@ func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help H
 
 // Agent may be used concurrently, so each entry must be thread-safe.
 type Agent struct {
-	GitHubClient     *github.Client
+	GitHubClient     github.Client
 	ProwJobClient    prowv1.ProwJobInterface
 	KubernetesClient kubernetes.Interface
 	GitClient        *git.Client
@@ -189,7 +189,7 @@ func (a *Agent) CommentPruner() (*commentpruner.EventClient, error) {
 
 // ClientAgent contains the various clients that are attached to the Agent.
 type ClientAgent struct {
-	GitHubClient     *github.Client
+	GitHubClient     github.Client
 	ProwJobClient    prowv1.ProwJobInterface
 	KubernetesClient kubernetes.Interface
 	GitClient        *git.Client

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -70,7 +70,7 @@ func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 	return handlePR(pc.GitHubClient, sizesOrDefault(pc.PluginConfig.Size), pc.Logger, pe)
 }
 
-// Strict subset of *github.Client methods.
+// Strict subset of github.Client methods.
 type githubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -63,7 +63,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-// Strict subset of *github.Client methods.
+// Strict subset of github.Client methods.
 type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	AddLabel(owner, repo string, number int, label string) error

--- a/prow/prstatus/prstatus_test.go
+++ b/prow/prstatus/prstatus_test.go
@@ -49,7 +49,7 @@ func (mh *MockQueryHandler) GetHeadContexts(ghc githubClient, pr PullRequest) ([
 	return mh.contextMap[int(pr.Number)], nil
 }
 
-func (mh *MockQueryHandler) BotName(*github.Client) (*github.User, error) {
+func (mh *MockQueryHandler) BotName(github.Client) (*github.User, error) {
 	login := "random_user"
 	return &github.User{
 		Login: login,

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -118,7 +118,7 @@ type Client struct {
 // NewClient is the constructor for Client
 func NewClient(
 	gc *git.Client,
-	ghc *github.Client,
+	ghc github.Client,
 	mdYAMLEnabled func(org, repo string) bool,
 	skipCollaborators func(org, repo string) bool,
 	ownersDirBlacklist func() prowConf.OwnersDirBlacklist,

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 // NewController constructs a new controller to reconcile stauses on config change
-func NewController(continueOnError bool, addedPresubmitBlacklist sets.String, prowJobClient prowv1.ProwJobInterface, githubClient *github.Client, configAgent *config.Agent, pluginAgent *plugins.ConfigAgent) *Controller {
+func NewController(continueOnError bool, addedPresubmitBlacklist sets.String, prowJobClient prowv1.ProwJobInterface, githubClient github.Client, configAgent *config.Agent, pluginAgent *plugins.ConfigAgent) *Controller {
 	return &Controller{
 		continueOnError:         continueOnError,
 		addedPresubmitBlacklist: addedPresubmitBlacklist,
@@ -62,7 +62,7 @@ type statusMigrator interface {
 }
 
 type gitHubMigrator struct {
-	githubClient    *github.Client
+	githubClient    github.Client
 	continueOnError bool
 }
 
@@ -86,7 +86,7 @@ type prowJobTriggerer interface {
 
 type kubeProwJobTriggerer struct {
 	prowJobClient prowv1.ProwJobInterface
-	githubClient  *github.Client
+	githubClient  github.Client
 	configAgent   *config.Agent
 }
 
@@ -111,7 +111,7 @@ type trustedChecker interface {
 }
 
 type githubTrustedChecker struct {
-	githubClient *github.Client
+	githubClient github.Client
 	pluginAgent  *plugins.ConfigAgent
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -200,7 +200,7 @@ func init() {
 }
 
 // NewController makes a Controller out of the given clients.
-func NewController(ghcSync, ghcStatus *github.Client, prowJobClient prowv1.ProwJobInterface, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*Controller, error) {
+func NewController(ghcSync, ghcStatus github.Client, prowJobClient prowv1.ProwJobInterface, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}


### PR DESCRIPTION
Also break up the interface in sub-interfaces based on API actions.

This PR is related to the generic git interface work started in PR #12241.

cc @wbrefvem @jstrachan @rawlingsj 