### PR TITLE
Reduce janitor log spam.

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -155,7 +155,11 @@ func handleAcquire(r *ranch.Ranch) http.HandlerFunc {
 		resource, err := r.Acquire(rtype, state, dest, owner)
 
 		if err != nil {
-			logrus.WithError(err).Errorf("No available resource")
+			if err2, ok := err.(ranch.ResourceNotFound); ok {
+				logrus.WithError(err2).Warningf("No available resource")
+			} else {
+				logrus.WithError(err).Errorf("No available resource")
+			}
 			http.Error(res, err.Error(), ErrorToStatus(err))
 			return
 		}


### PR DESCRIPTION
Janitor ends up spamming this log when there is nothing to clean, change to warning instead.

/cc @krzyzacy @fejta 