### PR TITLE
Allow pipeline prow jobs to be configured.

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//vendor/github.com/gorilla/sessions:go_default_library",
         "//vendor/github.com/knative/build/pkg/apis/build/v1alpha1:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/gopkg.in/robfig/cron.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1169,6 +1169,10 @@ func validateAgent(v JobBase, podNamespace string) error {
 		return fmt.Errorf("job build_specs require agent: %s (found %q)", b, agent)
 	case agent == b && v.BuildSpec == nil:
 		return errors.New("knative-build jobs require a build_spec")
+	case v.PipelineRunSpec != nil && agent != p:
+		return fmt.Errorf("job pipeline_run_spec require agent: %s (found %q)", p, agent)
+	case agent == p && v.PipelineRunSpec == nil:
+		return fmt.Errorf("agent: %s jobs require a pipeline_run_spec", p)
 	case v.DecorationConfig != nil && agent != k && agent != b:
 		// TODO(fejta): only source decoration supported...
 		return fmt.Errorf("decoration requires agent: %s or %s (found %q)", k, b, agent)

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -22,11 +22,12 @@ import (
 	"time"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
-	"k8s.io/test-infra/prow/github"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/github"
 )
 
 // Preset is intended to match the k8s' PodPreset feature, and may be removed
@@ -104,6 +105,8 @@ type JobBase struct {
 	Spec *v1.PodSpec `json:"spec,omitempty"`
 	// BuildSpec is the Knative build spec used if Agent is knative-build.
 	BuildSpec *buildv1alpha1.BuildSpec `json:"build_spec,omitempty"`
+	// PipelineRunSpec is the tekton pipeline spec used if Agent is tekton-pipeline.
+	PipelineRunSpec *pipelinev1alpha1.PipelineRunSpec `json:"pipeline_run_spec,omitempty"`
 	// Annotations are unused by prow itself, but provide a space to configure other automation.
 	Annotations map[string]string `json:"annotations,omitempty"`
 

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -172,8 +172,9 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 		ExtraRefs:        jb.ExtraRefs,
 		DecorationConfig: jb.DecorationConfig,
 
-		PodSpec:   jb.Spec,
-		BuildSpec: jb.BuildSpec,
+		PodSpec:         jb.Spec,
+		BuildSpec:       jb.BuildSpec,
+		PipelineRunSpec: jb.PipelineRunSpec,
 	}
 }
 


### PR DESCRIPTION
I think this is all we need to do to start specifying `agent: tekton-pipeline` jobs in config.
/assign @fejta @stevekuznetsov @ccojocar 