### PR TITLE
Setup test runtime handler.

### DIFF
--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -15,3 +15,7 @@ disabled_plugins = ["restart"]
 
 [plugins.cri.registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
+
+# Runtime handler used for runtime class test.
+[plugins.cri.containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runtime.v1.linux"


### PR DESCRIPTION
RuntimeClass test is failing, because we didn't setup test-handler. https://k8s-testgrid.appspot.com/sig-node-containerd#image-validation-node-features

This PR fixes it.
Signed-off-by: Lantao Liu <lantaol@google.com>