### PR TITLE
Handle newlines in GCS symlinks more

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -122,7 +122,7 @@ func (bucket gcsBucket) resolveSymLink(symLink string) (string, error) {
 		return "", fmt.Errorf("failed to read %s: %v", symLink, err)
 	}
 	// strip gs://<bucket-name> from global address `u`
-	u := string(data)
+	u := strings.TrimSpace(string(data))
 	return prefixRe.ReplaceAllString(u, ""), nil
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @Katharine 

I think we missed this one:

```
{"component":"deck","level":"warning","msg":"build 2498 information incomplete: failed to read started.json: failed to read pr-logs/pull/cri-o_cri-o/2380/test_pull_request_crio_critest_rhel/2498\n/started.json: failed to get reader for GCS object: googleapi: got HTTP response code 400 with body: \u003c?xml version='1.0' encoding='UTF-8'?\u003e\u003cError\u003e\u003cCode\u003eInvalidObjectName\u003c/Code\u003e\u003cMessage\u003eThe specified object name is not valid.\u003c/Message\u003e\u003cDetails\u003eDisallowed unicode characters present in object name ''pr-logs/pull/cri-o_cri-o/2380/test_pull_request_crio_critest_rhel/2498\n/start...''\u003c/Details\u003e\u003c/Error\u003e","time":"2019-05-31T15:12:28Z"}
```