### PR TITLE
Make gce-scale-correctness use dedidcated build cluster.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -2,6 +2,7 @@ periodics:
 # This is a sig-release-master-blocking job.
 - cron: '1 3 * * 1,2,3,4,5' # Run at 19:01PST on Sun-Thu (03:01 UTC on Mon-Fri)
   name: ci-kubernetes-e2e-gce-scale-correctness
+  cluster: scalability
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/12867

/assign @mm4tt 
/sig scalability
/kind cleanup