### PR TITLE
Run clusterloader2 as kubernetes/perf-tests presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -260,3 +260,53 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+
+
+  kubernetes/perf-tests:
+  - name: pull-perf-tests-clusterloader2
+    always_run: true
+    skip_report: false
+    max_concurrency: 12
+    branches:
+      - master
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-e2e-scalability-common: "true"
+    spec:
+      containers:
+        - args:
+            - --root=/go/src
+            - --repo=k8s.io/kubernetes=master
+            - --repo=k8s.io/perf-tests=$(PULL_REFS)
+            - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --timeout=120
+            - --scenario=kubernetes_e2e
+            - --
+            - --build=bazel
+            - --cluster=
+            - --extract=local
+            - --gcp-nodes=100
+            - --gcp-project=k8s-presubmit-scale
+            - --gcp-zone=us-east1-b
+            - --provider=gce
+            - --stage=gs://kubernetes-release-pull/ci/pull-perf-tests-clusterloader2
+            - --tear-down-previous
+            - --test=false
+            - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+            - --test-cmd-args=cluster-loader2
+            - --test-cmd-args=--nodes=100
+            - --test-cmd-args=--provider=gce
+            - --test-cmd-args=--report-dir=/workspace/_artifacts
+            - --test-cmd-args=--testconfig=testing/density/config.yaml
+            - --test-cmd-args=--testconfig=testing/load/config.yaml
+            - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
+            - --test-cmd-name=ClusterLoaderV2
+            - --timeout=100m
+            - --use-logexporter
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20190520-5580555-master
+          resources:
+            requests:
+              memory: "6Gi"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -859,6 +859,10 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
+- name: pull-perf-tests-clusterloader2
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-perf-tests-clusterloader2
+  days_of_results: 60
+  num_columns_recent: 20
 - name: pull-publishing-bot-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-publishing-bot-build
   num_columns_recent: 20
@@ -5101,6 +5105,9 @@ dashboards:
     base_options: width=10
   - name: pull-kubernetes-kubemark-e2e-gce-scale
     test_group_name: pull-kubernetes-kubemark-e2e-gce-scale
+    base_options: width=10
+  - name: pull-perf-tests-clusterloader2
+    test_group_name: pull-perf-tests-clusterloader2
     base_options: width=10
 
 - name: presubmits-test-infra


### PR DESCRIPTION
This will address all the issues caused by changed in kubernetes/perf-tests that break kubernetes/kubernetes presubmits, e.g. https://github.com/kubernetes/kubernetes/issues/77938