### PR TITLE
Don't use prow for client-go/unofficial-docs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -330,8 +330,6 @@ tide:
     - kubernetes-csi
     - kubernetes-incubator
     - kubernetes-sigs
-    repos:
-    - client-go/unofficial-docs
     excludedRepos:
     - kubernetes/kubernetes # Handled with a separate Tide query below.
     # The following are staging repos which do not normally support merging PRs.

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -79,7 +79,6 @@ approve:
   - kubernetes-client
   - kubernetes-csi
   - kubernetes-sigs
-  - client-go/unofficial-docs
   require_self_approval: false
 - repos:
   - bazelbuild
@@ -655,20 +654,6 @@ plugins:
   - hold
   - cat
   - dog
-  - wip
-
-  client-go/unofficial-docs:
-  - approve
-  - assign
-  - blunderbuss
-  - cat
-  - cla
-  - dog
-  - help
-  - hold
-  - label
-  - lgtm
-  - verify-owners
   - wip
 
   cncf/apisnoop:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/12863

The repo does not belong to the Kubernetes project and is inactive.

I'll also remove the webhook.

cc @sttts @munnerz @LiliC 
/assign @cblecker @spiffxp 