### PR TITLE
Add CAPV pre-submit to verify committed CRDs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -60,6 +60,16 @@ presets:
 
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
+  - name: pull-cluster-api-provider-vsphere-verify-crds
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-master
+        command:
+        - hack/verify-crds.sh
+
   - name: pull-cluster-api-provider-vsphere-test
     always_run: true
     decorate: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -702,6 +702,9 @@ test_groups:
 - name: pull-cluster-api-provider-ibmcloud-check
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-ibmcloud-check
   num_columns_recent: 20
+- name: pull-cluster-api-provider-vsphere-verify-crds
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-vsphere-verify-crds
+  num_columns_recent: 20
 - name: pull-cluster-api-provider-vsphere-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-vsphere-test
   num_columns_recent: 20
@@ -2369,6 +2372,11 @@ dashboards:
 
 - name: vmware-cluster-api-provider-vsphere
   dashboard_tab:
+  - name: pr-verify-crds
+    description: Verifies the CRDs
+    test_group_name: pull-cluster-api-provider-vsphere-verify-crds
+    alert_options:
+      alert_mail_to_addresses: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
   - name: pr-test
     description: Runs unit tests
     test_group_name: pull-cluster-api-provider-vsphere-test
@@ -3921,6 +3929,8 @@ dashboards:
 
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
   dashboard_tab:
+  - name: pr-verify-crds
+    test_group_name: pull-cluster-api-provider-vsphere-verify-crds
   - name: pr-test
     test_group_name: pull-cluster-api-provider-vsphere-test
   - name: pr-e2e


### PR DESCRIPTION
This patch adds a pre-submit for CAPV to verify that the CRDs in a commit match newly generated CRDs. If they do not match then the PR is rejected.

This PR is blocked by https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/299.

cc @frapposelli @figo