### PR TITLE
Update list of blockades

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -134,23 +134,14 @@ lgtm:
 
 blockades:
 - repos:
-  - kubernetes/kubernetes
-  blockregexps:
-  - ^examples/
-  explanation: "examples/ has moved to https://github.com/kubernetes/examples/"
-- repos:
   - kubernetes/community
   blockregexps:
   - ^events/2016
   - ^events/2017
+  - ^events/2018
   - ^events/elections/2017
   - ^events/elections/2018
   explanation: "These files are historical, and from events that have already occurred."
-- repos:
-  - kubernetes/community
-  blockregexps:
-  - ^keps/
-  explanation: "KEPs have been relocated to [kubernetes/enhancements](https://git.k8s.io/enhancements/)! Please submit any updates there."
 - repos:
   - kubernetes/enhancements
   blockregexps:


### PR DESCRIPTION
- KEP tombstones are being removed from k/community: kubernetes/community#3846
- Examples directory was removed from k/k: kubernetes/kubernetes#61246
- ~~The `NEXT_KEP_NUMBER` file was removed in: kubernetes/enhancements#815~~

/assign @cblecker @justaugustus 