### PR TITLE
Bump bazel version to 0.26.0 to satisfy '@npm//'.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ git_repository(
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
-versions.check(minimum_bazel_version = "0.23.0")
+versions.check(minimum_bazel_version = "0.26.0")
 
 # TODO(fejta): delete the com_google_protobuf rule once rules_go >= 0.18.4
 # This silences the shallow_since message (and increases cache hit rate)

--- a/images/bazelbuild/variants.yaml
+++ b/images/bazelbuild/variants.yaml
@@ -1,4 +1,6 @@
 variants:
+  0.26.0:
+    BAZEL_VERSION: 0.26.0
   0.24.0:
     BAZEL_VERSION: 0.24.0
   0.23.2:

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -3,7 +3,7 @@ variants:
     CONFIG: experimental
     GO_VERSION: 1.12.1
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: 0.26.0
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master


### PR DESCRIPTION
I'll update the appropriate jobs to use the new 0.26.0 bazelbuild image variant once the images are published.

/assign @Katharine @fejta 