### PR TITLE
Revert "Expose the size of responses in deck metrics"

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -172,7 +172,6 @@ func (trw *traceResponseWriter) WriteHeader(code int) {
 
 func init() {
 	prometheus.MustRegister(deckMetrics.httpRequestDuration)
-	prometheus.MustRegister(deckMetrics.httpResponseSize)
 }
 
 func traceHandler(h http.Handler) http.Handler {


### PR DESCRIPTION
This reverts commit bce877a3f0171569af6414bc8bdf91bbb9a842d0.

fixes: https://github.com/kubernetes/test-infra/issues/12946
/assign @stevekuznetsov 

Now also reverts this PR too: https://github.com/kubernetes/test-infra/pull/12874