### PR TITLE
flip github reporter to crier v2

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -31,8 +31,7 @@ spec:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20190620-f4e6553b2
         args:
-        - --github-workers=1
-        - --report-agent=knative-build
+        - --github-workers=5
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --github-endpoint=https://api.github.com
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --skip-report=true
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster


### PR DESCRIPTION
/assign @Katharine 
/cc @cjwagner @stevekuznetsov @fejta 

It's been a while, and I've pointed crier to ghproxy so hope this time it won't explode the token usage.

https://github.com/googlecloudplatform/oss-test-infra has crier enabled for github and worked fine so far (as my canary).

/hold
I'm OOO this afternoon, so preferably merge on Monday so I can :eyes:  

https://github.com/kubernetes/test-infra/issues/7741