### PR TITLE
Pass `false` instead of `null` for admin enforcement

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -207,7 +207,6 @@ new_git_repository(
     name = "operator_framework_community_operators",
     commit = "42131df7167ec0b264c892c1f3c49ba9a72142da",
     remote = "https://github.com/operator-framework/community-operators.git",
-    shallow_since = "1559569397 +0200",
     build_file_content = """
 exports_files([
     "upstream-community-operators/prometheus/alertmanager.crd.yaml",

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -268,6 +268,7 @@ func split(branch string) (string, string, string) {
 
 func TestProtect(t *testing.T) {
 	yes := true
+	no := false
 
 	cases := []struct {
 		name              string
@@ -303,22 +304,28 @@ branch-protection:
 `,
 			expected: []requirements{
 				{
-					Org:     "cfgdef",
-					Repo:    "repo1",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
-					Org:     "cfgdef",
-					Repo:    "repo1",
-					Branch:  "branch",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
-					Org:     "cfgdef",
-					Repo:    "repo2",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "cfgdef",
+					Repo:   "repo2",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 			},
 		},
@@ -335,10 +342,12 @@ branch-protection:
 `,
 			expected: []requirements{
 				{
-					Org:     "this",
-					Repo:    "yes",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "this",
+					Repo:   "yes",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
 					Org:     "that",
@@ -369,16 +378,19 @@ branch-protection:
 					Repo:   "test-infra",
 					Branch: "master",
 					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
 						RequiredStatusChecks: &github.RequiredStatusChecks{
 							Contexts: []string{"hello-world"},
 						},
 					},
 				},
 				{
-					Org:     "kubernetes",
-					Repo:    "publishing-bot",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "kubernetes",
+					Repo:   "publishing-bot",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 			},
 		},
@@ -439,16 +451,20 @@ branch-protection:
 `,
 			expected: []requirements{
 				{
-					Org:     "org",
-					Repo:    "repo1",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "org",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
-					Org:     "org",
-					Repo:    "repo1",
-					Branch:  "branch",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "org",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
 					Org:     "org",
@@ -472,16 +488,20 @@ branch-protection:
 			archived: "skip",
 			expected: []requirements{
 				{
-					Org:     "org",
-					Repo:    "repo1",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "org",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 				{
-					Org:     "org",
-					Repo:    "repo1",
-					Branch:  "branch",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "org",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 			},
 		},
@@ -506,6 +526,7 @@ branch-protection:
 					Repo:   "repo",
 					Branch: "master",
 					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
 						RequiredStatusChecks: &github.RequiredStatusChecks{
 							Contexts: []string{"duplicate-context", "hello-world"},
 						},
@@ -544,6 +565,7 @@ branch-protection:
 					Repo:   "repo",
 					Branch: "master",
 					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
 						RequiredStatusChecks: &github.RequiredStatusChecks{
 							Contexts: []string{"config-presubmit", "org-presubmit", "repo-presubmit", "branch-presubmit"},
 						},
@@ -582,6 +604,7 @@ branch-protection:
 					Repo:   "repo",
 					Branch: "master",
 					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
 						Restrictions: &github.RestrictionsRequest{
 							Users: &[]string{},
 							Teams: &[]string{"config-team", "org-team", "repo-team", "branch-team"},
@@ -703,10 +726,12 @@ branch-protection:
 			startUnprotected: true,
 			expected: []requirements{
 				{
-					Org:     "protect",
-					Repo:    "update",
-					Branch:  "master",
-					Request: &github.BranchProtectionRequest{},
+					Org:    "protect",
+					Repo:   "update",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
 				},
 			},
 		},

--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -35,12 +35,17 @@ func makeRequest(policy branchprotection.Policy) github.BranchProtectionRequest 
 
 }
 
-// makeAdmins returns true iff *val == true, else nil
+// makeAdmins returns true iff *val == true, else false
+// TODO(skuznets): the API documentation tells us to pass
+//    `nil` to unset, but that is broken so we need to pass
+//    false. Change back when it's fixed
 func makeAdmins(val *bool) *bool {
-	if v := makeBool(val); v {
-		return &v
+	if val != nil {
+		return val
+	} else {
+		no := false
+		return &no
 	}
-	return nil
 }
 
 // makeBool returns true iff *val == true

--- a/prow/cmd/branchprotector/request_test.go
+++ b/prow/cmd/branchprotector/request_test.go
@@ -118,6 +118,7 @@ func TestMakeReviews(t *testing.T) {
 
 func TestMakeRequest(t *testing.T) {
 	yes := true
+	no := false
 	cases := []struct {
 		name     string
 		policy   branchprotection.Policy
@@ -125,6 +126,9 @@ func TestMakeRequest(t *testing.T) {
 	}{
 		{
 			name: "Empty works",
+			expected: github.BranchProtectionRequest{
+				EnforceAdmins: &no,
+			},
 		},
 		{
 			name: "teams != nil => users != nil",
@@ -134,6 +138,7 @@ func TestMakeRequest(t *testing.T) {
 				},
 			},
 			expected: github.BranchProtectionRequest{
+				EnforceAdmins: &no,
 				Restrictions: &github.RestrictionsRequest{
 					Teams: &[]string{"hello"},
 					Users: &[]string{},
@@ -148,6 +153,7 @@ func TestMakeRequest(t *testing.T) {
 				},
 			},
 			expected: github.BranchProtectionRequest{
+				EnforceAdmins: &no,
 				Restrictions: &github.RestrictionsRequest{
 					Users: &[]string{"there"},
 					Teams: &[]string{},
@@ -162,6 +168,7 @@ func TestMakeRequest(t *testing.T) {
 				},
 			},
 			expected: github.BranchProtectionRequest{
+				EnforceAdmins: &no,
 				RequiredStatusChecks: &github.RequiredStatusChecks{
 					Strict:   true,
 					Contexts: []string{},


### PR DESCRIPTION
Although the GitHub API description states we should be passing `nil` to
the field when we want it to be unset, the API does not respond
correctly and we must instead explicitly pass `false`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 

I have a GitHub support ticket open but for now ...