### PR TITLE
bump bootstrap in kubekins-e2e to f71320b

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+FROM gcr.io/k8s-testimages/bootstrap:v20190606-f71320b
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
It uses the image with the changes introduced in https://github.com/kubernetes/test-infra/pull/12919
to enable ip6tables NAT modules