### PR TITLE
Updating k/website branch protection for 1.15

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -221,6 +221,8 @@ branch-protection:
           branches:
             master:
               protect: true
+            release-1.10:
+              protect: true
             release-1.11:
               protect: true
             release-1.12:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -221,8 +221,6 @@ branch-protection:
           branches:
             master:
               protect: true
-            release-1.10:
-              protect: true
             release-1.11:
               protect: true
             release-1.12:
@@ -230,6 +228,8 @@ branch-protection:
             release-1.13:
               protect: true
             release-1.14:
+              protect: true
+            release-1.15:
               protect: true
     kubernetes-client:
       protect: true


### PR DESCRIPTION
This also removes orphaned releases (<=1.10).