### PR TITLE
Improve mergecommitblocker bot comment

### DIFF
--- a/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
@@ -152,7 +152,7 @@ func TestHandle(t *testing.T) {
 			name: "merge commit label exists, PR has merge commits",
 			fakeGHClient: &fakeGHClient{
 				labels:   strSet{labels.MergeCommits: struct{}{}},
-				comments: map[int]string{12: blockedBody},
+				comments: map[int]string{12: commentBody},
 			},
 			prNum:         12,
 			checkout:      func() { checkoutBranch("pull/12/head") },
@@ -176,7 +176,7 @@ func TestHandle(t *testing.T) {
 			name: "merge commit label exists, PR doesn't have merge commits",
 			fakeGHClient: &fakeGHClient{
 				labels:   strSet{labels.MergeCommits: struct{}{}},
-				comments: map[int]string{14: blockedBody},
+				comments: map[int]string{14: commentBody},
 			},
 			prNum:         14,
 			checkout:      func() { checkoutBranch("pull/14/head") },


### PR DESCRIPTION
- Add a link to the github-workflow docs in the contributor guide.

- Currently, the main reason on why the label is being added can only be
seen from the dropdown. Update the comment so it's immediately clear on
why the label is added and how it can be fixed.

- Since there isn't a lot of text, skip using dropdown here.

/cc @Huang-Wei @cblecker @mrbobbytables 
/assign @cblecker 