### PR TITLE
Fix GCS secret namespace in Prow Getting Started

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -309,7 +309,7 @@ gsutil mb gs://prow-artifacts/ # step 2
 gsutil iam ch allUsers:objectViewer gs://prow-artifacts # step 3
 gsutil iam ch "serviceAccount:${identifier}:objectAdmin" gs://prow-artifacts # step 4
 gcloud iam service-accounts keys create --iam-account "${identifier}" service-account.json # step 5
-kubectl create secret generic gcs-credentials --from-file=service-account.json # step 6
+kubectl -n test-pods create secret generic gcs-credentials --from-file=service-account.json # step 6
 ```
 
 Before we can update plank's `default_decoration_config` we'll need to know the version we're using


### PR DESCRIPTION
The Prow Getting Started doc instructs the user to create a
`gcs-credentials` secret in the default namespace. This causes prow jobs
running in the `test-jobs` namespace to fail with:
```
MountVolume.SetUp failed for volume "gcs-credentials"
```

This change modifies the `gcs-credentials` create command to place the
secret in the `test-pods` namespace, consistent with the recommended
`config.yaml`'s `pod_namespace: test-pods`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

/area/prow