### PR TITLE
Add path_alias for cloud-provider-aws

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-cloud-provider-aws-check
     always_run: true
     decorate: true
+    path_alias: k8s.io/cloud-provider-aws
     labels:
       preset-service-account: "true"
     spec:
@@ -17,6 +18,7 @@ presubmits:
   - name: pull-cloud-provider-aws-test
     always_run: true
     decorate: true
+    path_alias: k8s.io/cloud-provider-aws
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
Fixes the failing test at https://github.com/kubernetes/cloud-provider-aws/pull/38

The tests fail with:

```
 go: github.com/kubernetes/cloud-provider-aws@v0.0.0-20190219041032-1448c509b4fb: parsing go.mod: unexpected module path "k8s.io/cloud-provider-aws" 
```

I guess this is because it requires the code to be checked out at `k8s.io` instead of `github.com/kubernetes`.

/assign @spiffxp @mcrute 