### PR TITLE
Improve spyglass lens configuration

### DIFF
--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
   var src = {{.Source}};
   var lensArtifacts = {{.LensArtifacts}};
-  var lenses = {{.LensNames}};
+  var lensIndexes = {{.LensIndexes}};
 </script>
 <script type="text/javascript" src="/static/spyglass_bundle.min.js"></script>
 <link rel="stylesheet" type="text/css" href="/static/spyglass/spyglass.css">
@@ -30,13 +30,15 @@
     {{end}}
   </div>
   {{end}}
-  {{range .Lenses}}
-  {{$config:=.Config}}
+  {{$lenses:=.Lenses}}
+  {{range $index := .LensIndexes}}
+  {{$lens:=index $lenses $index}}
+  {{$config:=$lens.Config}}
   <div class="mdl-card mdl-shadow--2dp lens-card">
     <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
-    <div id="{{.Config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
+    <div id="{{$config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
       <img src="/static/kubernetes-wheel.svg" alt="loading spinner" class="loading-spinner is-active lens-card-loading" id="{{$config.Name}}-loading">
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$config.Name}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
     </div>
   </div>
   {{end}}

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -53,7 +53,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header executes the "header" section of the template.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
 	return executeTemplate(resourceDir, "header", BuildLogsView{})
 }
 
@@ -117,7 +117,7 @@ type BuildLogsView struct {
 }
 
 // Body returns the <body> content for a build log (or multiple build logs)
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	buildLogsView := BuildLogsView{
 		LogViews:           []LogArtifactView{},
 		RawGetAllRequests:  make(map[string]string),
@@ -144,7 +144,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 }
 
 // Callback is used to retrieve new log segments
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	var request LineRequest
 	err := json.Unmarshal([]byte(data), &request)
 	if err != nil {

--- a/prow/spyglass/lenses/coverage/coverage.go
+++ b/prow/spyglass/lenses/coverage/coverage.go
@@ -53,7 +53,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the content of <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -66,12 +66,12 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	return ""
 }
 
 // Body renders the <body>
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	if len(artifacts) == 0 {
 		logrus.Error("coverage Body() called with no artifacts, which should never happen.")
 		return "Why am I here? There is no coverage file."

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -54,7 +54,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the content of <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -67,7 +67,7 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	return ""
 }
 
@@ -86,7 +86,7 @@ type TestResult struct {
 }
 
 // Body renders the <body> for JUnit tests
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	type testResults struct {
 		junit []junit.Result
 		link  string

--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -60,13 +60,13 @@ type Lens interface {
 	// Config returns a LensConfig that describes the lens.
 	Config() LensConfig
 	// Header returns a a string that is injected into the rendered lens's <head>
-	Header(artifacts []Artifact, resourceDir string) string
+	Header(artifacts []Artifact, resourceDir string, config interface{}) string
 	// Body returns a string that is initially injected into the rendered lens's <body>.
 	// The lens's front-end code may call back to Body again, passing in some data string of its choosing.
-	Body(artifacts []Artifact, resourceDir string, data string) string
+	Body(artifacts []Artifact, resourceDir string, data string, config interface{}) string
 	// Callback receives a string sent by the lens's front-end code and returns another string to be returned
 	// to that frontend code.
-	Callback(artifacts []Artifact, resourceDir string, data string) string
+	Callback(artifacts []Artifact, resourceDir string, data string, config interface{}) string
 }
 
 // Artifact represents some output of a prow job

--- a/prow/spyglass/lenses/lenses_test.go
+++ b/prow/spyglass/lenses/lenses_test.go
@@ -89,11 +89,11 @@ func (dumpLens) Config() LensConfig {
 	}
 }
 
-func (dumpLens) Header(artifacts []Artifact, resourceDir string) string {
+func (dumpLens) Header(artifacts []Artifact, resourceDir string, config interface{}) string {
 	return ""
 }
 
-func (dumpLens) Body(artifacts []Artifact, resourceDir, data string) string {
+func (dumpLens) Body(artifacts []Artifact, resourceDir string, data string, config interface{}) string {
 	var view []byte
 	for _, a := range artifacts {
 		data, err := a.ReadAll()
@@ -106,7 +106,7 @@ func (dumpLens) Body(artifacts []Artifact, resourceDir, data string) string {
 	return string(view)
 }
 
-func (dumpLens) Callback(artifacts []Artifact, resourceDir, data string) string {
+func (dumpLens) Callback(artifacts []Artifact, resourceDir string, data string, config interface{}) string {
 	return ""
 }
 
@@ -163,7 +163,7 @@ crazy`,
 		if tc.err == nil && lens == nil {
 			t.Fatalf("Expected lens %s but got nil.", tc.lensName)
 		}
-		if lens != nil && lens.Body(tc.artifacts, "", tc.raw) != tc.expected {
+		if lens != nil && lens.Body(tc.artifacts, "", tc.raw, nil) != tc.expected {
 			t.Errorf("%s expected view to be %s but got %s", tc.name, tc.expected, lens)
 		}
 	}

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -56,7 +56,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -69,12 +69,12 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string) string 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	return ""
 }
 
 // Body creates a view for prow job metadata.
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
 	var buf bytes.Buffer
 	type MetadataViewData struct {
 		Status       string


### PR DESCRIPTION
Currently, Spyglass lens configuration maps regexes to lists of lenses, like this:

```yaml
viewers:
  "started.json|finished.json":
  - "metadata"
  "build-log.txt":
  - "buildlog"
  "artifacts/junit.*\\.xml":
  - "junit"
```

This configuration poses some problems. Most notably, it is impossible to attach any additional information to the setup, such as configuration for the lens. It also provides lenses with no way to access artifacts that should not necessarily cause the lens to appear, but which the lens might like to use if they do happen to exist and it has otherwise appeared.

Additionally, it suggests that multiple instances of a single lens should be able to exist on a single page. This isn't true: if a lens appears more than once on a Spyglass page, things will break.

This PR implements a new config format, which might look like this:

```yaml
lenses:
- required_files:
  - started.json
  optional_files:
  - finished.json
  lens:
    name: metadata
- required_files:
  - build-log.txt
  lens:
    name: buildlog
    config:
      highlight_regexes:
      - timed out
      - 'ERROR:'
      - (\s|^)(FAIL|Failure \[)\b
      - (\s|^)panic\b
      - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
- required_files:
  - artifacts/junit.*\.xml
  lens:
    name: junit
```

This is somewhat more verbose, but comes with some benefits:

- We can specify whether files are optional or required
- We can required multiple files to exist to trigger a lens
- There is space to attach additional configuration information for a lens
- It leaves room for future expansion (e.g. overriding lens names or priorities)

The existing format is still supported by this PR, and will be translated to the new one during config loading. It does drop support for the _previous_ configuration remapping, and thus closes #10274.

This PR additionally makes it possible to include a single lens on a page more than once, with different configurations, if desired.

This PR does _not_ implement the `highlight_regexes` example above in the buildlog lens, but I have a followup PR that does.