### PR TITLE
Fix bold+color highlighting in spyglass buildlog

### DIFF
--- a/prow/spyglass/lenses/buildlog/buildlog.ts
+++ b/prow/spyglass/lenses/buildlog/buildlog.ts
@@ -35,7 +35,7 @@ function ansiToHTML(orig: string): string {
   const filtered = orig.replace(/\033\[([0-9;]*)\w(\033\[1m)?([^\033]*?)\033\[0m/g, (match: string, cmd: string, bold: string, body: string, offset: number, str: string) => {
     if (bold !== undefined) {
       // normal code + bold
-      return `<em>${annotate(cmd, body)}</em>`;
+      return `<strong>${annotate(cmd, body)}</strong>`;
     }
     return annotate(cmd, body);
   });


### PR DESCRIPTION
The code in this method tries to allow for users to set bold and coloured text by first setting the colour and then bold using ansi escape sequences (eg `\033[31m\033[1m` would set the colour to red and the weight to bold).

However the code here actually adds an `<em>` tag italicising the text rather than a `<strong>` tag to bold the text.