### PR TITLE
Fix merge behavior for sigs.k8s.io/cluster-api-provider-vsphere

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -458,7 +458,6 @@ tide:
     kubernetes-sigs/cluster-api-provider-gcp: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
-    kubernetes-sigs/cluster-api-provider-vsphere: squash
     kubernetes-sigs/krew: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/kubespray: squash


### PR DESCRIPTION
Reverting it back to default behavior (merge)

/cc @akutz @figo