### PR TITLE
Update toolchains to support 0.27.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,19 +19,9 @@ test:lint --test_tag_filters=lint
 # bazel test //... --config=unit
 test:unit --test_tag_filters=-lint
 
-# --config=remote-cache enables a remote bazel cache
-# Note needs an instance name
-# See --config=remote-fejta-cache for a concrete example
-build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
-build:remote-cache --tls_enabled=true
-build:remote-cache --remote_timeout=3600
-build:remote-cache --auth_enabled=true
-
-# --config=remote adds remote execution to the --config=remote-cache
 # Note needs an instance name
 # See --config=remote-fejta for a concrete example
-build:remote --config=remote-cache
-build:remote --remote_executor=remotebuildexecution.googleapis.com
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-0.27.0.bazelrc
 build:remote --jobs=500
 build:remote --host_javabase=@rbe_default//java:jdk
 build:remote --javabase=@rbe_default//java:jdk
@@ -39,15 +29,18 @@ build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:remote --crosstool_top=@rbe_default//cc:toolchain
 build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
 build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
 build:remote --extra_execution_platforms=:rbe_with_network
 build:remote --host_platform=:rbe_with_network
 build:remote --platforms=:rbe_with_network
-build:remote --spawn_strategy=remote
-build:remote --strategy=Javac=remote
-build:remote --strategy=Closure=remote
-build:remote --strategy=Genrule=remote
+
 build:remote --define=EXECUTOR=remote
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --remote_timeout=3600
+
+# --google_credentials=some_file.json
+build:remote --google_default_credentials=true
 
 # Compose the remote configs with an instance name
 # A couple examples below:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d",
-    strip_prefix = "bazel-toolchains-0.26.1",
+    sha256 = "4598bf5a8b4f5ced82c782899438a7ba695165d47b3bf783ce774e89a8c6e617",
+    strip_prefix = "bazel-toolchains-0.27.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
     ],
 )
 
@@ -213,8 +213,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 new_git_repository(
     name = "operator_framework_community_operators",
-    commit = "42131df7167ec0b264c892c1f3c49ba9a72142da",
-    remote = "https://github.com/operator-framework/community-operators.git",
     build_file_content = """
 exports_files([
     "upstream-community-operators/prometheus/alertmanager.crd.yaml",
@@ -223,4 +221,6 @@ exports_files([
     "upstream-community-operators/prometheus/servicemonitor.crd.yaml",
 ])
 """,
+    commit = "42131df7167ec0b264c892c1f3c49ba9a72142da",
+    remote = "https://github.com/operator-framework/community-operators.git",
 )


### PR DESCRIPTION
ref #13140 #13145

Modernized rbe settings
Rules version that will support <=0.27.0

/assign @cjwagner @BenTheElder 

From https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-0.27.0.bazelrc