### PR TITLE
Remove jobs from sig-release-<release_version>-all if they're also in -blocking or -informing

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -29,7 +29,7 @@ periodics:
     fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking
     testgrid-tab-name: gce-device-plugin-gpu-1.15
   cron: 0 0-23/2 * * *
   labels:
@@ -59,7 +59,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-node-kubelet, sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.15
   interval: 1h
   labels:
@@ -123,7 +123,7 @@ periodics:
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kuberentes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking
     testgrid-tab-name: build-1.15
   interval: 1h
   labels:
@@ -155,8 +155,7 @@ periodics:
     fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-scalability-gce, google-gce,
-      sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-1.15-scalability-100
   cron: 0 */6 * * *
   labels:
@@ -270,7 +269,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, google-unit, sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: integration-1.15
   interval: 2h
   labels:
@@ -298,7 +297,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, google-unit, sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: verify-1.15
   decorate: true
   extra_refs:
@@ -338,7 +337,7 @@ postsubmits:
   kubernetes/kubernetes:
   - annotations:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
-      testgrid-dashboards: sig-release-1.15-blocking, google-unit, sig-release-1.15-all
+      testgrid-dashboards: sig-release-1.15-blocking, google-unit
       testgrid-tab-name: bazel-build-1.15
     branches:
     - release-1.15

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -268,6 +268,14 @@ class E2ETest(object):
         tg_config['gcs_prefix'] = GCS_LOG_PREFIX + self.job_name
         return tg_config
 
+    def initialize_dashboards_with_release_blocking_info(self, version):
+        dashboards = []
+        if self.job.get('releaseBlocking'):
+            dashboards.append('sig-release-%s-blocking' % version)
+        else:
+            dashboards.append('sig-release-%s-all' % version)
+        return dashboards
+
     def generate(self):
         '''Returns the job and the Prow configurations for this test.'''
         fields = self.job_name.split('-')
@@ -294,12 +302,9 @@ class E2ETest(object):
         tg_config = self.__get_testgrid_config()
 
         annotations = prow_config.setdefault('annotations', {})
-        dashboards = ['sig-release-%s-all' % k8s_version['version']]
         tab_name = '%s-%s-%s-%s' % (fields[3], fields[4], fields[5], fields[6])
         annotations['testgrid-tab-name'] = tab_name
-        if self.job.get('releaseBlocking'):
-            dashboards.insert(
-                0, 'sig-release-%s-blocking' % k8s_version['version'])
+        dashboards = self.initialize_dashboards_with_release_blocking_info(k8s_version['version'])
         if image.get('testgrid_prefix') is not None:
             dashboard = '%s-%s-%s' % (image['testgrid_prefix'], fields[4],
                                       fields[5])

--- a/experiment/generate_tests_test.py
+++ b/experiment/generate_tests_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import tempfile
+import shutil
+from generate_tests import E2ETest
+
+class TestGenerateTests(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_directory = tempfile.mkdtemp()
+        self.job_name = "ci-kubernetes-e2e-gce-cos-k8sbeta-ingress"
+        self.job = {
+            "interval": "1h"
+        }
+        self.config = {
+            "jobs": {"ci-kubernetes-e2e-gce-cos-k8sbeta-ingress": self.job},
+            "common": {"args": []},
+            "cloudProviders": {"gce": {"args": []}},
+            "images": {"cos": {}},
+            "k8sVersions": {"beta": {"version": "2.4"}},
+            "testSuites": {"ingress": {"args": ["--timeout=10"]}},
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_directory)
+
+    def test_e2etests_testgrid_annotations_default(self):
+        generator = E2ETest(self.temp_directory, self.job_name, self.job, self.config)
+        _, prow_config, _ = generator.generate()
+        dashboards = prow_config["annotations"]["testgrid-dashboards"]
+        assert "sig-release-2.4-blocking" not in dashboards
+        assert "sig-release-2.4-all" in dashboards
+
+    def test_e2etests_testgrid_annotations_blocking_job(self):
+        self.job = {
+            "releaseBlocking": True,
+            "interval": "1h"
+        }
+
+        generator = E2ETest(self.temp_directory, self.job_name, self.job, self.config)
+        _, prow_config, _ = generator.generate()
+        dashboards = prow_config["annotations"]["testgrid-dashboards"]
+        assert "sig-release-2.4-blocking" in dashboards
+        assert "sig-release-2.4-all" not in dashboards
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/experiment/generate_tests_test.py
+++ b/experiment/generate_tests_test.py
@@ -43,8 +43,8 @@ class TestGenerateTests(unittest.TestCase):
         generator = E2ETest(self.temp_directory, self.job_name, self.job, self.config)
         _, prow_config, _ = generator.generate()
         dashboards = prow_config["annotations"]["testgrid-dashboards"]
-        assert "sig-release-2.4-blocking" not in dashboards
-        assert "sig-release-2.4-all" in dashboards
+        self.assertFalse("sig-release-2.4-blocking" in dashboards)
+        self.assertTrue("sig-release-2.4-all" in dashboards)
 
     def test_e2etests_testgrid_annotations_blocking_job(self):
         self.job = {
@@ -55,8 +55,8 @@ class TestGenerateTests(unittest.TestCase):
         generator = E2ETest(self.temp_directory, self.job_name, self.job, self.config)
         _, prow_config, _ = generator.generate()
         dashboards = prow_config["annotations"]["testgrid-dashboards"]
-        assert "sig-release-2.4-blocking" in dashboards
-        assert "sig-release-2.4-all" not in dashboards
+        self.assertTrue("sig-release-2.4-blocking" in dashboards)
+        self.assertFalse("sig-release-2.4-all" in dashboards)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR covers all jobs under sig-release dashboards that I could find; for now it just removes them if the existing tooling has already placed them in another sig-release dashboard. If jobs are monitored in other (not sig-release monitored)dashboards, this PR keeps them under sig-release-<release_version>-all for now (in practice I don't remember seeing of any such jobs).

xref: https://github.com/kubernetes/test-infra/issues/11977

/cc @spiffxp @alejandrox1 @Katharine 