### PR TITLE
Expose blocker issues in tide status contexts

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
         "//vendor/github.com/shurcooL/githubv4:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -43,25 +43,25 @@ type Blocker struct {
 	// TODO: time blocked? (when blocker label was added)
 }
 
-type orgRepo struct {
-	org, repo string
+type OrgRepo struct {
+	Org, Repo string
 }
 
-type orgRepoBranch struct {
-	org, repo, branch string
+type OrgRepoBranch struct {
+	Org, Repo, Branch string
 }
 
 // Blockers holds maps of issues that are blocking various repos/branches.
 type Blockers struct {
-	Repo   map[orgRepo][]Blocker       `json:"repo,omitempty"`
-	Branch map[orgRepoBranch][]Blocker `json:"branch,omitempty"`
+	Repo   map[OrgRepo][]Blocker       `json:"repo,omitempty"`
+	Branch map[OrgRepoBranch][]Blocker `json:"branch,omitempty"`
 }
 
 // GetApplicable returns the subset of blockers applicable to the specified branch.
 func (b Blockers) GetApplicable(org, repo, branch string) []Blocker {
 	var res []Blocker
-	res = append(res, b.Repo[orgRepo{org: org, repo: repo}]...)
-	res = append(res, b.Branch[orgRepoBranch{org: org, repo: repo, branch: branch}]...)
+	res = append(res, b.Repo[OrgRepo{Org: org, Repo: repo}]...)
+	res = append(res, b.Branch[OrgRepoBranch{Org: org, Repo: repo, Branch: branch}]...)
 
 	sort.Slice(res, func(i, j int) bool {
 		return res[i].Number < res[j].Number
@@ -86,7 +86,7 @@ func FindAll(ghc githubClient, log *logrus.Entry, label, orgRepoTokens string) (
 
 func fromIssues(issues []Issue, log *logrus.Entry) Blockers {
 	log.Debugf("Finding blockers from %d issues.", len(issues))
-	res := Blockers{Repo: make(map[orgRepo][]Blocker), Branch: make(map[orgRepoBranch][]Blocker)}
+	res := Blockers{Repo: make(map[OrgRepo][]Blocker), Branch: make(map[OrgRepoBranch][]Blocker)}
 	for _, issue := range issues {
 		logger := log.WithFields(logrus.Fields{"org": issue.Repository.Owner.Login, "repo": issue.Repository.Name, "issue": issue.Number})
 		strippedTitle := branchRE.ReplaceAllLiteralString(string(issue.Title), "")
@@ -97,18 +97,18 @@ func fromIssues(issues []Issue, log *logrus.Entry) Blockers {
 		}
 		if branches := parseBranches(string(issue.Title)); len(branches) > 0 {
 			for _, branch := range branches {
-				key := orgRepoBranch{
-					org:    string(issue.Repository.Owner.Login),
-					repo:   string(issue.Repository.Name),
-					branch: branch,
+				key := OrgRepoBranch{
+					Org:    string(issue.Repository.Owner.Login),
+					Repo:   string(issue.Repository.Name),
+					Branch: branch,
 				}
 				logger.WithField("branch", branch).Debug("Blocking merges to branch via issue.")
 				res.Branch[key] = append(res.Branch[key], block)
 			}
 		} else {
-			key := orgRepo{
-				org:  string(issue.Repository.Owner.Login),
-				repo: string(issue.Repository.Name),
+			key := OrgRepo{
+				Org:  string(issue.Repository.Owner.Login),
+				Repo: string(issue.Repository.Name),
 			}
 			logger.Debug("Blocking merges to all branches via issue.")
 			res.Repo[key] = append(res.Repo[key], block)

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/test-infra/pkg/io"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/tide/blockers"
 )
 
 const (
@@ -71,6 +73,7 @@ type statusController struct {
 
 	sync.Mutex
 	poolPRs map[string]PullRequest
+	blocks  blockers.Blockers
 
 	storedState
 	opener io.Opener
@@ -220,8 +223,21 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 // in order to generate a diff for the status description. We choose the query
 // for the repo that the PR is closest to meeting (as determined by the number
 // of unmet/violated requirements).
-func expectedStatus(queryMap *config.QueryMap, pr *PullRequest, pool map[string]PullRequest, cc contextChecker) (string, string) {
+func expectedStatus(queryMap *config.QueryMap, pr *PullRequest, pool map[string]PullRequest, cc contextChecker, blocks blockers.Blockers) (string, string) {
 	if _, ok := pool[prKey(pr)]; !ok {
+		// if the branch is blocked forget checking for a diff
+		blockingIssues := blocks.GetApplicable(string(pr.Repository.Owner.Login), string(pr.Repository.Name), string(pr.BaseRef.Name))
+		var numbers []string
+		for _, issue := range blockingIssues {
+			numbers = append(numbers, strconv.Itoa(issue.Number))
+		}
+		if len(numbers) > 0 {
+			var s string
+			if len(numbers) > 1 {
+				s = "s"
+			}
+			return github.StatusError, fmt.Sprintf(statusNotInPool, fmt.Sprintf(" Merging is blocked by issue%s %s.", s, strings.Join(numbers, ", ")))
+		}
 		minDiffCount := -1
 		var minDiff string
 		for _, q := range queryMap.ForRepo(string(pr.Repository.Owner.Login), string(pr.Repository.Name)) {
@@ -258,7 +274,7 @@ func targetURL(c config.Getter, pr *PullRequest, log *logrus.Entry) string {
 	return link
 }
 
-func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullRequest) {
+func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullRequest, blocks blockers.Blockers) {
 	// queryMap caches which queries match a repo.
 	// Make a new one each sync loop as queries will change.
 	queryMap := sc.config().Tide.Queries.QueryMap()
@@ -281,7 +297,7 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 			return
 		}
 
-		wantState, wantDesc := expectedStatus(queryMap, pr, pool, cr)
+		wantState, wantDesc := expectedStatus(queryMap, pr, pool, cr, blocks)
 		var actualState githubql.StatusState
 		var actualDesc string
 		for _, ctx := range contexts {
@@ -414,8 +430,9 @@ func (sc *statusController) waitSync() {
 		case <-wait:
 			sc.Lock()
 			pool := sc.poolPRs
+			blocks := sc.blocks
 			sc.Unlock()
-			sc.sync(pool)
+			sc.sync(pool, blocks)
 			return
 		case more := <-sc.newPoolPending:
 			if !more {
@@ -425,7 +442,7 @@ func (sc *statusController) waitSync() {
 	}
 }
 
-func (sc *statusController) sync(pool map[string]PullRequest) {
+func (sc *statusController) sync(pool map[string]PullRequest, blocks blockers.Blockers) {
 	sc.lastSyncStart = time.Now()
 	defer func() {
 		duration := time.Since(sc.lastSyncStart)
@@ -433,7 +450,7 @@ func (sc *statusController) sync(pool map[string]PullRequest) {
 		tideMetrics.statusUpdateDuration.Set(duration.Seconds())
 	}()
 
-	sc.setStatuses(sc.search(), pool)
+	sc.setStatuses(sc.search(), pool, blocks)
 }
 
 func (sc *statusController) search() []PullRequest {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -338,6 +338,7 @@ func (c *Controller) Sync() error {
 
 	// Notify statusController about the new pool.
 	c.sc.Lock()
+	c.sc.blocks = blocks
 	c.sc.poolPRs = poolPRMap(filteredPools)
 	select {
 	case c.sc.newPoolPending <- true:


### PR DESCRIPTION
Today, when a PR cannot be merged due to the pool being blocked, the
GitHub status context on the PR just shows it in the pool, which is
confusing. This change exposes the issues that are blocking merges.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 