### PR TITLE
Update cypress base image to 12.1.0

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: cypress/base:11.13.0
+          - image: cypress/base:12.1.0
             command:
               - /bin/bash
               - -c


### PR DESCRIPTION
Sorry, I have to update this image again. We need the latest node version for further Angular updates. Beside this, there seems a missing dependency in the 11.X.X image which currently blocks our CI.

Refers to https://github.com/kubernetes-sigs/release-notes/pull/31

/cc @jeefy