### PR TITLE
Enable mergecommitblocker plugin for k/k

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -210,6 +210,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="do-not-merge/contains-merge-commits" href="#do-not-merge/contains-merge-commits">`do-not-merge/contains-merge-commits`</a> | Indicates a PR which contains merge commits.| prow |  [mergecommitblocker](https://git.k8s.io/test-infra/prow/plugins/mergecommitblocker) |
 | <a id="needs-priority" href="#needs-priority">`needs-priority`</a> | Indicates a PR lacks a `priority/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 
 ## Labels that apply to kubernetes/org, only for issues

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -804,6 +804,12 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
+      - color: e11d21
+        description: Indicates a PR which contains merge commits.
+        name: do-not-merge/contains-merge-commits
+        target: prs
+        prowPlugin: mergecommitblocker
+        addedBy: prow
       - color: ededed
         description: Indicates a PR lacks a `priority/foo` label and requires one.
         name: needs-priority

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -451,6 +451,7 @@ plugins:
   kubernetes/kubernetes:
   - blockade
   - cherry-pick-unapproved
+  - mergecommitblocker
   - milestone
   - milestonestatus
   - override


### PR DESCRIPTION
It's necessary for k/k because the publishing-bot breaks whenever it sees merge commits, and for each such case (which is rare), we need to explicitly black list each merge commit.

This should help us in avoiding that. More context and info on this slack thread - https://kubernetes.slack.com/archives/C1TU9EB9S/p1559061476023400

/hold
sending an email to k-dev with lazy consenus

/assign @cblecker 
fyi @sttts @dims 