### PR TITLE
Sign GCS links when using authenticated GCS access

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -484,7 +484,7 @@ func initSpyglass(cfg config.Getter, o options, mux *http.ServeMux, ja *jobs.Job
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GCS client")
 	}
-	sg := spyglass.New(ja, cfg, c, context.Background())
+	sg := spyglass.New(ja, cfg, c, o.gcsCredentialsFile, context.Background())
 	sg.Start()
 
 	mux.Handle("/spyglass/static/", http.StripPrefix("/spyglass/static", staticHandlerFromDir(o.spyglassFilesLocation)))

--- a/prow/spyglass/gcsartifact_fetcher_test.go
+++ b/prow/spyglass/gcsartifact_fetcher_test.go
@@ -80,7 +80,7 @@ func TestNewGCSJobSource(t *testing.T) {
 // Tests listing objects associated with the current job in GCS
 func TestArtifacts_ListGCS(t *testing.T) {
 	fakeGCSClient := fakeGCSServer.Client()
-	testAf := NewGCSArtifactFetcher(fakeGCSClient)
+	testAf := NewGCSArtifactFetcher(fakeGCSClient, "")
 	testCases := []struct {
 		name              string
 		handle            artifactHandle
@@ -132,7 +132,7 @@ func TestArtifacts_ListGCS(t *testing.T) {
 // Tests getting handles to objects associated with the current job in GCS
 func TestFetchArtifacts_GCS(t *testing.T) {
 	fakeGCSClient := fakeGCSServer.Client()
-	testAf := NewGCSArtifactFetcher(fakeGCSClient)
+	testAf := NewGCSArtifactFetcher(fakeGCSClient, "")
 	maxSize := int64(500e6)
 	testCases := []struct {
 		name         string

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -76,12 +76,12 @@ type ExtraLink struct {
 }
 
 // New constructs a Spyglass object from a JobAgent, a config.Agent, and a storage Client.
-func New(ja *jobs.JobAgent, cfg config.Getter, c *storage.Client, ctx context.Context) *Spyglass {
+func New(ja *jobs.JobAgent, cfg config.Getter, c *storage.Client, gcsCredsFile string, ctx context.Context) *Spyglass {
 	return &Spyglass{
 		JobAgent:              ja,
 		config:                cfg,
 		PodLogArtifactFetcher: NewPodLogArtifactFetcher(ja),
-		GCSArtifactFetcher:    NewGCSArtifactFetcher(c),
+		GCSArtifactFetcher:    NewGCSArtifactFetcher(c, gcsCredsFile),
 		testgrid: &TestGrid{
 			conf:   cfg,
 			client: c,

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -233,7 +233,7 @@ func TestViews(t *testing.T) {
 				lenses.RegisterLens(l)
 			}
 			fca := config.Agent{}
-			sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
+			sg := New(fakeJa, fca.Config, fakeGCSClient, "", context.Background())
 			lenses := sg.Lenses(tc.matchCache)
 			for _, l := range lenses {
 				var found bool
@@ -429,7 +429,7 @@ func TestJobPath(t *testing.T) {
 	for _, tc := range testCases {
 		fakeGCSClient := fakeGCSServer.Client()
 		fca := config.Agent{}
-		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fca.Config, fakeGCSClient, "", context.Background())
 		jobPath, err := sg.JobPath(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: JobPath(%q) expected error", tc.name, tc.src)
@@ -554,7 +554,7 @@ func TestRunPath(t *testing.T) {
 				},
 			},
 		})
-		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fca.Config, fakeGCSClient, "", context.Background())
 		jobPath, err := sg.RunPath(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: RunPath(%q) expected error, got  %q", tc.name, tc.src, jobPath)
@@ -712,7 +712,7 @@ func TestRunToPR(t *testing.T) {
 				},
 			},
 		})
-		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fca.Config, fakeGCSClient, "", context.Background())
 		org, repo, num, err := sg.RunToPR(tc.src)
 		if tc.expError && err == nil {
 			t.Errorf("test %q: RunToPR(%q) expected error", tc.name, tc.src)
@@ -799,7 +799,7 @@ func TestProwToGCS(t *testing.T) {
 		}
 		fakeJa = jobs.NewJobAgent(kc, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
-		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, "", context.Background())
 
 		p, err := sg.prowToGCS(tc.key)
 		if err != nil && !tc.expectError {
@@ -932,7 +932,7 @@ func TestGCSPathRoundTrip(t *testing.T) {
 
 		fakeGCSClient := fakeGCSServer.Client()
 
-		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, "", context.Background())
 		gcspath, _, _ := gcsupload.PathsForJob(
 			&prowapi.GCSConfiguration{Bucket: "test-bucket", PathStrategy: tc.pathStrategy},
 			&downwardapi.JobSpec{
@@ -1044,7 +1044,7 @@ func TestTestGridLink(t *testing.T) {
 				},
 			},
 		})
-		sg := New(fakeJa, fca.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fca.Config, fakeGCSClient, "", context.Background())
 		sg.testgrid = &tg
 		link, err := sg.TestGridLink(tc.src)
 		if tc.expError {
@@ -1091,7 +1091,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 
 	fakeGCSClient := fakeGCSServer.Client()
 
-	sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
+	sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, "", context.Background())
 	testKeys := []string{
 		"prowjob/job/123",
 		"gcs/kubernetes-jenkins/logs/job/123/",
@@ -1249,7 +1249,7 @@ func TestResolveSymlink(t *testing.T) {
 
 		fakeGCSClient := fakeGCSServer.Client()
 
-		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, context.Background())
+		sg := New(fakeJa, fakeConfigAgent.Config, fakeGCSClient, "", context.Background())
 
 		result, err := sg.ResolveSymlink(tc.path)
 		if err != nil {
@@ -1341,7 +1341,7 @@ func TestExtraLinks(t *testing.T) {
 			fakeConfigAgent := fca{}
 			fakeJa = jobs.NewJobAgent(fkc{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA")}, fakeConfigAgent.Config)
 			fakeJa.Start()
-			sg := New(fakeJa, fakeConfigAgent.Config, gcsClient, context.Background())
+			sg := New(fakeJa, fakeConfigAgent.Config, gcsClient, "", context.Background())
 
 			result, err := sg.ExtraLinks("gcs/test-bucket/logs/some-job/42")
 			if err != nil {


### PR DESCRIPTION
When using authenticated GCS access, use [signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls) for spyglass links, enabling access to the buckets even if they are not publicly readable. There is no change in behaviour when performing unauthenticated GCS access.

This grants users the ability to effectively borrow prow's GCP service account for the specific purpose of reading that one file, for ten minutes after the link is generated. Given that if they can get this link, they can already access the file via prow proxying it (with added formatting), this seems entirely reasonable.

A side effect is that, for users who give deck authenticated GCS access, the "Raw build-log.txt" link will only work for ten minutes after the page loads. If this seems too short, we can increase the limit probably without much concern.

Aside: this was decidedly annoying to implement because the library expects me to give it the service account again, in a different way to how it is usually provided. This should've been doable without plumbing paths through and reading it manually, but it does not appear to be.

/cc @krzyzacy 