### PR TITLE
Only require contexts when protection is on

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -254,6 +254,7 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch) (*Policy, error) 
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies {
 				logrus.Warnf("%s/%s=%s has required jobs but has protect: false", org, repo, branch)
+				return nil, nil
 			} else {
 				return nil, fmt.Errorf("required prow jobs require branch protection")
 			}

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -769,6 +769,44 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 			},
 			expected: &Policy{Protect: yes},
 		},
+		{
+			name: "Explicit non-configuration takes precedence over ProtectTested",
+			config: Config{
+				ProwConfig: ProwConfig{
+					BranchProtection: BranchProtection{
+						AllowDisabledJobPolicies: true,
+						ProtectTested:            true,
+						Orgs: map[string]Org{
+							"org": {
+								Repos: map[string]Repo{
+									"repo": {
+										Policy: Policy{
+											Protect: no,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				JobConfig: JobConfig{
+					Presubmits: map[string][]Presubmit{
+						"org/repo": {
+							{
+								JobBase: JobBase{
+									Name: "required presubmit",
+								},
+								Reporter: Reporter{
+									Context: "required presubmit",
+								},
+								AlwaysRun: true,
+							},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 