### PR TITLE
Fix the name of milestone-maintainers team

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -226,7 +226,7 @@ repo_milestone:
     # responsible for maintaining the milestones. You may need to specify the page number.
     # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams?page=N"
     maintainers_id: 2460384
-    maintainers_team: kubernetes-milestone-maintainers
+    maintainers_team: milestone-maintainers
   kubernetes-sigs/cluster-api:
     maintainers_id: 3058957
     maintainers_team: cluster-api-maintainers
@@ -263,7 +263,7 @@ project_config:
           To do
       project_repo_configs:
         kubernetes:
-          repo_maintainers_team_id: 2460384 # kubernetes-milestone-maintainers
+          repo_maintainers_team_id: 2460384 # milestone-maintainers
           repo_default_column_map:
             component-base:
               To do


### PR DESCRIPTION
https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers/members -> 404 Error

Change name `kubernetes-milestone-maintainers` -> `milestone-maintainers`