### PR TITLE
Set E2E_VERBOSITY 8 for API operation logs

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3528,6 +3528,9 @@ presubmits:
         - --
         - -c
         - cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-e2e.sh
+        env:
+        - name: E2E_VERBOSITY
+          value: "8"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -43,6 +43,10 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
+          env:
+            # This E2E_VERBOSITY 8 is for outputting API operations on e2e.log
+            - name: E2E_VERBOSITY
+              value: "8"
 
 periodics:
   # conformance test using image against kubernetes master branch with `kind`


### PR DESCRIPTION
This sets 8 as E2E_VERBOSITY for outputting API operation on e2e.log
of pull-kubernetes-conformance-image-test job to verify confirmance
tests use GA APIs only as the requirement.

This comes from https://github.com/kubernetes/kubernetes/pull/78606

/cc @dims @timothysc @johnSchnake
