### PR TITLE
Optionally move Bugs to a new state on a valid link

### DIFF
--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -48,5 +48,20 @@ func (c *Fake) GetBug(id int) (*Bug, error) {
 	}
 }
 
+// UpdateBug updates the bug, if registered, or an error, if set,
+// or responds with an error that matches IsNotFound
+func (c *Fake) UpdateBug(id int, update BugUpdate) error {
+	if c.BugErrors.Has(id) {
+		return errors.New("injected error getting bug")
+	}
+	if bug, exists := c.Bugs[id]; exists {
+		bug.Status = update.Status
+		c.Bugs[id] = bug
+		return nil
+	} else {
+		return &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+	}
+}
+
 // the Fake is a Client
 var _ Client = &Fake{}

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -138,3 +138,10 @@ type Flag struct {
 	// The login name of the user this flag has been requested to be granted or denied. Note, this field is only returned if a requestee is set.
 	Requestee string `json:"requestee,omitempty"`
 }
+
+// BugUpdate contains fields to update on a Bug. See API documentation at:
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
+type BugUpdate struct {
+	// Status is the current status of the bug.
+	Status string `json:"status,omitempty"`
+}


### PR DESCRIPTION
When a bug is deemed valid and linked to a pull request, it is now
possible to configure the plugin to move it to a different state.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cblecker @hongkailiu @eparis @derekwaynecarr
depends on https://github.com/kubernetes/test-infra/pull/13106