### PR TITLE
Revert "Bump all 0.26.x pinned bazel versions to 0.26.1"

### DIFF
--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -5,7 +5,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.26.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - bazel
         args:
@@ -16,6 +16,6 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.26.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - ./hack/verify-all.sh

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.26.1
+    - image: launcher.gcr.io/google/bazel:0.26.0
       command:
       - hack/bazel.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -24,7 +24,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.26.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - hack/bazel.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.26.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         command:
         - hack/bazel.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -6,7 +6,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.26.1
+      - image: launcher.gcr.io/google/bazel:0.26.0
         imagePullPolicy: Always
         command:
         - bazel
@@ -589,7 +589,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.26.1
+    - image: launcher.gcr.io/google/bazel:0.26.0
       imagePullPolicy: Always
       command:
       - bazel
@@ -720,7 +720,7 @@ periodics:
       base_ref: master
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.26.1
+    - image: launcher.gcr.io/google/bazel:0.26.0
       command:
       - bazel
       args:


### PR DESCRIPTION
I strongly suspect this commit broke test-infra presubmits.

This is half of #13062.
