### PR TITLE
Add context to GitHub client logging

### DIFF
--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -54,14 +54,16 @@ func getClient(url string) *client {
 	}
 
 	return &client{
-		time:     &testTime{},
-		getToken: getToken,
-		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		delegate: &delegate{
+			time:     &testTime{},
+			getToken: getToken,
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
 			},
+			bases: []string{url},
 		},
-		bases: []string{url},
 	}
 }
 

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -59,7 +59,9 @@ func TestHook(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
-	clientAgent := &plugins.ClientAgent{}
+	clientAgent := &plugins.ClientAgent{
+		GitHubClient: github.NewFakeClient(),
+	}
 	metrics := NewMetrics()
 
 	getSecret := func() []byte {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -159,7 +159,7 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
 	return Agent{
-		GitHubClient:     clientAgent.GitHubClient,
+		GitHubClient:     clientAgent.GitHubClient.WithFields(logger.Data),
 		KubernetesClient: clientAgent.KubernetesClient,
 		ProwJobClient:    clientAgent.ProwJobClient,
 		GitClient:        clientAgent.GitClient,


### PR DESCRIPTION
Today it is not possible to trace log calls from the GitHub client to
the context in which they were called. This change allows that context
to be injected for plugins handling events while keeping the underlying
implementation of the client as a thread-safe singleton.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 