### PR TITLE
Fix containerd post and pre submit test.

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -905,7 +905,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-containerd-gce

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1081,6 +1081,7 @@ periodics:
     containers:
     - args:
       - --timeout=70
+      - --bare
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
@@ -1093,7 +1094,7 @@ periodics:
       - --image-family=cos-73-lts
       - --image-project=cos-cloud
       - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190521-76ded06-master
 
@@ -1108,6 +1109,7 @@ periodics:
     containers:
     - args:
       - --timeout=70
+      - --bare
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
@@ -1118,7 +1120,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud
       - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190521-76ded06-master
 

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             - --provider=gce
             - --runtime-config=batch/v2alpha1=true
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
-            - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+            - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-testimages/kubekins-e2e:v20190520-5580555-master
           resources:

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,9 +1,9 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-d1809-0-v20190506
+    image_family: pipeline-2
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:
-    image_regex: cos-73-11647-182-0
+    image_family: cos-73-lts
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
* Add missing `--bare`
* Use image family in node e2e
* Skipping runtime handler test in cluster e2e because the test handler is not configured in kube-up.sh script.

Signed-off-by: Lantao Liu <lantaol@google.com>