### PR TITLE
Add some logs, or else the sample command just hangs when run initially

### DIFF
--- a/prow/cmd/mkbuild-cluster/README.md
+++ b/prow/cmd/mkbuild-cluster/README.md
@@ -13,7 +13,7 @@ Create a new `cluster.yaml` to send to [plank] via `--build-cluster`:
 ```sh
 # Create initial entry
 bazel run //prow/cmd/mkbuild-cluster -- \
-  --project=P --zone=Z --cluster=C --alias=default > cluster.yaml
+  --project=P --zone=Z --cluster=C --alias=default --print-entry > cluster.yaml
 # Write secret with this entry
 kubectl create secret generic build-cluster --from-file=cluster.yaml
 ```

--- a/prow/cmd/mkbuild-cluster/main.go
+++ b/prow/cmd/mkbuild-cluster/main.go
@@ -256,6 +256,7 @@ func do(o options) error {
 	}
 
 	// Append the new entry to the current secret
+	fmt.Print("--print-entry is not set, waiting for existing cluster map config as input")
 
 	// First read in the secret from stdin
 	b, err := ioutil.ReadAll(os.Stdin)


### PR DESCRIPTION
The initial run hangs without `--print-entry` since it's waiting for the existing secret to be piped in

/assign @cjwagner @fejta 