### PR TITLE
Add a plugin to enforce valid links to Bugzilla bugs

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -65,6 +65,7 @@ filegroup(
         ":package-srcs",
         "//prow/apis/prowjobs:all-srcs",
         "//prow/artifact-uploader:all-srcs",
+        "//prow/bugzilla:all-srcs",
         "//prow/client/clientset/versioned:all-srcs",
         "//prow/client/informers/externalversions:all-srcs",
         "//prow/client/listers/prowjobs/v1:all-srcs",

--- a/prow/bugzilla/BUILD.bazel
+++ b/prow/bugzilla/BUILD.bazel
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "fake.go",
+        "types.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/bugzilla",
+    deps = [
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bugzilla
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Client interface {
+	Endpoint() string
+	GetBug(id int) (*Bug, error)
+}
+
+func NewClient(getAPIKey func() []byte, endpoint string) Client {
+	return &client{
+		logger:    logrus.WithField("client", "bugzilla"),
+		client:    &http.Client{},
+		endpoint:  endpoint,
+		getAPIKey: getAPIKey,
+	}
+}
+
+type client struct {
+	logger    *logrus.Entry
+	client    *http.Client
+	endpoint  string
+	getAPIKey func() []byte
+}
+
+// the client is a Client impl
+var _ Client = &client{}
+
+func (c *client) Endpoint() string {
+	return c.endpoint
+}
+
+func (c *client) GetBug(id int) (*Bug, error) {
+	logger := c.logger.WithFields(logrus.Fields{"method": "GetBug", "id": id})
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := c.getAPIKey(); len(apiKey) > 0 {
+		req.Header.Set("X-BUGZILLA-API-KEY", string(apiKey))
+	}
+	resp, err := c.client.Do(req)
+	logger.WithField("response", resp.StatusCode).Debug("Got response from Bugzilla.")
+	if err != nil {
+		code := -1
+		if resp != nil {
+			code = resp.StatusCode
+		}
+		return nil, &requestError{statusCode: code, message: err.Error()}
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.WithError(err).Warn("could not close response body")
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &requestError{statusCode: resp.StatusCode, message: fmt.Sprintf("response code %d not %d", resp.StatusCode, http.StatusOK)}
+	}
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %v", err)
+	}
+	var parsedResponse struct {
+		Bugs []*Bug `json:"bugs,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &parsedResponse); err != nil {
+		return nil, fmt.Errorf("could not unmarshal response body: %v", err)
+	}
+	if len(parsedResponse.Bugs) != 1 {
+		return nil, fmt.Errorf("did not get one bug, but %d: %v", len(parsedResponse.Bugs), parsedResponse)
+	}
+	return parsedResponse.Bugs[0], nil
+}
+
+type requestError struct {
+	statusCode int
+	message    string
+}
+
+func (e requestError) Error() string {
+	return e.message
+}
+
+func IsNotFound(err error) bool {
+	reqError, ok := err.(*requestError)
+	if !ok {
+		return false
+	}
+	return reqError.statusCode == http.StatusNotFound
+}

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bugzilla
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+var (
+	bugData   = []byte(`{"bugs":[{"alias":[],"assigned_to":"Steve Kuznetsov","assigned_to_detail":{"email":"skuznets","id":381851,"name":"skuznets","real_name":"Steve Kuznetsov"},"blocks":[],"cc":["Sudha Ponnaganti"],"cc_detail":[{"email":"sponnaga","id":426940,"name":"sponnaga","real_name":"Sudha Ponnaganti"}],"classification":"Red Hat","component":["Test Infrastructure"],"creation_time":"2019-05-01T19:33:36Z","creator":"Dan Mace","creator_detail":{"email":"dmace","id":330250,"name":"dmace","real_name":"Dan Mace"},"deadline":null,"depends_on":[],"docs_contact":"","dupe_of":null,"groups":[],"id":1705243,"is_cc_accessible":true,"is_confirmed":true,"is_creator_accessible":true,"is_open":true,"keywords":[],"last_change_time":"2019-05-17T15:13:13Z","op_sys":"Unspecified","platform":"Unspecified","priority":"unspecified","product":"OpenShift Container Platform","qa_contact":"","resolution":"","see_also":[],"severity":"medium","status":"VERIFIED","summary":"[ci] cli image flake affecting *-images jobs","target_milestone":"---","target_release":["3.11.z"],"url":"","version":["3.11.0"],"whiteboard":""}],"faults":[]}`)
+	bugStruct = &Bug{Alias: []int{}, AssignedTo: "Steve Kuznetsov", AssignedToDetail: &User{Email: "skuznets", ID: 381851, Name: "skuznets", RealName: "Steve Kuznetsov"}, Blocks: []int{}, CC: []string{"Sudha Ponnaganti"}, CCDetail: []User{{Email: "sponnaga", ID: 426940, Name: "sponnaga", RealName: "Sudha Ponnaganti"}}, Classification: "Red Hat", Component: []string{"Test Infrastructure"}, CreationTime: "2019-05-01T19:33:36Z", Creator: "Dan Mace", CreatorDetail: &User{Email: "dmace", ID: 330250, Name: "dmace", RealName: "Dan Mace"}, DependsOn: []int{}, ID: 1705243, IsCCAccessible: true, IsConfirmed: true, IsCreatorAccessible: true, IsOpen: true, Groups: []string{}, Keywords: []string{}, LastChangeTime: "2019-05-17T15:13:13Z", OperatingSystem: "Unspecified", Platform: "Unspecified", Priority: "unspecified", Product: "OpenShift Container Platform", SeeAlso: []string{}, Severity: "medium", Status: "VERIFIED", Summary: "[ci] cli image flake affecting *-images jobs", TargetRelease: []string{"3.11.z"}, TargetMilestone: "---", Version: []string{"3.11.0"}}
+)
+
+func clientForUrl(url string) *client {
+	return &client{
+		logger:   logrus.WithField("testing", "true"),
+		endpoint: url,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+		getAPIKey: func() []byte {
+			return []byte("api-key")
+		},
+	}
+}
+
+func TestGetBug(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-BUGZILLA-API-KEY") != "api-key" {
+			t.Error("did not get api-key passed in X-BUGZILLA-API-KEY header")
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, "/rest/bug/") {
+			t.Errorf("incorrect path to get a bug: %s", r.URL.Path)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/rest/bug/")); err != nil {
+			t.Errorf("malformed bug id: %s", r.URL.Path)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		} else {
+			if id == 1705243 {
+				w.Write(bugData)
+			} else {
+				http.Error(w, "404 Not Found", http.StatusNotFound)
+			}
+		}
+	}))
+	defer testServer.Close()
+	client := clientForUrl(testServer.URL)
+
+	// this should give us what we want
+	bug, err := client.GetBug(1705243)
+	if err != nil {
+		t.Errorf("expected no error, but got one: %v", err)
+	}
+	if !reflect.DeepEqual(bug, bugStruct) {
+		t.Errorf("got incorrect bug: %v", diff.ObjectReflectDiff(bug, bugStruct))
+	}
+
+	// this should 404
+	otherBug, err := client.GetBug(1)
+	if err == nil {
+		t.Error("expected an error, but got none")
+	} else if !IsNotFound(err) {
+		t.Errorf("expected a not found error, got %v", err)
+	}
+	if otherBug != nil {
+		t.Errorf("expected no bug, got: %v", otherBug)
+	}
+}

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bugzilla
+
+import (
+	"errors"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Fake is a fake Bugzilla client with injectable fields
+type Fake struct {
+	EndpointString string
+	Bugs           map[int]Bug
+	BugErrors      sets.Int
+}
+
+// Endpoint returns the endpoint for this fake
+func (c *Fake) Endpoint() string {
+	return c.EndpointString
+}
+
+// GetBug retrieves the bug, if registered, or an error, if set,
+// or responds with an error that matches IsNotFound
+func (c *Fake) GetBug(id int) (*Bug, error) {
+	if c.BugErrors.Has(id) {
+		return nil, errors.New("injected error getting bug")
+	}
+	if bug, exists := c.Bugs[id]; exists {
+		return &bug, nil
+	} else {
+		return nil, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+	}
+}
+
+// the Fake is a Client
+var _ Client = &Fake{}

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bugzilla
+
+// Bug is a record of a bug. See API documentation at:
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
+type Bug struct {
+	// ActualTime is the total number of hours that this bug has taken so far. If you are not in the time-tracking group, this field will not be included in the return value.
+	ActualTime int `json:"actual_time,omitempty"`
+	// Alias is the unique aliases of this bug. An empty array will be returned if this bug has no aliases.
+	Alias []int `json:"alias,omitempty"`
+	// AssignedTo is the login name of the user to whom the bug is assigned.
+	AssignedTo string `json:"assigned_to,omitempty"`
+	// AssignedToDetail is an object containing detailed user information for the assigned_to. To see the keys included in the user detail object, see below.
+	AssignedToDetail *User `json:"assigned_to_detail,omitempty"`
+	// Blocks is the IDs of bugs that are "blocked" by this bug.
+	Blocks []int `json:"blocks,omitempty"`
+	// CC is the login names of users on the CC list of this bug.
+	CC []string `json:"cc,omitempty"`
+	// CCDetail is array of objects containing detailed user information for each of the cc list members. To see the keys included in the user detail object, see below.
+	CCDetail []User `json:"cc_detail,omitempty"`
+	// Classification is the name of the current classification the bug is in.
+	Classification string `json:"classification,omitempty"`
+	// Component is an array of names of the current components of this bug.
+	Component []string `json:"component,omitempty"`
+	// CreationTime is when the bug was created.
+	CreationTime string `json:"creation_time,omitempty"`
+	// Creator is the login name of the person who filed this bug (the reporter).
+	Creator string `json:"creator,omitempty"`
+	// CreatorDetail is an object containing detailed user information for the creator. To see the keys included in the user detail object, see below.
+	CreatorDetail *User `json:"creator_detail,omitempty"`
+	// Deadline is the day that this bug is due to be completed, in the format YYYY-MM-DD.
+	Deadline string `json:"deadline,omitempty"`
+	// DependsOn is the IDs of bugs that this bug "depends on".
+	DependsOn []int `json:"depends_on,omitempty"`
+	// DupeOf is the bug ID of the bug that this bug is a duplicate of. If this bug isn't a duplicate of any bug, this will be null.
+	DupeOf int `json:"dupe_of,omitempty"`
+	// EstimatedTime is the number of hours that it was estimated that this bug would take. If you are not in the time-tracking group, this field will not be included in the return value.
+	EstimatedTime int `json:"estimated_time,omitempty"`
+	// Flags is an array of objects containing the information about flags currently set for the bug. Each flag objects contains the following items
+	Flags []Flag `json:"flags,omitempty"`
+	// Groups is the names of all the groups that this bug is in.
+	Groups []string `json:"groups,omitempty"`
+	// ID is the unique numeric ID of this bug.
+	ID int `json:"id,omitempty"`
+	// IsCCAccessible is if true, this bug can be accessed by members of the CC list, even if they are not in the groups the bug is restricted to.
+	IsCCAccessible bool `json:"is_cc_accessible,omitempty"`
+	// IsConfirmed is true if the bug has been confirmed. Usually this means that the bug has at some point been moved out of the UNCONFIRMED status and into another open status.
+	IsConfirmed bool `json:"is_confirmed,omitempty"`
+	// IsOpen is true if this bug is open, false if it is closed.
+	IsOpen bool `json:"is_open,omitempty"`
+	// IsCreatorAccessible is if true, this bug can be accessed by the creator of the bug, even if they are not a member of the groups the bug is restricted to.
+	IsCreatorAccessible bool `json:"is_creator_accessible,omitempty"`
+	// Keywords is each keyword that is on this bug.
+	Keywords []string `json:"keywords,omitempty"`
+	// LastChangeTime is when the bug was last changed.
+	LastChangeTime string `json:"last_change_time,omitempty"`
+	// OperatingSystem is the name of the operating system that the bug was filed against.
+	OperatingSystem string `json:"op_sys,omitempty"`
+	// Platform is the name of the platform (hardware) that the bug was filed against.
+	Platform string `json:"platform,omitempty"`
+	// Priority is the priority of the bug.
+	Priority string `json:"priority,omitempty"`
+	// Product is the name of the product this bug is in.
+	Product string `json:"product,omitempty"`
+	// QAContact is the login name of the current QA Contact on the bug.
+	QAContact string `json:"qa_contact,omitempty"`
+	// QAContactDetail is an object containing detailed user information for the qa_contact. To see the keys included in the user detail object, see below.
+	QAContactDetail *User `json:"qa_contact_detail,omitempty"`
+	// RemainingTime is the number of hours of work remaining until work on this bug is complete. If you are not in the time-tracking group, this field will not be included in the return value.
+	RemainingTime int `json:"remaining_time,omitempty"`
+	// Resolution is the current resolution of the bug, or an empty string if the bug is open.
+	Resolution string `json:"resolution,omitempty"`
+	// SeeAlso is the URLs in the See Also field on the bug.
+	SeeAlso []string `json:"see_also,omitempty"`
+	// Severity is the current severity of the bug.
+	Severity string `json:"severity,omitempty"`
+	// Status is the current status of the bug.
+	Status string `json:"status,omitempty"`
+	// Summary is the summary of this bug.
+	Summary string `json:"summary,omitempty"`
+	// TargetMilestone is the milestone that this bug is supposed to be fixed by, or for closed bugs, the milestone that it was fixed for.
+	TargetMilestone string `json:"target_milestone,omitempty"`
+	// TargetRelease are the releases that the bug will be fixed in.
+	TargetRelease []string `json:"target_release,omitempty"`
+	// UpdateToken is the token that you would have to pass to the process_bug.cgi page in order to update this bug. This changes every time the bug is updated. This field is not returned to logged-out users.
+	UpdateToken string `json:"update_token,omitempty"`
+	// URL is a URL that demonstrates the problem described in the bug, or is somehow related to the bug report.
+	URL string `json:"url,omitempty"`
+	// Version are the versions the bug was reported against.
+	Version []string `json:"version,omitempty"`
+	// Whiteboard is he value of the "status whiteboard" field on the bug.
+	Whiteboard string `json:"whiteboard,omitempty"`
+}
+
+// User holds information about a user
+type User struct {
+	// The user ID for this user.
+	ID int `json:"id,omitempty"`
+	// The 'real' name for this user, if any.
+	RealName string `json:"real_name,omitempty"`
+	// The user's Bugzilla login.
+	Name string `json:"name,omitempty"`
+	// The user's e-mail.
+	Email string `json:"email,omitempty"`
+}
+
+// Flag holds information about a flag set on a bug
+type Flag struct {
+	// The ID of the flag.
+	ID int `json:"id,omitempty"`
+	// The name of the flag.
+	Name string `json:"name,omitempty"`
+	// The type ID of the flag.
+	TypeID int `json:"type_id,omitempty"`
+	// The timestamp when this flag was originally created.
+	CreationDate string `json:"creation_date,omitempty"`
+	// The timestamp when the flag was last modified.
+	ModificationDate string `json:"modification_date,omitempty"`
+	// The current status of the flag.
+	Status string `json:"status,omitempty"`
+	// The login name of the user who created or last modified the flag.
+	Setter string `json:"setter,omitempty"`
+	// The login name of the user this flag has been requested to be granted or denied. Note, this field is only returned if a requestee is set.
+	Requestee string `json:"requestee,omitempty"`
+}

--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//prow/plugins/approve:go_default_library",
         "//prow/plugins/blockade:go_default_library",
         "//prow/plugins/blunderbuss:go_default_library",
+        "//prow/plugins/bugzilla:go_default_library",
         "//prow/plugins/cherrypickunapproved:go_default_library",
         "//prow/plugins/hold:go_default_library",
         "//prow/plugins/lgtm:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/plugins/bugzilla"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -506,11 +507,13 @@ func validateTideRequirements(cfg *config.Config, pcfg *plugins.Configuration, i
 	configs := []plugin{
 		{name: lgtm.PluginName, label: labels.LGTM, matcher: requires},
 		{name: approve.PluginName, label: labels.Approved, matcher: requires},
+		{name: bugzilla.PluginName, label: labels.ValidBug, matcher: requires},
 	}
 	if includeForbidden {
 		configs = append(configs,
 			plugin{name: hold.PluginName, label: labels.Hold, matcher: forbids},
 			plugin{name: wip.PluginName, label: labels.WorkInProgress, matcher: forbids},
+			plugin{name: bugzilla.PluginName, label: labels.InvalidBug, matcher: forbids},
 			plugin{name: verifyowners.PluginName, label: labels.InvalidOwners, matcher: forbids},
 			plugin{name: releasenote.PluginName, label: releasenote.ReleaseNoteLabelNeeded, matcher: forbids},
 			plugin{name: cherrypickunapproved.PluginName, label: labels.CpUnapproved, matcher: forbids},

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/hook",
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//prow/bugzilla:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
@@ -48,6 +49,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp/hook:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/bugzilla:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bool.go",
+        "bugzilla.go",
         "doc.go",
         "github.go",
         "k8s_client.go",
@@ -14,6 +15,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/flagutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/bugzilla:go_default_library",
         "//prow/client/clientset/versioned:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config/secret:go_default_library",

--- a/prow/flagutil/bugzilla.go
+++ b/prow/flagutil/bugzilla.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/bugzilla"
+	"k8s.io/test-infra/prow/config/secret"
+)
+
+// BugzillaOptions holds options for interacting with Bugzilla.
+type BugzillaOptions struct {
+	endpoint   string
+	ApiKeyPath string
+}
+
+// AddFlags injects Bugzilla options into the given FlagSet.
+func (o *BugzillaOptions) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&o.endpoint, "bugzilla-endpoint", "", "Bugzilla's API endpoint.")
+	fs.StringVar(&o.ApiKeyPath, "bugzilla-api-key-path", "", "Path to the file containing the Bugzilla API key.")
+}
+
+// Validate validates Bugzilla options.
+func (o *BugzillaOptions) Validate(dryRun bool) error {
+	if o.endpoint == "" {
+		logrus.Warn("empty -bugzilla-endpoint, will not create Bugzilla client")
+		return nil
+	}
+
+	if _, err := url.ParseRequestURI(o.endpoint); err != nil {
+		return fmt.Errorf("invalid -bugzilla-endpoint URI: %q", o.endpoint)
+	}
+
+	if o.ApiKeyPath == "" {
+		logrus.Warn("empty -bugzilla-api-key-path, will use anonymous Bugzilla client")
+	}
+
+	return nil
+}
+
+// BugzillaClient returns a Bugzilla client.
+func (o *BugzillaOptions) BugzillaClient(secretAgent *secret.Agent) (bugzilla.Client, error) {
+	if o.endpoint == "" {
+		return nil, fmt.Errorf("empty -bugzilla-endpoint, cannot create Bugzilla client")
+	}
+
+	var generator *func() []byte
+	if o.ApiKeyPath == "" {
+		generatorFunc := func() []byte {
+			return []byte{}
+		}
+		generator = &generatorFunc
+	} else {
+		if secretAgent == nil {
+			return nil, fmt.Errorf("cannot store token from %q without a secret agent", o.ApiKeyPath)
+		}
+		generatorFunc := secretAgent.GetTokenGenerator(o.ApiKeyPath)
+		generator = &generatorFunc
+	}
+
+	return bugzilla.NewClient(*generator, o.endpoint), nil
+}

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//prow/plugins/blockade:go_default_library",
         "//prow/plugins/blunderbuss:go_default_library",
         "//prow/plugins/branchcleaner:go_default_library",
+        "//prow/plugins/bugzilla:go_default_library",
         "//prow/plugins/buildifier:go_default_library",
         "//prow/plugins/cat:go_default_library",
         "//prow/plugins/cherrypickunapproved:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -24,6 +24,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/blockade"
 	_ "k8s.io/test-infra/prow/plugins/blunderbuss"
 	_ "k8s.io/test-infra/prow/plugins/branchcleaner"
+	_ "k8s.io/test-infra/prow/plugins/bugzilla"
 	_ "k8s.io/test-infra/prow/plugins/buildifier"
 	_ "k8s.io/test-infra/prow/plugins/cat"
 	_ "k8s.io/test-infra/prow/plugins/cherrypickunapproved"

--- a/prow/labels/labels.go
+++ b/prow/labels/labels.go
@@ -29,6 +29,7 @@ const (
 	Help            = "help wanted"
 	Hold            = "do-not-merge/hold"
 	InvalidOwners   = "do-not-merge/invalid-owners-file"
+	InvalidBug      = "bugzilla/invalid-bug"
 	LGTM            = "lgtm"
 	LifecycleActive = "lifecycle/active"
 	LifecycleFrozen = "lifecycle/frozen"
@@ -41,4 +42,5 @@ const (
 	OkToTest        = "ok-to-test"
 	Shrug           = "¯\\_(ツ)_/¯"
 	WorkInProgress  = "do-not-merge/work-in-progress"
+	ValidBug        = "bugzilla/valid-bug"
 )

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/plugins",
     deps = [
+        "//prow/bugzilla:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",
@@ -62,6 +63,7 @@ filegroup(
         "//prow/plugins/blockade:all-srcs",
         "//prow/plugins/blunderbuss:all-srcs",
         "//prow/plugins/branchcleaner:all-srcs",
+        "//prow/plugins/bugzilla:all-srcs",
         "//prow/plugins/buildifier:all-srcs",
         "//prow/plugins/cat:all-srcs",
         "//prow/plugins/cherrypickunapproved:all-srcs",

--- a/prow/plugins/bugzilla/BUILD.bazel
+++ b/prow/plugins/bugzilla/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["bugzilla.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/bugzilla",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/bugzilla:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/labels:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bugzilla_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/bugzilla:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bugzilla ensures that pull requests reference a Bugzilla bug in their title
+package bugzilla
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/bugzilla"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+var (
+	titleMatch   = regexp.MustCompile(`(?i)^.*Bug ([0-9]+):`)
+	commandMatch = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
+)
+
+const (
+	PluginName = "bugzilla"
+	bugLink    = `[Bugzilla bug](%s/show_bug.cgi?id=%d)`
+)
+
+func init() {
+	plugins.RegisterGenericCommentHandler(PluginName, handleGenericComment, helpProvider)
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	configInfo := make(map[string]string)
+	for _, orgRepo := range enabledRepos {
+		parts := strings.Split(orgRepo, "/")
+		var opts map[string]plugins.BugzillaBranchOptions
+		switch len(parts) {
+		case 2:
+			opts = config.Bugzilla.OptionsForRepo(parts[0], parts[1])
+		default:
+			return nil, fmt.Errorf("invalid repo in enabledRepos: %q", orgRepo)
+		}
+		if len(opts) == 0 {
+			continue
+		}
+		// we need to make sure the order of this help is consistent for page reloads and testing
+		var branches []string
+		for branch := range opts {
+			branches = append(branches, branch)
+		}
+		sort.Strings(branches)
+		var configInfoStrings []string
+		configInfoStrings = append(configInfoStrings, "The plugin has the following configuration:<ul>")
+		for _, branch := range branches {
+			var message string
+			if branch == plugins.BugzillaOptionsWildcard {
+				message = "by default, "
+			} else {
+				message = fmt.Sprintf("on the %q branch, ", branch)
+			}
+			message += "valid bugs must "
+			var conditionsExist bool
+			if opts[branch].IsOpen != nil {
+				conditionsExist = true
+				if *opts[branch].IsOpen {
+					message += "be open"
+				} else {
+					message += "be closed"
+				}
+			}
+			if opts[branch].TargetRelease != nil {
+				conditionsExist = true
+				if opts[branch].IsOpen != nil {
+					message += " and "
+				}
+				message += fmt.Sprintf("target the %q release", *opts[branch].TargetRelease)
+			}
+			if !conditionsExist {
+				message += "exist"
+			}
+			configInfoStrings = append(configInfoStrings, "<li>"+message+"</li>")
+		}
+		configInfoStrings = append(configInfoStrings, fmt.Sprintf("</ul>"))
+		configInfo[orgRepo] = strings.Join(configInfoStrings, "\n")
+	}
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The bugzilla plugin ensures that pull requests reference a valid Bugzilla bug in their title.",
+		Config:      configInfo,
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/bugzilla refresh",
+		Description: "Check Bugzilla for a valid bug referenced in the PR title",
+		Featured:    false,
+		WhoCanUse:   "Anyone",
+		Examples:    []string{"/bugzilla refresh"},
+	})
+	return pluginHelp, nil
+}
+
+type githubClient interface {
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	CreateComment(owner, repo string, number int, comment string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+}
+
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+	event, err := digestComment(pc.GitHubClient, pc.Logger, e)
+	if err != nil {
+		return err
+	}
+	if event != nil {
+		options := pc.PluginConfig.Bugzilla.OptionsForBranch(event.org, event.repo, event.baseRef)
+		return handle(*event, pc.GitHubClient, pc.BugzillaClient, options, pc.Logger)
+	}
+	return nil
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
+	event, err := digestPR(pc.Logger, pre)
+	if err != nil {
+		return err
+	}
+	if event != nil {
+		options := pc.PluginConfig.Bugzilla.OptionsForBranch(event.org, event.repo, event.baseRef)
+		return handle(*event, pc.GitHubClient, pc.BugzillaClient, options, pc.Logger)
+	}
+	return nil
+}
+
+// digestPR determines if any action is necessary and creates the objects for handle() if it is
+func digestPR(log *logrus.Entry, pre github.PullRequestEvent) (*event, error) {
+	// These are the only actions indicating the PR title may have changed.
+	if pre.Action != github.PullRequestActionOpened &&
+		pre.Action != github.PullRequestActionReopened &&
+		pre.Action != github.PullRequestActionEdited {
+		return nil, nil
+	}
+
+	var (
+		org     = pre.PullRequest.Base.Repo.Owner.Login
+		repo    = pre.PullRequest.Base.Repo.Name
+		baseRef = pre.PullRequest.Base.Ref
+		number  = pre.PullRequest.Number
+		title   = pre.PullRequest.Title
+	)
+
+	// Make sure the PR title is referencing a bug
+	e := &event{org: org, repo: repo, baseRef: baseRef, number: number, body: title, htmlUrl: pre.PullRequest.HTMLURL, login: pre.PullRequest.User.Login}
+	mat := titleMatch.FindStringSubmatch(title)
+	if mat == nil {
+		// in the case that the title used to reference a bug and no longer does we
+		// want to handle this to remove labels
+		e.missing = true
+	} else {
+		id, err := strconv.Atoi(mat[1])
+		if err != nil {
+			// should be impossible based on the regex
+			log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
+			return nil, err
+		}
+		e.bugId = id
+	}
+
+	// when exiting early from errors trying to find out if the PR previously referenced a bug,
+	// we want to handle the event only if a bug is currently referenced. Only when we know the
+	// PR previously referenced a bug can we handle events where the PR currently does not
+	var intermediate *event
+	if !e.missing {
+		intermediate = e
+	}
+
+	// Check if the previous version of the title referenced a bug.
+	var changes struct {
+		Title struct {
+			From string `json:"from"`
+		} `json:"title"`
+	}
+	if err := json.Unmarshal(pre.Changes, &changes); err != nil {
+		// we're detecting this best-effort so we can handle it anyway
+		return intermediate, nil
+	}
+	prevMat := titleMatch.FindStringSubmatch(changes.Title.From)
+	if prevMat == nil {
+		// title did not previously reference a bug
+		return intermediate, nil
+	}
+	prevId, err := strconv.Atoi(prevMat[1])
+	if err != nil {
+		// should be impossible based on the regex, ignore err as this is best-effort
+		log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
+		return intermediate, nil
+	}
+
+	// if the referenced bug has not changed in the update, ignore it
+	if prevId == e.bugId {
+		logrus.Debugf("Referenced Bugzilla ID (%d) has not changed, not handling event.", e.bugId)
+		return nil, nil
+	}
+
+	// we know the PR previously referenced a bug, so whether
+	// it currently does or does not reference a bug, we should
+	// handle the event
+	return e, nil
+}
+
+// digestComment determines if any action is necessary and creates the objects for handle() if it is
+func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericCommentEvent) (*event, error) {
+	// Only consider new comments.
+	if gce.Action != github.GenericCommentActionCreated {
+		return nil, nil
+	}
+	// Make sure they are requesting a bug refresh
+	if !commandMatch.MatchString(gce.Body) {
+		return nil, nil
+	}
+	var (
+		org    = gce.Repo.Owner.Login
+		repo   = gce.Repo.Name
+		number = gce.Number
+	)
+
+	// We don't support linking issues to Bugs
+	if !gce.IsPR {
+		log.Debug("Bug refresh requested on an issue, ignoring")
+		return nil, gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, gce.User.Login, `Bugzilla bug referencing is only supported for Pull Requests, not issues.`))
+	}
+
+	// Make sure the PR title is referencing a bug
+	pr, err := gc.GetPullRequest(org, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &event{org: org, repo: repo, baseRef: pr.Base.Ref, number: number, body: gce.Body, htmlUrl: gce.HTMLURL, login: gce.User.Login}
+	mat := titleMatch.FindStringSubmatch(pr.Title)
+	if mat == nil {
+		e.missing = true
+		return e, nil
+	}
+	id, err := strconv.Atoi(mat[1])
+	if err != nil {
+		// should be impossible based on the regex
+		log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
+		return nil, err
+	}
+	e.bugId = id
+
+	return e, nil
+}
+
+type event struct {
+	org, repo, baseRef   string
+	number, bugId        int
+	missing              bool
+	body, htmlUrl, login string
+}
+
+func handle(e event, gc githubClient, bc bugzilla.Client, options plugins.BugzillaBranchOptions, log *logrus.Entry) error {
+	comment := func(body string) error {
+		return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlUrl, e.login, body))
+	}
+
+	var needsValidLabel, needsInvalidLabel bool
+	var response string
+	if e.missing {
+		log.WithField("bugMissing", true)
+		log.Debug("No bug referenced.")
+		needsValidLabel, needsInvalidLabel = false, false
+		response = `No Bugzilla bug is referenced in the title of this pull request.
+To reference a bug, add 'Bug XXX:' to the title of this pull request and request another bug refresh with <code>/bugzilla refresh</code>.`
+	} else {
+		log = log.WithField("bugId", e.bugId)
+
+		bug, err := bc.GetBug(e.bugId)
+		if err != nil && !bugzilla.IsNotFound(err) {
+			log.WithError(err).Warn("Unexpected error searching for Bugzilla bug.")
+			return comment(fmt.Sprintf(`An error was encountered searching the Bugzilla server at %s for bug %d:
+> %v
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.`,
+				bc.Endpoint(), e.bugId, err))
+		}
+		if bugzilla.IsNotFound(err) || bug == nil {
+			log.Debug("No bug found.")
+			return comment(fmt.Sprintf(`No Bugzilla bug with ID %d exists in the tracker at %s.
+Once a valid bug is referenced in the title of this pull request, request a bug refresh with <code>/bugzilla refresh</code>.`,
+				e.bugId, bc.Endpoint()))
+		}
+
+		valid, why := validateBug(*bug, options)
+		needsValidLabel, needsInvalidLabel = valid, !valid
+		if valid {
+			log.Debug("Valid bug found.")
+			response = fmt.Sprintf(`This pull request references a valid `+bugLink+`.`, bc.Endpoint(), e.bugId)
+		} else {
+			log.Debug("Invalid bug found.")
+			var formattedReasons string
+			for _, reason := range why {
+				formattedReasons += fmt.Sprintf(" - %s\n", reason)
+			}
+			response = fmt.Sprintf(`This pull request references an invalid `+bugLink+`:
+%s`, bc.Endpoint(), e.bugId, formattedReasons)
+		}
+	}
+
+	// ensure label state is correct. Do not propagate errors
+	// as it is more important to report to the user than to
+	// fail early on a label check.
+	currentLabels, err := gc.GetIssueLabels(e.org, e.repo, e.number)
+	if err != nil {
+		log.WithError(err).Warn("Could not list labels on PR")
+	}
+	var hasValidLabel, hasInvalidLabel bool
+	for _, l := range currentLabels {
+		if l.Name == labels.ValidBug {
+			hasValidLabel = true
+		}
+		if l.Name == labels.InvalidBug {
+			hasInvalidLabel = true
+		}
+	}
+
+	if needsValidLabel && !hasValidLabel {
+		if err := gc.AddLabel(e.org, e.repo, e.number, labels.ValidBug); err != nil {
+			log.WithError(err).Error("Failed to add valid bug label.")
+		}
+	} else if !needsValidLabel && hasValidLabel {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, labels.ValidBug); err != nil {
+			log.WithError(err).Error("Failed to remove valid bug label.")
+		}
+	}
+
+	if needsInvalidLabel && !hasInvalidLabel {
+		if err := gc.AddLabel(e.org, e.repo, e.number, labels.InvalidBug); err != nil {
+			log.WithError(err).Error("Failed to add invalid bug label.")
+		}
+	} else if !needsInvalidLabel && hasInvalidLabel {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, labels.InvalidBug); err != nil {
+			log.WithError(err).Error("Failed to remove invalid bug label.")
+		}
+	}
+
+	return comment(response)
+}
+
+// validateBug determines if the bug matches the options and returns a description of why not
+func validateBug(bug bugzilla.Bug, options plugins.BugzillaBranchOptions) (bool, []string) {
+	valid := true
+	var errors []string
+	if options.IsOpen != nil && *options.IsOpen != bug.IsOpen {
+		valid = false
+		not := ""
+		was := "isn't"
+		if !*options.IsOpen {
+			not = "not "
+			was = "is"
+		}
+		errors = append(errors, fmt.Sprintf("expected the bug to %sbe open, but it %s", not, was))
+	}
+
+	if options.TargetRelease != nil {
+		if len(bug.TargetRelease) == 0 {
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected the bug to target the %q release, but no target release was set", *options.TargetRelease))
+		} else if *options.TargetRelease != bug.TargetRelease[0] {
+			// the BugZilla web UI shows one option for target release, but returns the
+			// field as a list in the REST API. We only care for the first item and it's
+			// not even clear if the list can have more than one item in the response
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected the bug to target the %q release, but it targets %q instead", *options.TargetRelease, bug.TargetRelease[0]))
+		}
+	}
+
+	return valid, errors
+}

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1,0 +1,679 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bugzilla
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/bugzilla"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func TestHelpProvider(t *testing.T) {
+	rawConfig := `default:
+  "*":
+    target_release: global-default
+  "global-branch":
+    is_open: false
+    target_release: global-branch-default
+orgs:
+  my-org:
+    default:
+      "*":
+        is_open: true
+        target_release: my-org-default
+      "my-org-branch":
+        target_release: my-org-branch-default
+    repos:
+      my-repo:
+        branches:
+          "*":
+            is_open: false
+            target_release: my-repo-default
+          "my-repo-branch":
+            target_release: my-repo-branch`
+	var config plugins.Bugzilla
+	if err := yaml.Unmarshal([]byte(rawConfig), &config); err != nil {
+		t.Fatalf("couldn't unmarshal config: %v", err)
+	}
+
+	pc := &plugins.Configuration{Bugzilla: config}
+	help, err := helpProvider(pc, []string{"some-org/some-repo", "my-org/some-repo", "my-org/my-repo"})
+	if err != nil {
+		t.Fatalf("unexpected error creating help provider: %v", err)
+	}
+
+	expected := &pluginhelp.PluginHelp{
+		Description: "The bugzilla plugin ensures that pull requests reference a valid Bugzilla bug in their title.",
+		Config: map[string]string{
+			"some-org/some-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must target the "global-default" release</li>
+<li>on the "global-branch" branch, valid bugs must be closed and target the "global-branch-default" release</li>
+</ul>`,
+			"my-org/some-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must be open and target the "my-org-default" release</li>
+<li>on the "my-org-branch" branch, valid bugs must be open and target the "my-org-branch-default" release</li>
+</ul>`,
+			"my-org/my-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must be closed and target the "my-repo-default" release</li>
+<li>on the "my-repo-branch" branch, valid bugs must be closed and target the "my-repo-branch" release</li>
+</ul>`,
+		},
+		Commands: []pluginhelp.Command{{
+			Usage:       "/bugzilla refresh",
+			Description: "Check Bugzilla for a valid bug referenced in the PR title",
+			Featured:    false,
+			WhoCanUse:   "Anyone",
+			Examples:    []string{"/bugzilla refresh"},
+		}},
+	}
+
+	if actual := help; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("resolved incorrect plugin help: %v", diff.ObjectReflectDiff(actual, expected))
+	}
+}
+
+func TestDigestPR(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		pre         github.PullRequestEvent
+		expected    *event
+		expectedErr bool
+	}{
+		{
+			name: "unrelated event gets ignored",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestFileAdded,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number: 1,
+					Title:  "Bug 123: fixed it!",
+				},
+			},
+		},
+		{
+			name: "unrelated title gets ignored",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number: 1,
+					Title:  "fixing a typo",
+				},
+			},
+		},
+		{
+			name: "title referencing bug gets an event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "Bug 123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, bugId: 123, body: "Bug 123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change referencing same bug gets no event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "Bug 123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"Bug 123: fixed it! (WIP)"}}`),
+			},
+		},
+		{
+			name: "title change referencing new bug gets event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "Bug 123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"fixed it! (WIP)"}}`),
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, bugId: 123, body: "Bug 123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change dereferencing bug gets event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"Bug 123: fixed it! (WIP)"}}`),
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, missing: true, body: "fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change to no bug with unrelated changes gets no event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"oops":{"doops":"payload"}}`),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			event, err := digestPR(logrus.WithField("testCase", testCase.name), testCase.pre)
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct event: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestDigestComment(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		e               github.GenericCommentEvent
+		title           string
+		expected        *event
+		expectedComment string
+		expectedErr     bool
+	}{
+		{
+			name: "unrelated event gets ignored",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionDeleted,
+				IsPR:   true,
+				Body:   "/bugzilla refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+			},
+			title: "Bug 123: oopsie doopsie",
+		},
+		{
+			name: "unrelated title gets an event saying so",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/bugzilla refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title: "cole, please review this typo fix",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, missing: true, body: "/bugzilla refresh", htmlUrl: "www.com", login: "user",
+			},
+		},
+		{
+			name: "comment on issue gets no event but a comment",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   false,
+				Body:   "/bugzilla refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+			},
+			title: "someone misspelled words in this repo",
+			expectedComment: `org/repo#1:@: Bugzilla bug referencing is only supported for Pull Requests, not issues.
+
+<details>
+
+In response to [this]():
+
+>/bugzilla refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name: "title referencing bug gets an event",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/bugzilla refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title: "Bug 123: oopsie doopsie",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, bugId: 123, body: "/bugzilla refresh", htmlUrl: "www.com", login: "user",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fakegithub.FakeClient{
+				PullRequests: map[int]*github.PullRequest{
+					1: {Base: github.PullRequestBranch{Ref: "branch"}, Title: testCase.title},
+				},
+				IssueComments: map[int][]github.IssueComment{},
+			}
+			event, err := digestComment(&client, logrus.WithField("testCase", testCase.name), testCase.e)
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct event: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+
+			checkComments(client, testCase.name, testCase.expectedComment, t)
+		})
+	}
+}
+
+func TestHandle(t *testing.T) {
+	open := true
+	e := event{
+		org: "org", repo: "repo", baseRef: "branch", number: 1, bugId: 123, body: "Bug 123: fixed it!", htmlUrl: "http.com", login: "user",
+	}
+	var testCases = []struct {
+		name            string
+		labels          []string
+		missing         bool
+		bug             *bugzilla.Bug
+		bugError        bool
+		options         plugins.BugzillaBranchOptions
+		expectedLabels  []string
+		expectedErr     bool
+		expectedComment string
+	}{
+		{
+			name: "no bug found leaves a comment",
+			expectedComment: `org/repo#1:@user: No Bugzilla bug with ID 123 exists in the tracker at www.bugzilla.
+Once a valid bug is referenced in the title of this pull request, request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:     "error fetching bug leaves a comment",
+			bugError: true,
+			expectedComment: `org/repo#1:@user: An error was encountered searching the Bugzilla server at www.bugzilla for bug 123:
+> injected error getting bug
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "valid bug removes invalid label, adds valid label and comments",
+			bug:            &bugzilla.Bug{ID: 123},
+			options:        plugins.BugzillaBranchOptions{}, // no requirements --> always valid
+			labels:         []string{"bugzilla/invalid-bug"},
+			expectedLabels: []string{"bugzilla/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references a valid [Bugzilla bug](www.bugzilla/show_bug.cgi?id=123).
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "invalid bug adds invalid label, removes valid label and comments",
+			bug:            &bugzilla.Bug{ID: 123},
+			options:        plugins.BugzillaBranchOptions{IsOpen: &open},
+			labels:         []string{"bugzilla/valid-bug"},
+			expectedLabels: []string{"bugzilla/invalid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references an invalid [Bugzilla bug](www.bugzilla/show_bug.cgi?id=123):
+ - expected the bug to be open, but it isn't
+
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:    "no bug removes all labels and comments",
+			missing: true,
+			labels:  []string{"bugzilla/valid-bug", "bugzilla/invalid-bug"},
+			expectedComment: `org/repo#1:@user: No Bugzilla bug is referenced in the title of this pull request.
+To reference a bug, add 'Bug XXX:' to the title of this pull request and request another bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			gc := fakegithub.FakeClient{
+				IssueLabelsExisting: []string{},
+				IssueComments:       map[int][]github.IssueComment{},
+			}
+			for _, label := range testCase.labels {
+				gc.IssueLabelsExisting = append(gc.IssueLabelsExisting, fmt.Sprintf("%s/%s#%d:%s", e.org, e.repo, e.number, label))
+			}
+			bc := bugzilla.Fake{
+				EndpointString: "www.bugzilla",
+				Bugs:           map[int]bugzilla.Bug{},
+				BugErrors:      sets.NewInt(),
+			}
+			if testCase.bug != nil {
+				bc.Bugs[e.bugId] = *testCase.bug
+			}
+			if testCase.bugError {
+				bc.BugErrors.Insert(e.bugId)
+			}
+			e.missing = testCase.missing
+			err := handle(e, &gc, &bc, testCase.options, logrus.WithField("testCase", testCase.name))
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			expected := sets.NewString()
+			for _, label := range testCase.expectedLabels {
+				expected.Insert(fmt.Sprintf("%s/%s#%d:%s", e.org, e.repo, e.number, label))
+			}
+
+			actual := sets.NewString(gc.IssueLabelsExisting...)
+			actual.Insert(gc.IssueLabelsAdded...)
+			actual.Delete(gc.IssueLabelsRemoved...)
+
+			if missing := expected.Difference(actual); missing.Len() > 0 {
+				t.Errorf("%s: missing expected labels: %v", testCase.name, missing.List())
+			}
+			if extra := actual.Difference(expected); extra.Len() > 0 {
+				t.Errorf("%s: unexpected labels: %v", testCase.name, extra.List())
+			}
+
+			checkComments(gc, testCase.name, testCase.expectedComment, t)
+		})
+	}
+}
+
+func checkComments(client fakegithub.FakeClient, name, expectedComment string, t *testing.T) {
+	wantedComments := 0
+	if expectedComment != "" {
+		wantedComments = 1
+	}
+	if len(client.IssueCommentsAdded) != wantedComments {
+		t.Errorf("%s: wanted %d comment, got %d: %v", name, wantedComments, len(client.IssueCommentsAdded), client.IssueCommentsAdded)
+	}
+
+	if expectedComment != "" && len(client.IssueCommentsAdded) == 1 {
+		if expectedComment != client.IssueCommentsAdded[0] {
+			t.Errorf("%s: got incorrect comment: %v", name, diff.StringDiff(expectedComment, client.IssueCommentsAdded[0]))
+		}
+	}
+}
+
+func TestValidateBug(t *testing.T) {
+	open, closed := true, false
+	one, two := "v1", "v2"
+	var testCases = []struct {
+		name    string
+		bug     bugzilla.Bug
+		options plugins.BugzillaBranchOptions
+		valid   bool
+		why     []string
+	}{
+		{
+			name:    "no requirements means a valid bug",
+			bug:     bugzilla.Bug{},
+			options: plugins.BugzillaBranchOptions{},
+			valid:   true,
+		},
+		{
+			name:    "matching open requirement means a valid bug",
+			bug:     bugzilla.Bug{IsOpen: true},
+			options: plugins.BugzillaBranchOptions{IsOpen: &open},
+			valid:   true,
+		},
+		{
+			name:    "matching closed requirement means a valid bug",
+			bug:     bugzilla.Bug{IsOpen: false},
+			options: plugins.BugzillaBranchOptions{IsOpen: &closed},
+			valid:   true,
+		},
+		{
+			name:    "not matching open requirement means an invalid bug",
+			bug:     bugzilla.Bug{IsOpen: false},
+			options: plugins.BugzillaBranchOptions{IsOpen: &open},
+			valid:   false,
+			why:     []string{"expected the bug to be open, but it isn't"},
+		},
+		{
+			name:    "not matching closed requirement means an invalid bug",
+			bug:     bugzilla.Bug{IsOpen: true},
+			options: plugins.BugzillaBranchOptions{IsOpen: &closed},
+			valid:   false,
+			why:     []string{"expected the bug to not be open, but it is"},
+		},
+		{
+			name:    "matching target release requirement means a valid bug",
+			bug:     bugzilla.Bug{TargetRelease: []string{"v1"}},
+			options: plugins.BugzillaBranchOptions{TargetRelease: &one},
+			valid:   true,
+		},
+		{
+			name:    "not matching target release requirement means an invalid bug",
+			bug:     bugzilla.Bug{TargetRelease: []string{"v2"}},
+			options: plugins.BugzillaBranchOptions{TargetRelease: &one},
+			valid:   false,
+			why:     []string{"expected the bug to target the \"v1\" release, but it targets \"v2\" instead"},
+		},
+		{
+			name:    "not setting target release requirement means an invalid bug",
+			bug:     bugzilla.Bug{},
+			options: plugins.BugzillaBranchOptions{TargetRelease: &one},
+			valid:   false,
+			why:     []string{"expected the bug to target the \"v1\" release, but no target release was set"},
+		},
+		{
+			name:    "matching both requirements means a valid bug",
+			bug:     bugzilla.Bug{IsOpen: false, TargetRelease: []string{"v1"}},
+			options: plugins.BugzillaBranchOptions{IsOpen: &closed, TargetRelease: &one},
+			valid:   true,
+		},
+		{
+			name:    "matching neither requirements means an invalid bug",
+			bug:     bugzilla.Bug{IsOpen: false, TargetRelease: []string{"v1"}},
+			options: plugins.BugzillaBranchOptions{IsOpen: &open, TargetRelease: &two},
+			valid:   false,
+			why: []string{
+				"expected the bug to be open, but it isn't",
+				"expected the bug to target the \"v2\" release, but it targets \"v1\" instead",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			valid, why := validateBug(testCase.bug, testCase.options)
+			if valid != testCase.valid {
+				t.Errorf("%s: didn't validate bug correctly, expected %t got %t", testCase.name, testCase.valid, valid)
+			}
+			if !reflect.DeepEqual(why, testCase.why) {
+				t.Errorf("%s: didn't get correct reasons why: %v", testCase.name, diff.ObjectReflectDiff(testCase.why, why))
+			}
+		})
+	}
+}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/test-infra/prow/bugzilla"
 	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
 	"sigs.k8s.io/yaml"
 
@@ -137,6 +138,7 @@ type Agent struct {
 	KubernetesClient kubernetes.Interface
 	GitClient        *git.Client
 	SlackClient      *slack.Client
+	BugzillaClient   bugzilla.Client
 
 	OwnersClient *repoowners.Client
 
@@ -163,6 +165,7 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 		GitClient:        clientAgent.GitClient,
 		SlackClient:      clientAgent.SlackClient,
 		OwnersClient:     clientAgent.OwnersClient,
+		BugzillaClient:   clientAgent.BugzillaClient,
 		Config:           prowConfig,
 		PluginConfig:     pluginConfig,
 		Logger:           logger,
@@ -195,6 +198,7 @@ type ClientAgent struct {
 	GitClient        *git.Client
 	SlackClient      *slack.Client
 	OwnersClient     *repoowners.Client
+	BugzillaClient   bugzilla.Client
 }
 
 // ConfigAgent contains the agent mutex and the Agent configuration.


### PR DESCRIPTION
Often, GitHub Issues are not the only mechanism by which organizations
will track bugs against a product. Bugzilla is a common external bug
tracker; the new bugzilla plugin allows validation that the pull request
title references a bug that is valid as configured for the specific
branch.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta @smarterclayton @wking 
/cc @bbguimaraes @petr-muller @hongkailiu @droslean 