### PR TITLE
SetPresubmitRegexes: Verify that trigger is not an empty string

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1276,6 +1276,10 @@ func validateTriggering(job Presubmit) error {
 		return fmt.Errorf("job %s is set to report but has no context configured", job.Name)
 	}
 
+	if (job.Trigger != "" && job.RerunCommand == "") || (job.Trigger == "" && job.RerunCommand != "") {
+		return fmt.Errorf("Either both of job.Trigger and job.RerunCommand must be set, wasnt the case for job %q", job.Name)
+	}
+
 	return nil
 }
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2219,3 +2219,52 @@ func TestSlackReporterValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTriggering(t *testing.T) {
+	testCases := []struct {
+		name        string
+		presubmit   Presubmit
+		errExpected bool
+	}{
+		{
+			name: "Trigger set, rerun command unset, err",
+			presubmit: Presubmit{
+				Trigger: "my-trigger",
+				Reporter: Reporter{
+					Context: "my-context",
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "Triger unset, rerun command set, err",
+			presubmit: Presubmit{
+				RerunCommand: "my-rerun-command",
+				Reporter: Reporter{
+					Context: "my-context",
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "Both trigger and rerun command set, no err",
+			presubmit: Presubmit{
+				Trigger:      "my-trigger",
+				RerunCommand: "my-rerun-command",
+				Reporter: Reporter{
+					Context: "my-context",
+				},
+			},
+			errExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTriggering(tc.presubmit)
+			if err != nil != tc.errExpected {
+				t.Errorf("Expected err: %t but got err %v", tc.errExpected, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Otherwise the compiled regex will match _everything_.

Extracted from #12836 