### PR TITLE
Add plugin to automatically apply milestone after PR merge

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -242,6 +242,8 @@ type PullRequest struct {
 	// background job was started to compute it. When the job is complete, the response
 	// will include a non-null value for the mergeable attribute.
 	Mergable *bool `json:"mergeable,omitempty"`
+	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
+	Milestone *Milestone `json:"milestone,omitempty"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//prow/plugins/lifecycle:go_default_library",
         "//prow/plugins/mergecommitblocker:go_default_library",
         "//prow/plugins/milestone:go_default_library",
+        "//prow/plugins/milestoneapplier:go_default_library",
         "//prow/plugins/milestonestatus:go_default_library",
         "//prow/plugins/override:go_default_library",
         "//prow/plugins/owners-label:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -42,6 +42,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/lifecycle"
 	_ "k8s.io/test-infra/prow/plugins/mergecommitblocker"
 	_ "k8s.io/test-infra/prow/plugins/milestone"
+	_ "k8s.io/test-infra/prow/plugins/milestoneapplier"
 	_ "k8s.io/test-infra/prow/plugins/milestonestatus"
 	_ "k8s.io/test-infra/prow/plugins/override"
 	_ "k8s.io/test-infra/prow/plugins/owners-label"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -82,6 +82,7 @@ filegroup(
         "//prow/plugins/lifecycle:all-srcs",
         "//prow/plugins/mergecommitblocker:all-srcs",
         "//prow/plugins/milestone:all-srcs",
+        "//prow/plugins/milestoneapplier:all-srcs",
         "//prow/plugins/milestonestatus:all-srcs",
         "//prow/plugins/override:all-srcs",
         "//prow/plugins/owners-label:all-srcs",

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -52,28 +52,29 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
-	Approve                    []Approve              `json:"approve,omitempty"`
-	UseDeprecatedSelfApprove   bool                   `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`
-	UseDeprecatedReviewApprove bool                   `json:"use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019,omitempty"`
-	Blockades                  []Blockade             `json:"blockades,omitempty"`
-	Blunderbuss                Blunderbuss            `json:"blunderbuss,omitempty"`
-	Bugzilla                   Bugzilla               `json:"bugzilla"`
-	Cat                        Cat                    `json:"cat,omitempty"`
-	CherryPickUnapproved       CherryPickUnapproved   `json:"cherry_pick_unapproved,omitempty"`
-	ConfigUpdater              ConfigUpdater          `json:"config_updater,omitempty"`
-	Golint                     Golint                 `json:"golint"`
-	Heart                      Heart                  `json:"heart,omitempty"`
-	Label                      Label                  `json:"label"`
-	Lgtm                       []Lgtm                 `json:"lgtm,omitempty"`
-	RepoMilestone              map[string]Milestone   `json:"repo_milestone,omitempty"`
-	Project                    ProjectConfig          `json:"project_config,omitempty"`
-	RequireMatchingLabel       []RequireMatchingLabel `json:"require_matching_label,omitempty"`
-	RequireSIG                 RequireSIG             `json:"requiresig,omitempty"`
-	Slack                      Slack                  `json:"slack,omitempty"`
-	SigMention                 SigMention             `json:"sigmention,omitempty"`
-	Size                       Size                   `json:"size"`
-	Triggers                   []Trigger              `json:"triggers,omitempty"`
-	Welcome                    []Welcome              `json:"welcome,omitempty"`
+	Approve                    []Approve                    `json:"approve,omitempty"`
+	UseDeprecatedSelfApprove   bool                         `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`
+	UseDeprecatedReviewApprove bool                         `json:"use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019,omitempty"`
+	Blockades                  []Blockade                   `json:"blockades,omitempty"`
+	Blunderbuss                Blunderbuss                  `json:"blunderbuss,omitempty"`
+	Bugzilla                   Bugzilla                     `json:"bugzilla"`
+	Cat                        Cat                          `json:"cat,omitempty"`
+	CherryPickUnapproved       CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
+	ConfigUpdater              ConfigUpdater                `json:"config_updater,omitempty"`
+	Golint                     Golint                       `json:"golint"`
+	Heart                      Heart                        `json:"heart,omitempty"`
+	Label                      Label                        `json:"label"`
+	Lgtm                       []Lgtm                       `json:"lgtm,omitempty"`
+	MilestoneApplier           map[string]BranchToMilestone `json:"milestone_applier,omitempty"`
+	RepoMilestone              map[string]Milestone         `json:"repo_milestone,omitempty"`
+	Project                    ProjectConfig                `json:"project_config,omitempty"`
+	RequireMatchingLabel       []RequireMatchingLabel       `json:"require_matching_label,omitempty"`
+	RequireSIG                 RequireSIG                   `json:"requiresig,omitempty"`
+	Slack                      Slack                        `json:"slack,omitempty"`
+	SigMention                 SigMention                   `json:"sigmention,omitempty"`
+	Size                       Size                         `json:"size"`
+	Triggers                   []Trigger                    `json:"triggers,omitempty"`
+	Welcome                    []Welcome                    `json:"welcome,omitempty"`
 }
 
 // Golint holds configuration for the golint plugin
@@ -363,6 +364,10 @@ type Milestone struct {
 	MaintainersTeam         string `json:"maintainers_team,omitempty"`
 	MaintainersFriendlyName string `json:"maintainers_friendly_name,omitempty"`
 }
+
+// BranchToMilestone is a map of the branch name to the configured milestone for that branch.
+// This is used by the milestoneapplier plugin.
+type BranchToMilestone map[string]string
 
 // Slack contains the configuration for the slack plugin.
 type Slack struct {

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -86,7 +86,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.RepoMilestone)
 }
 
-func buildMilestoneMap(milestones []github.Milestone) map[string]int {
+func BuildMilestoneMap(milestones []github.Milestone) map[string]int {
 	m := make(map[string]int)
 	for _, ms := range milestones {
 		m[ms.Title] = ms.Number
@@ -145,7 +145,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		return nil
 	}
 
-	milestoneMap := buildMilestoneMap(milestones)
+	milestoneMap := BuildMilestoneMap(milestones)
 	milestoneNumber, ok := milestoneMap[proposedMilestone]
 	if !ok {
 		slice := make([]string, 0, len(milestoneMap))

--- a/prow/plugins/milestoneapplier/BUILD.bazel
+++ b/prow/plugins/milestoneapplier/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["milestoneapplier.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/milestoneapplier",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/plugins/milestone:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["milestoneapplier_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/milestoneapplier/milestoneapplier.go
+++ b/prow/plugins/milestoneapplier/milestoneapplier.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package milestoneapplier implements the plugin to automatically apply
+// the configured milestone after a PR is merged.
+package milestoneapplier
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/milestone"
+)
+
+const pluginName = "milestoneapplier"
+
+type githubClient interface {
+	SetMilestone(org, repo string, issueNum, milestoneNum int) error
+	ListMilestones(org, repo string) ([]github.Milestone, error)
+}
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	configInfo := map[string]string{}
+	for _, orgRepo := range enabledRepos {
+		var branchesToMilestone []string
+		for branch, milestone := range config.MilestoneApplier[orgRepo] {
+			branchesToMilestone = append(branchesToMilestone, fmt.Sprintf("- `%s`: `%s`", branch, milestone))
+		}
+		configInfo[orgRepo] = fmt.Sprintf("The configured branches and milestones for this repo are:\n%s", strings.Join(branchesToMilestone, "\n"))
+
+	}
+
+	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
+	return &pluginhelp.PluginHelp{
+		Description: "The milestoneapplier plugin automatically applies the configured milestone for the base branch after a PR is merged. If a PR targets a non-default branch, it also adds the milestone when the PR is opened.",
+		Config:      configInfo,
+	}, nil
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
+	org := pre.PullRequest.Base.Repo.Owner.Login
+	repo := pre.PullRequest.Base.Repo.Name
+	baseBranch := pre.PullRequest.Base.Ref
+
+	// if there are no branch to milestone mappings for this repo, return early
+	branchToMilestone, ok := pc.PluginConfig.MilestoneApplier[fmt.Sprintf("%s/%s", org, repo)]
+	if !ok {
+		return nil
+	}
+	// if the repo does not define milestones for this branch, return early
+	milestone, ok := branchToMilestone[baseBranch]
+	if !ok {
+		return nil
+	}
+
+	return handle(pc.GitHubClient, pc.Logger, milestone, pre)
+}
+
+func handle(gc githubClient, log *logrus.Entry, configuredMilestone string, pre github.PullRequestEvent) error {
+	pr := pre.PullRequest
+
+	// if the current milestone is equal to the configured milestone, return early
+	if pr.Milestone != nil && pr.Milestone.Title == configuredMilestone {
+		return nil
+	}
+
+	// if a PR targets a non-default branch, apply milestone when opened and on merge
+	// if a PR targets the default branch, apply the milestone only on merge
+	merged := pre.Action == github.PullRequestActionClosed && pr.Merged
+	if pr.Base.Repo.DefaultBranch != pr.Base.Ref {
+		if !merged && pre.Action != github.PullRequestActionOpened {
+			return nil
+		}
+	} else if !merged {
+		return nil
+	}
+
+	number := pre.Number
+	org := pr.Base.Repo.Owner.Login
+	repo := pr.Base.Repo.Name
+
+	milestones, err := gc.ListMilestones(org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Error listing the milestones in the %s/%s repo", org, repo)
+		return err
+	}
+
+	milestoneMap := milestone.BuildMilestoneMap(milestones)
+	configuredMilestoneNumber, ok := milestoneMap[configuredMilestone]
+	if !ok {
+		return fmt.Errorf("The configured milestone %s for %s branch does not exist in the %s/%s repo", configuredMilestone, pr.Base.Ref, org, repo)
+	}
+
+	if err := gc.SetMilestone(org, repo, number, configuredMilestoneNumber); err != nil {
+		log.WithError(err).Errorf("Error adding the milestone %s to %s/%s#%d.", configuredMilestone, org, repo, number)
+		return err
+	}
+
+	return nil
+}

--- a/prow/plugins/milestoneapplier/milestoneapplier_test.go
+++ b/prow/plugins/milestoneapplier/milestoneapplier_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package milestoneapplier
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestMilestoneApplier(t *testing.T) {
+	var milestonesMap = map[string]int{"v1.0": 1, "v2.0": 2}
+	testcases := []struct {
+		name                string
+		baseBranch          string
+		prAction            github.PullRequestEventAction
+		merged              bool
+		previousMilestone   int
+		configuredMilestone int
+		expectedMilestone   int
+	}{
+		{
+			name:                "opened PR on default branch => do nothing",
+			baseBranch:          "master",
+			prAction:            github.PullRequestActionOpened,
+			expectedMilestone:   0,
+			configuredMilestone: 1,
+		},
+		{
+			name:                "closed (not merged) PR on default branch => do nothing",
+			baseBranch:          "master",
+			prAction:            github.PullRequestActionClosed,
+			merged:              false,
+			expectedMilestone:   0,
+			configuredMilestone: 1,
+		},
+		{
+			name:                "merged PR but has existing milestone on default branch => apply configured milestone",
+			baseBranch:          "master",
+			prAction:            github.PullRequestActionClosed,
+			merged:              true,
+			previousMilestone:   1,
+			configuredMilestone: 2,
+			expectedMilestone:   2,
+		},
+		{
+			name:                "merged PR but already has configured milestone on default branch => do nothing",
+			baseBranch:          "master",
+			prAction:            github.PullRequestActionClosed,
+			merged:              true,
+			previousMilestone:   2,
+			configuredMilestone: 2,
+			expectedMilestone:   2,
+		},
+		{
+			name:                "merged PR but does not have existing milestone on default branch => add milestone",
+			prAction:            github.PullRequestActionClosed,
+			baseBranch:          "master",
+			merged:              true,
+			previousMilestone:   0,
+			configuredMilestone: 2,
+			expectedMilestone:   2,
+		},
+		{
+			name:                "opened PR on non-default branch => add milestone",
+			baseBranch:          "release-1.0",
+			prAction:            github.PullRequestActionOpened,
+			configuredMilestone: 1,
+			expectedMilestone:   1,
+		},
+		{
+			name:                "synced PR on non-default branch => do nothing",
+			baseBranch:          "release-1.0",
+			prAction:            github.PullRequestActionSynchronize,
+			previousMilestone:   0,
+			configuredMilestone: 1,
+			expectedMilestone:   0,
+		},
+		{
+			name:                "closed (not merged) PR on non-default branch => do nothing",
+			baseBranch:          "release-1.0",
+			prAction:            github.PullRequestActionClosed,
+			merged:              false,
+			expectedMilestone:   0,
+			configuredMilestone: 1,
+		},
+		{
+			name:                "merged PR but has existing milestone on non-default branch => add configured milestone",
+			baseBranch:          "release-1.0",
+			prAction:            github.PullRequestActionClosed,
+			merged:              true,
+			previousMilestone:   1,
+			configuredMilestone: 2,
+			expectedMilestone:   2,
+		},
+		{
+			name:                "merged PR but already has configured milestone on non-default branch => do nothing",
+			baseBranch:          "release-1.0",
+			prAction:            github.PullRequestActionClosed,
+			merged:              true,
+			previousMilestone:   2,
+			configuredMilestone: 2,
+			expectedMilestone:   2,
+		},
+		{
+			name:                "merged PR but does not have existing milestone on non-default branch => add milestone",
+			prAction:            github.PullRequestActionClosed,
+			baseBranch:          "release-1.0",
+			merged:              true,
+			previousMilestone:   0,
+			configuredMilestone: 1,
+			expectedMilestone:   1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			basicPR := github.PullRequest{
+				Number: 1,
+				Base: github.PullRequestBranch{
+					Repo: github.Repo{
+						Owner: github.User{
+							Login: "kubernetes",
+						},
+						Name:          "kubernetes",
+						DefaultBranch: "master",
+					},
+					Ref: tc.baseBranch,
+				},
+			}
+
+			basicPR.Merged = tc.merged
+			if tc.previousMilestone != 0 {
+				basicPR.Milestone = &github.Milestone{
+					Number: tc.previousMilestone,
+				}
+			}
+
+			event := github.PullRequestEvent{
+				Action:      tc.prAction,
+				Number:      basicPR.Number,
+				PullRequest: basicPR,
+			}
+
+			fakeClient := &fakegithub.FakeClient{
+				PullRequests: map[int]*github.PullRequest{
+					basicPR.Number: &basicPR,
+				},
+				MilestoneMap: milestonesMap,
+				Milestone:    tc.previousMilestone,
+			}
+
+			var configuredMilestoneTitle string
+			for title, number := range milestonesMap {
+				if number == tc.configuredMilestone {
+					configuredMilestoneTitle = title
+				}
+			}
+
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), configuredMilestoneTitle, event); err != nil {
+				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
+			}
+
+			if fakeClient.Milestone != tc.expectedMilestone {
+				t.Fatalf("%s: expected milestone: %d, received milestone: %d", tc.name, tc.expectedMilestone, fakeClient.Milestone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/11611

The milestoneapplier plugin configuration allows to define the current milestone for each branch in a repo. For example, `master: v1.16`, `release-1.15: v1.15`, etc.

For the default branch of the repo, generally `master`, it applies the configured milestone after a PR is merged against the branch (even if the PR had an older/different milestone).

For non-default branches, like `release-1.15`, it applies the configured milestone after a (cherry-pick) PR is opened _and_ when the PR is merged (even if the PR had an older/different milestone).

Note that it doesn't add the milestone when the PR is synced/updated because we don't want the milestone to be added again if it's manually removed.
Example scenario: if `v1.15.1` is the current milestone for `release-1.15` branch, and a cherry-pick PR is opened but we want to move it to `v1.15.2`, the milestone shouldn't be automatically updated to `v1.15.1`.