### PR TITLE
Removal of commands.md redirect file

### DIFF
--- a/prow/commands.md
+++ b/prow/commands.md
@@ -1,7 +1,0 @@
-# k8s Bot Commands
-
-The command list has been migrated to https://go.k8s.io/bot-commands
-
-<!--
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
--->


### PR DESCRIPTION
This file was tombstoned by @cblecker in February, with removal slated for 3 months later or kubernetes 1.10. Both milestones have passed.

I have codesearched through kubernetes looking for references to the old commands help file, and I found three and filed PRs to fix those links:
[Kubefed](https://github.com/kubernetes-sigs/kubefed/pull/1001)
[Cluster Registry](https://github.com/kubernetes/cluster-registry/pull/275)
[Kops - ES](https://github.com/kubernetes/kops/issues/7161). Filed as an issue because I can't claim to speak spanish.