### PR TITLE
prow: ignore TravisCI for Kubernetes-CSI repos

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -247,31 +247,6 @@ branch-protection:
       required_status_checks:
         contexts:
         - cla/linuxfoundation
-      repos:
-        csi-test:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-        drivers:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-        external-attacher:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-        external-provisioner:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-        external-snapshotter:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-        livenessprobe:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
     kubernetes-incubator:
       protect: true
       required_status_checks:


### PR DESCRIPTION
All tests also already run in Prow and only run Travis CI because it's
still used for image publishing. The pre-submit results can be
ignored.