### PR TITLE
Fix test_infra workspace references in typescript.

### DIFF
--- a/prow/spyglass/lenses/lens.d.ts
+++ b/prow/spyglass/lenses/lens.d.ts
@@ -1,4 +1,4 @@
-import {Spyglass} from "test_infra/prow/cmd/deck/static/spyglass/lens";
+import {Spyglass} from "io_k8s_test_infra/prow/cmd/deck/static/spyglass/lens";
 
 declare global {
     // The `spyglass` global is injected into the environment the lens runs in by spyglass.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // NB: Bazel ignores whatever we put here, so any other values won't work.
     "baseUrl": ".",
     "paths": {
-      "test_infra/*": ["*"]
+      "io_k8s_test_infra/*": ["*"]
     }
   },
   "bazelOptions": {


### PR DESCRIPTION
`rules_typescript` supports workspace-relative references that are prefixed by the workspace name. #10757 renamed the workspace, but didn't change the typescript references to it. Fix this to match.

I'm not entirely sure how this has been working since January. I imagine it's because the sole reference is in a declaration file rather than a code one? It is concerning that this kept working.

I've since noticed this because I attempted to do a workspace-relative import and it didn't work.

/cc @fejta 