### PR TITLE
Add a first pass at a coverage lens for spyglass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "dependencies": {
+    "color": "^3.1.2",
     "dialog-polyfill": "^0.5.0",
-    "moment": "^2.22.2"
+    "moment": "^2.22.2",
+    "pako": "^1.0.10"
   },
   "devDependencies": {
-    "@bazel/typescript": "^0.30.2",
     "@bazel/jasmine": "^0.30.2",
+    "@bazel/typescript": "^0.30.2",
+    "@types/color": "^3.0.0",
     "@types/google.visualization": "^0.0.43",
     "@types/jasmine": "~3.3.13",
+    "@types/pako": "^1.0.1",
     "jasmine": "~3.4.0",
     "tslint": "^5.12.1",
     "typescript": ">=2.8 <2.9"

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -117,6 +117,7 @@ go_library(
         "//prow/spyglass:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "//prow/spyglass/lenses/buildlog:go_default_library",
+        "//prow/spyglass/lenses/coverage:go_default_library",
         "//prow/spyglass/lenses/junit:go_default_library",
         "//prow/spyglass/lenses/metadata:go_default_library",
         "//prow/tide:go_default_library",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -67,6 +67,7 @@ import (
 
 	"k8s.io/test-infra/prow/spyglass/lenses"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/buildlog"
+	_ "k8s.io/test-infra/prow/spyglass/lenses/coverage"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/junit"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/metadata"
 )

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -36,6 +36,8 @@ deck:
       - "buildlog"
       "artifacts/junit.*\\.xml":
       - "junit"
+      "artifacts/filtered.cov":
+      - "coverage"
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.k8s.io/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to sig-testing."
   tide_update_period: 1s
   hidden_repos:

--- a/prow/spyglass/lenses/BUILD.bazel
+++ b/prow/spyglass/lenses/BUILD.bazel
@@ -7,6 +7,7 @@ filegroup(
     name = "templates",
     srcs = [
         "//prow/spyglass/lenses/buildlog:template",
+        "//prow/spyglass/lenses/coverage:template",
         "//prow/spyglass/lenses/junit:template",
         "//prow/spyglass/lenses/metadata:template",
     ],
@@ -16,6 +17,7 @@ filegroup(
     name = "resources",
     srcs = [
         "//prow/spyglass/lenses/buildlog:resources",
+        "//prow/spyglass/lenses/coverage:resources",
         "//prow/spyglass/lenses/junit:resources",
         "//prow/spyglass/lenses/metadata:resources",
     ],
@@ -46,6 +48,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//prow/spyglass/lenses/buildlog:all-srcs",
+        "//prow/spyglass/lenses/coverage:all-srcs",
         "//prow/spyglass/lenses/junit:all-srcs",
         "//prow/spyglass/lenses/metadata:all-srcs",
     ],

--- a/prow/spyglass/lenses/coverage/BUILD.bazel
+++ b/prow/spyglass/lenses/coverage/BUILD.bazel
@@ -1,0 +1,68 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["coverage.go"],
+    importpath = "k8s.io/test-infra/prow/spyglass/lenses/coverage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/spyglass/lenses:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+ts_library(
+    name = "script",
+    srcs = [
+        "coverage.ts",
+        "vendor.d.ts",
+    ],
+    deps = [
+        "//gopherage/cmd/html/static:parser",
+        "//prow/spyglass/lenses:lens_api",
+        "@npm//@types/color",
+        "@npm//@types/pako",
+    ],
+)
+
+rollup_bundle(
+    name = "script_bundle",
+    entry_point = "prow/spyglass/lenses/coverage/coverage",
+    deps = [
+        ":script",
+        "//gopherage/cmd/html/static:parser",
+        "@npm//color",
+        "@npm//pako",
+    ],
+)
+
+filegroup(
+    name = "resources",
+    srcs = [
+        "coverage.css",
+        ":script_bundle.es2015.js",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "template",
+    srcs = ["template.html"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/spyglass/lenses/coverage/coverage.css
+++ b/prow/spyglass/lenses/coverage/coverage.css
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+body {
+  overflow: hidden;
+}
+
+.leaf {
+  border: 0.5px solid #303030;
+  box-sizing: border-box;
+}

--- a/prow/spyglass/lenses/coverage/coverage.go
+++ b/prow/spyglass/lenses/coverage/coverage.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coverage provides a coverage viewer for Spyglass
+package coverage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"html/template"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/spyglass/lenses"
+)
+
+const (
+	name     = "coverage"
+	title    = "Coverage"
+	priority = 7
+)
+
+func init() {
+	lenses.RegisterLens(Lens{})
+}
+
+// Lens is the implementation of a coverage-rendering Spyglass lens.
+type Lens struct{}
+
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:     name,
+		Title:    title,
+		Priority: priority,
+	}
+}
+
+// Header renders the content of <head> from template.html.
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string {
+	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "header", nil); err != nil {
+		return fmt.Sprintf("<!-- FAILED EXECUTING HEADER TEMPLATE: %v -->", err)
+	}
+	return buf.String()
+}
+
+// Callback does nothing.
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string) string {
+	return ""
+}
+
+// Body renders the <body>
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string) string {
+	if len(artifacts) == 0 {
+		logrus.Error("coverage Body() called with no artifacts, which should never happen.")
+		return "Why am I here? There is no coverage file."
+	}
+
+	content, err := artifacts[0].ReadAll()
+	if err != nil {
+		logrus.WithError(err).Warn("Couldn't read a coverage file that should exist.")
+		return fmt.Sprintf("Faiiled to read the coverage file: %v", err)
+	}
+
+	coverageTemplate, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		logrus.WithError(err).Error("Error executing template.")
+		return fmt.Sprintf("Failed to load template file: %v", err)
+	}
+
+	w := &bytes.Buffer{}
+	g := gzip.NewWriter(w)
+	_, err = g.Write(content)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to compress coverage file")
+		return fmt.Sprintf("Failed to compress coverage file: %v", err)
+	}
+	if err := g.Close(); err != nil {
+		logrus.WithError(err).Warn("Failed to close gzip for coverage file")
+		return fmt.Sprintf("Failed to close gzip for coverage file: %v", err)
+	}
+	result := base64.StdEncoding.EncodeToString(w.Bytes())
+
+	t := struct {
+		CoverageContent string
+	}{
+		CoverageContent: result,
+	}
+	var buf bytes.Buffer
+	if err := coverageTemplate.ExecuteTemplate(&buf, "body", t); err != nil {
+		logrus.WithError(err).Error("Error executing template.")
+	}
+
+	return buf.String()
+}

--- a/prow/spyglass/lenses/coverage/coverage.ts
+++ b/prow/spyglass/lenses/coverage/coverage.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Color from "color";
+import {Coverage, parseCoverage} from 'io_k8s_test_infra/gopherage/cmd/html/static/parser';
+import {inflate} from "pako/lib/inflate";
+
+declare const COVERAGE_FILE: string;
+
+const NO_COVERAGE = Color('#FF0000');
+const FULL_COVERAGE = Color('#00FF00');
+
+// Inspired by https://dl.acm.org/citation.cfm?id=949654
+function renderChildren(parent: Node, coverage: Coverage, horizontal: boolean): void {
+  let offset = 0;
+  for (const child of coverage.children.values()) {
+    const node = document.createElement('div');
+    parent.appendChild(node);
+    const percentage = child.totalStatements / coverage.totalStatements * 100;
+    node.style.position = 'absolute';
+    if (horizontal) {
+      node.style.width = `${percentage}%`;
+      node.style.height = '100%';
+      node.style.top = '0';
+      node.style.left = `${offset}%`;
+    } else {
+      node.style.width = '100%';
+      node.style.height = `${percentage}%`;
+      node.style.top = `${offset}%`;
+      node.style.left = `0`;
+    }
+    offset += percentage;
+    if (child.totalFiles === 1) {
+      node.classList.add('leaf');
+      const [filename, file] = child.files.entries().next().value;
+      node.title = `${filename}: ${(file.coveredStatements / file.totalStatements * 100).toFixed(0)}%`;
+      node.style.backgroundColor = NO_COVERAGE.mix(FULL_COVERAGE, file.coveredStatements / file.totalStatements).hex();
+      // Not having a border looks weird, but using a constant colour causes tiny boxes
+      // to consist entirely of that colour. By using a border colour based on the
+      // box colour, we still show some information.
+      node.style.borderColor = Color(node.style.backgroundColor).darken(0.3).hex();
+    } else {
+      renderChildren(node, child, !horizontal);
+    }
+  }
+}
+
+window.onload = () => {
+  // Because the coverage files are a) huge, and b) compress excellently, we send it as
+  // gzipped base64. This is faster unless your internet connection is faster than
+  // about 300 Mb/s.
+  const content = inflate(atob(COVERAGE_FILE), {to: 'string'});
+  const coverage = parseCoverage(content);
+  document.getElementById('statement-coverage')!.innerText = `${(coverage.coveredStatements / coverage.totalStatements * 100).toFixed(0)}% (${coverage.coveredStatements.toLocaleString()} of ${coverage.totalStatements.toLocaleString()} statements)`;
+  document.getElementById('file-coverage')!.innerText = `${(coverage.coveredFiles / coverage.totalFiles * 100).toFixed(0)}% (${coverage.coveredFiles.toLocaleString()} of ${coverage.totalFiles.toLocaleString()} files)`;
+  renderChildren(document.getElementById('treemap')!, coverage, true);
+};

--- a/prow/spyglass/lenses/coverage/template.html
+++ b/prow/spyglass/lenses/coverage/template.html
@@ -1,0 +1,26 @@
+{{define "header"}}
+  <link rel="stylesheet" type="text/css" href="coverage.css">
+  <script type="text/javascript" src="script_bundle.es2015.js"></script>
+{{end}}
+
+{{define "body"}}
+  <script type="text/javascript">
+    var COVERAGE_FILE = {{ .CoverageContent }};
+  </script>
+  <div id="treemap" style="width: 100%; height: 300px; position: relative;">
+
+  </div>
+  <div id="stats">
+    <table class="mdl-data-table mdl-js-data-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric" style="width: 200px;">Covered statements</td>
+        <td class="mdl-data-table__cell--non-numeric" id="statement-coverage"></td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Covered files</td>
+        <td class="mdl-data-table__cell--non-numeric" id="file-coverage">{{.StartTime}}</td>
+      </tr>
+    </table>
+  </div>
+{{end}}

--- a/prow/spyglass/lenses/coverage/vendor.d.ts
+++ b/prow/spyglass/lenses/coverage/vendor.d.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// For exciting Bazel/rollup reasons (ugh), it is impossible to `import "pako"`, which
+// is the intended way to use this library. However, we *can*
+// `import "pako/lib/inflate". Unfortunately, @types/pako doesn't define this
+// module, so that then becomes a type error. This is a subset of @types/pako
+// that we actually care about,
+declare module "pako/lib/inflate" {
+  export = Pako;
+  namespace Pako {
+    interface InflateFunctionOptions {
+      windowBits?: number;
+      raw?: boolean;
+      to?: 'string';
+    }
+
+    type Data = Uint8Array | number[] | string;
+
+    /**
+     * Decompress data with inflate/ungzip and options. Autodetect format via wrapper header
+     * by default. That's why we don't provide separate ungzip method.
+     */
+    function inflate(data: Data, options: InflateFunctionOptions & { to: 'string' }): string;
+    function inflate(data: Data, options?: InflateFunctionOptions): Uint8Array;
+
+    /**
+     * The same as inflate, but creates raw data, without wrapper (header and adler32 crc).
+     */
+    function inflateRaw(data: Data, options: InflateFunctionOptions & { to: 'string' }): string;
+    function inflateRaw(data: Data, options?: InflateFunctionOptions): Uint8Array;
+
+    /**
+     * Just shortcut to inflate, because it autodetects format by header.content. Done for convenience.
+     */
+    function ungzip(data: Data, options: InflateFunctionOptions & { to: 'string' }): string;
+    function ungzip(data: Data, options?: InflateFunctionOptions): Uint8Array;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,25 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@types/color-convert@*":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-1.9.0.tgz#bfa8203e41e7c65471e9841d7e306a7cd8b5172d"
+  integrity sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.0.tgz#40f8a6bf2fd86e969876b339a837d8ff1b0a6e30"
+  integrity sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==
+  dependencies:
+    "@types/color-convert" "*"
+
 "@types/google.visualization@^0.0.43":
   version "0.0.43"
   resolved "https://registry.yarnpkg.com/@types/google.visualization/-/google.visualization-0.0.43.tgz#d4172f94292b68a49a5666033386ce177f0ead9d"
@@ -92,6 +111,11 @@
   version "10.14.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.8.tgz#fe444203ecef1162348cd6deb76c62477b2cc6e9"
   integrity sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==
+
+"@types/pako@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.1.tgz#33b237f3c9aff44d0f82fe63acffa4a365ef4a61"
+  integrity sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -189,7 +213,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -200,6 +224,27 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
+  integrity sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
 
 commander@^2.12.1:
   version "2.19.0"
@@ -407,6 +452,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -684,6 +734,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pako@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -831,6 +886,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 source-map-support@0.5.9:
   version "0.5.9"


### PR DESCRIPTION
This PR adds a coverage lens to Spyglass, and enables it for our e2e conformance coverage job. In the future we will want to link to line coverage as well (quite probably by using go's built in generation and linking to that). You can hover over a square to see the filename and statement coverage for it.

It looks like this:

![image](https://user-images.githubusercontent.com/110792/59459547-e4557d80-8dd1-11e9-8993-796aaeb2da3c.png)

/assign @spiffxp 