### PR TITLE
Make gce-scale-performance test use a dedicated build cluster.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -42,6 +42,7 @@ periodics:
   tags:
   - "perfDashPrefix: gce-5000Nodes"
   - "perfDashJobType: performance"
+  cluster: scalability
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
Make gce-scale-performance test use a dedicated build cluster. The dedicated cluster has not been tested yet, but test has troubles to pass anyway, so this shouldn't make things worse.

/sig scalability 
/assign @mborsz 
ref https://github.com/kubernetes/test-infra/issues/12867