### PR TITLE
Re-Enable 'Run older jobs first when concurrency is limited'

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -73,11 +73,15 @@ type Controller struct {
 	// selector that will be applied on prowjobs and pods.
 	selector string
 
+	// If both this and pjLock are acquired, this must be acquired first
 	lock sync.RWMutex
+
 	// pendingJobs is a short-lived cache that helps in limiting
 	// the maximum concurrency of jobs.
 	pendingJobs map[string]int
 
+	// If `lock` is acquired as well, `lock` must be acquired before locking
+	// pjLock
 	pjLock sync.RWMutex
 	// shared across the controller and a goroutine that gathers metrics.
 	pjs []prowapi.ProwJob

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1429,7 +1429,7 @@ func TestMaxConcurency(t *testing.T) {
 				{
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
-						State: prowapi.PendingState,
+						State: prowapi.TriggeredState,
 					}},
 			},
 			pendingJobs:    map[string]int{"my-pj": 9},
@@ -1449,7 +1449,7 @@ func TestMaxConcurency(t *testing.T) {
 				{
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
-						State: prowapi.PendingState,
+						State: prowapi.TriggeredState,
 					}},
 			},
 			pendingJobs:    map[string]int{"my-pj": 10},
@@ -1469,13 +1469,13 @@ func TestMaxConcurency(t *testing.T) {
 					},
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
-						State: prowapi.PendingState,
+						State: prowapi.TriggeredState,
 					}},
 			},
 			expectedResult: true,
 		},
 		{
-			name: "Have older jobs that are not pending, can execute",
+			name: "Have older jobs that are not triggered, can execute",
 			prowJob: prowapi.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					CreationTimestamp: metav1.Now(),
@@ -1488,7 +1488,7 @@ func TestMaxConcurency(t *testing.T) {
 				{
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
-						State: prowapi.TriggeredState,
+						State: prowapi.PendingState,
 					}},
 			},
 			pendingJobs:    map[string]int{"my-pj": 1},


### PR DESCRIPTION
/assign @cjwagner @stevekuznetsov 

Re-enables the ordering by creation date for prowJobs with limited concurrency, which got disabled in #12706. 