### PR TITLE
Update kind conformance test to build go-runner

### DIFF
--- a/experiment/kind-conformance-e2e.sh
+++ b/experiment/kind-conformance-e2e.sh
@@ -23,7 +23,12 @@ source $(dirname "${BASH_SOURCE[0]}")/kind-e2e.sh
 run_tests() {
   # binaries needed by the conformance image
   rm -rf _output/bin
-  make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
+  NEW_GO_RUNNER_DIR="cluster/images/conformance/go-runner"
+  if [ -d "$NEW_GO_RUNNER_DIR" ]; then
+      make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl cluster/images/conformance/go-runner"
+  else
+      make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
+  fi
 
   # grab the version number for kubernetes
   export KUBE_ROOT=${PWD}

--- a/experiment/kind-e2e.sh
+++ b/experiment/kind-e2e.sh
@@ -71,8 +71,13 @@ build() {
     kind build node-image --type=bazel --kube-root="${PWD}"
 
     # make sure we have e2e requirements
-    #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo"
-    bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
+    #make all WHAT="cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cluster/images/conformance/go-runner"
+    NEW_GO_RUNNER_DIR="cluster/images/conformance/go-runner"
+    if [ -d "$NEW_GO_RUNNER_DIR" ]; then
+        bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo //cluster/images/conformance/go-runner
+    else
+        bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
+    fi
 
     # try to make sure the kubectl we built is in PATH
     local maybe_kubectl
@@ -146,7 +151,7 @@ run_tests() {
     # add ginkgo args
     KUBETEST_ARGS="${KUBETEST_ARGS} --test_args=\"--ginkgo.focus=${FOCUS} --ginkgo.skip=${SKIP} --report-dir=${ARTIFACTS} --disable-log-dump=true --num-nodes=${NUM_NODES}\""
 
-    # setting this env prevents ginkg e2e from trying to run provider setup
+    # setting this env prevents ginkgo e2e from trying to run provider setup
     export KUBERNETES_CONFORMANCE_TEST="y"
 
     # run kubetest, if it fails clean up and exit failure


### PR DESCRIPTION
A PR in k/k is adding a test binary into the conformance
image in an effort to expand capabilities and reliability.

Due to lack of coordination between repos, this test-infra
script currently fails on the proposed PR because it doesn't
know about the new binary.

This change tries to build that new component if it is there
but will not fail the run if it is not. This way the timing
between the PRs is more forgiving.

A follow-up should build it like the other components, causing
a failure if it is not built correctly.