### PR TITLE
adding kubectl GCE test to master blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -223,9 +223,15 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190830-36b022d-master
 
   annotations:
-    testgrid-dashboards: sig-cli-master
+    testgrid-dashboards: sig-release-master-blocking, sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce
-    description: stable1 e2e tests run against a master gce cluster using a stable1 kubectl binary
+    testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
+    description: "stable1 e2e tests run against a master gce cluster using a stable1 kubectl binary"
+    testgrid-num-columns-recent: "3"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+    fork-per-release: "true"
+    fork-per-release-generic-suffix: "true"
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   labels:


### PR DESCRIPTION
Context from Slack (6/6/19) in #sig-release:
> liggitt [10:59 AM]
>qq about which test jobs are in release blocking... the kubectl skew test turned red about two weeks ago and no one noticed (https://testgrid.k8s.io/sig-cli-master#skew-cluster-latest-kubectl-stable1-gce&width=5) (edited) 
>turns out the test was flawed (fixing it now), but that is the sort of test I'd expect us to notice before releasing
>
> liggitt [11:06 AM]
> I just know that CI was called green in the 1.15 burndown this morning which made me suspect this job was not in release-blocking or release-informing
> 
> liggitt [11:06 AM]
> and I think it should be

Also:
> spiffxp [12:21 PM]
https://github.com/kubernetes/test-infra/pull/11245 @liggitt FWIW, SIG CLI was onboard with dropping the tests off, since they were on their own dashboard (not that I’m objecting to bringing them back on if they exercise useful functionality and will be owned)
>
>spiffxp [12:24 PM]
>yeah no objections to bringing it back, was just trying to add the history of how we got to now

Should the `alert_mail_to_addresses:` field be another team or will the release team suffice?

/priority critical-urgent
/milestone v1.15
/sig release
/kind cleanup
/area config
/cc @liggitt @spiffxp @alejandrox1 