### PR TITLE
Set up GitHub oauth for rerun button

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -453,13 +453,14 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 		githubOAuthConfig.InitGitHubOAuthConfig(cookie)
 
 		goa := githuboauth.NewAgent(&githubOAuthConfig, logrus.WithField("client", "githuboauth"))
-		oauthClient := &oauth2.Config{
+		oauthClient := githuboauth.NewClient(&oauth2.Config{
 			ClientID:     githubOAuthConfig.ClientID,
 			ClientSecret: githubOAuthConfig.ClientSecret,
 			RedirectURL:  githubOAuthConfig.RedirectURL,
 			Scopes:       githubOAuthConfig.Scopes,
 			Endpoint:     github.Endpoint,
-		}
+		},
+		)
 
 		repoSet := make(map[string]bool)
 		for r := range cfg().Presubmits {
@@ -1231,6 +1232,5 @@ func handleFavicon(staticFilesLocation string, cfg config.Getter) http.HandlerFu
 
 func isValidatedGitOAuthConfig(githubOAuthConfig *config.GitHubOAuthConfig) bool {
 	return githubOAuthConfig.ClientID != "" && githubOAuthConfig.ClientSecret != "" &&
-		githubOAuthConfig.RedirectURL != "" &&
-		githubOAuthConfig.FinalRedirectURL != ""
+		githubOAuthConfig.RedirectURL != ""
 }

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -204,3 +204,18 @@ export namespace tidehistory {
     return link;
   }
 }
+
+export function getCookieByName(name: string): string {
+  if (!document.cookie) {
+    return "";
+  }
+  const docCookies = decodeURIComponent(document.cookie).split(";");
+  for (const cookie of docCookies) {
+    const c = cookie.trim();
+    const pref = name + "=";
+    if (c.indexOf(pref) === 0) {
+      return c.slice(pref.length);
+    }
+  }
+  return "";
+}

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -4,7 +4,7 @@ import {Context} from '../api/github';
 import {Label, PullRequest, UserData} from '../api/pr';
 import {Job, JobState} from '../api/prow';
 import {Blocker, TideData, TidePool, TideQuery as ITideQuery} from '../api/tide';
-import {tidehistory} from '../common/common';
+import {getCookieByName, tidehistory} from '../common/common';
 
 declare const tideData: TideData;
 declare const allBuilds: Job[];
@@ -175,24 +175,6 @@ function onLoadQuery(): string {
     const val = params[0].slice("query=".length);
     if (val && val !== "") {
         return decodeURIComponent(val.replace(/\+/g, ' '));
-    }
-    return "";
-}
-
-/**
- * Gets cookie by its name.
- */
-function getCookieByName(name: string): string {
-    if (!document.cookie) {
-        return "";
-    }
-    const cookies = decodeURIComponent(document.cookie).split(";");
-    for (const cookie of cookies) {
-        const c = cookie.trim();
-        const pref = name + "=";
-        if (c.indexOf(pref) === 0) {
-            return c.slice(pref.length);
-        }
     }
     return "";
 }
@@ -1154,7 +1136,7 @@ function createPRCard(pr: PullRequest, builds: UnifiedContext[] = [], queries: P
  * Redirect to initiate github login flow.
  */
 function forceGitHubLogin(): void {
-    window.location.href = window.location.origin + "/github-login";
+    window.location.href = window.location.origin + "/github-login?dest=%2Fpr";
 }
 
 type VagueState = "succeeded" | "failed" | "pending" | "unknown";

--- a/prow/config/githuboauth.go
+++ b/prow/config/githuboauth.go
@@ -31,11 +31,10 @@ type Cookie struct {
 // GitHubOAuthConfig is a config for requesting users access tokens from GitHub API. It also has
 // a Cookie Store that retains user credentials deriving from GitHub API.
 type GitHubOAuthConfig struct {
-	ClientID         string   `json:"client_id"`
-	ClientSecret     string   `json:"client_secret"`
-	RedirectURL      string   `json:"redirect_url"`
-	Scopes           []string `json:"scopes,omitempty"`
-	FinalRedirectURL string   `json:"final_redirect_url"`
+	ClientID     string   `json:"client_id"`
+	ClientSecret string   `json:"client_secret"`
+	RedirectURL  string   `json:"redirect_url"`
+	Scopes       []string `json:"scopes,omitempty"`
 
 	CookieStore *sessions.CookieStore `json:"-"`
 }

--- a/prow/githuboauth/githuboauth.go
+++ b/prow/githuboauth/githuboauth.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-github/github"
@@ -54,11 +55,41 @@ type GitHubClientGetter interface {
 
 // OAuthClient is an interface for a GitHub OAuth client.
 type OAuthClient interface {
+	WithFinalRedirectURL(url string) (OAuthClient, error)
 	// Exchanges code from GitHub OAuth redirect for user access token.
 	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	// Returns a URL to GitHub's OAuth 2.0 consent page. The state is a token to protect the user
 	// from an XSRF attack.
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
+}
+
+type client struct {
+	*oauth2.Config
+}
+
+func NewClient(config *oauth2.Config) client {
+	return client{
+		config,
+	}
+}
+
+func (cli client) WithFinalRedirectURL(path string) (OAuthClient, error) {
+	parsedURL, err := url.Parse(cli.RedirectURL)
+	if err != nil {
+		return nil, err
+	}
+	q := parsedURL.Query()
+	q.Set("dest", path)
+	parsedURL.RawQuery = q.Encode()
+	return NewClient(
+		&oauth2.Config{
+			ClientID:     cli.ClientID,
+			ClientSecret: cli.ClientSecret,
+			RedirectURL:  parsedURL.String(),
+			Scopes:       cli.Scopes,
+			Endpoint:     cli.Endpoint,
+		},
+	), nil
 }
 
 type githubClientGetter struct{}
@@ -92,6 +123,7 @@ func NewAgent(config *config.GitHubOAuthConfig, logger *logrus.Entry) *Agent {
 // redirect user to GitHub OAuth end-point for authentication.
 func (ga *Agent) HandleLogin(client OAuthClient) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		destPage := r.URL.Query().Get("dest")
 		stateToken := xsrftoken.Generate(ga.gc.ClientSecret, "", "")
 		state := hex.EncodeToString([]byte(stateToken))
 		oauthSession, err := ga.gc.CookieStore.New(r, oauthSessionCookie)
@@ -108,8 +140,11 @@ func (ga *Agent) HandleLogin(client OAuthClient) http.HandlerFunc {
 			ga.serverError(w, "Save oauth session", err)
 			return
 		}
-
-		redirectURL := client.AuthCodeURL(state, oauth2.ApprovalForce, oauth2.AccessTypeOnline)
+		newClient, err := client.WithFinalRedirectURL(destPage)
+		if err != nil {
+			ga.serverError(w, "Failed to parse redirect URL", err)
+		}
+		redirectURL := newClient.AuthCodeURL(state, oauth2.ApprovalForce, oauth2.AccessTypeOnline)
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 	}
 }
@@ -135,7 +170,7 @@ func (ga *Agent) HandleLogout(client OAuthClient) http.HandlerFunc {
 			loginCookie.Expires = time.Now().Add(-time.Hour * 24)
 			http.SetCookie(w, loginCookie)
 		}
-		http.Redirect(w, r, ga.gc.FinalRedirectURL, http.StatusFound)
+		http.Redirect(w, r, r.URL.Host, http.StatusFound)
 	}
 }
 
@@ -144,6 +179,14 @@ func (ga *Agent) HandleLogout(client OAuthClient) http.HandlerFunc {
 // the final destination in the config, which should be the front-end.
 func (ga *Agent) HandleRedirect(client OAuthClient, getter GitHubClientGetter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		finalRedirectURL, err := r.URL.Parse(r.URL.Query().Get("dest"))
+		//This check prevents someone from specifying a different host to redirect to.
+		if finalRedirectURL.Host != "" {
+			ga.serverError(w, "Invalid hostname", fmt.Errorf("%s, expected %s", finalRedirectURL.Host, r.URL.Host))
+		}
+		if err != nil {
+			ga.serverError(w, "Failed to parse final destination from OAuth redirect payload", err)
+		}
 		state := r.FormValue("state")
 		stateTokenRaw, err := hex.DecodeString(state)
 		if err != nil {
@@ -163,7 +206,7 @@ func (ga *Agent) HandleRedirect(client OAuthClient, getter GitHubClientGetter) h
 		}
 		secretState, ok := oauthSession.Values[stateKey].(string)
 		if !ok {
-			ga.serverError(w, "Get secret state", fmt.Errorf("empty string or cannot convert to string"))
+			ga.serverError(w, "Get secret state", fmt.Errorf("empty string or cannot convert to string. this probably means the options passed to GitHub don't match what was expected"))
 			return
 		}
 		// Validate the state parameter to prevent cross-site attack.
@@ -219,7 +262,7 @@ func (ga *Agent) HandleRedirect(client OAuthClient, getter GitHubClientGetter) h
 			Expires: time.Now().Add(time.Hour * 24 * 30),
 			Secure:  true,
 		})
-		http.Redirect(w, r, ga.gc.FinalRedirectURL, http.StatusFound)
+		http.Redirect(w, r, finalRedirectURL.String(), http.StatusFound)
 	}
 }
 


### PR DESCRIPTION
More specifically, this change will make it check if the user is logged in when they click the rerun button. If they are, the rerun button will do what it already does and show a popup with a command to run to rerun the test.
If the user is not logged in, it will redirect to GitHub oauth, then redirect back to prow.k8s.io

/assign @cjwagner 
/cc @fejta 
/cc @Katharine 