### PR TITLE
Enable metrics serving on ghproxy

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -55,6 +55,7 @@ spec:
         - --cache-dir=/cache
         - --cache-sizeGB=99
         - --push-gateway=pushgateway
+        - --serve-metrics=true
         ports:
         - containerPort: 8888
         volumeMounts:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/blob/e4c04640c21b369fb2bc418a93f9061d257ce7fa/ghproxy/ghproxy.go#L120