### PR TITLE
Fix autobump job to use correct bazel version.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -685,7 +685,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20190401-918468dbb-0.24.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20190611-6adfc2e-0.26.0
       command:
       - bazel
       - run


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/12981
/assign @Katharine @fejta 
[gcr.io/k8s-testimages/bazelbuild:v20190611-6adfc
2e-0.26.0](http://gcr.io/k8s-testimages/bazelbuild:v20190611-6adfc2e-0.26.0)