### PR TITLE
Record repo version from main configured refs

### DIFF
--- a/prow/initupload/BUILD.bazel
+++ b/prow/initupload/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/initupload",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/gcsupload:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
@@ -27,6 +28,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/gcsupload:go_default_library",
+        "//prow/pod-utils/clone:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
     ],

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -177,3 +177,14 @@ func GetRevisionFromSpec(spec *JobSpec) string {
 	}
 	return ""
 }
+
+// MainRefs determines the main refs under test, if there are any
+func (s *JobSpec) MainRefs() *prowapi.Refs {
+	if s.Refs != nil {
+		return s.Refs
+	}
+	if len(s.ExtraRefs) > 0 {
+		return &s.ExtraRefs[0]
+	}
+	return nil
+}


### PR DESCRIPTION
When the repo version is exposed in the started record, we need to
expose the resolved SHA for the main configured ref under test, which
may or may not be the first to be cloned in the clone records.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @BenTheElder @krzyzacy 