### PR TITLE
Add NPD test jobs with custom flags

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -118,6 +118,38 @@ periodics:
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
 
+- name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - >-
+        ./test/build.sh -f get-ci-env &&
+        source ci-custom-flags.env &&
+        /workspace/scenarios/kubernetes_e2e.py
+        --cluster=
+        --extract=ci/latest
+        --provider=gce
+        --gcp-node-image=gci
+        --gcp-zone=us-west1-b
+        --ginkgo-parallel=30
+        --test_args=--ginkgo.focus=NodeProblemDetector
+        --timeout=60m
+
 - name: ci-npd-e2e-kubernetes-gce-ubuntu
   interval: 2h
   decorate: true
@@ -140,6 +172,38 @@ periodics:
       - >-
         ./test/build.sh get-ci-env &&
         source ci.env &&
+        /workspace/scenarios/kubernetes_e2e.py
+        --cluster=
+        --extract=ci/latest
+        --provider=gce
+        --gcp-node-image=ubuntu
+        --gcp-zone=us-west1-b
+        --ginkgo-parallel=30
+        --test_args=--ginkgo.focus=NodeProblemDetector
+        --timeout=60m
+
+- name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+  interval: 2h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - >-
+        ./test/build.sh -f get-ci-env &&
+        source ci-custom-flags.env &&
         /workspace/scenarios/kubernetes_e2e.py
         --cluster=
         --extract=ci/latest

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
         - bash
         - -c
         - >-
-          ./test/build.sh pr $(PULL_NUMBER) &&
+          ./test/build.sh -p $(PULL_NUMBER) pr &&
           source pr.env &&
           cd $(GOPATH)/src/k8s.io/kubernetes &&
           /workspace/scenarios/kubernetes_e2e.py
@@ -109,7 +109,7 @@ presubmits:
         - bash
         - -c
         - >-
-          ./test/build.sh pr $(PULL_NUMBER) &&
+          ./test/build.sh -p $(PULL_NUMBER) pr &&
           source pr.env &&
           /workspace/scenarios/kubernetes_e2e.py
           --cluster=
@@ -124,6 +124,39 @@ presubmits:
         securityContext:
           privileged: true
 
+  - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/node-problem-detector
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          ./test/build.sh -p $(PULL_NUMBER) -f pr &&
+          source pr.env &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --cluster=
+          --extract=ci/latest
+          --provider=gce
+          --gcp-node-image=gci
+          --gcp-zone=us-west1-b
+          --ginkgo-parallel=30
+          --test_args=--ginkgo.focus=NodeProblemDetector
+          --timeout=60m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
 
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
     branches:
@@ -144,7 +177,41 @@ presubmits:
         - bash
         - -c
         - >-
-          ./test/build.sh pr $(PULL_NUMBER) &&
+          ./test/build.sh -p $(PULL_NUMBER) pr &&
+          source pr.env &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --cluster=
+          --extract=ci/latest
+          --provider=gce
+          --gcp-node-image=ubuntu
+          --gcp-zone=us-west1-b
+          --ginkgo-parallel=30
+          --test_args=--ginkgo.focus=NodeProblemDetector
+          --timeout=60m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+
+  - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/node-problem-detector
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          ./test/build.sh -p $(PULL_NUMBER) -f pr &&
           source pr.env &&
           /workspace/scenarios/kubernetes_e2e.py
           --cluster=

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1949,8 +1949,14 @@ test_groups:
 - name: pull-npd-e2e-kubernetes-gce-gci
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-gci
   num_columns_recent: 30
+- name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-gci-custom-flags
+  num_columns_recent: 30
 - name: pull-npd-e2e-kubernetes-gce-ubuntu
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-ubuntu
+  num_columns_recent: 30
+- name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
   num_columns_recent: 30
 
 - name: ci-npd-build
@@ -1973,8 +1979,18 @@ test_groups:
   num_columns_recent: 30
   alert_stale_results_hours: 24
   num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-gci-custom-flags
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
 - name: ci-npd-e2e-kubernetes-gce-ubuntu
   gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-ubuntu
+  num_columns_recent: 30
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
+- name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+  gcs_prefix: kubernetes-jenkins/logs/ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
   num_columns_recent: 30
   alert_stale_results_hours: 24
   num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
@@ -4542,8 +4558,16 @@ dashboards:
     test_group_name: ci-npd-e2e-kubernetes-gce-gci
     alert_options:
       alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
+    test_group_name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
   - name: ci-npd-e2e-kubernetes-gce-ubuntu
     test_group_name: ci-npd-e2e-kubernetes-gce-ubuntu
+    alert_options:
+      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
+  - name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+    test_group_name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
     alert_options:
       alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
 
@@ -5513,8 +5537,12 @@ dashboards:
     test_group_name: pull-npd-e2e-node
   - name: pull-npd-e2e-kubernetes-gce-gci
     test_group_name: pull-npd-e2e-kubernetes-gce-gci
+  - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
+    test_group_name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
     test_group_name: pull-npd-e2e-kubernetes-gce-ubuntu
+  - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
+    test_group_name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
 
 - name: google-rules_k8s
   dashboard_tab:


### PR DESCRIPTION
This PR adds NPD test jobs with custom flags. This is part of https://github.com/kubernetes/node-problem-detector/issues/291.