### PR TITLE
Remove most of gingko.skip for tests focusing on Conformance

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -252,8 +252,7 @@ presubmits:
         - --test
         - --check-version-skew=false
         - --down
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-          --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         command:
@@ -335,8 +334,7 @@ presubmits:
         - --test
         - --check-version-skew=false
         - --down
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-          --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         command:
@@ -418,8 +416,7 @@ presubmits:
         - --test
         - --check-version-skew=false
         - --down
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-          --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         command:
@@ -503,8 +500,7 @@ presubmits:
         - --test
         - --check-version-skew=false
         - --down
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]
-          --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         command:

--- a/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
@@ -46,7 +46,7 @@ periodics:
       - --gce-ssh=
       - --extract=ci/latest-1.11
       - --ginkgo-parallel=30
-      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\] --minStartupPods=8
       - --timeout=180m
 
 # Kubernetes performance e2e tests against EKS 1.11 build.

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -50,7 +50,7 @@ periodics:
       - --down
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
       - --ginkgo-parallel
       - --timeout=30m
       # we need privileged mode in order to do docker in docker
@@ -129,7 +129,7 @@ periodics:
       - --down
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
       - --ginkgo-parallel
       - --timeout=30m
       # we need privileged mode in order to do docker in docker
@@ -208,7 +208,7 @@ periodics:
       - --down
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
       - --ginkgo-parallel
       - --timeout=30m
       # we need privileged mode in order to do docker in docker
@@ -287,7 +287,7 @@ periodics:
       - --down
       # specific e2e test args
       # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
       - --ginkgo-parallel
       - --timeout=30m
       # we need privileged mode in order to do docker in docker
@@ -364,7 +364,7 @@ presubmits:
         - --down
         # specific e2e test args
         # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         # we need privileged mode in order to do docker in docker
@@ -438,7 +438,7 @@ presubmits:
         - --down
         # specific e2e test args
         # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         # we need privileged mode in order to do docker in docker
@@ -512,7 +512,7 @@ presubmits:
         - --down
         # specific e2e test args
         # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         # we need privileged mode in order to do docker in docker
@@ -588,7 +588,7 @@ presubmits:
         - --down
         # specific e2e test args
         # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\] --num-nodes=3
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
         - --ginkgo-parallel
         - --timeout=30m
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
@@ -22,7 +22,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-master
 
@@ -44,7 +44,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.12
 
@@ -65,7 +65,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.13
 
@@ -86,7 +86,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.14
 
@@ -108,6 +108,6 @@ periodics:
           - --gcp-node-image=gci
           - --gcp-zone=us-west1-b
           - --provider=gce
-          - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+          - --test_args=--ginkgo.focus=\[Conformance\]
           - --timeout=200m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.15

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -22,7 +22,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.12
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -22,7 +22,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.13
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -22,7 +22,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.14
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -20,7 +20,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]
+      - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-1.15
       name: ""

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -40,7 +40,7 @@ periodics:
           --gcp-zone=us-west1-b \
           --provider=gce \
           --timeout=150m \
-          --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
+          --test_args="--ginkgo.focus=\[Conformance\]"
         cd ../test-infra
         bazel run //gopherage -- merge "${ARTIFACTS}"/before/**/*.cov > "${ARTIFACTS}/before/merged.cov"
         bazel run //gopherage -- merge "${ARTIFACTS}"/after/**/*.cov > "${ARTIFACTS}/after/merged.cov"


### PR DESCRIPTION
Any tests that would have been skipped by these regexes have been
demoted from Conformance since v1.12, and are now prevented from
promotion to Conformancea (ref:
https://github.com/kubernetes/kubernetes/pull/78710)

The one exception is [Serial], there are some Conformance tests that
we have been as yet unable to rewrite to run safely in parallel.

ref: https://github.com/kubernetes/test-infra/issues/9697

/area conformance