### PR TITLE
Log less often at warning level in deck

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -131,6 +131,7 @@ go_library(
         "//vendor/google.golang.org/api/iterator:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",


### PR DESCRIPTION
When something unexpected is encountered serving someone an HTTP
response in Deck, but it's something that is entirely on the user to
handle and not something an admin needs to see, we should not log it at
the error level.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @Katharine 