### PR TITLE
Update kubekins-e2e image used by cluster-api-provider-aws jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
       command:
       - "./scripts/ci-aws-cred-test.sh"
 - name: periodic-cluster-api-provider-aws-bazel-e2e
@@ -32,7 +32,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
       command: ["runner.sh"]
       args: ["make", "e2e"]
       env:
@@ -59,7 +59,7 @@ postsubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command: ["runner.sh"]
         args: ["make", "e2e"]
         env:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,8 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command:
         - "./hack/verify-bazel.sh"
   - name: pull-cluster-api-provider-aws-bazel-test
@@ -18,8 +17,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command:
         - "./scripts/ci-bazel-test.sh"
   - name: pull-cluster-api-provider-aws-bazel-build
@@ -29,8 +27,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command:
         - "./scripts/ci-bazel-build.sh"
   - name: pull-cluster-api-provider-aws-bazel-integration
@@ -42,8 +39,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command:
         - "runner.sh"
         - "./scripts/ci-bazel-integration.sh"
@@ -72,7 +68,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190614-260dce7-1.15
         command:
         - "./hack/verify_boilerplate.py"


### PR DESCRIPTION
We need a newer version of bazel, so update the kubekins-e2e image to one with a new enough version of bazel.

/assign @chuckha 