### PR TITLE
Enable admin access to grafana in prow-monitoring

### DIFF
--- a/prow/monitoring/grafana_configmaps.yaml
+++ b/prow/monitoring/grafana_configmaps.yaml
@@ -24,9 +24,6 @@ metadata:
   name: grafana-config
 data:
   grafana.ini: |
-    [auth]
-    disable_login_form = true
-    disable_signout_menu = true
     [auth.basic]
     enabled = false
     [auth.anonymous]

--- a/prow/monitoring/grafana_deployment.yaml
+++ b/prow/monitoring/grafana_deployment.yaml
@@ -20,6 +20,14 @@ spec:
         - -config=/etc/grafana/grafana.ini
         image: grafana/grafana:6.1.4
         name: grafana
+        env:
+          - name: GF_SECURITY_ADMIN_USER
+            value: adm
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: password
         ports:
         - containerPort: 3001
           name: http

--- a/prow/monitoring/grafana_secret.yaml
+++ b/prow/monitoring/grafana_secret.yaml
@@ -1,0 +1,10 @@
+### Please modify CHANGE_ME before
+### kubectl apply -f grafana_secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: prow-monitoring
+  name: grafana
+type: Opaque
+stringData:
+  password: CHANGE_ME


### PR DESCRIPTION
This PR enables the admin access to the grafana instance.
The `password` is from a `secret`: The simplest way is to create it manually. We could also integrate the update of the secret into the CI system (eg, postsubmit action: `sed` the secret yaml file and then `kubectl apply -f`). 