### PR TITLE
Config-forker no longer adds jobs to -all if they're also in -blocking/-informing dashboards

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -1,7 +1,6 @@
 periodics:
 - annotations:
-    testgrid-dashboards: sig-release-1.15-informing, conformance-all, conformance-gce,
-      sig-release-1.15-all
+    testgrid-dashboards: sig-release-1.15-informing, conformance-all, conformance-gce
     testgrid-tab-name: GCE, 1.15 (dev)
   interval: 6h
   labels:

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -275,8 +275,9 @@ annotations:
 	for k, v := range annotations {
 		switch k {
 		case testgridDashboardsAnnotation:
+			fmt.Println(v)
 			v = r.Replace(v)
-			if !isPresubmit {
+			if !isPresubmit && !inOtherSigReleaseDashboard(v, version) {
 				v += ", " + "sig-release-" + version + "-all"
 			}
 			didDashboards = true
@@ -294,6 +295,10 @@ annotations:
 	}
 	return a
 
+}
+
+func inOtherSigReleaseDashboard(existingDashboards, version string) bool {
+	return strings.Contains(existingDashboards, "sig-release-"+version)
 }
 
 func generateNameVariant(name, version string, generic bool) string {

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -537,6 +537,13 @@ func TestGeneratePeriodics(t *testing.T) {
 			},
 		},
 		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name:        "some-generic-periodic-will-end-up-in-all-master",
+				Annotations: map[string]string{forkAnnotation: "true", suffixAnnotation: "true", testgridDashboardsAnnotation: "google-unit"},
+			},
+		},
+		{
 			Interval: "1h",
 			JobBase: config.JobBase{
 				Name: "periodic-with-replacements",
@@ -589,6 +596,13 @@ func TestGeneratePeriodics(t *testing.T) {
 			JobBase: config.JobBase{
 				Name:        "some-generic-periodic-beta",
 				Annotations: map[string]string{suffixAnnotation: "true", testgridDashboardsAnnotation: "sig-release-1.15-all"},
+			},
+		},
+		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name:        "some-generic-periodic-will-end-up-in-all-beta",
+				Annotations: map[string]string{suffixAnnotation: "true", testgridDashboardsAnnotation: "google-unit, sig-release-1.15-all"},
 			},
 		},
 		{
@@ -660,6 +674,19 @@ func TestGeneratePostsubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
+					Name: "post-kubernetes-generic-will-end-up-in-all",
+					Annotations: map[string]string{
+						forkAnnotation:               "true",
+						suffixAnnotation:             "true",
+						testgridDashboardsAnnotation: "google-unit",
+					},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
 					Name: "post-replace-some-things-master",
 					Annotations: map[string]string{
 						forkAnnotation:        "true",
@@ -706,6 +733,18 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Annotations: map[string]string{
 						suffixAnnotation:             "true",
 						testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit",
+					},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "post-kubernetes-generic-will-end-up-in-all-beta",
+					Annotations: map[string]string{
+						suffixAnnotation:             "true",
+						testgridDashboardsAnnotation: "google-unit, sig-release-1.15-all",
 					},
 				},
 				Brancher: config.Brancher{

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -358,9 +358,9 @@ func TestFixTestgridAnnotations(t *testing.T) {
 			isPresubmit: true,
 		},
 		{
-			name:        "periodic updates master-blocking to point at 1.15-blocking and adds 1.15-all",
+			name:        "periodic updates master-blocking to point at 1.15-blocking",
 			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking"},
-			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking, sig-release-1.15-all"},
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking"},
 			isPresubmit: false,
 		},
 		{
@@ -705,7 +705,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Name: "post-kubernetes-generic-beta",
 					Annotations: map[string]string{
 						suffixAnnotation:             "true",
-						testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit, sig-release-1.15-all",
+						testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit",
 					},
 				},
 				Brancher: config.Brancher{


### PR DESCRIPTION
If a postsubmit or periodic job is configured to be added to a -blocking or -informing sig-release dashboard, config-forker will no longer add it to `sig-release-<version>-all`.

Other postsubmit/periodic jobs continue to be added to -all for now.

xref: https://github.com/kubernetes/test-infra/issues/11977 and https://github.com/kubernetes/test-infra/issues/12848

/cc @alejandrox1 @spiffxp @Katharine 