### PR TITLE
Retest flaky PRs in test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -140,6 +140,7 @@ periodics:
         -label:needs-ok-to-test
         -label:"cncf-cla: no"
         repo:kubernetes/kubernetes
+        repo:kubernetes/test-infra
       - --token=/etc/token/bot-github-token
       - |-
         --comment=/retest


### PR DESCRIPTION
/assign @cblecker @spiffxp 

In k/k, if a PR that can merge has failing tests, we will occasionally drop a /retest comment on the PR to help expedite merge.

Would like to:
a) Enable this for k/test-infra
b) Send out a mail encouraging other repos that use prow to turn this on as well, referencing this PR for how to do it.