### PR TITLE
branchprotector checks if updates are needed

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -75,10 +75,11 @@ func TestOptions_Validate(t *testing.T) {
 }
 
 type fakeClient struct {
-	repos    map[string][]github.Repo
-	branches map[string][]github.Branch
-	deleted  map[string]bool
-	updated  map[string]github.BranchProtectionRequest
+	repos             map[string][]github.Repo
+	branches          map[string][]github.Branch
+	deleted           map[string]bool
+	updated           map[string]github.BranchProtectionRequest
+	branchProtections map[string]github.BranchProtection
 }
 
 func (c fakeClient) GetRepo(org string, repo string) (github.Repo, error) {
@@ -124,6 +125,14 @@ func (c fakeClient) GetBranches(org, repo string, onlyProtected bool) ([]github.
 		}
 	}
 	return b, nil
+}
+
+func (c *fakeClient) GetBranchProtection(org, repo, branch string) (*github.BranchProtection, error) {
+	ctx := org + "/" + repo + "=" + branch
+	if bp, ok := c.branchProtections[ctx]; ok {
+		return &bp, nil
+	}
+	return nil, nil
 }
 
 func (c *fakeClient) UpdateBranchProtection(org, repo, branch string, config github.BranchProtectionRequest) error {
@@ -261,13 +270,14 @@ func TestProtect(t *testing.T) {
 	yes := true
 
 	cases := []struct {
-		name             string
-		branches         []string
-		startUnprotected bool
-		config           string
-		archived         string
-		expected         []requirements
-		errors           int
+		name              string
+		branches          []string
+		startUnprotected  bool
+		config            string
+		archived          string
+		expected          []requirements
+		branchProtections map[string]github.BranchProtection
+		errors            int
 	}{
 		{
 			name: "nothing",
@@ -697,6 +707,98 @@ branch-protection:
 				},
 			},
 		},
+		{
+			name:     "do not make update request if the branch is already up-to-date",
+			branches: []string{"kubernetes/test-infra=master"},
+			config: `
+branch-protection:
+  enforce_admins: true
+  required_status_checks:
+    contexts:
+    - config-presubmit
+    strict: true
+  required_pull_request_reviews:
+    required_approving_review_count: 3
+    dismiss_stale: false
+    require_code_owner_reviews: true
+    dismissal_restrictions:
+      users:
+      - bob
+      - jane
+      teams:
+      - oncall
+      - sres
+  restrictions:
+    teams:
+    - config-team
+    users:
+    - cindy
+  protect: true
+  orgs:
+    kubernetes:
+      repos:
+        test-infra:
+`,
+			branchProtections: map[string]github.BranchProtection{
+				"kubernetes/test-infra=master": {
+					EnforceAdmins: github.EnforceAdmins{Enabled: true},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   true,
+						Contexts: []string{"config-presubmit"},
+					},
+					RequiredPullRequestReviews: &github.RequiredPullRequestReviews{
+						DismissStaleReviews:          false,
+						RequireCodeOwnerReviews:      true,
+						RequiredApprovingReviewCount: 3,
+						DismissalRestrictions: github.Restrictions{
+							Users: &[]string{"bob", "jane"},
+							Teams: &[]string{"oncall", "sres"},
+						},
+					},
+					Restrictions: &github.Restrictions{
+						Users: &[]string{"cindy"},
+						Teams: &[]string{"config-team"},
+					},
+				},
+			},
+		},
+		{
+			name:     "make request if branch protection is present, but out of date",
+			branches: []string{"kubernetes/test-infra=master"},
+			config: `
+branch-protection:
+  enforce_admins: true
+  required_pull_request_reviews:
+    required_approving_review_count: 3
+  protect: true
+  orgs:
+    kubernetes:
+      repos:
+        test-infra:
+`,
+			branchProtections: map[string]github.BranchProtection{
+				"kubernetes/test-infra=master": {
+					EnforceAdmins: github.EnforceAdmins{Enabled: true},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   true,
+						Contexts: []string{"config-presubmit"},
+					},
+				},
+			},
+			expected: []requirements{
+				{
+					Org:    "kubernetes",
+					Repo:   "test-infra",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &yes,
+						RequiredPullRequestReviews: &github.RequiredPullRequestReviews{
+							RequiredApprovingReviewCount: 3,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -717,8 +819,9 @@ branch-protection:
 				repos[org][repo] = true
 			}
 			fc := fakeClient{
-				branches: branches,
-				repos:    map[string][]github.Repo{},
+				branches:          branches,
+				repos:             map[string][]github.Repo{},
+				branchProtections: tc.branchProtections,
 			}
 			for org, r := range repos {
 				for rname := range r {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -135,6 +135,7 @@ type RepositoryClient interface {
 	GetRepo(owner, name string) (Repo, error)
 	GetRepos(org string, isUser bool) ([]Repo, error)
 	GetBranches(org, repo string, onlyProtected bool) ([]Branch, error)
+	GetBranchProtection(org, repo, branch string) (*BranchProtection, error)
 	RemoveBranchProtection(org, repo, branch string) error
 	UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error
 	AddRepoLabel(org, repo, label, description, color string) error
@@ -1566,6 +1567,51 @@ func (c *client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, er
 		return nil, err
 	}
 	return branches, nil
+}
+
+// GetBranchProtection returns current protection object for the branch
+//
+// See https://developer.github.com/v3/repos/branches/#get-branch-protection
+func (c *client) GetBranchProtection(org, repo, branch string) (*BranchProtection, error) {
+	c.log("GetBranchProtection", org, repo, branch)
+	code, body, err := c.requestRaw(&request{
+		method: http.MethodGet,
+		path:   fmt.Sprintf("/repos/%s/%s/branches/%s/protection", org, repo, branch),
+		// GitHub returns 404 for this call if either:
+		// - The branch is not protected
+		// - The access token used does not have sufficient privileges
+		// We therefore need to introspect the response body.
+		exitCodes: []int{200, 404},
+	})
+
+	switch {
+	case err != nil:
+		return nil, err
+	case code == 200:
+		var bp BranchProtection
+		if err := json.Unmarshal(body, &bp); err != nil {
+			return nil, err
+		}
+		return &bp, nil
+	case code == 404:
+		// continue
+	default:
+		return nil, fmt.Errorf("unexpected status code: %v", code)
+	}
+
+	var ge githubError
+	if err := json.Unmarshal(body, &ge); err != nil {
+		return nil, err
+	}
+
+	// If the error was because the branch is not protected, we return a
+	// nil pointer to indicate this.
+	if ge.Message == "Branch not protected" {
+		return nil, nil
+	}
+
+	// Otherwise we got some other 404 error.
+	return nil, fmt.Errorf("getting branch protection 404: %s", ge.Message)
 }
 
 // RemoveBranchProtection unprotects org/repo=branch.

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1498,6 +1498,134 @@ func TestGetBranches(t *testing.T) {
 	}
 }
 
+func TestGetBranchProtection(t *testing.T) {
+	contexts := []string{"foo-pr-test", "other"}
+	pushers := []string{"movers", "awesome-team", "shakers"}
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/org/repo/branches/master/protection" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		bp := BranchProtection{
+			RequiredStatusChecks: &RequiredStatusChecks{
+				Contexts: contexts,
+			},
+			Restrictions: &Restrictions{
+				Teams: &pushers,
+			},
+		}
+		b, err := json.Marshal(&bp)
+		if err != nil {
+			t.Fatalf("Didn't expect error: %v", err)
+		}
+		fmt.Fprint(w, string(b))
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	bp, err := c.GetBranchProtection("org", "repo", "master")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	switch {
+	case bp.Restrictions == nil:
+		t.Errorf("Restrictions unset")
+	case bp.Restrictions.Teams == nil:
+		t.Errorf("Teams unset")
+	case len(*bp.Restrictions.Teams) != len(pushers):
+		t.Errorf("Bad teams: expected %v, got: %v", pushers, *bp.Restrictions.Teams)
+	case bp.RequiredStatusChecks == nil:
+		t.Errorf("RequiredStatusChecks unset")
+	case len(bp.RequiredStatusChecks.Contexts) != len(contexts):
+		t.Errorf("Bad contexts: expected: %v, got: %v", contexts, bp.RequiredStatusChecks.Contexts)
+	default:
+		mc := map[string]bool{}
+		for _, k := range bp.RequiredStatusChecks.Contexts {
+			mc[k] = true
+		}
+		var missing []string
+		for _, k := range contexts {
+			if mc[k] != true {
+				missing = append(missing, k)
+			}
+		}
+		if n := len(missing); n > 0 {
+			t.Errorf("missing %d required contexts: %v", n, missing)
+		}
+		mp := map[string]bool{}
+		for _, k := range *bp.Restrictions.Teams {
+			mp[k] = true
+		}
+		missing = nil
+		for _, k := range pushers {
+			if mp[k] != true {
+				missing = append(missing, k)
+			}
+		}
+		if n := len(missing); n > 0 {
+			t.Errorf("missing %d pushers: %v", n, missing)
+		}
+	}
+}
+
+// GetBranchProtection should return nil if the github API call
+// returns 404 with "Branch not protected" message
+func TestGetBranchProtection404BranchNotProtected(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/org/repo/branches/master/protection" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		ge := &githubError{
+			Message: "Branch not protected",
+		}
+		b, err := json.Marshal(&ge)
+		if err != nil {
+			t.Fatalf("Didn't expect error: %v", err)
+		}
+		http.Error(w, string(b), http.StatusNotFound)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	bp, err := c.GetBranchProtection("org", "repo", "master")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if bp != nil {
+		t.Errorf("Expected nil as BranchProtection object, got: %v", *bp)
+	}
+}
+
+// GetBranchProtection should fail on any 404 which is NOT due to
+// branch not being protected.
+func TestGetBranchProtectionFailsOnOther404(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/org/repo/branches/master/protection" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		ge := &githubError{
+			Message: "Not Found",
+		}
+		b, err := json.Marshal(&ge)
+		if err != nil {
+			t.Fatalf("Didn't expect error: %v", err)
+		}
+		http.Error(w, string(b), http.StatusNotFound)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	_, err := c.GetBranchProtection("org", "repo", "master")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}
+
 func TestRemoveBranchProtection(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -357,6 +357,22 @@ type Branch struct {
 	// TODO(fejta): consider including undocumented protection key
 }
 
+// BranchProtection represents protections
+// in place for a branch
+// See also: https://developer.github.com/v3/repos/branches/#get-branch-protection
+type BranchProtection struct {
+	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
+	EnforceAdmins              EnforceAdmins               `json:"enforce_admins"`
+	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
+	Restrictions               *Restrictions               `json:"restrictions"`
+}
+
+// EnforceAdmins specifies whether to enforce the
+// configured branch restrictions for administrators.
+type EnforceAdmins struct {
+	Enabled bool `json:"enabled"`
+}
+
 // BranchProtectionRequest represents
 // protections in place for a branch.
 // See also: https://developer.github.com/v3/repos/branches/#update-branch-protection


### PR DESCRIPTION
branchprotector now fetches the current protection object of a branch from the github API, and matches it against the configured policy. An update is requested only if the two do not match. Closes #11989 .