### PR TITLE
Re-enable prometheus in GCE 5K Performance tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -76,8 +76,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/5000_nodes/override.yaml
-      # TODO(https://github.com/kubernetes/kubernetes/issues/75294): Enable when fixed
-      - --test-cmd-args=--enable-prometheus-server=false
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter


### PR DESCRIPTION
We've ruled out that the prometheus was a cause of the regressions a long time ago. Actually it helps a lot when debugging.

The positive side effect of this change will be a mitigation of the faster MIG startup problem, in the end it will add an O(a few minutes) delay before running the tests.

Ref. https://github.com/kubernetes/kubernetes/issues/76579