### PR TITLE
Revert Prow bump and rules_nodejs bump.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,10 +144,12 @@ git_repository(
     shallow_since = "1517262872 -0800",
 )
 
-http_archive(
+git_repository(
     name = "build_bazel_rules_nodejs",
-    sha256 = "395b7568f20822c13fc5abc65b1eced637446389181fda3a108fdd6ff2cac1e9",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.29.2/rules_nodejs-0.29.2.tar.gz"],
+    commit = "0eb4a19507211ab3863f4d82e9412a33f759abcd",
+    remote = "https://github.com/bazelbuild/rules_nodejs.git",
+    shallow_since = "1548802468 -0800",
+    #tag = "0.16.6",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
@@ -161,10 +163,20 @@ yarn_install(
     yarn_lock = "//:yarn.lock",
 )
 
-load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+http_archive(
+    name = "build_bazel_rules_typescript",
+    sha256 = "136ba6be39b4ff934cc0f41f043912305e98cb62254d9e6af467e247daafcd34",
+    strip_prefix = "rules_typescript-0.22.0",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.22.0.zip",
+)
 
-install_bazel_dependencies()
+# Fetch our Bazel dependencies that aren't distributed on npm
+load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
 
+rules_typescript_dependencies()
+
+# Setup TypeScript toolchain
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 load("//def:test_infra.bzl", "http_archive_with_pkg_path")
 
 http_archive_with_pkg_path(

--- a/boskos/deployment.yaml
+++ b/boskos/deployment.yaml
@@ -86,7 +86,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-testimages/boskos:v20190529-49b63a5
+        image: gcr.io/k8s-testimages/boskos:v20190528-0d7c4b5
         args:
         - --storage=/store/boskos.json
         - --config=/etc/config/config

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20190529-49b63a5
+        image: gcr.io/k8s-testimages/janitor:v20190528-0d7c4b5
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gke-project
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-nongke
-        image: gcr.io/k8s-testimages/janitor:v20190529-49b63a5
+        image: gcr.io/k8s-testimages/janitor:v20190528-0d7c4b5
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-project

--- a/boskos/metrics/deployment.yaml
+++ b/boskos/metrics/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-testimages/metrics:v20190529-49b63a5
+        image: gcr.io/k8s-testimages/metrics:v20190528-0d7c4b5
         args:
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account
         ports:

--- a/boskos/reaper/deployment.yaml
+++ b/boskos/reaper/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-testimages/reaper:v20190529-49b63a5
+        image: gcr.io/k8s-testimages/reaper:v20190528-0d7c4b5
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account

--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -43,7 +43,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
@@ -66,7 +66,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src

--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
@@ -43,7 +43,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes"
@@ -54,7 +54,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+    - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       args:
       - --repo=github.com/google/cadvisor
       - --root=/go/src
@@ -75,7 +75,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --job=$(JOB_NAME)
       - --root=/go/src

--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -40,7 +40,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - sh
         - -c
@@ -84,7 +84,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - sh
         - -c
@@ -128,7 +128,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - sh
         - -c
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       # Use go 1.10 for old branches, because gofmt result changed in go 1.11.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -176,7 +176,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -32,7 +32,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster
@@ -60,7 +60,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster-features
@@ -87,7 +87,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta
@@ -115,7 +115,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1
@@ -143,7 +143,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster
@@ -171,7 +171,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster-features
@@ -199,7 +199,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster
@@ -226,7 +226,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster-features
@@ -252,7 +252,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster
@@ -279,7 +279,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster-features
@@ -306,7 +306,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gke-cos-containerd
@@ -338,4 +338,4 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=800m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=github.com/helm/charts=$(PULL_REFS)"
         - "--root=/go/src/"
@@ -44,4 +44,4 @@ periodics:
       - --provider=gce
       - --test=false
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -179,7 +179,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -255,7 +255,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -289,7 +289,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ./test/upgrade-tests.sh
         args:
@@ -303,7 +303,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -87,7 +87,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -126,7 +126,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -195,7 +195,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -230,7 +230,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -265,7 +265,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -300,7 +300,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -335,7 +335,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -370,7 +370,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -405,7 +405,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -440,7 +440,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -475,7 +475,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -510,7 +510,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -545,7 +545,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -586,7 +586,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -627,7 +627,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -668,7 +668,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -87,7 +87,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -126,7 +126,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -195,7 +195,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -230,7 +230,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -87,7 +87,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -126,7 +126,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -195,7 +195,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -230,7 +230,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -69,7 +69,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -69,7 +69,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -87,7 +87,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -126,7 +126,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -195,7 +195,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -230,7 +230,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-incubator/service-catalog/service-catalog-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
         - "--timeout=45"
@@ -42,7 +42,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
         - "--timeout=90"

--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -26,7 +26,7 @@ presubmits:
         - /home/prow/go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
         command:
         - go
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources: {}
         volumeMounts:
@@ -73,7 +73,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-correctness
         - --timeout=180m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aws-eks-1-11-correctness
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         imagePullPolicy: Always
         name: ""
         resources: {}
@@ -130,7 +130,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -193,7 +193,7 @@ presubmits:
         - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[sig-node\]\sMount\spropagation|\[sig-network\]\sNetwork\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|\[sig-storage\]\sPersistentVolumes-local\sStress\swith\slocal\svolume\sprovisioner\s\[Serial\]\sshould\suse\sbe\sable\sto\sprocess\smany\spods\sand\sreuse\slocal\svolumes|should\sunmount\sif\spod\sis\sgracefully\sdeleted\swhile\skubelet\sis\sdown\s\[Disruptive\]\[Slow\]|should\sunmount\sif\spod\sis\sforce\sdeleted\swhile\skubelet\sis\sdown\s\[Disruptive\]\[Slow\]|\[sig-network\]\sServices\sshould\sbe\sable\sto\screate\sa\sfunctioning\sNodePort\sservice|\[sig-scheduling\]\sSchedulerPredicates\s\[Serial\]\svalidates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun\s\[Slow\]|\[sig-storage\]\sDynamic\sProvisioning\sDynamicProvisioner\sDefault\sshould\screate\sand\sdelete\sdefault\spersistent\svolumes\s\[Slow\]|\[sig-storage\]\sDynamic\sProvisioning\sDynamicProvisioner\sshould\sprovision\sstorage\swith\sdifferent\sparameters|\[sig-storage\]\sDynamic\sProvisioning\sDynamicProvisioner\sshould\stest\sthat\sdeleting\sa\sclaim\sbefore\sthe\svolume\sis\sprovisioned\sdeletes\sthe\svolume.|\[sig-apps\]\sStatefulSet\s\[k8s.io\]\sBasic\sStatefulSet\sfunctionality\s\[StatefulSetBasic\]\sshould\sadopt\smatching\sorphans\sand\srelease\snon-matching\spods|\[sig-apps\]\sStatefulSet\s\[k8s.io\]\sBasic\sStatefulSet\sfunctionality\s\[StatefulSetBasic\]\sshould\snot\sdeadlock\swhen\sa\spod.s\spredecessor\sfails|\[sig-apps\]\sStatefulSet\s\[k8s.io\]\sBasic\sStatefulSet\sfunctionality\s\[StatefulSetBasic\]\sshould\sperform\srolling\supdates\sand\sroll\sbacks\sof\stemplate\smodifications\swith\sPVCs|\[sig-apps\]\sStatefulSet\s\[k8s.io\]\sBasic\sStatefulSet\sfunctionality\s\[StatefulSetBasic\]\sshould\sprovide\sbasic\sidentity|\[sig-storage\]\sPersistentVolumes\sDefault\sStorageClass\spods\sthat\suse\smultiple\svolumes\sshould\sbe\sreschedulable|\[sig-storage\]\sPVC\sProtection|\[sig-storage\]\sDynamic\sProvisioning\s\[k8s.io\]\sGlusterDynamicProvisioner|\[sig-storage\]\sVolumes\sAzure\sDisk\sshould\sbe\smountable\s\[Slow\]|\[sig-apps\]\sNetwork\sPartition\s\[Disruptive\]\s\[Slow\]|\[sig-network\]\sDNS\sconfigMap|\[k8s.io\]\s\[sig-node\]\sKubelet\s\[Serial\]\s\[Slow\]\s\[k8s.io\]\s\[sig-node\]\sregular\sresource\susage\stracking\sresource\stracking\sfor\s0\spods\sper\snode|\[k8s.io\]\s\[sig-node\]\sKubelet\s\[Serial\]\s\[Slow\]\s\[k8s.io\]\s\[sig-node\]\sregular\sresource\susage\stracking\sresource\stracking\sfor\s100\spods\sper\snode|Horizontal\spod\sautoscaling\s\(scale\sresource:\sCPU\)|\[sig-storage\]\sDynamic\sProvisioning\sDynamicProvisioner\sExternal\sshould\slet\san\sexternal\sdynamic\sprovisioner\screate\sand\sdelete\spersistent\svolumes\s\[Slow\]|ESIPP|\[sig-network\]\sServices\sshould\spreserve\ssource\spod\sIP\sfor\straffic\sthru\sservice\scluster\sIP|In-tree\sVolumes|PersistentVolumes-local|CSI\sVolumes|should\swrite\sentries\sto\s/etc/hosts|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:.+\]
         - --timeout=420m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aks-engine-azure
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources: {}
         securityContext:
@@ -584,7 +584,7 @@ presubmits:
         - --timeout=60m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -637,7 +637,7 @@ presubmits:
         - --timeout=80m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -698,7 +698,7 @@ presubmits:
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-rbe
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources: {}
         volumeMounts:
@@ -749,7 +749,7 @@ presubmits:
         - --timeout=180m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-alpha-features
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -805,7 +805,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -854,7 +854,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -910,7 +910,7 @@ presubmits:
         - --timeout=80m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-containerd-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -963,7 +963,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -1013,7 +1013,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -1051,7 +1051,7 @@ presubmits:
         - --env=KUBE_RELEASE_RUN_TESTS=n
         - make
         - release
-        image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+        image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         name: ""
         resources:
           requests:
@@ -1107,7 +1107,7 @@ presubmits:
         - --timeout=65m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1164,7 +1164,7 @@ presubmits:
         - --timeout=60m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1213,7 +1213,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1253,7 +1253,7 @@ presubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build
         - --gcs-shared=gs://kubernetes-security-prow/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1295,7 +1295,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1331,7 +1331,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: main
         resources: {}
         volumeMounts:
@@ -1400,7 +1400,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1460,7 +1460,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -1513,7 +1513,7 @@ presubmits:
         - --timeout=65m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1570,7 +1570,7 @@ presubmits:
         - --timeout=60m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1619,7 +1619,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1659,7 +1659,7 @@ presubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build
         - --gcs-shared=gs://kubernetes-security-prow/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1701,7 +1701,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1737,7 +1737,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: main
         resources: {}
         volumeMounts:
@@ -1806,7 +1806,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1866,7 +1866,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -1919,7 +1919,7 @@ presubmits:
         - --timeout=65m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -1976,7 +1976,7 @@ presubmits:
         - --timeout=60m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2025,7 +2025,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2065,7 +2065,7 @@ presubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-security-prow/ci/pull-security-kubernetes-bazel-build
         - --gcs-shared=gs://kubernetes-security-prow/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2107,7 +2107,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2143,7 +2143,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: main
         resources: {}
         volumeMounts:
@@ -2212,7 +2212,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2272,7 +2272,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -2330,7 +2330,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-kops-aws
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -2387,7 +2387,7 @@ presubmits:
         - --timeout=60m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-device-plugin-gpu
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -2440,7 +2440,7 @@ presubmits:
         - --timeout=80m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -2501,7 +2501,7 @@ presubmits:
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-rbe
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources: {}
         volumeMounts:
@@ -2548,7 +2548,7 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -2619,7 +2619,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -2734,7 +2734,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: main
         resources: {}
         volumeMounts:
@@ -2796,7 +2796,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-100-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -2860,7 +2860,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-big-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -2924,7 +2924,7 @@ presubmits:
         - --use-logexporter
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-large-performance
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -2995,7 +2995,7 @@ presubmits:
         - --timeout=100m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-big
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3065,7 +3065,7 @@ presubmits:
         - --timeout=1200m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-kubemark-e2e-gce-scale
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3120,7 +3120,7 @@ presubmits:
         - --timeout=80m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-storage-slow
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3185,7 +3185,7 @@ presubmits:
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-storage-slow-rbe
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources: {}
         volumeMounts:
@@ -3237,7 +3237,7 @@ presubmits:
         - --timeout=120m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-gce-csi-serial
         - --gcp-project=k8s-jkns-pr-gce-etcd3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3363,7 +3363,7 @@ presubmits:
         - --
         - -c
         - cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3404,7 +3404,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: main
         resources: {}
         securityContext:
@@ -3447,7 +3447,7 @@ presubmits:
           value: https://proxy.golang.org
         - name: GOSUMDB
           value: sum.golang.org
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: main
         resources: {}
         securityContext:
@@ -3491,7 +3491,7 @@ presubmits:
           value: "Y"
         - name: WHAT
           value: godeps staging-godeps godep-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: main
         resources: {}
         securityContext:
@@ -3527,7 +3527,7 @@ presubmits:
         - --
         - --branch=${PULL_BASE_REF}
         - --prow
-        image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+        image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         name: ""
         resources:
           requests:
@@ -3733,7 +3733,7 @@ presubmits:
         - --provider=local
         - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[sig\-apps\]\sDaemon\sset\s\[Serial\]\sshould\srollback\swithout\sunnecessary\srestarts\s\[Conformance\]
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources:
           requests:
@@ -3770,7 +3770,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: main
         resources: {}
         volumeMounts:
@@ -3813,7 +3813,7 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         imagePullPolicy: Always
         name: ""
         resources:
@@ -3861,7 +3861,7 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         imagePullPolicy: Always
         name: ""
         resources:
@@ -3906,7 +3906,7 @@ presubmits:
         - --exclude-typecheck
         - --exclude-godep
         - --script=./hack/jenkins/verify-dockerized.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+        image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         name: ""
         resources:
           requests:
@@ -3972,7 +3972,7 @@ presubmits:
           --ginkgo.skip=\[LinuxOnly\]|GMSA|\[Serial\]
         - --timeout=450m
         - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-aks-engine-azure-windows
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         name: ""
         resources: {}
         securityContext:

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -20,7 +20,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -44,7 +44,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -20,7 +20,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -47,7 +47,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -79,7 +79,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       command:
       - "./scripts/ci-aws-cred-test.sh"
 - name: periodic-cluster-api-provider-aws-bazel-e2e
@@ -32,7 +32,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       command: ["runner.sh"]
       args: ["make", "e2e"]
       env:
@@ -59,7 +59,7 @@ postsubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         command: ["runner.sh"]
         args: ["make", "e2e"]
         env:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
       path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -85,7 +85,7 @@ presubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         resources:
           requests:
             memory: "6Gi"
@@ -48,7 +48,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -82,7 +82,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -75,7 +75,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -31,7 +31,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.4.0"
       - "--root=/go/src"
@@ -58,7 +58,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
     path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - "./hack/ci/build-all.sh"
       # trialing this on kind jobs, we are using FQDN for in-cluster services, now

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - "./hack/ci/build-all.sh"
   - name: pull-kind-verify
@@ -18,7 +18,7 @@ presubmits:
     preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         command:
         - "./hack/verify-all.sh"
   # conformance test against kubernetes master branch with `kind`, skipping
@@ -35,7 +35,7 @@ presubmits:
     optional: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -82,7 +82,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -123,7 +123,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -164,7 +164,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -205,7 +205,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - "./hack/ci/build-all.sh"
 # conformance test against kubernetes master branch with `kind`
@@ -25,7 +25,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -58,7 +58,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -94,7 +94,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -126,7 +126,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -158,7 +158,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - make
         - test
@@ -19,7 +19,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -48,7 +48,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -6,6 +6,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - "./hack/ci/test.sh"

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
@@ -35,7 +35,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -74,7 +74,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -136,7 +136,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -49,7 +49,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -94,7 +94,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -135,7 +135,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -175,7 +175,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - go
       args:
@@ -29,7 +29,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - bash
       - -c

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - go
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - bash
         - -c

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -21,7 +21,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -58,7 +58,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=v1.14.0"
@@ -105,7 +105,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=v1.14.0"
@@ -148,7 +148,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -173,7 +173,7 @@ periodics:
     path_alias: k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=v1.14.0
@@ -227,7 +227,7 @@ periodics:
     path_alias: k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=v1.14.0
@@ -283,7 +283,7 @@ periodics:
     path_alias: k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=v1.14.0
@@ -338,7 +338,7 @@ periodics:
     path_alias: k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=v1.14.0

--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
+++ b/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -27,7 +27,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -28,7 +28,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -60,7 +60,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable3-gkespec
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
@@ -92,7 +92,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -124,7 +124,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -154,7 +154,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -185,7 +185,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -220,7 +220,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-gpu
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -251,7 +251,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -284,7 +284,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -314,7 +314,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -347,7 +347,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -379,7 +379,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -410,7 +410,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -443,7 +443,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -475,7 +475,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:ClusterSizeAutoscalingScaleWithNAP\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-autoscaling
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -507,7 +507,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-flaky
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -540,7 +540,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -572,7 +572,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -604,7 +604,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: cos2-k8sstable3-serial
     testgrid-dashboards: cos-cos2-k8sstable3
@@ -636,7 +636,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-autoscaling
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -664,7 +664,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all
@@ -697,7 +697,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -727,7 +727,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -760,7 +760,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -793,7 +793,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -823,7 +823,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -856,7 +856,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-updown
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -889,7 +889,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -920,7 +920,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -951,7 +951,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -983,7 +983,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable3-serial
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
@@ -1016,7 +1016,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -1049,7 +1049,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -1077,7 +1077,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
@@ -1108,7 +1108,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -1140,7 +1140,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable1-gkespec
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
@@ -1171,7 +1171,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: cos1-k8sstable1-gkespec
     testgrid-dashboards: cos-cos1-k8sstable1
@@ -1203,7 +1203,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-autoscaling
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -1233,7 +1233,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-all
@@ -1263,7 +1263,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -1294,7 +1294,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all
@@ -1324,7 +1324,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -1359,7 +1359,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-gpu
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -1391,7 +1391,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: cos1-k8sbeta-serial
     testgrid-dashboards: cos-cos1-k8sbeta
@@ -1422,7 +1422,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -1454,7 +1454,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -1486,7 +1486,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:ClusterSizeAutoscalingScaleWithNAP\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-autoscaling
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -1518,7 +1518,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-autoscaling
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -1551,7 +1551,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -1583,7 +1583,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-flaky
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -1615,7 +1615,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -1648,7 +1648,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-updown
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -1680,7 +1680,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-flaky
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -1713,7 +1713,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -1746,7 +1746,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-updown
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -1774,7 +1774,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
@@ -1805,7 +1805,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -1837,7 +1837,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -1869,7 +1869,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-autoscaling
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -1896,7 +1896,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -1928,7 +1928,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -1958,7 +1958,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -1990,7 +1990,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-autoscaling
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -2023,7 +2023,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -2055,7 +2055,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable2-gkespec
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
@@ -2088,7 +2088,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -2120,7 +2120,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable3-serial
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
@@ -2151,7 +2151,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.12-all
@@ -2183,7 +2183,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-flaky
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -2218,7 +2218,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-gpu
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -2249,7 +2249,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all
@@ -2281,7 +2281,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable1-serial
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
@@ -2313,7 +2313,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: ubuntu1-k8sbeta-serial
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
@@ -2344,7 +2344,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: cos2-k8sstable2-gkespec
     testgrid-dashboards: cos-cos2-k8sstable2
@@ -2375,7 +2375,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.14-all
@@ -2406,7 +2406,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -2438,7 +2438,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -2470,7 +2470,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -2499,7 +2499,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -2527,7 +2527,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -2557,7 +2557,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -2588,7 +2588,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all
@@ -2618,7 +2618,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -2653,7 +2653,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-gpu
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -2681,7 +2681,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -2714,7 +2714,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-updown
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -2746,7 +2746,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -2779,7 +2779,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-updown
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -2810,7 +2810,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all
@@ -2842,7 +2842,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -2873,7 +2873,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all
@@ -2905,7 +2905,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-autoscaling
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -2937,7 +2937,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: ubuntu1-k8sbeta-gkespec
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
@@ -2972,7 +2972,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-gpu
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -3004,7 +3004,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -3035,7 +3035,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -3067,7 +3067,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-flaky
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -3100,7 +3100,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-updown
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -3130,7 +3130,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -3162,7 +3162,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-autoscaling
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -3195,7 +3195,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-updown
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -3227,7 +3227,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-autoscaling
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -3260,7 +3260,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -3292,7 +3292,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-flaky
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -3327,7 +3327,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-gpu
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -3359,7 +3359,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: ubuntu1-k8sstable2-serial
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
@@ -3391,7 +3391,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -3421,7 +3421,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -3454,7 +3454,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -3487,7 +3487,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -3520,7 +3520,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -3548,7 +3548,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -3580,7 +3580,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable3-gkespec
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
@@ -3613,7 +3613,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -3645,7 +3645,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:ClusterSizeAutoscalingScaleWithNAP\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-autoscaling
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -3676,7 +3676,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -3709,7 +3709,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -3741,7 +3741,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-flaky
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -3774,7 +3774,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -3806,7 +3806,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -3836,7 +3836,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -3868,7 +3868,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-autoscaling
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -3901,7 +3901,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-updown
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -3931,7 +3931,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -3964,7 +3964,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -3996,7 +3996,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -4028,7 +4028,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:ClusterSizeAutoscalingScaleWithNAP\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-autoscaling
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -4063,7 +4063,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-gpu
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -4096,7 +4096,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -4127,7 +4127,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all
@@ -4155,7 +4155,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -4186,7 +4186,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all
@@ -4219,7 +4219,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -4251,7 +4251,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-autoscaling
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -4279,7 +4279,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -4309,7 +4309,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-all
@@ -4344,7 +4344,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-gpu
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -4376,7 +4376,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -4406,7 +4406,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -4439,7 +4439,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-updown
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -4471,7 +4471,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -4501,7 +4501,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -4534,7 +4534,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -4566,7 +4566,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -4598,7 +4598,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: ubuntu2-k8sbeta-serial
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
@@ -4629,7 +4629,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -4660,7 +4660,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: cos2-k8sstable3-gkespec
     testgrid-dashboards: cos-cos2-k8sstable3
@@ -4690,7 +4690,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -4722,7 +4722,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -4752,7 +4752,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-all
@@ -4785,7 +4785,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -4817,7 +4817,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -4850,7 +4850,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -4881,7 +4881,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: cos1-k8sbeta-gkespec
     testgrid-dashboards: cos-cos1-k8sbeta
@@ -4912,7 +4912,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -4944,7 +4944,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-flaky
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -4975,7 +4975,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all
@@ -5007,7 +5007,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: cos1-k8sstable2-serial
     testgrid-dashboards: cos-cos1-k8sstable2
@@ -5035,7 +5035,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -5066,7 +5066,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -5098,7 +5098,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -5129,7 +5129,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -5160,7 +5160,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -5191,7 +5191,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -5223,7 +5223,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-flaky
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -5254,7 +5254,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -5285,7 +5285,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: cos1-k8sstable2-gkespec
     testgrid-dashboards: cos-cos1-k8sstable2
@@ -5318,7 +5318,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -5350,7 +5350,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-flaky
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -5382,7 +5382,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -5415,7 +5415,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-updown
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu1-k8sstable2
@@ -5445,7 +5445,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -5478,7 +5478,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -5510,7 +5510,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-flaky
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -5542,7 +5542,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: ubuntu2-k8sbeta-gkespec
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
@@ -5569,7 +5569,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -5604,7 +5604,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-gpu
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -5632,7 +5632,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -5667,7 +5667,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-gpu
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -5702,7 +5702,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-gpu
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -5735,7 +5735,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-updown
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -5768,7 +5768,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -5799,7 +5799,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -5829,7 +5829,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-all
@@ -5862,7 +5862,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -5893,7 +5893,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -5921,7 +5921,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -5953,7 +5953,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: cos1-k8sstable3-serial
     testgrid-dashboards: cos-cos1-k8sstable3
@@ -5985,7 +5985,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -6018,7 +6018,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-updown
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -6050,7 +6050,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-autoscaling
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -6083,7 +6083,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -6118,7 +6118,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-gpu
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -6148,7 +6148,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -6180,7 +6180,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable2-gkespec
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
@@ -6210,7 +6210,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -6238,7 +6238,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -6270,7 +6270,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-flaky
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu1-k8sstable3
@@ -6303,7 +6303,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-updown
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -6334,7 +6334,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
   annotations:
     testgrid-tab-name: cos1-k8sstable3-gkespec
     testgrid-dashboards: cos-cos1-k8sstable3
@@ -6362,7 +6362,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
@@ -6394,7 +6394,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable1-serial
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
@@ -6426,7 +6426,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -6456,7 +6456,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -6489,7 +6489,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -6517,7 +6517,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -6545,7 +6545,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -6577,7 +6577,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -6608,7 +6608,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -6640,7 +6640,7 @@ periodics:
       - --timeout=600m
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-autoscaling
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -6672,7 +6672,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-flaky
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -6699,7 +6699,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -6731,7 +6731,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-flaky
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -6764,7 +6764,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -6797,7 +6797,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -6827,7 +6827,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sstable1-serial
     testgrid-dashboards: sig-release-1.14-all, cos-cos2-k8sstable1
@@ -6858,7 +6858,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -6889,7 +6889,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: cos2-k8sbeta-gkespec
     testgrid-dashboards: cos-cos2-k8sbeta
@@ -6921,7 +6921,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: cos1-k8sstable1-serial
     testgrid-dashboards: cos-cos1-k8sstable1
@@ -6949,7 +6949,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
@@ -6976,7 +6976,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
@@ -7007,7 +7007,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all
@@ -7039,7 +7039,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   annotations:
     testgrid-tab-name: cos2-k8sbeta-serial
     testgrid-dashboards: cos-cos2-k8sbeta
@@ -7072,7 +7072,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu1-k8sbeta
@@ -7104,7 +7104,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -7136,7 +7136,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable1-gkespec
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
@@ -7166,7 +7166,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -7198,7 +7198,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -7226,7 +7226,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
@@ -7259,7 +7259,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -7292,7 +7292,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-default
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -7325,7 +7325,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -7357,7 +7357,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -7389,7 +7389,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: cos2-k8sstable1-serial
     testgrid-dashboards: cos-cos2-k8sstable1
@@ -7421,7 +7421,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-flaky
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -7452,7 +7452,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all
@@ -7484,7 +7484,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -7519,7 +7519,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-gpu
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -7550,7 +7550,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.15-all
@@ -7580,7 +7580,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos1-k8sstable3-slow
     testgrid-dashboards: sig-release-1.12-all, cos-cos1-k8sstable3
@@ -7613,7 +7613,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -7648,7 +7648,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-gpu
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -7680,7 +7680,7 @@ periodics:
       - --ginkgo-parallel=30
       - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling,KubernetesDashboard
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-all
@@ -7711,7 +7711,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   annotations:
     testgrid-tab-name: cos2-k8sstable1-gkespec
     testgrid-dashboards: cos-cos2-k8sstable1
@@ -7742,7 +7742,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -7775,7 +7775,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-updown
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -7808,7 +7808,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable2-slow
     testgrid-dashboards: sig-release-1.13-all, cos-cos2-k8sstable2
@@ -7841,7 +7841,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-1.12-all, canonical-ubuntu2-k8sstable3
@@ -7876,7 +7876,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-gpu
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu2-k8sstable1
@@ -7909,7 +7909,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, cos-cos1-k8sbeta
@@ -7941,7 +7941,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.13-all, cos-cos1-k8sstable2
@@ -7971,7 +7971,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos2-k8sbeta-slow
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -8003,7 +8003,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-flaky
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -8031,7 +8031,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
@@ -8063,7 +8063,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: ubuntu2-k8sstable2-serial
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
@@ -8094,7 +8094,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.13-all
@@ -8127,7 +8127,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -8160,7 +8160,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-updown
     testgrid-dashboards: sig-release-1.14-all, canonical-ubuntu1-k8sstable1
@@ -8192,7 +8192,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.15-all, cos-cos2-k8sbeta
@@ -8224,7 +8224,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   annotations:
     testgrid-tab-name: cos2-k8sstable2-serial
     testgrid-dashboards: cos-cos2-k8sstable2
@@ -8257,7 +8257,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-default
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3
@@ -8292,7 +8292,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-gpu
     testgrid-dashboards: sig-release-1.15-all, canonical-ubuntu2-k8sbeta
@@ -8325,7 +8325,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-default
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -8356,7 +8356,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-1.13-all, canonical-ubuntu2-k8sstable2
@@ -8389,7 +8389,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos1-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all, cos-cos1-k8sstable1
@@ -8418,7 +8418,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
@@ -8449,7 +8449,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.14-all
@@ -8482,7 +8482,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   annotations:
     testgrid-tab-name: gke-cos2-k8sstable3-updown
     testgrid-dashboards: sig-release-1.12-all, cos-cos2-k8sstable3

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -36,7 +36,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -133,7 +133,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -189,7 +189,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
@@ -215,7 +215,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -7,6 +7,6 @@ presubmits:
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - "./kinder/hack/verify-all.sh"

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -35,7 +35,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -66,7 +66,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -99,7 +99,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:
@@ -131,7 +131,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -66,7 +66,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -102,7 +102,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:
@@ -137,7 +137,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
           path_alias: k8s.io/publishing-bot
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
             command:
               - go
             args:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -29,7 +29,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -20,4 +20,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/kubernetes-sigs/application=master
       - --upload=gs://kubernetes-jenkins/logs/
@@ -54,7 +54,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 
 - interval: 30m
@@ -75,4 +75,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -63,7 +63,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -91,7 +91,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -119,7 +119,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -169,7 +169,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
@@ -191,7 +191,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
@@ -223,7 +223,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
@@ -245,7 +245,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling
@@ -271,7 +271,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:ClusterSizeAutoscalingScaleWithNAP\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=600m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
@@ -297,7 +297,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=420m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
@@ -324,4 +324,4 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=400m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -33,7 +33,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -58,7 +58,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-11: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       imagePullPolicy: Always
       args:
       - --timeout=320

--- a/config/jobs/kubernetes/sig-aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/eks-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kubernetes-e2e-aws-eks-1-11: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         imagePullPolicy: Always
         args:
           - --root=/go/src

--- a/config/jobs/kubernetes/sig-aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/kops/kops-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-beta
@@ -45,7 +45,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
@@ -255,7 +255,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-stable2
@@ -279,7 +279,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-kops-aws-stable3
@@ -303,7 +303,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-updown
@@ -328,7 +328,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
       - --timeout=30m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 24h
   name: ci-kubernetes-e2e-kops-aws-weave
@@ -353,7 +353,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce
@@ -377,7 +377,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-kops-gce-channelalpha
@@ -401,7 +401,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce-ha
@@ -425,4 +425,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/kops/kops-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-azure/sig-azure-config.yaml
@@ -38,7 +38,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gce-sig-cli
@@ -42,7 +42,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gke-sig-cli
@@ -68,7 +68,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
@@ -92,7 +92,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-kops-aws-sig-cli
@@ -115,7 +115,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 # kubectl skew tests
 - interval: 2h
@@ -141,7 +141,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
@@ -165,7 +165,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
@@ -190,7 +190,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
@@ -214,7 +214,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
@@ -238,7 +238,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
@@ -261,7 +261,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\]  --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
@@ -285,7 +285,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
@@ -308,7 +308,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
@@ -333,7 +333,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
@@ -357,7 +357,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
@@ -381,7 +381,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
@@ -404,7 +404,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
@@ -432,7 +432,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
@@ -459,7 +459,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
@@ -487,7 +487,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
@@ -514,7 +514,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
@@ -541,7 +541,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
@@ -567,7 +567,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
@@ -595,7 +595,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
@@ -622,7 +622,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
@@ -650,7 +650,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
@@ -677,7 +677,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
@@ -705,7 +705,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
@@ -732,4 +732,4 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
   labels:
@@ -48,7 +48,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
@@ -74,7 +74,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel
   labels:
@@ -100,7 +100,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
@@ -125,7 +125,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master-parallel
   labels:
@@ -150,7 +150,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 
 - interval: 12h
@@ -177,7 +177,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster-parallel
@@ -204,7 +204,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
@@ -229,7 +229,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
@@ -254,7 +254,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
@@ -279,7 +279,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster
@@ -311,7 +311,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster-parallel
@@ -344,7 +344,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
@@ -371,7 +371,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
@@ -399,7 +399,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster
@@ -431,7 +431,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 # ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new has a -parallel form for the parallel-safe tests,
 # and the non-parallel form runs the Serial & Disruptive tests (only)
@@ -459,7 +459,7 @@ periodics:
       - --timeout=900m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new-parallel
@@ -486,7 +486,7 @@ periodics:
       - --timeout=900m
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-parallel
@@ -518,7 +518,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-master
@@ -544,7 +544,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-master-parallel
@@ -571,4 +571,4 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
@@ -25,7 +25,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
 # The non -parallel form of the test includes Serial and Disruptive, so it must run serially;
@@ -56,7 +56,7 @@ periodics:
       - --timeout=1200m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new-parallel
@@ -85,7 +85,7 @@ periodics:
       - --timeout=1200m
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-parallel
@@ -113,7 +113,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master
@@ -140,7 +140,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
@@ -167,7 +167,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
@@ -195,7 +195,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
@@ -224,7 +224,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
@@ -252,7 +252,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
@@ -280,7 +280,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
@@ -308,7 +308,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
@@ -336,7 +336,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
@@ -365,7 +365,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
@@ -393,7 +393,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
@@ -421,7 +421,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
@@ -449,7 +449,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
@@ -477,7 +477,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
@@ -505,7 +505,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
@@ -534,7 +534,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster
@@ -562,7 +562,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
@@ -591,4 +591,4 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -20,7 +20,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -51,7 +51,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -82,7 +82,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -20,7 +20,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -51,7 +51,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -82,7 +82,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
@@ -19,7 +19,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:HAMaster\] --minStartupPods=8
       - --timeout=220m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 24h
   name: ci-kubernetes-e2e-gce-min-node-permissions
@@ -44,4 +44,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 # manual-release-bump-required (add a job for the new version and delete the job for the oldest version)
 - interval: 6h
@@ -46,7 +46,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
 
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-13
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
 
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-14
@@ -88,7 +88,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
 
 
 - interval: 6h
@@ -110,4 +110,4 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
           - --timeout=200m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingGpu\] --ginkgo.skip=\[Flaky\]
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 2-23/4 * * *"
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-p100
@@ -51,7 +51,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingGpu\] --ginkgo.skip=\[Flaky\]
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 4h
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-v100
@@ -78,4 +78,4 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingGpu\] --ginkgo.skip=\[Flaky\]
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
@@ -39,4 +39,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   cron: "30 0-23/2 * * *"
@@ -49,7 +49,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
   cron: "30 0-23/3 * * *"
@@ -75,7 +75,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverAcceleratorMonitoring\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100
   cron: "30 2-23/12 * * *" #expensive test
@@ -101,7 +101,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   cron: "30 8-23/12 * * *" #expensive test
@@ -127,7 +127,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable1
   cron: "0 0-23/12 * * *" #expensive test
@@ -153,7 +153,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2
   cron: "0 6-23/12 * * *" #expensive test
@@ -179,7 +179,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   cron: "0 1-23/6 * * *"
@@ -205,7 +205,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
   cron: "0 2-23/12 * * *"
@@ -231,7 +231,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-ubuntu
   cron: "0 1-23/2 * * *"
@@ -258,4 +258,4 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-presubmit.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-pull-gce-device-plugin-gpu: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -66,7 +66,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 5-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
@@ -51,7 +51,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 1-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
@@ -78,7 +78,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 7-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
@@ -105,7 +105,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 3-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
@@ -132,7 +132,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 9-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
@@ -159,7 +159,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 10-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
@@ -187,7 +187,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - cron: "0 11-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
@@ -215,4 +215,4 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -52,7 +52,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -82,7 +82,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -130,7 +130,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(StorageVersionHash|Audit|BlockVolume|CustomResourcePublishOpenAPI|CustomResourceWebhookConversion|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|gcePD-external --minStartupPods=8
         - --timeout=180m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -160,7 +160,7 @@ periodics:
       - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
@@ -186,7 +186,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=70m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-alpha-features
@@ -211,7 +211,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|CustomResourcePublishOpenAPI|CustomResourceWebhookConversion|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|VolumeSubpathEnvExpansion|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|gcePD-external --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-flaky
@@ -232,7 +232,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
@@ -255,7 +255,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-reboot
@@ -277,7 +277,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial
@@ -300,7 +300,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-slow
@@ -323,7 +323,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gce-multizone
@@ -350,7 +350,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gce-gci
@@ -377,7 +377,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-beta
@@ -404,7 +404,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable1
@@ -431,7 +431,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable2
@@ -457,7 +457,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable3
@@ -483,4 +483,4 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gke-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gke-config.yaml
@@ -37,7 +37,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -67,7 +67,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-features
@@ -93,7 +93,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(DynamicKubeletConfig|BlockVolume|ExpandCSIVolumes|ExpandInUseVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-enabled-default
@@ -120,7 +120,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-flaky
@@ -145,7 +145,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-multizone
@@ -172,7 +172,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-reboot
@@ -197,7 +197,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-serial
@@ -222,7 +222,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-slow
@@ -248,7 +248,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-updown
@@ -273,7 +273,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --timeout=30m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional
@@ -299,7 +299,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional-serial
@@ -323,7 +323,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional-slow
@@ -348,7 +348,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-kubernetes-e2e-gke-gci-ci-master
@@ -373,7 +373,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 12h
   name: ci-kubernetes-soak-gke-gci
@@ -402,7 +402,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=800m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: istio-periodic-e2e-gke-addon
@@ -411,7 +411,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/ostromart/istio=k8s-prow-test
       - --timeout=90

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: OVERRIDE_NODE_BINARY_TAR_URL
         value: "https://storage.googleapis.com/kubernetes-release/release/v1.14.1/kubernetes-node-windows-amd64.tar.gz"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           memory: "8Gi"
@@ -94,7 +94,7 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-windows-gce-k8sbeta
   decorate: true
@@ -126,7 +126,7 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-windows-gce-k8sstable1
   decorate: true
@@ -194,7 +194,7 @@ periodics:
       env:
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-kubernetes-e2e-windows-gce-serial
   decorate: true
@@ -226,7 +226,7 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[Flaky\]|\[LinuxOnly\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=240m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 presubmits:
   kubernetes/kubernetes:
@@ -267,7 +267,7 @@ presubmits:
         - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
         - --test-cmd-args=--node-os-distro=windows
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:InfluxdbMonitoring\]
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gce-prometheus
@@ -38,7 +38,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:PrometheusMonitoring\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gce-stackdriver
@@ -61,7 +61,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-es-logging
@@ -84,7 +84,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-sd-logging
@@ -107,7 +107,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
@@ -131,7 +131,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
@@ -155,7 +155,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
@@ -179,7 +179,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
@@ -203,7 +203,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
@@ -227,7 +227,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
@@ -251,7 +251,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gke-stackdriver
@@ -276,4 +276,4 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -938,7 +938,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gce-netd-calico
@@ -961,7 +961,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -989,7 +989,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-ubuntu-gce-netd-calico
@@ -1013,7 +1013,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1045,7 +1045,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-kubernetes-e2e-containerd-gce-netd-calico
@@ -1074,7 +1074,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1106,4 +1106,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -167,7 +167,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -191,7 +191,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare
@@ -218,7 +218,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare
@@ -246,7 +246,7 @@ periodics:
     preset-ingress-v1.3-and-above-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare
@@ -270,7 +270,7 @@ periodics:
     preset-ingress-v1.3-and-above-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare
@@ -294,7 +294,7 @@ periodics:
     preset-ingress-v1.3-and-above-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare
@@ -318,7 +318,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=340
       - --bare

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -43,7 +43,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance
@@ -68,7 +68,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-kubedns-performance
@@ -93,7 +93,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-coredns
@@ -116,7 +116,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -142,7 +142,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-kubedns-performance-nodecache
@@ -168,7 +168,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-coredns-nodecache
@@ -192,7 +192,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -216,7 +216,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
@@ -239,7 +239,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ip-alias
@@ -265,7 +265,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-ipvs
@@ -291,7 +291,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-kube-dns
@@ -314,7 +314,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -338,7 +338,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -362,7 +362,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
@@ -388,7 +388,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gke-network-policy
@@ -414,7 +414,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:NetworkPolicy\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       - --gke-create-command=container clusters create --enable-network-policy
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 120m
   name: ci-kubernetes-e2e-gce-lb-finalizer
@@ -437,4 +437,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\]|\[Feature:ServiceFinalizer\]  --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -45,7 +45,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -61,7 +61,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/containerd/containerd=release/1.1
       - --repo=github.com/containerd/cri=release/1.0
@@ -78,7 +78,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/containerd/containerd=release/1.2
       - --repo=github.com/containerd/cri=release/1.2
@@ -115,7 +115,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-1
@@ -172,7 +172,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
 
 
 - interval: 1h
@@ -201,7 +201,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-containerd-node-e2e
   interval: 1h
@@ -210,7 +210,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -266,7 +266,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.12
@@ -294,7 +294,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -350,7 +350,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.12
@@ -399,7 +399,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-cri-containerd-build
   interval: 30m
@@ -407,7 +407,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -439,7 +439,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-multizone
@@ -467,7 +467,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-stackdriver
@@ -493,7 +493,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce
@@ -519,7 +519,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-alpha-features
@@ -546,7 +546,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-es-logging
@@ -571,7 +571,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-flaky
@@ -594,7 +594,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ingress
@@ -620,7 +620,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ip-alias
@@ -647,7 +647,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-proto
@@ -672,7 +672,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-reboot
@@ -695,7 +695,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging
@@ -720,7 +720,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging-k8s-resources
@@ -749,7 +749,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-serial
@@ -772,7 +772,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-slow
@@ -796,7 +796,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-statefulset
@@ -818,7 +818,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - interval: 1h
   name: ci-cri-containerd-e2e-ubuntu-gce
@@ -844,7 +844,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-cri-containerd-node-e2e
   interval: 1h
@@ -853,7 +853,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -881,7 +881,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -909,7 +909,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -937,7 +937,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -965,7 +965,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1014,7 +1014,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
 
 - interval: 1h
   name: ci-containerd-e2e-shielded-gci-gce-slow-1-2
@@ -1042,7 +1042,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
 
 - interval: 1h
   name: ci-containerd-e2e-shielded-gci-gce-serial-1-2
@@ -1069,7 +1069,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
 
 - interval: 1h
   name: ci-cos-containerd-e2e-gci-gce
@@ -1096,7 +1096,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 
 - interval: 1h
@@ -1122,7 +1122,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 
 - name: ci-cos-containerd-node-e2e
   interval: 1h
@@ -1131,7 +1131,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1158,7 +1158,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -32,7 +32,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -58,7 +58,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -14,7 +14,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -41,7 +41,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -68,7 +68,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -96,7 +96,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -129,7 +129,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -156,7 +156,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -183,7 +183,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -210,7 +210,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=265
@@ -237,7 +237,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -24,4 +24,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -71,7 +71,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
           resources:
             requests:
               memory: "6Gi"
@@ -86,7 +86,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -118,7 +118,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+    - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
@@ -60,7 +60,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+    - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       args:
       - --repo=k8s.io/release
       - --root=/go/src
@@ -89,7 +89,7 @@ periodics:
     testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         args:
           - --repo=k8s.io/kubernetes
           - --repo=k8s.io/release
@@ -115,7 +115,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+    - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       name: ""
       resources: {}
 - annotations:
@@ -80,7 +80,7 @@ periodics:
       - --extra-publish-file=k8s-stable3
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -107,7 +107,7 @@ periodics:
       - --branch=release-1.12
       - --force
       - --script=./hack/jenkins/verify-dockerized.sh
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -140,7 +140,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       name: ""
       resources:
         requests:
@@ -175,7 +175,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
       name: ""
       resources:
         requests:
@@ -199,7 +199,7 @@ periodics:
       - --branch=release-1.12
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -230,7 +230,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
 - annotations:
@@ -273,7 +273,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
   tags:
@@ -306,7 +306,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.12.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -337,7 +337,7 @@ postsubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -377,7 +377,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -418,7 +418,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -460,7 +460,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -502,7 +502,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -536,7 +536,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -561,7 +561,7 @@ presubmits:
         - --
         - --build=//... -//vendor/...
         - --release=//build/release-tars
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -590,7 +590,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -612,7 +612,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: main
         resources: {}
   - always_run: true
@@ -665,7 +665,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/legacy/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:
@@ -711,7 +711,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
       name: ""
       resources: {}
 - annotations:
@@ -80,7 +80,7 @@ periodics:
       - --extra-publish-file=k8s-stable2
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -107,7 +107,7 @@ periodics:
       - --branch=release-1.13
       - --force
       - --script=./hack/jenkins/verify-dockerized.sh
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -140,7 +140,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
       name: ""
       resources:
         requests:
@@ -175,7 +175,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
       name: ""
       resources:
         requests:
@@ -199,7 +199,7 @@ periodics:
       - --branch=release-1.13
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -230,7 +230,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
 - annotations:
@@ -274,7 +274,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
   tags:
@@ -307,7 +307,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.13.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -338,7 +338,7 @@ postsubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -378,7 +378,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -419,7 +419,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -461,7 +461,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -503,7 +503,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -537,7 +537,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -562,7 +562,7 @@ presubmits:
         - --
         - --build=//... -//vendor/...
         - --release=//build/release-tars
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -591,7 +591,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -613,7 +613,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: main
         resources: {}
   - always_run: true
@@ -666,7 +666,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/legacy/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:
@@ -712,7 +712,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       name: ""
       resources: {}
 - annotations:
@@ -57,7 +57,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       name: ""
       resources: {}
 - interval: 1h
@@ -85,7 +85,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       name: ""
       resources: {}
   annotations:
@@ -113,7 +113,7 @@ periodics:
       - --extra-publish-file=k8s-stable1
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -151,7 +151,7 @@ periodics:
         value: release-1.14
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       imagePullPolicy: Always
       name: ""
       resources:
@@ -185,7 +185,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       name: ""
       resources:
         requests:
@@ -217,7 +217,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
       name: ""
       resources:
         requests:
@@ -241,7 +241,7 @@ periodics:
       - --branch=release-1.14
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -273,7 +273,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
 - annotations:
@@ -315,7 +315,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       name: ""
       resources: {}
   tags:
@@ -348,7 +348,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.14.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -379,7 +379,7 @@ postsubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -419,7 +419,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -460,7 +460,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -502,7 +502,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -544,7 +544,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -578,7 +578,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -603,7 +603,7 @@ presubmits:
         - --
         - --build=//... -//vendor/...
         - --release=//build/release-tars
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -632,7 +632,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -654,7 +654,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: main
         resources: {}
   - always_run: true
@@ -707,7 +707,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:
@@ -753,7 +753,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -22,7 +22,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
 - annotations:
@@ -52,7 +52,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
 - annotations:
@@ -86,7 +86,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
 - annotations:
@@ -117,7 +117,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
 - annotations:
@@ -143,7 +143,7 @@ periodics:
       - --extra-publish-file=k8s-beta
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -192,7 +192,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
   tags:
@@ -230,7 +230,7 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       name: ""
       resources: {}
 - annotations:
@@ -286,7 +286,7 @@ periodics:
       - --branch=release-1.15
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       name: ""
       resources:
         requests:
@@ -325,7 +325,7 @@ periodics:
         value: release-1.15
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
       imagePullPolicy: Always
       name: ""
       resources:
@@ -361,7 +361,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -437,7 +437,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -479,7 +479,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -521,7 +521,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -559,7 +559,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -604,7 +604,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources: {}
   - always_run: false
@@ -643,7 +643,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -677,7 +677,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -732,7 +732,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: ""
         resources:
           requests:
@@ -805,6 +805,6 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
         name: main
         resources: {}

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -48,7 +48,7 @@ periodics:
     preset-e2e-scalability-node: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -116,7 +116,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -165,7 +165,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=570m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -200,7 +200,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8
       - --timeout=210m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -248,7 +248,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1270m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -268,7 +268,7 @@ periodics:
     preset-e2e-kubemark-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -315,7 +315,7 @@ periodics:
     preset-e2e-kubemark-gce-big: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -363,7 +363,7 @@ periodics:
     preset-e2e-kubemark-gce-scale: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -412,7 +412,7 @@ periodics:
     preset-e2e-kubemark-common: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -454,7 +454,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -481,7 +481,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -500,7 +500,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=55
@@ -525,7 +525,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -583,7 +583,7 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
           - --timeout=300
           - --bare

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -44,7 +44,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -92,7 +92,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -140,7 +140,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -162,7 +162,7 @@ presubmits:
       preset-e2e-kubemark-gce-big: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -222,7 +222,7 @@ presubmits:
       preset-e2e-kubemark-gce-scale: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -309,7 +309,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -364,7 +364,7 @@ presubmits:
             - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
           resources:
             requests:
               memory: "6Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -30,7 +30,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=210m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -82,7 +82,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 6
@@ -108,7 +108,7 @@ periodics:
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -45,7 +45,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"
@@ -84,7 +84,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -141,7 +141,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|gcePD-external --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -69,7 +69,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -99,7 +99,7 @@ postsubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         command:
         - bash
         args:
@@ -197,7 +197,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - bash
       args:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
           args:
             - "--job=$(JOB_NAME)"
             - "--root=/go/src"
@@ -56,7 +56,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
           args:
             - "--job=$(JOB_NAME)"
             - "--root=/go/src"
@@ -93,7 +93,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
           args:
             - "--job=$(JOB_NAME)"
             - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -23,7 +23,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - bash
@@ -82,7 +82,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       command:
       - runner.sh
       - bash

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -15,7 +15,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - make
         - verify
@@ -42,7 +42,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - make
         - verify
@@ -77,7 +77,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -74,7 +74,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+    - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
       args:
       - --repo=k8s.io/kubernetes
       - --timeout=100

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -50,7 +50,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       args:
       - "--timeout=140"
       - "--bare"

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -15,7 +15,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -46,7 +46,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
           imagePullPolicy: Always
           command:
             - runner.sh
@@ -81,7 +81,7 @@ presubmits:
     - release-1.11
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190529-e02d20c
+      - image: gcr.io/k8s-testimages/bootstrap:v20190529-b281789
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -122,7 +122,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -47,7 +47,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -83,7 +83,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -120,7 +120,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -165,7 +165,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -205,7 +205,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -273,7 +273,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20190601-ccef44ece
+    - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
       command:
       - /app/robots/commenter/app.binary
       args:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -51,7 +51,7 @@ periodics:
       - --config-path=prow/config.yaml
       - --job-config-path=config/jobs
       - --janitor-path=boskos/janitor/gcp_janitor.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
       resources:
         requests:
           cpu: 5
@@ -72,7 +72,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
       resources:
         requests:
           cpu: 5
@@ -94,7 +94,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
       resources:
         requests:
           cpu: 5

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -42,7 +42,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         command:
         - runner.sh
         args:
@@ -69,7 +69,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-experimental
         command:
         - ./hack/verify-file-perms.sh
 

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -57,7 +57,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master # whatever image you use here must have bash 4.4+
         command:
         - prow/push.sh
         env:
@@ -775,7 +775,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20190601-ccef44ece
+      image: gcr.io/k8s-prow/branchprotector:v20190528-0d7c4b53a
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -802,7 +802,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20190601-ccef44ece
+      image: gcr.io/k8s-prow/label_sync:v20190528-0d7c4b53a
       command:
       - /app/label_sync/app.binary
       args:

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -45,7 +45,7 @@ PROW_CONFIG_TEMPLATE = """
       containers:
       - args:
         env:
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
 """
 
 

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -1403,23 +1403,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.15
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.15
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.15
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.14
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.14
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.14
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.13
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.13
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.13
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.12
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-1.12
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20190528-0d7c4b5-1.12
 
 nodeTestSuites:
   default:

--- a/gopherage/cmd/html/html.go
+++ b/gopherage/cmd/html/html.go
@@ -78,7 +78,7 @@ func run(flags *flags, cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Couldn't read the HTML template: %v.", err)
 		os.Exit(1)
 	}
-	script, err := ioutil.ReadFile(filepath.Join(resourceDir, "browser_bundle.es2015.js"))
+	script, err := ioutil.ReadFile(filepath.Join(resourceDir, "browser_bundle.es6.js"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't read JavaScript: %v.", err)
 		os.Exit(1)

--- a/gopherage/cmd/html/static/BUILD.bazel
+++ b/gopherage/cmd/html/static/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "rollup_bundle")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
     name = "utils",
@@ -58,7 +57,7 @@ filegroup(
     name = "static",
     srcs = [
         "browser.html",
-        ":browser_bundle.es2015.js",
+        ":browser_bundle.es6.js",
     ],
 )
 

--- a/hack/update-protos.sh
+++ b/hack/update-protos.sh
@@ -48,7 +48,7 @@ genproto() {
 }
 
 echo -n "Generating protos: " >&2
-for p in $(find . -not '(' -path './vendor'  -prune ')' -not '(' -path './node_modules' -prune ')' -name '*.proto'); do
+for p in $(find . -not '(' -path './vendor' -prune ')' -name '*.proto'); do
   echo -n "$p "
   genproto "$p"
 done

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20190601-ccef44ece
+              image: gcr.io/k8s-prow/label_sync:v20190528-0d7c4b53a
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/label_sync:v20190528-0d7c4b53a
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "moment": "^2.22.2"
   },
   "devDependencies": {
-    "@bazel/jasmine": "0.29.2",
-    "@bazel/typescript": "0.29.2",
+    "@bazel/typescript": "^0.22.0",
     "@types/google.visualization": "^0.0.43",
     "@types/jasmine": "~2.8.0",
     "jasmine": "~2.8.0",

--- a/prow/cluster/build_deployment.yaml
+++ b/prow/cluster/build_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       # serviceAccountName: prow-build # build_rbac.yaml
       containers:
       - name: build
-        image: gcr.io/k8s-prow/build:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/build:v20190528-0d7c4b53a
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/crier:v20190528-0d7c4b53a
         args:
         - --github-workers=1
         - --report-agent=knative-build

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/deck:v20190528-0d7c4b53a
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/ghproxy:v20190528-0d7c4b53a
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/grandmatriarch:v20190528-0d7c4b53a
         args:
         - /etc/robot/service-account.json
         - http-cookiefile

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/hook:v20190528-0d7c4b53a
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/horologium:v20190528-0d7c4b53a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/needs-rebase:v20190528-0d7c4b53a
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/pipeline_deployment.yaml
+++ b/prow/cluster/pipeline_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       # serviceAccountName: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-prow/pipeline:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/pipeline:v20190528-0d7c4b53a
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/plank:v20190528-0d7c4b53a
         args:
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/sinker:v20190528-0d7c4b53a
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -139,7 +139,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/hook:v20190528-0d7c4b53a
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -218,7 +218,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/plank:v20190528-0d7c4b53a
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -254,7 +254,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/sinker:v20190528-0d7c4b53a
         args:
         - --config-path=/etc/config/config.yaml
         volumeMounts:
@@ -289,7 +289,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/deck:v20190528-0d7c4b53a
         args:
         - --config-path=/etc/config/config.yaml
         - --tide-url=http://tide/
@@ -352,7 +352,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/horologium:v20190528-0d7c4b53a
         args:
         - --config-path=/etc/config/config.yaml
         volumeMounts:
@@ -383,7 +383,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/tide:v20190528-0d7c4b53a
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -454,7 +454,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/status-reconciler:v20190528-0d7c4b53a
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/status-reconciler:v20190528-0d7c4b53a
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/tide:v20190528-0d7c4b53a
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190601-ccef44ece
+        image: gcr.io/k8s-prow/tot:v20190528-0d7c4b53a
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/cmd/branchprotector/cronjob.yaml
+++ b/prow/cmd/branchprotector/cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20190601-ccef44ece
+            image: gcr.io/k8s-prow/branchprotector:v20190528-0d7c4b53a
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "rollup_bundle")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
     name = "api",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,10 +7,10 @@ plank:
     timeout: 2h
     grace_period: 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190601-ccef44ece"
-      initupload: "gcr.io/k8s-prow/initupload:v20190601-ccef44ece"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190601-ccef44ece"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190601-ccef44ece"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190528-0d7c4b53a"
+      initupload: "gcr.io/k8s-prow/initupload:v20190528-0d7c4b53a"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190528-0d7c4b53a"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190528-0d7c4b53a"
     gcs_configuration:
       bucket: "kubernetes-jenkins"
       path_strategy: "legacy"

--- a/prow/spyglass/lenses/BUILD.bazel
+++ b/prow/spyglass/lenses/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 filegroup(
     name = "templates",

--- a/prow/spyglass/lenses/buildlog/BUILD.bazel
+++ b/prow/spyglass/lenses/buildlog/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 go_library(
     name = "go_default_library",

--- a/prow/spyglass/lenses/junit/BUILD.bazel
+++ b/prow/spyglass/lenses/junit/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 go_library(
     name = "go_default_library",

--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 go_library(
     name = "go_default_library",

--- a/triage/BUILD.bazel
+++ b/triage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 py_test(
     name = "summarize_test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,77 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@0.29.2":
-  version "0.29.2"
-  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.29.2.tgz#ddf5b5d1af8d942981840a2a50bf6233872c3e49"
-  integrity sha512-pqFsngUtzU/+d1l8gOQIPuTYnYe01RHhrrPD0DbfduvBeE/uaYJ/JIHUATpxfsn1cNqxgoFoPR7oG9EkfIvEjg==
+"@bazel/typescript@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.22.0.tgz#8b38183125c3f25e6023b12a371561d9b54182d8"
+  integrity sha512-2oKxPHlt3TNJx2RVVvC00ahcYNuIg1pQPjKQO7qyMNGGme3fqqzv5gRUDa5be/B01FxQDFpuBCHoavH7PilPRA==
   dependencies:
-    jasmine "~3.3.1"
-    jasmine-core "~3.3.0"
-    v8-coverage "1.0.9"
-
-"@bazel/typescript@0.29.2":
-  version "0.29.2"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.29.2.tgz#05098b575ef704dd00a3a44c699dbd948ac19dca"
-  integrity sha512-+ruhfyejL1pym8uattgC/ZcW+mwrPjaGrGvMjr6HGXn/BKdIdt3/qzM6RR6Px63I2TNJKdQgAwfnUYI/gnZMUQ==
-  dependencies:
-    protobufjs "6.8.8"
-    semver "5.6.0"
+    protobufjs "5.0.3"
     source-map-support "0.5.9"
     tsutils "2.27.2"
-
-"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
-  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
-
-"@protobufjs/base64@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
-  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
-
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
-
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
-
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
-
-"@protobufjs/float@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
-  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
-
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
-  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
-
-"@protobufjs/path@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
-  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
-
-"@protobufjs/pool@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
-  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
-
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
-  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
 "@types/google.visualization@^0.0.43":
   version "0.0.43"
@@ -82,24 +19,9 @@
   version "2.8.14"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.14.tgz#42a87032418b7d70f427d1df16a9921fca28d8c7"
 
-"@types/long@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
-  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
-
-"@types/node@^10.1.0":
-  version "10.14.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
-  integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -119,6 +41,13 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+ascli@~1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
+  dependencies:
+    colour "~0.7.1"
+    optjs "~3.2.2"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -143,17 +72,21 @@ brace-expansion@^1.1.7:
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+bytebuffer@~5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  dependencies:
+    long "~3"
+
+camelcase@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -175,19 +108,17 @@ chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+cliui@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
   dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -201,48 +132,22 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colour@~0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
+
 commander@^2.12.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
-commander@~2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-cross-spawn@^4:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 dialog-polyfill@^0.4.10:
   version "0.4.10"
@@ -252,13 +157,6 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-error-ex@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  dependencies:
-    is-arrayish "^0.2.1"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -275,60 +173,15 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
-  dependencies:
-    locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
-
-foreground-child@^1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
-  integrity sha1-T9ca0t/elnibmApcCilZN8svXOk=
-  dependencies:
-    cross-spawn "^4"
-    signal-exit "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-get-caller-file@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
-
-glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -340,34 +193,6 @@ glob@^7.0.6, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-graceful-fs@^4.1.2:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-handlebars@^4.0.3:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -375,20 +200,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
-
-hosted-git-info@^2.1.4:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -404,65 +219,16 @@ inherits@2:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
-
-is-arrayish@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
-
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
-  integrity sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==
-
-istanbul-lib-report@^1.1.3:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#f2a657fc6282f96170aaf281eb30a458f7f4170c"
-  integrity sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==
-  dependencies:
-    istanbul-lib-coverage "^1.2.1"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
-
-istanbul-reports@^1.3.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.1.tgz#97e4dbf3b515e8c484caea15d6524eebd3ff4e1a"
-  integrity sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
-  dependencies:
-    handlebars "^4.0.3"
 
 jasmine-core@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
-
-jasmine-core@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.3.0.tgz#dea1cdc634bc93c7e0d4ad27185df30fa971b10e"
-  integrity sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==
 
 jasmine@~2.8.0:
   version "2.8.0"
@@ -471,14 +237,6 @@ jasmine@~2.8.0:
     exit "^0.1.2"
     glob "^7.0.6"
     jasmine-core "~2.8.0"
-
-jasmine@~3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.3.1.tgz#d61bb1dd8888859bd11ea83074a78ee13d949905"
-  integrity sha512-/vU3/H7U56XsxIXHwgEuWpCgQ0bRi2iiZeUpx7Nqo8n1TpoDHfZhkPIc7CO8I4pnMzYsi3XaSZEiy8cnTfujng==
-  dependencies:
-    glob "^7.0.6"
-    jasmine-core "~3.3.0"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -493,68 +251,15 @@ js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-json-parse-better-errors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
 
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-    strip-bom "^3.0.0"
-
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
-lru-cache@^4.0.1:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
-
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
-  dependencies:
-    mimic-fn "^1.0.0"
-
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+long@~3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -562,58 +267,13 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
-
-mkdirp@^0.5.0, mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-ms@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-neo-async@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
-  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-normalize-package-data@^2.3.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
-npm-run-path@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
-  dependencies:
-    path-key "^2.0.0"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 once@^1.3.0:
   version "1.4.0"
@@ -621,172 +281,34 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
+optjs@~3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
 
-os-homedir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
-    execa "^0.7.0"
     lcid "^1.0.0"
-    mem "^1.1.0"
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
-
-p-limit@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
-  dependencies:
-    p-try "^2.0.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
-  dependencies:
-    p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
-
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-key@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
-
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-type@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+protobufjs@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
+  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
   dependencies:
-    pify "^3.0.0"
-
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
-
-protobufjs@6.8.8:
-  version "6.8.8"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
-  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.0"
-    "@types/node" "^10.1.0"
-    long "^4.0.0"
-
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-
-read-pkg-up@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
-  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
-  dependencies:
-    find-up "^3.0.0"
-    read-pkg "^3.0.0"
-
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
-
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
-
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-resolve@^1.10.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
-  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
-  dependencies:
-    path-parse "^1.0.6"
+    ascli "~1"
+    bytebuffer "~5"
+    glob "^7.0.5"
+    yargs "^3.10.0"
 
 resolve@^1.3.2:
   version "1.10.0"
@@ -795,94 +317,21 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-rimraf@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-"semver@2 || 3 || 4 || 5":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
-
-semver@5.6.0, semver@^5.3.0:
+semver@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-signal-exit@^3.0.0, signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
 source-map-support@0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-spawn-wrap@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
-  integrity sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==
-  dependencies:
-    foreground-child "^1.5.6"
-    mkdirp "^0.5.0"
-    os-homedir "^1.0.1"
-    rimraf "^2.6.2"
-    signal-exit "^3.0.2"
-    which "^1.3.0"
-
-spdx-correct@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
-  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
-  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
-  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -892,19 +341,10 @@ sprintf-js@~1.0.2:
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^2.0.0, string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -912,34 +352,10 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
-
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^3.1.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -947,16 +363,6 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-test-exclude@^5.2.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
-  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
-  dependencies:
-    glob "^7.1.3"
-    minimatch "^3.0.4"
-    read-pkg-up "^4.0.0"
-    require-main-filename "^2.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
@@ -998,72 +404,13 @@ tsutils@^2.27.2:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
 
-uglify-js@^3.1.4:
-  version "3.5.15"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.15.tgz#fe2b5378fd0b09e116864041437bff889105ce24"
-  integrity sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==
-  dependencies:
-    commander "~2.20.0"
-    source-map "~0.6.1"
-
-uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
-v8-coverage@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/v8-coverage/-/v8-coverage-1.0.9.tgz#780889680c0fea0f587adf22e2b5f443b9434745"
-  integrity sha512-JolsCH1JDI2QULrxkAGZaovJPvg/Q0p20Uj0F5N8fPtYDtz38gNBRPQ/WVXlLLd3d8WHvKN96AfE4XFk4u0g2g==
-  dependencies:
-    debug "^3.1.0"
-    foreground-child "^1.5.6"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-report "^1.1.3"
-    istanbul-reports "^1.3.0"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.2"
-    signal-exit "^3.0.2"
-    spawn-wrap "^1.4.2"
-    test-exclude "^5.2.2"
-    uuid "^3.3.2"
-    v8-to-istanbul "1.2.0"
-    yargs "^11.0.0"
-
-v8-to-istanbul@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-1.2.0.tgz#f6a22ffb08b2202aaba8c2be497d1d41fe8fb4b6"
-  integrity sha512-rVSmjdEfJmOHN8GYCbg+XUhbzXZr7DzdaXIslB9DdcopGZEMsW5x5qIdxr/8DcW7msULHNnvs/xUY1TszvhKRw==
-
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
-
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
-which@^1.2.9, which@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
+window-size@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
+  resolved "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -1072,37 +419,18 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-y18n@^3.2.1:
+y18n@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+yargs@^3.10.0:
+  version "3.32.0"
+  resolved "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
   dependencies:
-    camelcase "^4.1.0"
-
-yargs@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
-  dependencies:
-    cliui "^4.0.0"
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
     decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"


### PR DESCRIPTION
See this issue for details: https://github.com/kubernetes/test-infra/issues/12852

TLDR; The `/pr` endpoint is broken and `/plugins` and `/command-help` are experiencing problems due to an apparent missing dependency problem. It is likely that this problem was introduced in https://github.com/kubernetes/test-infra/pull/12806 so we are reverting that and [the most recent Prow bump](https://github.com/kubernetes/test-infra/pull/12813) that deployed it.

Reverted commits are
- [270a6824e0105ce6f40609ea4b845fe625d78872](https://github.com/kubernetes/test-infra/pull/12806/commits/270a6824e0105ce6f40609ea4b845fe625d78872)
- [e0844969a43202587e0c0883932797403a3704d5](https://github.com/kubernetes/test-infra/pull/12813/commits/e0844969a43202587e0c0883932797403a3704d5)

/cc @tony-yang @stevekuznetsov @Katharine @fejta  