### PR TITLE
add periodic CI job that mirrors pull-kubernetes-e2e-containerd-gce

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -925,7 +925,7 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-containerd-gce,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - master
     cluster: security

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -1,0 +1,27 @@
+periodics:
+- interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-containerd
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_CONTAINER_RUNTIME=containerd
+      - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-nodes=4
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
+      - --timeout=50m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190522-9bf3ab0-master

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -78,7 +78,7 @@ presubmits:
   - name: pull-kubernetes-node-e2e-containerd
     branches:
     - master
-    always_run: false
+    always_run: true
     max_concurrency: 12
     labels:
       preset-service-account: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2420,6 +2420,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-flaky
   - name: gci-gce-single-flake-attempt
     test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
+  - name: gci-gce-containerd
+    test_group_name: ci-kubernetes-e2e-gci-gce-containerd
   - name: gci-gce-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
   - name: gce-multizone
@@ -3201,6 +3203,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
     base_options: include-filter-by-regex=sig-api-machinery
     description: apimachinery gce e2e tests for master branch with reduced flake attempt
+  - name: gce-containerd
+    test_group_name: ci-kubernetes-e2e-gci-gce-containerd
+    base_options: include-filter-by-regex=sig-node
+    description: node gce e2e tests for master branch using containerd
   - name: gke-flaky
     test_group_name: ci-kubernetes-e2e-gci-gke-flaky
     base_options: include-filter-by-regex=sig-api-machinery
@@ -4492,6 +4498,9 @@ dashboards:
     description: storage gce e2e tests for master branch with reduced flake attempt
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
+  - name: gce-containerd
+    test_group_name: ci-kubernetes-e2e-gci-gce-containerd
+    description: node gce e2e tests for master branch using containerd
   - name: gke-flaky
     test_group_name: ci-kubernetes-e2e-gci-gke-flaky
     base_options: include-filter-by-regex=Volume%7Cstorage


### PR DESCRIPTION
Also make sure that pull-kubernetes-node-e2e-containerd runs on all PR(s) (Still non-blocking!)

Change-Id: Ic4fd2e9e2bf0bd2a372507155364912b271311c1