### PR TITLE
Add Windows 1.15 release job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -126,7 +126,7 @@ periodics:
       securityContext:
         privileged: true
 
-- interval: 6h
+- interval: 12h
   name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -166,6 +166,46 @@ periodics:
       securityContext:
         privileged: true
 
+- interval: 6h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
+  labels:
+    preset-service-account: "true"
+    preset-azure-acsengine: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190520-5580555-master
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.15"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=650"
+      - "--scenario=kubernetes_e2e"
+      - --
+      - "--test=true"
+      - "--up=true"
+      - "--down=true"
+      - "--deployment=acsengine"
+      - "--provider=skeleton"
+      - "--build=bazel"
+      - "--acsengine-admin-username=azureuser"
+      - "--acsengine-admin-password=AdminPassw0rd"
+      - "--acsengine-creds=$AZURE_CREDENTIALS"
+      - "--acsengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/acs-engine-dirty-10-05-2019.tar.gz"
+      - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
+      - "--acsengine-winZipBuildScript=$WIN_BUILD"
+      - "--acsengine-orchestratorRelease=1.15"
+      - "--acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_15.json"
+      - "--acsengine-win-binaries"
+      - "--acsengine-hyperkube"
+      - "--acsengine-agentpoolcount=2"
+      - "--test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|GMSA"
+      - "--timeout=620m"
+      securityContext:
+        privileged: true
+
 - interval: 3h
   name: ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
   labels:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2685,6 +2685,8 @@ dashboards:
   # TODO(Katharine): fork this job.
   - name: soak-gci-gce-1.15
     test_group_name: ci-kubernetes-soak-gci-gce-beta
+  - name: aks-engine-azure-1-15-windows-release
+    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
 
 - name: sig-release-1.14-all
   dashboard_tab:
@@ -5747,6 +5749,9 @@ dashboards:
   - name: aks-engine-azure-1-14-windows
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
     test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
+  - name: aks-engine-azure-1-15-windows
+    description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
+    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
   - name: aks-engine-azure-windows-presubmit
     description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
     test_group_name: pull-kubernetes-e2e-aks-engine-azure-windows


### PR DESCRIPTION
Adds new release job for 1.15 release branch.
Adds 1.15 release job results to testgrid.

Also piggybacked 1.14 periodic interval change to free up resource for 1.15.