### PR TITLE
Avoid reinvoking bazel from prepare_release_branch.py

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -31,6 +31,18 @@ py_binary(
 py_binary(
     name = "prepare_release_branch",
     srcs = ["prepare_release_branch.py"],
+    args = [
+        "$(location //experiment/config-rotator)",
+        "$(location //experiment/config-forker)",
+        "$(location :generate_tests)",
+        "$(location //config/jobs/kubernetes-security:genjobs)",
+    ],
+    data = [
+        ":generate_tests",
+        "//config/jobs/kubernetes-security:genjobs",
+        "//experiment/config-forker",
+        "//experiment/config-rotator",
+    ],
     deps = [
         "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
         requirement("sh"),

--- a/experiment/prepare_release_branch.py
+++ b/experiment/prepare_release_branch.py
@@ -28,7 +28,9 @@ import ruamel.yaml as yaml
 
 TEST_CONFIG_YAML = "experiment/test_config.yaml"
 JOB_CONFIG = "config/jobs"
+PROW_CONFIG = "prow/config.yaml"
 BRANCH_JOB_DIR = "config/jobs/kubernetes/sig-release/release-branch-jobs"
+SECURITY_JOBS = "config/jobs/kubernetes-security/generated-security-jobs.yaml"
 
 
 class ToolError(Exception):
@@ -53,31 +55,31 @@ def delete_dead_branch(branch_path, current_version):
     os.unlink(os.path.join(branch_path, filename))
 
 
-def rotate_files(branch_path, current_version):
+def rotate_files(rotator_bin, branch_path, current_version):
     suffixes = ['beta', 'stable1', 'stable2', 'stable3']
     for i in xrange(0, 3):
         filename = '%d.%d.yaml' % (current_version[0], current_version[1] - i)
         from_suffix = suffixes[i]
         to_suffix = suffixes[i+1]
-        sh.bazel.run("//experiment/config-rotator", "--",
-                     old=from_suffix,
-                     new=to_suffix,
-                     config_file=os.path.join(branch_path, filename),
-                     _fg=True)
+        sh.Command(rotator_bin)(
+            old=from_suffix,
+            new=to_suffix,
+            config_file=os.path.join(branch_path, filename),
+            _fg=True)
 
 
-def fork_new_file(branch_path, prowjob_path, current_version):
+def fork_new_file(forker_bin, branch_path, prowjob_path, current_version):
     next_version = (current_version[0], current_version[1] + 1)
     filename = '%d.%d.yaml' % (next_version[0], next_version[1])
-    sh.bazel.run("//experiment/config-forker", "--",
-                 job_config=os.path.abspath(prowjob_path),
-                 output=os.path.abspath(os.path.join(branch_path, filename)),
-                 version='%d.%d' % next_version,
-                 _fg=True)
+    sh.Command(forker_bin)(
+        job_config=os.path.abspath(prowjob_path),
+        output=os.path.abspath(os.path.join(branch_path, filename)),
+        version='%d.%d' % next_version,
+        _fg=True)
 
 
-def update_generated_config(latest_version):
-    with open(TEST_CONFIG_YAML, 'r') as f:
+def update_generated_config(path, latest_version):
+    with open(path, 'r') as f:
         config = yaml.round_trip_load(f)
 
     v = latest_version
@@ -91,36 +93,49 @@ def update_generated_config(latest_version):
                 r'release-\d+\.\d+', 'release-%s' % vs, arg)
         node['prowImage'] = node['prowImage'].rpartition('-')[0] + '-' + vs
 
-    with open(TEST_CONFIG_YAML, 'w') as f:
+    with open(path, 'w') as f:
         yaml.round_trip_dump(config, f)
 
 
-def regenerate_files():
-    sh.bazel.run("//experiment:generate_tests", "--",
-                 yaml_config_path=TEST_CONFIG_YAML,
-                 _fg=True)
-    sh.bazel.run("//hack:update-config", _fg=True)
+def regenerate_files(generate_tests_bin, generate_security_bin, test_config,
+                     prow_config, job_dir, security_config):
+    sh.Command(generate_tests_bin)(
+        yaml_config_path=test_config,
+        _fg=True)
+    sh.Command(generate_security_bin)(
+        config=prow_config,
+        jobs=job_dir,
+        output=security_config,
+        _fg=True)
 
 
 def main():
-    if os.environ.get('BUILD_WORKSPACE_DIRECTORY'):
-        os.chdir(os.environ.get('BUILD_WORKSPACE_DIRECTORY'))
-    else:
+    if not os.environ.get('BUILD_WORKSPACE_DIRECTORY'):
         print("Please run me via bazel!")
         print("bazel run //experiment:prepare_release_branch")
         sys.exit(1)
-    version = check_version(BRANCH_JOB_DIR)
+    rotator_bin = sys.argv[1]
+    forker_bin = sys.argv[2]
+    generate_tests_bin = sys.argv[3]
+    generate_security_bin = sys.argv[4]
+    d = os.environ.get('BUILD_WORKSPACE_DIRECTORY')
+    version = check_version(os.path.join(d, BRANCH_JOB_DIR))
     print("Current version: %d.%d" % (version[0], version[1]))
     print("Deleting dead branch...")
-    delete_dead_branch(BRANCH_JOB_DIR, version)
+    delete_dead_branch(os.path.join(d, BRANCH_JOB_DIR), version)
     print("Rotating files...")
-    rotate_files(BRANCH_JOB_DIR, version)
+    rotate_files(rotator_bin, os.path.join(d, BRANCH_JOB_DIR), version)
     print("Forking new file...")
-    fork_new_file(BRANCH_JOB_DIR, JOB_CONFIG, version)
+    fork_new_file(forker_bin, os.path.join(d, BRANCH_JOB_DIR),
+                  os.path.join(d, JOB_CONFIG), version)
     print("Updating test_config.yaml...")
-    update_generated_config(version)
+    update_generated_config(os.path.join(d, TEST_CONFIG_YAML), version)
     print("Regenerating files...")
-    regenerate_files()
+    regenerate_files(generate_tests_bin, generate_security_bin,
+                     os.path.join(d, TEST_CONFIG_YAML),
+                     os.path.join(d, PROW_CONFIG),
+                     os.path.join(d, JOB_CONFIG),
+                     os.path.join(d, SECURITY_JOBS))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`prepare_release_branch.py` both expected to be run under bazel, and itself invoked bazel to run other tools. This worked, but is probably not the best way to go about it.

Instead, we now mark the tools we depend on as bazel dependencies, pass in the paths, and invoke them directly.