### PR TITLE
Made kubeflow-pipeline-sample-test mandatory

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -266,7 +266,6 @@ presubmits:
   - name: kubeflow-pipeline-sample-test
     always_run: true
     decorate: true
-    skip_report: true
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
This test is important and the consensus is that it's desirable to make this test mandatory for PRs.
The e2e test runs for 45 minutes and the samples test runs for 60 minutes, so making the test mandatory adds no more than 15 minutes of wait time. In reality this will probably save lots of human time and prevent broken releases.
