### PR TITLE
fix markdown link to Next Steps

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -51,7 +51,7 @@ The will help you through the following steps:
 * Deploying prow into that cluster
 * Configuring GitHub to send prow webhooks for your repos. This is where you'll provide the absolute `/path/to/oauth/secret`
 
-See the [Next Steps][#next-steps] section after running this utility.
+See the [Next Steps](#next-steps) section after running this utility.
 
 ## Manual deployment
 


### PR DESCRIPTION
Fixing markdown syntax for the Next Steps link

Signed-off-by: Craig Tabita <ctab@google.com>