### PR TITLE
Enable retitle plugin for k-sigs/contributor-playground

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -617,6 +617,7 @@ plugins:
 
   kubernetes-sigs/contributor-playground:
   - require-sig
+  - retitle
 
   containerd/cri:
   - assign


### PR DESCRIPTION
The plugin was added in https://github.com/kubernetes/test-infra/pull/12945 and requires a prow bump to work.
Once we verify on contributor-playground, we can enable it across all orgs.

/cc @stevekuznetsov 
/assign @cblecker 