### PR TITLE
Fixing location of import

### DIFF
--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"


### PR DESCRIPTION
Fixing the import location of sets, as mentioned by @fejta  in my previous PR here: https://github.com/kubernetes/test-infra/pull/12834