### PR TITLE
 Prefix deck HTTP metrics with job name

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -148,12 +148,21 @@ func staticHandlerFromDir(dir string) http.Handler {
 var (
 	deckMetrics = struct {
 		httpRequestDuration *prometheus.HistogramVec
+		httpResponseSize    *prometheus.HistogramVec
 	}{
 		httpRequestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "deck_http_request_duration_seconds",
-				Help:    "http request duration seconds for deck server",
+				Name:    "http_request_duration_seconds",
+				Help:    "http request duration in seconds",
 				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			},
+			[]string{"path", "method", "status"},
+		),
+		httpResponseSize: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "http_response_size_bytes",
+				Help:    "http response size in bytes",
+				Buckets: []float64{16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216},
 			},
 			[]string{"path", "method", "status"},
 		),
@@ -163,6 +172,7 @@ var (
 type traceResponseWriter struct {
 	http.ResponseWriter
 	statusCode int
+	size       int
 }
 
 func (trw *traceResponseWriter) WriteHeader(code int) {
@@ -170,21 +180,27 @@ func (trw *traceResponseWriter) WriteHeader(code int) {
 	trw.ResponseWriter.WriteHeader(code)
 }
 
+func (trw *traceResponseWriter) Write(data []byte) (int, error) {
+	size, err := trw.ResponseWriter.Write(data)
+	trw.size += size
+	return size, err
+}
+
 func init() {
 	prometheus.MustRegister(deckMetrics.httpRequestDuration)
+	prometheus.MustRegister(deckMetrics.httpResponseSize)
 }
 
 func traceHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
 		// Initialize the status to 200 in case WriteHeader is not called
-		trw := &traceResponseWriter{w, http.StatusOK}
+		trw := &traceResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		h.ServeHTTP(trw, r)
 		latency := time.Since(t)
-		pathPrefix := getPathPrefix(r.URL.Path)
-		deckMetrics.httpRequestDuration.With(
-			prometheus.Labels{"path": pathPrefix, "method": r.Method, "status": strconv.Itoa(trw.statusCode)}).
-			Observe(latency.Seconds())
+		labels := prometheus.Labels{"path": getPathPrefix(r.URL.Path), "method": r.Method, "status": strconv.Itoa(trw.statusCode)}
+		deckMetrics.httpRequestDuration.With(labels).Observe(latency.Seconds())
+		deckMetrics.httpResponseSize.With(labels).Observe(float64(trw.size))
 	})
 }
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -152,7 +152,7 @@ var (
 	}{
 		httpRequestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "http_request_duration_seconds",
+				Name:    "deck_http_request_duration_seconds",
 				Help:    "http request duration in seconds",
 				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 			},
@@ -160,7 +160,7 @@ var (
 		),
 		httpResponseSize: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "http_response_size_bytes",
+				Name:    "deck_http_response_size_bytes",
 				Help:    "http response size in bytes",
 				Buckets: []float64{16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216},
 			},


### PR DESCRIPTION
/assign @cjwagner 
/cc @midnightconman 

There is a lot of prior art for this (in the default configuration, you have both `alertmanager_http_request_duration_seconds` and `prometheus_http_request_duration_seconds`. The issue in #12946 might be caused by `http_response_size_bytes` being published by some other component as a summary, not a histogram. In any case it's not interesting or useful to compare the response size _between_ components, so I don't think there's any compelling reason to use one metric.