### PR TITLE
Add whitelist of users authorized to rerun all jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,6 +43,18 @@ deck:
   hidden_repos:
   - kubernetes-security
   google_analytics: UA-82843984-5
+  rerun_auth_config:
+    authorized_users:
+      - mirandachrist
+      - cjwagner
+      - amwat
+      - fejta
+      - ixdy
+      - Katharine
+      - krzyzacy
+      - michelle192837
+      - spiffxp
+      - stevekuznetsov
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Users on this whitelist will be able to rerun any job by clicking the rerun button when that feature is enabled. It is currently disabled, so functionally these changes don't do anything yet. 
https://docs.google.com/document/d/1ykgWeEnh4SwX9AuQz28sicFCpqjuEaYclLVTlStNggg/edit#heading=h.3x94kmsnwfs2
/assign @cjwagner 
/cc @fejta 