### PR TITLE
tidying up some go routines

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -388,9 +388,13 @@ func (sc *statusController) save(ticker *time.Ticker) {
 
 func (sc *statusController) run() {
 	sc.load()
+	done := make(chan int)
 	ticks := time.NewTicker(time.Hour)
 	defer ticks.Stop()
-	go sc.save(ticks)
+	go func() {
+		sc.save(ticks)
+		done <- 1
+	}()
 	for {
 		// wait for a new pool
 		if !<-sc.newPoolPending {
@@ -399,6 +403,7 @@ func (sc *statusController) run() {
 		}
 		sc.waitSync()
 	}
+	<-done
 	close(sc.shutDown)
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -217,7 +217,7 @@ func NewController(ghcSync, ghcStatus github.Client, prowJobClient prowv1.ProwJo
 		opener:         opener,
 		path:           statusURI,
 	}
-	go sc.run()
+	sc.run()
 	return &Controller{
 		logger:        logger.WithField("controller", "sync"),
 		ghc:           ghcSync,


### PR DESCRIPTION
Please let me know if I'm wrong in any of these changes, but I think I found two bugs with goroutines in `tide.go` and `status.go` as I try to learn the codebase.

In `tide.go`, `go sc.run()` seems like it would never finish because the enclosing function would return `&Controller` first. I thought the best way around this would be to get rid of the `go` keyword entirely.

In `status.go`, I found a similar issue but luckily, here, I think you can keep using concurrency. I opted not to use a `sync.WaitGroup` because we know ahead of time only one goroutine will be necessary.

Please let me know any improvements that I can make, or if I'm just totally wrong in my assumptions.