### PR TITLE
Fix watch issue when --all-contexts is enabled

### DIFF
--- a/prow/cmd/build/main.go
+++ b/prow/cmd/build/main.go
@@ -171,6 +171,9 @@ func main() {
 
 	buildConfigs := map[string]buildConfig{}
 	for context, cfg := range configs {
+		if context == kube.InClusterContext {
+			continue
+		}
 		var bc *buildConfig
 		bc, err = newBuildConfig(cfg, stop)
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
When `--all-contexts` is enabled, the `configs` map returned by `kube.LoadClusterConfigs` would have at least two keys: `kube.InClusterContext` and `kube.DefaultClusterAlias`.

If we don't filter out `kube.InClusterContext` which is an empty string, we would enqueue update events for `Build` resource with bad key. This would lead to errors shown in the log below:

```
time="2019-06-05T16:04:46Z" level=warning msg="/test-pods/e17dc2c9-86eb-11e9-ae52-0a580a3403d3 found in context  not default"
time="2019-06-05T16:04:46Z" level=info msg="Observed deleted /test-pods/e17dc2c9-86eb-11e9-ae52-0a580a3403d3"
time="2019-06-05T16:04:46Z" level=info msg="Observed finished default/test-pods/2b97f08a-872c-11e9-ae52-0a580a3403d3"
time="2019-06-05T16:04:46Z" level=warning msg="/test-pods/2b97f08a-872c-11e9-ae52-0a580a3403d3 found in context  not default"
time="2019-06-05T16:04:46Z" level=info msg="Observed deleted /test-pods/2b97f08a-872c-11e9-ae52-0a580a3403d3"
time="2019-06-05T16:04:46Z" level=warning msg="/test-pods/d4ece04f-873b-11e9-ae52-0a580a3403d3 found in context  not default"
time="2019-06-05T16:04:46Z" level=info msg="Observed deleted /test-pods/d4ece04f-873b-11e9-ae52-0a580a3403d3"
time="2019-06-05T16:04:46Z" level=info msg="Observed finished default/test-pods/d4ece04f-873b-11e9-ae52-0a580a3403d3"
```
We could use `delete(configs, kube.InClusterContext)` as well. IMO keeping `configs` unchanged should be better.