### PR TITLE
Return error when using decoration and BuildTemplate at the same time

### DIFF
--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -777,6 +777,9 @@ func makeBuild(pj prowjobv1.ProwJob, defaultTimeout time.Duration) (*buildv1alph
 	}
 	injectTimeout(&b.Spec, pj.Spec.DecorationConfig, defaultTimeout)
 	if pj.Spec.DecorationConfig != nil {
+		if b.Spec.Template != nil {
+			return nil, errors.New("cannot decorate Build using BuildTemplate")
+		}
 		encodedJobSpec := rawEnv[downwardapi.JobSpecEnv]
 		err = decorateBuild(&b.Spec, encodedJobSpec, *pj.Spec.DecorationConfig, injectedSource)
 		if err != nil {

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -1461,6 +1461,19 @@ func TestMakeBuild(t *testing.T) {
 			err:  true,
 		},
 		{
+			name: "reject decorate prow job with BuildTemplate",
+			job: func(pj prowjobv1.ProwJob) prowjobv1.ProwJob {
+				pj.Spec.BuildSpec.Template = &buildv1alpha1.TemplateInstantiationSpec{}
+				pj.Spec.DecorationConfig = &prowjobv1.DecorationConfig{
+					UtilityImages: &prowjobv1.UtilityImages{},
+					Timeout:       &prowjobv1.Duration{Duration: 0},
+					GracePeriod:   &prowjobv1.Duration{Duration: 0},
+				}
+				return pj
+			},
+			err: true,
+		},
+		{
 			name: "return valid build with valid prowjob",
 		},
 		{
@@ -1499,7 +1512,6 @@ func TestMakeBuild(t *testing.T) {
 			pj.Spec.Type = prowjobv1.PeriodicJob
 			pj.Spec.BuildSpec = &buildv1alpha1.BuildSpec{}
 			pj.Spec.BuildSpec.Steps = append(pj.Spec.BuildSpec.Steps, corev1.Container{})
-			pj.Spec.BuildSpec.Template = &buildv1alpha1.TemplateInstantiationSpec{}
 			pj.Status.BuildID = randomBuildID
 			if tc.job != nil {
 				pj = tc.job(pj)


### PR DESCRIPTION
When we are using decoration and `BuildTemplate` at the same time, we would create a bad `Build` resource with both `Steps` and `Template`. The proper behavior is to block this action and mark `ProwJob` with error status.