### PR TITLE
Update all cluster-api images to latest kubekins-e2e 1.15

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190620-c9d7409-1.15
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -36,7 +36,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190619-f71580d-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190620-c9d7409-1.15
         resources:
           requests:
             memory: "6Gi"
@@ -48,7 +48,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190619-f71580d-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190620-c9d7409-1.15
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -64,7 +64,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/cluster-api:v20190114-652973a54
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190620-c9d7409-1.15
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -82,7 +82,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190619-f71580d-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190620-c9d7409-1.15
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

Go 1.12 is required for https://github.com/kubernetes-sigs/cluster-api/pull/1054