### PR TITLE
Add gardener dashboard group and corresponding dashboards

### DIFF
--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -47,6 +47,7 @@ var (
 		"kopeio",
 		"redhat",
 		"vmware",
+		"gardener",
 	}
 	orgs = []string{
 		"conformance",

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1652,62 +1652,62 @@ test_groups:
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
 
-# Gardener Test Groups
+# Gardener Conformance Test Groups
 - name: ci-gardener-e2e-conformance-aws-v1.14
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.14
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-gce-v1.14
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.14
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-openstack-v1.14
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.14
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-azure-v1.14
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.14
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-alicloud-v1.14
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.14
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-aws-v1.13
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.13
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-gce-v1.13
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.13
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-openstack-v1.13
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.13
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-azure-v1.13
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.13
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-alicloud-v1.13
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.13
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-aws-v1.12
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.12
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-gce-v1.12
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.12
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-openstack-v1.12
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.12
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-azure-v1.12
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.12
-  alert_stale_results_hours: 72
+  alert_stale_results_hours: 168
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-aws-v1.11
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.11
@@ -1739,6 +1739,96 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-azure-v1.10
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.10
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+
+# Gardener General Test Groups
+- name: ci-gardener-e2e-aws-v1.14
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.14
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.14
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.14
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.14
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.14
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.14
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.14
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-alicloud-v1.14
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-alicloud-v1.14
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-aws-v1.13
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.13
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.13
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.13
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.13
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.13
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.13
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.13
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-alicloud-v1.13
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-alicloud-v1.13
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-aws-v1.12
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.12
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.12
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.12
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.12
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.12
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.12
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.12
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-aws-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.11
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.11
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.11
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.11
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.11
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-aws-v1.10
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.10
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.10
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.10
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.10
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.10
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.10
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.10
   alert_stale_results_hours: 168
   num_failures_to_alert: 1
 
@@ -6098,119 +6188,249 @@ dashboards:
   - name: kops-postsubmit
     test_group_name: kops-postsubmit
 
-# Gardener Dashboard
+# Gardener AWS Dashboard
+- name: gardener-aws
+  dashboard_tab:
+  - name: Gardener, v1.14 AWS
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+    test_group_name: ci-gardener-e2e-aws-v1.14
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.13 AWS
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+    test_group_name: ci-gardener-e2e-aws-v1.13
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.12 AWS
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+    test_group_name: ci-gardener-e2e-aws-v1.12
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.11 AWS
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+    test_group_name: ci-gardener-e2e-aws-v1.11
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.10 AWS
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+    test_group_name: ci-gardener-e2e-aws-v1.10
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+
+# Gardener GCE Dashboard
+- name: gardener-gce
+  dashboard_tab:
+  - name: Gardener, v1.14 GCE
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+    test_group_name: ci-gardener-e2e-gce-v1.14
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.13 GCE
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+    test_group_name: ci-gardener-e2e-gce-v1.13
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.12 GCE
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+    test_group_name: ci-gardener-e2e-gce-v1.12
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.11 GCE
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+    test_group_name: ci-gardener-e2e-gce-v1.11
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.10 GCE
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+    test_group_name: ci-gardener-e2e-gce-v1.10
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+
+# Gardener Alicloud Dashboard
+- name: gardener-alicloud
+  dashboard_tab:
+  - name: Gardener, v1.14 Alicloud
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
+    test_group_name: ci-gardener-e2e-alicloud-v1.14
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.13 Alicloud
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
+    test_group_name: ci-gardener-e2e-alicloud-v1.13
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+
+# Gardener Azure Dashboard
+- name: gardener-azure
+  dashboard_tab:
+  - name: Gardener, v1.14 Azure
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+    test_group_name: ci-gardener-e2e-azure-v1.14
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.13 Azure
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+    test_group_name: ci-gardener-e2e-azure-v1.13
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.12 Azure
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+    test_group_name: ci-gardener-e2e-azure-v1.12
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.11 Azure
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+    test_group_name: ci-gardener-e2e-azure-v1.11
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.10 Azure
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+    test_group_name: ci-gardener-e2e-azure-v1.10
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+
+# Gardener OpenStack Dashboard
+- name: gardener-openstack
+  dashboard_tab:
+  - name: Gardener, v1.14 OpenStack
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+    test_group_name: ci-gardener-e2e-openstack-v1.14
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.13 OpenStack
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+    test_group_name: ci-gardener-e2e-openstack-v1.13
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.12 OpenStack
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+    test_group_name: ci-gardener-e2e-openstack-v1.12
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.11 OpenStack
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+    test_group_name: ci-gardener-e2e-openstack-v1.11
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+  - name: Gardener, v1.10 OpenStack
+    description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+    test_group_name: ci-gardener-e2e-openstack-v1.10
+    alert_options:
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+
+# Gardener Conformance Dashboard
 - name: conformance-gardener
   dashboard_tab:
   - name: Gardener, v1.14 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.14
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.14
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.14
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.14
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Alibaba Cloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
     test_group_name: ci-gardener-e2e-conformance-alicloud-v1.14
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.13
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.13
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.13
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.13
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Alibaba Cloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
     test_group_name: ci-gardener-e2e-conformance-alicloud-v1.13
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.12
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.12
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.12
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.12
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.11
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.11
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.11
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.11
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.10
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.10
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.10
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.10
     alert_options:
-      alert_mail_to_addresses: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
 
 - name: sig-api-machinery-kube-storage-version-migrator
   dashboard_tab:
@@ -6686,3 +6906,12 @@ dashboard_groups:
 - name: presubmits-release-notes
   dashboard_names:
   - presubmits-release-notes-master
+
+- name: gardener
+  dashboard_names:
+  - gardener-gce
+  - gardener-aws
+  - gardener-openstack
+  - gardener-alicloud
+  - gardener-azure
+  - conformance-gardener

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6872,12 +6872,12 @@ dashboard_groups:
   - conformance-alibaba-cloud-provider
   - conformance-cloud-provider-vsphere
   - conformance-vsphere
-  - conformance-gardener
   - conformance-hack-local-up-cluster
   - conformance-arm
   - conformance-ppc64le
   - conformance-eks
   - conformance-oracle-cloud-infrastructure
+  - conformance-gardener
 
 - name: vmware
   dashboard_names:
@@ -6914,4 +6914,3 @@ dashboard_groups:
   - gardener-openstack
   - gardener-alicloud
   - gardener-azure
-  - conformance-gardener


### PR DESCRIPTION
In addition to the conformance tests, gardener also executes more than 400 additional e2e tests. To make the test coverage more transparent and clear, a new gardener dashgroup is introduced. This dashboard contains e2e test results for multiple providers and k8s release versions (and in near future multiple operation systems).