### PR TITLE
kubernetes-csi: skip prow unit test jobs for older branches

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -222,6 +222,7 @@ presubmits:
     always_run: true
     decorate: true
     skip_report: false
+    skip_branches: []
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -222,6 +222,7 @@ presubmits:
     always_run: true
     decorate: true
     skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -222,6 +222,7 @@ presubmits:
     always_run: true
     decorate: true
     skip_report: false
+    skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -265,6 +265,7 @@ EOF
     always_run: true
     decorate: true
     skip_report: false
+    skip_branches: [$(skip_branches $repo)]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -21,7 +21,7 @@
 base="$(dirname $0)"
 
 # We need this image because it has Docker in Docker and go.
-dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20190420-93fab49-master"
+dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20190523-0ebbc9b-master"
 
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix.

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -222,6 +222,7 @@ presubmits:
     always_run: true
     decorate: true
     skip_report: false
+    skip_branches: ["^(release-1.0)$"]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Older branches don't have the necessary config files for Prow.
This was already done for other jobs, but was missing in the unit test job.

/assign @msau42 