### PR TITLE
cloud builder setup script for image promoter

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/cloudbuilder.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/cloudbuilder.yaml
@@ -1,0 +1,20 @@
+promoter:
+  setup.sh: |
+    #!/bin/sh
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+    set -o xtrace
+
+    shopt -s dotglob
+
+    git \
+      clone https://sigs.k8s.io/${_REPO} \
+      --depth 1 \
+      --branch $BRANCH_NAME \
+      ${_GOPATH}/src/sigs.k8s.io/${_REPO}
+
+    # Get golangci-lint; install into /workspace/bin/golangci-lint.
+    pushd go
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
+      | sh -s ${_GOLANGCI_LINT_VERSION}

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -1,5 +1,30 @@
 presubmits:
   kubernetes/k8s.io:
+  - name: setup-k8sio-cip
+    decorate: true
+    skip_report: false
+    always_run: true
+    max_concurrency: 10
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/cloud-builders/git:latest
+        command:
+        - bash
+        args:
+        - -c
+        - /etc/promoter/setup.sh
+        env:
+        - name: _GOLANGCI_LINT_VERSION
+          value: v1.13.2
+        volumeMounts:
+        - name: promoter
+          mountPath: /etc/promoter
+      volumes:
+      - name: promoter
+        configMap:
+          name: promoter
   - name: pull-k8sio-cip
     decorate: true
     skip_report: false


### PR DESCRIPTION
Migrated the cloud builder setup script for image promotion. This is related to issue: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/6 and https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/5

Summary: 
I am migrating these scripts: https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/cloudbuild.yaml into prow.

cc/ @listx 