### PR TITLE
reintroduce dryrun on all cloud-provider-vsphere conformance tests

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -156,6 +156,8 @@ periodics:
       env:
       - name: K8S_VERSION
         value: ci/latest.txt
+      - name: DESTROY_FORCE
+        value: "dryrun"
 - name: ci-cloud-provider-vsphere-conformance-stable-1-14
   interval: 12h
   decorate: true
@@ -182,6 +184,8 @@ periodics:
       env:
       - name: K8S_VERSION
         value: release/stable-1.14.txt
+      - name: DESTROY_FORCE
+        value: "dryrun"
 - name: ci-cloud-provider-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
@@ -208,6 +212,8 @@ periodics:
       env:
       - name: K8S_VERSION
         value: release/stable-1.13.txt
+      - name: DESTROY_FORCE
+        value: "dryrun"
 - name: ci-cloud-provider-vsphere-conformance-stable-1-12
   interval: 12h
   decorate: true
@@ -234,6 +240,8 @@ periodics:
       env:
       - name: K8S_VERSION
         value: release/stable-1.12.txt
+      - name: DESTROY_FORCE
+        value: "dryrun"
 
 # Runs the e2e conformance suite against a cluster turned up with the
 # in-tree vSphere cloud provider. This job is duplicated for multiple versions


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

This re-introduce dry-running the delete for clusters generated by all cloud-provider-vsphere conformance jobs. This is an attempt to get the root cause of latest failures.


/assign @akutz 