### PR TITLE
Correct other uses of ci/latest for gke to ci-cross/latest

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -22,7 +22,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=cos_containerd
       - --gcp-zone=us-central1-f
@@ -325,7 +325,7 @@ periodics:
       - --cluster=
       - --deployment=gke
       - --down=false
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=cos_containerd
       - --gcp-project=k8s-jkns-e2e-gci-gke-staging

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -262,7 +262,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=ca
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-e2e-gci-gke-autoscaling
@@ -288,7 +288,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=hpa
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-e2e-gci-gke-autoscaling
@@ -313,7 +313,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-gci-autoscaling-regio

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -59,7 +59,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -84,7 +84,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -477,7 +477,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -505,7 +505,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -531,7 +531,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -558,7 +558,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
@@ -15,7 +15,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -24,7 +24,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
 
 # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
@@ -45,7 +45,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -55,7 +55,7 @@ periodics:
       - --skew
       - --timeout=1200m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
 
 - interval: 2h
@@ -73,7 +73,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -84,7 +84,7 @@ periodics:
       - --skew
       - --timeout=1200m
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
 
 - interval: 2h
@@ -102,7 +102,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -112,7 +112,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
 
 - interval: 2h
@@ -130,7 +130,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -139,7 +139,7 @@ periodics:
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-master
 
 - interval: 2h
@@ -157,7 +157,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --extract=ci/k8s-stable2
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -552,7 +552,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -580,7 +580,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
@@ -15,7 +15,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-k80
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -42,7 +42,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-p100
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -69,7 +69,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-v100
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-gke-gpu-boskos-v100

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
@@ -13,7 +13,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -65,7 +65,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -91,7 +91,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -248,7 +248,7 @@ periodics:
       - --check-leaked-resources
       - --deployment=gke
       - --env=NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
       - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -147,7 +147,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -219,7 +219,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
@@ -267,7 +267,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-e2e-gke-stackdriver

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -379,7 +379,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=ingress-project
@@ -405,7 +405,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci/latest
+      - --extract=ci-cross/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
Several other configs were using GKE but extracting from ci/latest
instead of ci-cross/latest. Same issue as #12742.

Some other tests, unfortunately, use builds that don't have cross-build equivalents (ci/k8s-beta, ci/k8s-stable1, etc.). @krzyzacy is going to look at making it possible to use official GKE builds, instead of OSS CI builds which don't necessarily have the same config and output that GKE expects.

/assign @krzyzacy 
/cc @seans3 @jpbetz 