### PR TITLE
Add repo whitelist field to label_sync config yaml

### DIFF
--- a/label_sync/main_test.go
+++ b/label_sync/main_test.go
@@ -82,6 +82,18 @@ func TestValidate(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "only yaml config field and orgs option both set",
+			config: Configuration{
+				Default: RepoConfig{Labels: []Label{
+					{Name: "lab1", Description: "Test Label 1", Color: "deadbe"},
+				}},
+				OnlyRepos: []string{
+					"org1/repo1",
+				},
+			},
+			expectedError: true,
+		},
 	}
 	// Do tests
 	for _, tc := range testcases {


### PR DESCRIPTION
The label_sync yaml configuration now allows an 'only' field to specify
a white-list of the repositories that need to be synced.
This is an alternative to the '--only' CLI option. Closes #12667.