### PR TITLE
prow/plugins/bugzilla: Non-greedy prefix

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	titleMatch   = regexp.MustCompile(`(?i)^.*Bug ([0-9]+):`)
+	titleMatch   = regexp.MustCompile(`(?i)^.*?Bug ([0-9]+):`)
 	commandMatch = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
 )
 


### PR DESCRIPTION
Use [the non-greedy `*?`][1] to avoid matching the later of several bug references:

```console
$ go test .
time="2019-06-05T15:34:09-07:00" level=warning msg="Unexpected error searching for Bugzilla bug." bugId=123 error="injected error getting bug" testCase="error fetching bug leaves a comment"
--- FAIL: TestTitleMatch (0.00s)
    --- FAIL: TestTitleMatch/Bug_34:_Revert:_"Bug_12:_Revert_default" (0.00s)
    		bugzilla_test.go:637: unexpected 12 != 34
FAIL
FAIL		k8s.io/test-infra/prow/plugins/bugzilla	0.014s
```

/assign @stevekuznetsov

[1]: https://github.com/google/re2/wiki/Syntax