### PR TITLE
Kind job updates

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -36,6 +36,14 @@ presubmits:
     always_run: false
     optional: true
     spec:
+      # run on the ubuntu node pool, which has ipv6 modules
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "ubuntu"
+        effect: "NoSchedule"
+      nodeSelector:
+        dedicated: "ubuntu"
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190516-576b68c-master
         env:

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -10,7 +10,8 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190516-576b68c-master
         command:
-        - "./hack/ci/build-all.sh"
+        - runner.sh
+        - ./hack/ci/build-all.sh
   - name: pull-kind-verify
     decorate: true
     path_alias: sigs.k8s.io/kind
@@ -20,7 +21,8 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190516-576b68c-experimental
         command:
-        - "./hack/verify-all.sh"
+        - runner.sh
+        - ./hack/verify-all.sh
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # IPv6 enabled variant


### PR DESCRIPTION
- use runner.sh when we set preset-dind-enabled :upside_down_face: 
- schedule the ipv6 job to the ipv6 capable (kernel) node
/cc @amwat @aojea 