### PR TITLE
Add mergecommitblocker plugin to hook

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/lifecycle:go_default_library",
+        "//prow/plugins/mergecommitblocker:go_default_library",
         "//prow/plugins/milestone:go_default_library",
         "//prow/plugins/milestonestatus:go_default_library",
         "//prow/plugins/override:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -39,6 +39,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/lifecycle"
+	_ "k8s.io/test-infra/prow/plugins/mergecommitblocker"
 	_ "k8s.io/test-infra/prow/plugins/milestone"
 	_ "k8s.io/test-infra/prow/plugins/milestonestatus"
 	_ "k8s.io/test-infra/prow/plugins/override"


### PR DESCRIPTION
PR which created the plugin: https://github.com/kubernetes/test-infra/pull/11937

We intend to enable the plugin for k/k in https://github.com/kubernetes/test-infra/pull/12783, so this first needs to be added to hook and prow needs to be bumped. 

/cc @cblecker @fejta 
/assign @fejta 