### PR TITLE
Add a plugin to allow users to re-title issues and PRs

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -35,7 +35,7 @@ const (
 
 // FakeClient is like client, but fake.
 type FakeClient struct {
-	Issues              []github.Issue
+	Issues              map[int]*github.Issue
 	OrgMembers          map[string][]string
 	Collaborators       []string
 	IssueComments       map[int][]github.IssueComment
@@ -204,9 +204,36 @@ func (f *FakeClient) DeleteStaleComments(org, repo string, number int, comments 
 func (f *FakeClient) GetPullRequest(owner, repo string, number int) (*github.PullRequest, error) {
 	val, exists := f.PullRequests[number]
 	if !exists {
-		return nil, fmt.Errorf("Pull request number %d does not exit", number)
+		return nil, fmt.Errorf("pull request number %d does not exist", number)
 	}
 	return val, nil
+}
+
+// EditPullRequest edits the pull request.
+func (f *FakeClient) EditPullRequest(org, repo string, number int, issue *github.PullRequest) (*github.PullRequest, error) {
+	if _, exists := f.PullRequests[number]; !exists {
+		return nil, fmt.Errorf("issue number %d does not exist", number)
+	}
+	f.PullRequests[number] = issue
+	return issue, nil
+}
+
+// GetIssue returns the issue.
+func (f *FakeClient) GetIssue(owner, repo string, number int) (*github.Issue, error) {
+	val, exists := f.Issues[number]
+	if !exists {
+		return nil, fmt.Errorf("issue number %d does not exist", number)
+	}
+	return val, nil
+}
+
+// EditIssue edits the issue.
+func (f *FakeClient) EditIssue(org, repo string, number int, issue *github.Issue) (*github.Issue, error) {
+	if _, exists := f.Issues[number]; !exists {
+		return nil, fmt.Errorf("issue number %d does not exist", number)
+	}
+	f.Issues[number] = issue
+	return issue, nil
 }
 
 // GetPullRequestChanges returns the file modifications in a PR.
@@ -316,7 +343,11 @@ func (f *FakeClient) RemoveLabel(owner, repo string, number int, label string) e
 
 // FindIssues returns f.Issues
 func (f *FakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
-	return f.Issues, nil
+	var issues []github.Issue
+	for _, issue := range f.Issues {
+		issues = append(issues, *issue)
+	}
+	return issues, nil
 }
 
 // AssignIssue adds assignees.

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//prow/plugins/releasenote:go_default_library",
         "//prow/plugins/require-matching-label:go_default_library",
         "//prow/plugins/requiresig:go_default_library",
+        "//prow/plugins/retitle:go_default_library",
         "//prow/plugins/shrug:go_default_library",
         "//prow/plugins/sigmention:go_default_library",
         "//prow/plugins/size:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -50,6 +50,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/releasenote"
 	_ "k8s.io/test-infra/prow/plugins/require-matching-label"
 	_ "k8s.io/test-infra/prow/plugins/requiresig"
+	_ "k8s.io/test-infra/prow/plugins/retitle"
 	_ "k8s.io/test-infra/prow/plugins/shrug"
 	_ "k8s.io/test-infra/prow/plugins/sigmention"
 	_ "k8s.io/test-infra/prow/plugins/size"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -89,6 +89,7 @@ filegroup(
         "//prow/plugins/releasenote:all-srcs",
         "//prow/plugins/require-matching-label:all-srcs",
         "//prow/plugins/requiresig:all-srcs",
+        "//prow/plugins/retitle:all-srcs",
         "//prow/plugins/shrug:all-srcs",
         "//prow/plugins/sigmention:all-srcs",
         "//prow/plugins/size:all-srcs",

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -147,9 +147,14 @@ func TestCLALabels(t *testing.T) {
 			pullRequests[pr.Number] = &pr
 		}
 
+		issues := make(map[int]*github.Issue)
+		for _, issue := range tc.issues {
+			issues[issue.Number] = &issue
+		}
+
 		fc := &fakegithub.FakeClient{
 			PullRequests:  pullRequests,
-			Issues:        tc.issues,
+			Issues:        issues,
 			IssueComments: make(map[int][]github.IssueComment),
 		}
 		se := github.StatusEvent{

--- a/prow/plugins/help/help_test.go
+++ b/prow/plugins/help/help_test.go
@@ -175,7 +175,7 @@ func TestLabel(t *testing.T) {
 	for _, tc := range testcases {
 		sort.Strings(tc.expectedNewLabels)
 		fakeClient := &fakegithub.FakeClient{
-			Issues:             make([]github.Issue, 1),
+			Issues:             make(map[int]*github.Issue),
 			IssueComments:      make(map[int][]github.IssueComment),
 			RepoLabelsExisting: []string{labels.Help, labels.GoodFirstIssue},
 			IssueLabelsAdded:   []string{},

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -434,7 +434,7 @@ func TestLabel(t *testing.T) {
 		t.Logf("Running scenario %q", tc.name)
 		sort.Strings(tc.expectedNewLabels)
 		fakeClient := &fakegithub.FakeClient{
-			Issues:             make([]github.Issue, 1),
+			Issues:             make(map[int]*github.Issue),
 			IssueComments:      make(map[int][]github.IssueComment),
 			RepoLabelsExisting: tc.repoLabels,
 			OrgMembers:         map[string][]string{"org": {orgMember}},

--- a/prow/plugins/retitle/BUILD.bazel
+++ b/prow/plugins/retitle/BUILD.bazel
@@ -1,0 +1,46 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["retitle_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["retitle.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/retitle",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/trigger:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/plugins/retitle/retitle.go
+++ b/prow/plugins/retitle/retitle.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package retitle implements the retitle plugin
+package retitle
+
+import (
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/trigger"
+)
+
+const (
+	// pluginName defines this plugin's registered name.
+	pluginName = "retitle"
+)
+
+var (
+	retitleRe = regexp.MustCompile(`(?mi)^/retitle\s*(.*)$`)
+)
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The Config field is omitted because this plugin is not configurable.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The retitle plugin allows users to re-title pull requests and issues where GitHub permissions don't allow them to.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/retitle <title>",
+		Description: "Edits the pull request or issue title.",
+		Featured:    true,
+		WhoCanUse:   "Collaborators on the repository.",
+		Examples:    []string{"/retitle New Title"},
+	})
+	return pluginHelp, nil
+}
+
+func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
+	var (
+		org  = e.Repo.Owner.Login
+		repo = e.Repo.Name
+	)
+	return handleGenericComment(pc.GitHubClient, func(user string) (bool, error) {
+		return trigger.TrustedUser(pc.GitHubClient, pc.PluginConfig.TriggerFor(org, repo), user, org, repo)
+	}, pc.Logger, e)
+}
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	EditPullRequest(org, repo string, number int, pr *github.PullRequest) (*github.PullRequest, error)
+	GetIssue(org, repo string, number int) (*github.Issue, error)
+	EditIssue(org, repo string, number int, issue *github.Issue) (*github.Issue, error)
+}
+
+func handleGenericComment(gc githubClient, isTrusted func(string) (bool, error), log *logrus.Entry, gce github.GenericCommentEvent) error {
+	// Only consider open PRs and issues, and new comments.
+	if gce.IssueState != "open" || gce.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	// Make sure they are requesting a re-title
+	if !retitleRe.MatchString(gce.Body) {
+		return nil
+	}
+
+	var (
+		org    = gce.Repo.Owner.Login
+		repo   = gce.Repo.Name
+		number = gce.Number
+		user   = gce.User.Login
+	)
+
+	trusted, err := isTrusted(user)
+	if err != nil {
+		log.WithError(err).Error("Could not check if user was trusted.")
+		return err
+	}
+	if !trusted {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Re-titling can only be requested by trusted users, like repository collaborators.`))
+	}
+
+	matches := retitleRe.FindStringSubmatch(gce.Body)
+	if matches == nil {
+		// this shouldn't happen since we checked above
+		return nil
+	}
+	newTitle := matches[1]
+	if newTitle == "" {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not be empty.`))
+	}
+
+	if gce.IsPR {
+		pr, err := gc.GetPullRequest(org, repo, number)
+		if err != nil {
+			return err
+		}
+		pr.Title = newTitle
+		_, err = gc.EditPullRequest(org, repo, number, pr)
+		return err
+	} else {
+		issue, err := gc.GetIssue(org, repo, number)
+		if err != nil {
+			return err
+		}
+		issue.Title = newTitle
+		_, err = gc.EditIssue(org, repo, number, issue)
+		return err
+	}
+}

--- a/prow/plugins/retitle/retitle_test.go
+++ b/prow/plugins/retitle/retitle_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retitle
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestHandleGenericComment(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		state           string
+		action          github.GenericCommentEventAction
+		isPr            bool
+		body            string
+		trusted         func(string) (bool, error)
+		expectedTitle   string
+		expectedErr     bool
+		expectedComment string
+	}{
+		{
+			name:   "comment on closed issue is ignored",
+			state:  "closed",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle foobar",
+		},
+		{
+			name:   "edited comment on open issue is ignored",
+			state:  "open",
+			action: github.GenericCommentActionEdited,
+			body:   "/retitle foobar",
+		},
+		{
+			name:   "new unrelated comment on open issue is ignored",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "whatever else",
+		},
+		{
+			name:   "new comment on open issue returns error when failing to check trusted",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle foobar",
+			trusted: func(user string) (bool, error) {
+				return false, errors.New("oops")
+			},
+			expectedErr: true,
+		},
+		{
+			name:   "new comment on open issue comments when user is not trusted",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle foobar",
+			trusted: func(user string) (bool, error) {
+				return false, nil
+			},
+			expectedComment: `org/repo#1:@user: Re-titling can only be requested by trusted users, like repository collaborators.
+
+<details>
+
+In response to [this]():
+
+>/retitle foobar
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:   "new comment on open issue comments with no title",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle     ",
+			trusted: func(user string) (bool, error) {
+				return true, nil
+			},
+			expectedComment: `org/repo#1:@user: Titles may not be empty.
+
+<details>
+
+In response to [this]():
+
+>/retitle     
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:   "trusted user edits PR title",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle foobar",
+			isPr:   true,
+			trusted: func(user string) (bool, error) {
+				return true, nil
+			},
+			expectedTitle: "foobar",
+		},
+		{
+			name:   "trusted user edits issue title",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle foobar",
+			isPr:   false,
+			trusted: func(user string) (bool, error) {
+				return true, nil
+			},
+			expectedTitle: "foobar",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			gce := github.GenericCommentEvent{
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				User: github.User{
+					Login: "user",
+				},
+				Number:     1,
+				IssueState: testCase.state,
+				Action:     testCase.action,
+				IsPR:       testCase.isPr,
+				Body:       testCase.body,
+			}
+			gc := fakegithub.FakeClient{
+				Issues:        map[int]*github.Issue{1: {Title: "Old"}},
+				PullRequests:  map[int]*github.PullRequest{1: {Title: "Old"}},
+				IssueComments: map[int][]github.IssueComment{},
+			}
+
+			err := handleGenericComment(&gc, testCase.trusted, logrus.WithField("test-case", testCase.name), gce)
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			var actual string
+			if testCase.isPr {
+				actual = gc.PullRequests[gce.Number].Title
+			} else {
+				actual = gc.Issues[gce.Number].Title
+			}
+
+			if testCase.expectedTitle != "" && actual != testCase.expectedTitle {
+				t.Errorf("%s: expected title %q, got %q", testCase.name, testCase.expectedTitle, actual)
+			}
+
+			wantedComments := 0
+			if testCase.expectedComment != "" {
+				wantedComments = 1
+			}
+			if len(gc.IssueCommentsAdded) != wantedComments {
+				t.Errorf("%s: wanted %d comment, got %d: %v", testCase.name, wantedComments, len(gc.IssueCommentsAdded), gc.IssueCommentsAdded)
+			}
+
+			if testCase.expectedComment != "" && len(gc.IssueCommentsAdded) == 1 {
+				if testCase.expectedComment != gc.IssueCommentsAdded[0] {
+					t.Errorf("%s: got incorrect comment: %v", testCase.name, diff.StringDiff(testCase.expectedComment, gc.IssueCommentsAdded[0]))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a robot or other automated process creates an issue or pull
request, users cannot change the title of that issue or pull request
without write access to the repository in question. This plugin allows
trusted users to re-title with a command.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 
/cc @smarterclayton @derekwaynecarr @deads2k @eparis 