### PR TITLE
ingress-nginx: remove hardcoded token in presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
@@ -81,9 +81,6 @@ presubmits:
         - /bin/bash
         - -c
         - "GIT_COMMIT=${PULL_PULL_SHA} make cover"
-        env:
-        - name: CODECOV_TOKEN
-          value: 9d09c10d-af0f-446e-94a2-e534c604d235
 
   - name: pull-ingress-nginx-e2e-1-12
     always_run: true


### PR DESCRIPTION
The token isn't really being used anywhere right now as well - https://github.com/kubernetes/ingress-nginx/search?q=CODECOV_TOKEN&unscoped_q=CODECOV_TOKEN

@aledbf PTAL if this is ok. You might also want to revoke the token. :grimacing: 

/assign @aledbf @MrHohn 
/cc @jeefy 