### PR TITLE
Increse num_failures_to_alert to 2 for gce-cos-master-scalability-100

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -229,7 +229,7 @@ test_groups:
   num_failures_to_alert: 1
 - name: ci-kubernetes-e2e-gci-gce-scalability
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability
-  num_failures_to_alert: 1
+  num_failures_to_alert: 2
 - name: ci-kubernetes-e2e-gci-gce-ipvs
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ipvs
   alert_stale_results_hours: 24


### PR DESCRIPTION
This tests is running quite often (every ~1h). It has a tendency to being flaky every now and then. Increasing this value to 2 protects us from overly spammy alerts, but at the same time, we will be able to catch problems.

/assign @mm4tt @wojtek-t 
/sig scalability 
/kind cleanup