### PR TITLE
Experimental etcd image for 5k node scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -57,6 +57,11 @@ periodics:
       # TODO(mborsz): Adjust or remove this change once we understand coredns
       # memory usage regression.
       - --env=DNS_MEMORY_LIMIT=300Mi
+      # TODO(wojtek-t): Remove once we confirm the impact.
+      # That etcd image has an experimental support for concurrent reads
+      # and should visibly help with issues we observer in density test.
+      - --env=ETCD_DOCKER_REPOSITORY=gcr.io/jingyih-gke-dev/etcd-amd64
+      - --env=ETCD_IMAGE=v3.3.10-experimental.2
       - --extract=ci/latest
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale


### PR DESCRIPTION
We have an experimental etcd image that is adding support for "Concurrent Reads". I believe that this should help with the issues that we're currently facing with density test.

I propose to enable this for one or two runs of 5k-node tests. With this we would hit two birds with one stone:
- we will verify the performance impact of that change to Kubernetes
- we will see if the problems with density test are really mostly caused by etcd (in which case they should be mitigated) [i.e. we know those are triggerred by taint manager, but the question is what is happening when processing its LIST pods requests]

/assign @mborsz 