### PR TITLE
Use decorate for pull-community-verify

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -1,22 +1,20 @@
 presubmits:
   kubernetes/community:
   - name: pull-community-verify
+    decorate: true
     branches:
-    - master
+    - ^master$
     always_run: true
     labels:
       preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+        command:
+        - "/bin/bash"
         args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
-        - make
-        - verify
+        - -c
+        - "make verify"
   - name: pull-community-tempelis-check
     decorate: true
     branches:


### PR DESCRIPTION
We shouldn't need to use bootstrap.py

Attempts to address https://github.com/kubernetes/test-infra/issues/13118