### PR TITLE
cluster-api-provider-docker: add presubmit job and OWNERS file

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- chuckha
+- detiber
+- justinsb
+- vincepri
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -1,0 +1,13 @@
+# sigs.k8s.io/cluster-api-provider-docker presubmits
+presubmits:
+  kubernetes-sigs/cluster-api-provider-docker:
+  - name: pull-cluster-api-provider-docker-verify
+    path_alias: "sigs.k8s.io/cluster-api-provider-docker"
+    always_run: true
+    optional: false
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190624-0fabd2e-master
+        command:
+        - "./hack/verify-all.sh"

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -604,7 +604,7 @@ plugins:
 
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - release-note
-  
+
   kubernetes-sigs/kind:
   - override
 
@@ -621,6 +621,9 @@ plugins:
   - require-matching-label
 
   kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - milestone
+
+  kubernetes-sigs/cluster-api-provider-docker:
   - milestone
 
   kubernetes-sigs/contributor-playground:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -723,6 +723,9 @@ test_groups:
 - name: pull-cluster-api-provider-openstack-check
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-openstack-check
   num_columns_recent: 20
+- name: pull-cluster-api-provider-docker-verify
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-docker-verify
+  num_columns_recent: 20
 - name: pull-kubernetes-bazel-build
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-build
   num_columns_recent: 20
@@ -4156,6 +4159,11 @@ dashboards:
     test_group_name: pull-cluster-api-provider-openstack-check
   - name: pr-test
     test_group_name: pull-cluster-api-provider-openstack-test
+
+- name: sig-cluster-lifecycle-cluster-api-provider-docker
+  dashboard_tab:
+  - name: pr-verify
+    test_group_name: pull-cluster-api-provider-docker-verify
 
 - name: sig-multicluster-kubemci
   dashboard_tab:


### PR DESCRIPTION
also include:
- milestone plugin for this repo
- testgrid entries

once the owners and yamls are LGTM'd we can assign a test-infra approver.

/assign @chuckha 
/kind feature
/area config
/sig cluster-lifecycle
