### PR TITLE
merge warnings: add for k/sig-release and k/release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -217,6 +217,13 @@ slack:
     - testing-ops
     whitelist:
     - k8s-ci-robot
+  - repos:
+    - kubernetes/sig-release
+    - kubernetes/release
+    channels:
+    - sig-release
+    whitelist:
+    - k8s-ci-robot
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
The release team has a gradual turn over of volunteer leads and shadows
involved with managing content of the release.  Some of them have
elevated merge privileges during their tenure.  Use of these higher
priv's is relatively rare and while mistakes are rare exceptions, it
is easy in the heat of an issue to be on an unintended repo or branch
while working.  Adding slack notifications to #sig-release for usage of
these elevated privileges on SIG Release related repos will give us a
little more visibility into the teams' actions and allow us to better
support each other.  Alerts are already in place for k/k to #kubernetes-dev.

Signed-off-by: Tim Pepper <tpepper@vmware.com>