### PR TITLE
Remove Kubectl from skiplist for 1.14 conformance tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -22,7 +22,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190523-0ebbc9b-1.14
       name: ""


### PR DESCRIPTION
This should have been removed going forward from 1.13 onward,
not sure how it ended up here

/area conformance
/cc @Katharine
Want to make sure I'm not attempting to edit a generated file