### PR TITLE
Fix ginkgo flags for load balancer finalizer job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -435,6 +435,6 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Slow\]|\[Feature:ServiceFinalizer\]  --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[sig-network\]\sServices --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190529-49b63a5-master


### PR DESCRIPTION
Sorry that I made another mistake in #12842 :/

The previous filter gives us thousands of tests and that is not what we want. This should be much better:
```
Ran 31 of 4411 Specs in 0.028 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 4380 Skipped
```

/assign @krzyzacy 