### PR TITLE
Update test-infra to bazel 0.26.0

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.24.1
+    - image: launcher.gcr.io/google/bazel:0.26.0
       command:
       - hack/bazel.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -24,7 +24,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.24.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - hack/bazel.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.25.2
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - hack/bazel.sh
         args:


### PR DESCRIPTION
/assign @cjwagner @Katharine 


Passes canary: https://prow.k8s.io/?repo=kubernetes%2Ftest-infra&type=presubmit&job=*-bazel*

ref https://github.com/kubernetes/test-infra/issues/12876