### PR TITLE
kubeadm e2e test for HA

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -199,7 +199,7 @@ periodics:
       - --provider=skeleton
       - --deployment=kind
       - --kind-binary-version=build
-      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/multi-cp/multi-cp.yaml
       # generic e2e test args
       - --build=bazel
       - --up
@@ -278,7 +278,7 @@ periodics:
       - --provider=skeleton
       - --deployment=kind
       - --kind-binary-version=build
-      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/multi-cp/multi-cp.yaml
       # generic e2e test args
       - --build=bazel
       - --up
@@ -503,7 +503,7 @@ presubmits:
         - --provider=skeleton
         - --deployment=kind
         - --kind-binary-version=build
-        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/multi-cp/multi-cp.yaml
         # generic e2e test args
         - --build=bazel
         - --up
@@ -579,7 +579,7 @@ presubmits:
         - --provider=skeleton
         - --deployment=kind
         - --kind-binary-version=build
-        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/multi-cp/multi-cp.yaml
         # generic e2e test args
         - --build=bazel
         - --up


### PR DESCRIPTION
This PR adds a config file for testing kubeadm HA when executing E2E test jobs implemented with kind (kubeadm regular test)

rif https://github.com/kubernetes/kubeadm/issues/1567

NB. In case I'm out of sync with other helping to this effort, feel free to close.

/kind test
/assign @neolit123
/cc @RA489

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews