### PR TITLE
Re-run config-forker for v1.15

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -2559,6 +2559,62 @@ presubmits:
           secretName: ssh-security
     trigger: (?m)^/test( | .* )pull-security-kubernetes-node-e2e,?($|\s.*)
   - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.15
+    cluster: security
+    context: pull-security-kubernetes-e2e-containerd-gce
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-e2e-containerd-gce
+    optional: true
+    rerun_command: /test pull-security-kubernetes-e2e-containerd-gce
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --root=/go/src
+        - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-security-prow/pr-logs
+        - --timeout=105
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --env=KUBE_CONTAINER_RUNTIME=containerd
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --gcp-node-image=gci
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
+          --minStartupPods=8
+        - --timeout=80m
+        - --stage=gs://kubernetes-security-prow/ci/pull-security-kubernetes-e2e-containerd-gce
+        - --gcp-project=k8s-jkns-pr-gce-etcd3
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190607-c90971a-1.15
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-containerd-gce,?($|\s.*)
+  - agent: kubernetes
     always_run: true
     branches:
     - release-1.15
@@ -2656,7 +2712,7 @@ presubmits:
           ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
         volumeMounts:
@@ -2698,7 +2754,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
         volumeMounts:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -121,7 +121,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: kuberentes-release-team@googlegroups.com
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.15-blocking
     testgrid-tab-name: build-1.15
   interval: 1h
@@ -153,7 +153,7 @@ periodics:
 - annotations:
     fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
     fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com,cloud-kubernetes-scalability-oncall@google.com
     testgrid-dashboards: sig-release-1.15-blocking, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-1.15-scalability-100
   cron: 0 */6 * * *
@@ -188,6 +188,7 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testoverrides=./testing/density/100_nodes/override.yaml
+      - --test-cmd-args=--testoverrides=./testing/prometheus/scrape-etcd.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
@@ -261,7 +262,7 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: launcher.gcr.io/google/bazel:0.24.1
+      image: launcher.gcr.io/google/bazel:0.25.2
       name: ""
       resources: {}
 - annotations:
@@ -392,7 +393,7 @@ postsubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
 presubmits:
@@ -681,6 +682,47 @@ presubmits:
         resources:
           requests:
             memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.15
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-containerd-gce
+    optional: true
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=105
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --env=KUBE_CONTAINER_RUNTIME=containerd
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --gcp-node-image=gci
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
+          --minStartupPods=8
+        - --timeout=80m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190607-c90971a-1.15
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
   - always_run: true
     branches:
     - release-1.15
@@ -758,7 +800,7 @@ presubmits:
           ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
   - always_run: true
@@ -786,7 +828,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.24.1
+        image: launcher.gcr.io/google/bazel:0.25.2
         name: ""
         resources: {}
   - always_run: true


### PR DESCRIPTION
I did this mostly as a test to see if the latest changes make it idempotent vs. the manual changes that have already been made to the v1.15 config. It seems like there have been a few changes to master during this time, and given that we're still in code freeze I think they're all still relevant to the 1.15 jobs.  How do we feel about a refresh?

ref: https://github.com/kubernetes/test-infra/issues/12848 - the issue I was trying to verify prior to closure
ref: https://github.com/kubernetes/test-infra/pull/12894 - the "latest changes" I'm referring to

/cc @mariantalla @Katharine
mostly an FYI and whether you think re-running is a good idea

/cc @alejandrox1
v1.15 CI Signal - I think you get final say