### PR TITLE
Fix cypress base image for release notes e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: cypress/base:11
+          - image: cypress/base:11.13.0
             command:
               - /bin/bash
               - -c


### PR DESCRIPTION
The base:11 image does not seem to exist any more, so we simply use the latest for now.

Relates to https://github.com/kubernetes-sigs/release-notes/pull/29