### PR TITLE
Permit missing users in org sync

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -440,6 +440,11 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 		om, err := client.UpdateOrgMembership(orgName, user, super)
 		if err != nil {
 			logrus.WithError(err).Warnf("UpdateOrgMembership(%s, %s, %t) failed", orgName, user, super)
+			if github.IsNotFound(err) {
+				// this could be caused by someone removing their account
+				// or a typo in the configuration but should not crash the sync
+				err = nil
+			}
 		} else if om.State == github.StatePending {
 			logrus.Infof("Invited %s to %s as a %s", user, orgName, role)
 		} else {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -343,6 +343,24 @@ func (r requestError) ErrorMessages() []string {
 	return []string{}
 }
 
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	requestErr, ok := err.(*requestError)
+	if !ok {
+		return false
+	}
+
+	for _, errorMsg := range requestErr.ErrorMessages() {
+		if strings.Contains(errorMsg, "status code 404") {
+			return true
+		}
+	}
+	return false
+}
+
 // Make a request with retries. If ret is not nil, unmarshal the response body
 // into it. Returns an error if the exit code is not one of the provided codes.
 func (c *Client) request(r *request, ret interface{}) (int, error) {


### PR DESCRIPTION
When a username refers to a user that the robot account cannot see or
that does not exist, the organization membership update call returns
404. We do not want the entire peribolos sync to terminate on this
condition.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 

Not super thrilled with this, the way the client is implemented it's not easy to implement a check for the 404, and the fake makes it hard to test, too. Feedback appreciated.