### PR TITLE
Make buildlog lens regex configurable

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -20,6 +20,7 @@ package config
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -284,7 +285,7 @@ type LensConfig struct {
 	Name string `json:"name"`
 	// Config is some lens-specific configuration. Interpreting it is the responsibility of the
 	// lens in question.
-	Config interface{} `json:"config"`
+	Config json.RawMessage `json:"config"`
 }
 
 // LensFileConfig is a single entry under Lenses, describing how to configure a lens

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -53,7 +53,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header executes the "header" section of the template.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
 	return executeTemplate(resourceDir, "header", BuildLogsView{})
 }
 
@@ -117,7 +117,7 @@ type BuildLogsView struct {
 }
 
 // Body returns the <body> content for a build log (or multiple build logs)
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
 	buildLogsView := BuildLogsView{
 		LogViews:           []LogArtifactView{},
 		RawGetAllRequests:  make(map[string]string),
@@ -144,7 +144,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 }
 
 // Callback is used to retrieve new log segments
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
 	var request LineRequest
 	err := json.Unmarshal([]byte(data), &request)
 	if err != nil {

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -40,6 +40,10 @@ const (
 	maxHighlightLength = 10000 // Maximum length of a line worth highlighting
 )
 
+type config struct {
+	HighlightRegexes []string `json:"highlight_regexes"`
+}
+
 // Lens implements the build lens.
 type Lens struct{}
 
@@ -57,8 +61,9 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config 
 	return executeTemplate(resourceDir, "header", BuildLogsView{})
 }
 
-// errRE matches keywords and glog error messages
-var errRE = regexp.MustCompile(`timed out|ERROR:|(\s|^)(FAIL|Failure \[)\b|(\s|^)panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
+// defaultErrRE matches keywords and glog error messages.
+// It is only used if higlight_regexes is not specified in the lens config.
+var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(\s|^)(FAIL|Failure \[)\b|(\s|^)panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
 
 func init() {
 	lenses.RegisterLens(Lens{})
@@ -116,6 +121,24 @@ type BuildLogsView struct {
 	RawGetMoreRequests map[string]string
 }
 
+func getHighlightRegex(rawConfig json.RawMessage) *regexp.Regexp {
+	var c config
+	if err := json.Unmarshal(rawConfig, &c); err != nil {
+		logrus.WithError(err).Error("Failed to decode buildlog config")
+		return defaultErrRE
+	}
+	if len(c.HighlightRegexes) == 0 {
+		return defaultErrRE
+	}
+
+	re, err := regexp.Compile(strings.Join(c.HighlightRegexes, "|"))
+	if err != nil {
+		logrus.WithError(err).Warn("Couldn't compile %q", c.HighlightRegexes)
+		return defaultErrRE
+	}
+	return re
+}
+
 // Body returns the <body> content for a build log (or multiple build logs)
 func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
 	buildLogsView := BuildLogsView{
@@ -124,6 +147,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		RawGetMoreRequests: make(map[string]string),
 	}
 
+	highlightRe := getHighlightRegex(rawConfig)
 	// Read log artifacts and construct template structs
 	for _, a := range artifacts {
 		av := LogArtifactView{
@@ -135,7 +159,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 			logrus.WithError(err).Info("Error reading log.")
 			continue
 		}
-		av.LineGroups = groupLines(highlightLines(lines, 0))
+		av.LineGroups = groupLines(highlightLines(lines, 0, highlightRe))
 		av.ViewAll = true
 		buildLogsView.LogViews = append(buildLogsView.LogViews, av)
 	}
@@ -165,7 +189,7 @@ func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data 
 		return fmt.Sprintf("failed to retrieve log lines: %v", err)
 	}
 
-	logLines := highlightLines(lines, request.StartLine)
+	logLines := highlightLines(lines, request.StartLine, getHighlightRegex(rawConfig))
 	return executeTemplate(resourceDir, "line group", logLines)
 }
 
@@ -205,19 +229,19 @@ func logLines(artifact lenses.Artifact, offset, length int64) ([]string, error) 
 	return strings.Split(string(b), "\n"), nil
 }
 
-func highlightLines(lines []string, startLine int) []LogLine {
+func highlightLines(lines []string, startLine int, highlightRegex *regexp.Regexp) []LogLine {
 	// mark highlighted lines
 	logLines := make([]LogLine, 0, len(lines))
 	for i, text := range lines {
 		length := len(text)
 		subLines := []SubLine{}
 		if length <= maxHighlightLength {
-			loc := errRE.FindStringIndex(text)
+			loc := highlightRegex.FindStringIndex(text)
 			for loc != nil {
 				subLines = append(subLines, SubLine{false, text[:loc[0]]})
 				subLines = append(subLines, SubLine{true, text[loc[0]:loc[1]]})
 				text = text[loc[1]:]
-				loc = errRE.FindStringIndex(text)
+				loc = highlightRegex.FindStringIndex(text)
 			}
 		}
 		subLines = append(subLines, SubLine{false, text})

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -172,7 +172,7 @@ func TestGroupLines(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := groupLines(highlightLines(test.lines, 0))
+			got := groupLines(highlightLines(test.lines, 0, defaultErrRE))
 			if len(got) != len(test.groups) {
 				t.Fatalf("Expected %d groups, got %d", len(test.groups), len(got))
 			}

--- a/prow/spyglass/lenses/coverage/coverage.go
+++ b/prow/spyglass/lenses/coverage/coverage.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"path/filepath"
@@ -53,7 +54,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the content of <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -66,12 +67,12 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	return ""
 }
 
 // Body renders the <body>
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	if len(artifacts) == 0 {
 		logrus.Error("coverage Body() called with no artifacts, which should never happen.")
 		return "Why am I here? There is no coverage file."

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -19,6 +19,7 @@ package junit
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"path/filepath"
@@ -54,7 +55,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the content of <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -67,7 +68,7 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	return ""
 }
 
@@ -86,7 +87,7 @@ type TestResult struct {
 }
 
 // Body renders the <body> for JUnit tests
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	type testResults struct {
 		junit []junit.Result
 		link  string

--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -20,6 +20,7 @@ package lenses
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/sirupsen/logrus"
@@ -60,13 +61,13 @@ type Lens interface {
 	// Config returns a LensConfig that describes the lens.
 	Config() LensConfig
 	// Header returns a a string that is injected into the rendered lens's <head>
-	Header(artifacts []Artifact, resourceDir string, config interface{}) string
+	Header(artifacts []Artifact, resourceDir string, config json.RawMessage) string
 	// Body returns a string that is initially injected into the rendered lens's <body>.
 	// The lens's front-end code may call back to Body again, passing in some data string of its choosing.
-	Body(artifacts []Artifact, resourceDir string, data string, config interface{}) string
+	Body(artifacts []Artifact, resourceDir string, data string, config json.RawMessage) string
 	// Callback receives a string sent by the lens's front-end code and returns another string to be returned
 	// to that frontend code.
-	Callback(artifacts []Artifact, resourceDir string, data string, config interface{}) string
+	Callback(artifacts []Artifact, resourceDir string, data string, config json.RawMessage) string
 }
 
 // Artifact represents some output of a prow job

--- a/prow/spyglass/lenses/lenses_test.go
+++ b/prow/spyglass/lenses/lenses_test.go
@@ -19,6 +19,7 @@ package lenses
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 
@@ -89,11 +90,11 @@ func (dumpLens) Config() LensConfig {
 	}
 }
 
-func (dumpLens) Header(artifacts []Artifact, resourceDir string, config interface{}) string {
+func (dumpLens) Header(artifacts []Artifact, resourceDir string, config json.RawMessage) string {
 	return ""
 }
 
-func (dumpLens) Body(artifacts []Artifact, resourceDir string, data string, config interface{}) string {
+func (dumpLens) Body(artifacts []Artifact, resourceDir string, data string, config json.RawMessage) string {
 	var view []byte
 	for _, a := range artifacts {
 		data, err := a.ReadAll()
@@ -106,7 +107,7 @@ func (dumpLens) Body(artifacts []Artifact, resourceDir string, data string, conf
 	return string(view)
 }
 
-func (dumpLens) Callback(artifacts []Artifact, resourceDir string, data string, config interface{}) string {
+func (dumpLens) Callback(artifacts []Artifact, resourceDir string, data string, config json.RawMessage) string {
 	return ""
 }
 

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -56,7 +56,7 @@ func (lens Lens) Config() lenses.LensConfig {
 }
 
 // Header renders the <head> from template.html.
-func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
 		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
@@ -69,12 +69,12 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config 
 }
 
 // Callback does nothing.
-func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	return ""
 }
 
 // Body creates a view for prow job metadata.
-func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	var buf bytes.Buffer
 	type MetadataViewData struct {
 		Status       string

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -18,6 +18,7 @@ package spyglass
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
@@ -182,11 +183,11 @@ func (dumpLens) Config() lenses.LensConfig {
 	}
 }
 
-func (dumpLens) Header(artifacts []lenses.Artifact, resourceDir string, config interface{}) string {
+func (dumpLens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
 	return ""
 }
 
-func (dumpLens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (dumpLens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	var view []byte
 	for _, a := range artifacts {
 		data, err := a.ReadAll()
@@ -199,7 +200,7 @@ func (dumpLens) Body(artifacts []lenses.Artifact, resourceDir string, data strin
 	return string(view)
 }
 
-func (dumpLens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config interface{}) string {
+func (dumpLens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
 	return ""
 }
 


### PR DESCRIPTION
This PR makes the highlight regex used by the buildlog lens configurable, as promised in #13030. In so doing, it fixes #12662. The config looks like this:

```yaml
- required_files:
  - build-log.txt
  lens:
    name: buildlog
    config:
      highlight_regexes:
      - timed out
      - 'ERROR:'
      - (\s|^)(FAIL|Failure \[)\b
      - (\s|^)panic\b
      - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
```

If `highlight_regexes` is empty or not specified, or the config is still using the old style, the existing value is used by default.

This PR also changes the type of the lens config from `interface{}` to ` json.RawMessage`, making the intent more explicit.