### PR TITLE
Move kubemark-100 back to the default pool.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -260,7 +260,8 @@ periodics:
   - "perfDashPrefix: kubemark-100Nodes"
   - "perfDashJobType: performance"
   interval: 3h
-  cluster: scalability
+  # TODO(oxddr): renable this once we have a project pool in scalability build cluster
+  # cluster: scalability
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
Move kubemark-100 back to the default pool and wait for project pool to be added (https://github.com/kubernetes/perf-tests/issues/553) and move it back together with other tests (https://github.com/kubernetes/test-infra/issues/12867). 

/assign @mborsz 