### PR TITLE
kubetest/kind: bump the stable version to v0.2.0

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -245,7 +245,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
         - --build=bazel
         - --up
@@ -328,7 +328,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
         - --build=bazel
         - --up
@@ -411,7 +411,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
         - --build=bazel
         - --up
@@ -496,7 +496,7 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
         - --build=bazel
         - --up

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -40,7 +40,7 @@ periodics:
       # kind specific args
       - --provider=skeleton
       - --deployment=kind
-      - --kind-binary-version=build
+      - --kind-binary-version=stable
       - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
       # generic e2e test args
       - --build=bazel
@@ -119,7 +119,7 @@ periodics:
       # kind specific args
       - --provider=skeleton
       - --deployment=kind
-      - --kind-binary-version=build
+      - --kind-binary-version=stable
       - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
       # generic e2e test args
       - --build=bazel
@@ -198,7 +198,7 @@ periodics:
       # kind specific args
       - --provider=skeleton
       - --deployment=kind
-      - --kind-binary-version=build
+      - --kind-binary-version=stable
       - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
       # generic e2e test args
       - --build=bazel
@@ -277,7 +277,7 @@ periodics:
       # kind specific args
       - --provider=skeleton
       - --deployment=kind
-      - --kind-binary-version=build
+      - --kind-binary-version=stable
       - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
       # generic e2e test args
       - --build=bazel
@@ -354,7 +354,7 @@ presubmits:
         # kind specific args
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
         # generic e2e test args
         - --build=bazel
@@ -428,7 +428,7 @@ presubmits:
         # kind specific args
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
         # generic e2e test args
         - --build=bazel
@@ -502,7 +502,7 @@ presubmits:
         # kind specific args
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
         # generic e2e test args
         - --build=bazel
@@ -578,7 +578,7 @@ presubmits:
         # kind specific args
         - --provider=skeleton
         - --deployment=kind
-        - --kind-binary-version=build
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
         # generic e2e test args
         - --build=bazel

--- a/kubetest/kind/kind.go
+++ b/kubetest/kind/kind.go
@@ -46,7 +46,7 @@ const (
 	kindBinaryStable = "stable"
 
 	// If a new version of kind is released this value has to be updated.
-	kindBinaryStableTag = "0.1.0"
+	kindBinaryStableTag = "0.2.0"
 
 	kindClusterNameDefault = "kind-kubetest"
 


### PR DESCRIPTION
Also move all kubeadm-kind jobs to use "stable" instead of "build".

we are seeing some regressions in terms of HA clusters:
https://github.com/kubernetes-sigs/kind/issues/588

pinning the kubeadm jobs to an older stable version.
we might amend this post v1.15, but should really focus to get the signal green for this release.

/assign @BenTheElder @krzyzacy 
/kind bug
/priority important-soon
