### PR TITLE
Enable basic.auth on grafana of prow-monitoring

### DIFF
--- a/prow/monitoring/grafana_configmaps.yaml
+++ b/prow/monitoring/grafana_configmaps.yaml
@@ -24,8 +24,6 @@ metadata:
   name: grafana-config
 data:
   grafana.ini: |
-    [auth.basic]
-    enabled = false
     [auth.anonymous]
     enabled = true
     org_role = Viewer


### PR DESCRIPTION
Currently, adm can login but that is it. adm cannot, eg,
`save dashboard`, because `permission denied`.

Hopefully this will unblock the admin operations.

https://grafana.com/docs/auth/overview/#basic-authentication