### PR TITLE
adding optional presubmit verify-shellcheck.sh job

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,3 +46,18 @@ presubmits:
           args:
             - test
             - ./...
+  - name: pull-release-verify
+    always_run: true
+    optional: true
+    decorate: true
+    path_alias: k8s.io/release
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-master
+          command:
+            - runner.sh
+            - make verify
+      securityContext:
+        privileged: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1888,6 +1888,9 @@ test_groups:
 - name: pull-release-unit
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-unit
   num_columns_recent: 30
+- name: pull-release-verify
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-release-verify
+  num_columns_recent: 30
 
 # Add New Testgroups Here
 
@@ -3106,6 +3109,10 @@ dashboards:
       alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
   - name: release-unit
     test_group_name: pull-release-unit
+    alert_options:
+      alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
+  - name: release-verify
+    test_group_name: pull-release-verify
     alert_options:
       alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
 


### PR DESCRIPTION
/sig release
/cc @justaugustus 

Continues this PR: https://github.com/kubernetes/release/pull/740

Which addresses this issue: https://github.com/kubernetes/release/issues/726

Specifically, this will run a job that links the shell scripts in kubernetes/release. I will use this test to clean up the shell scripts, and then make it an always-run job 