### PR TITLE
Don't use cwd for image builder image entrypoint

### DIFF
--- a/images/builder/run.sh
+++ b/images/builder/run.sh
@@ -24,7 +24,7 @@ gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIAL
 echo "Running..."
 if [[ ! -z "${ARTIFACTS}" ]]; then
   echo "\$ARTIFACTS is set, sending logs to ${ARTIFACTS}"
-  ./builder --log-dir="${ARTIFACTS}" "$@"
+  /builder --log-dir="${ARTIFACTS}" "$@"
 else
-  ./builder "$@"
+  /builder "$@"
 fi


### PR DESCRIPTION
This works poorly when run under podutils, which changes the cwd.