### PR TITLE
removing vpshere-conformance from master informing

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2804,12 +2804,6 @@ dashboards:
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
     description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
-  - name: Conformance - vSphere-cloud-provider
-    test_group_name: ci-cloud-provider-vsphere-conformance-latest
-    description: "OWNER: sig-vmware; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere"
-  - name: Conformance - vSphere
-    test_group_name: ci-vsphere-conformance-latest
-    description: "OWNER: sig-vmware; Runs conformance tests using e2e.test against latest kubernetes master with in-tree vSphere"
   - name: gce-master-scale-correctness
     test_group_name: ci-kubernetes-e2e-gce-scale-correctness
     description: "OWNER: sig-scalability; Runs 1000-node performance test once a week and checks that operational results are still all correct at that scale"


### PR DESCRIPTION
Removes test groups `ci-cloud-provider-vsphere-conformance-latest` & `ci-vsphere-conformance-latest` from `sig-release-master-informing` due to priority shifts within vmware.

Context from #sig-vmware on Slack:
>akutz   [May 28th at 2:09 PM]
>The conformance tests were hinged on the sk8 update which got pushed in January due to reorg and then recently due to CAPV
>
>akutz   [5 days ago]
>[...] There is an issue with timeouts and the install process shifting away from what sk8 supports.To combat this I made plans to refactor sk8, a shell script, to a Go lib/program in January that uses kubeadm. That effort was delayed due to internal org changes.I worked on all this recently again, this time with sk8 using Cluster API even, but that has been delayed due to my new priorities on Cluster API for vSphere.
>
>alejandrox1   [4 days ago]
>[...] it sounds like fixing the conformance tests in testgrid is not going to be a one/two week type of thing, correct?
>
>[follow up to that convo a few days later]
>
>jimangel [9:31 PM]
>@fabio @akutz both `ci-cloud-provider-vsphere-conformance-latest` & `ci-vsphere-conformance-latest` in `master-informing` have been failing for awhile now. Can I move those tests into a VMware dashboard (like `vmware-conformance-cloud-provider` / `conformance-vsphere`) or do you believe it still meets the https://github.com/kubernetes/sig-release/blob/master/release-blocking-jobs.md#release-informing-criteria? (edited) 
>
>akutz [9:41 PM]
>Please move them for now

**Note:** `ci-cloud-provider-vsphere-conformance-latest` & `ci-vsphere-conformance-latest` still exists in other conformance dashboards.

/cc @alejandrox1 @akutz