### PR TITLE
Allow nested jUnit suites

### DIFF
--- a/testgrid/metadata/junit/junit.go
+++ b/testgrid/metadata/junit/junit.go
@@ -34,6 +34,7 @@ type Suites struct {
 // Suite holds <testsuite/> results
 type Suite struct {
 	XMLName  xml.Name `xml:"testsuite"`
+	Suites   []Suite  `xml:"testsuite"`
 	Name     string   `xml:"name,attr"`
 	Time     float64  `xml:"time,attr"` // Seconds
 	Failures int      `xml:"failures,attr"`


### PR DESCRIPTION
Some providers will nest jUnit suites to subdivide jUnit output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @katharine @michelle192837 