### PR TITLE
Configure tide to automerge PRs on repos owned by our team

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -426,8 +426,33 @@ tide:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+  # Auto-merge PRs generated for automatic configs release by robot.
+  - repos:
+    - bazelbuild/bazel-toolchains
+    labels:
+    - automerge
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+  - repos:
+    - bazelbuild/bazel-toolchains
+    - bazelbuild/rules_docker
+    - bazelbuild/rules_k8s
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
 
   merge_method:
+    bazelbuild/bazel-toolchains: squash
+    bazelbuild/rules_docker: squash
+    bazelbuild/rules_k8s: squash
     helm/charts: squash
     kubeflow: squash
     kubernetes-client/csharp: squash

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -416,7 +416,10 @@ tide:
     - needs-rebase
     - needs-sig
   - repos:
-    -  GoogleCloudPlatform/netd
+    - GoogleCloudPlatform/netd
+    - bazelbuild/bazel-toolchains
+    - bazelbuild/rules_docker
+    - bazelbuild/rules_k8s
     labels:
     - lgtm
     - approved
@@ -431,18 +434,6 @@ tide:
     - bazelbuild/bazel-toolchains
     labels:
     - automerge
-    missingLabels:
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-  - repos:
-    - bazelbuild/bazel-toolchains
-    - bazelbuild/rules_docker
-    - bazelbuild/rules_k8s
-    labels:
-    - lgtm
-    - approved
     missingLabels:
     - do-not-merge
     - do-not-merge/hold


### PR DESCRIPTION
bazel-toolchains: Automerge un-approved PRs generated by robot & approved PRs by everyone else.
rules_docker & rules_k8s: Automerge approved PRs