### PR TITLE
add a daemonset to incresase file handle limit

### DIFF
--- a/experiment/ulimit-ds.yaml
+++ b/experiment/ulimit-ds.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ulimit-ds
+  namespace: kube-system
+  labels:
+    k8s-app: ulimit-ds
+spec:
+  template:
+    spec:
+      hostPID: true
+      containers:
+      - name: set-ulimits
+        image: alpine
+        cmd:
+        - sh
+        - -c
+        - ulimit -n 65536; while true; do sleep 10; done
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi


### PR DESCRIPTION
untested and not deployed. should work in theory, and probably help sort out the build cluster(s)

checking one of the nodes I see:
```
bentheelder@gke-prow-containerd-pool-bigger-170c3937-glwj ~ $ ulimit -a
core file size          (blocks, -c) unlimited
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 209312
max locked memory       (kbytes, -l) 64
max memory size         (kbytes, -m) unlimited
open files                      (-n) 1024
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 209312
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
```

I bet a bazel / go build pod or two will happily right right through file handles, which might explain some forking issues we're seeing with CNI when starting pods...