### PR TITLE
Make bazel cache in bootstrap image configurable

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CACHE_HOST="bazel-cache.default.svc.cluster.local."
-CACHE_PORT="8080"
+CACHE_HOST="${CACHE_HOST:-bazel-cache.default.svc.cluster.local.}"
+CACHE_PORT="${CACHE_PORT:-8080}"
 
 # get the installed version of a debian package
 package_to_version () {


### PR DESCRIPTION
Making the bazel remote cache url configurable is helpful when running prow on a cluster which has multiple zones. There it can be preferable to run a cache in each zone and point prow jobs  which are tied to specific zones to the right cache.