### PR TITLE
Stop linking to gubernator from spyglass

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -38,7 +38,7 @@ deck:
       - "junit"
       "artifacts/filtered.cov":
       - "coverage"
-    announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator.k8s.io/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to sig-testing."
+    announcement: "The old job viewer has been deprecated. If you need it, please contact #sig-testing on Slack."
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security


### PR DESCRIPTION
Deprecate gubernator further by making it hard to get to.

In the last thirty days, 15,741 spyglass views led to 471 gubernator views, which is about 3%. We have received no negative feedback since switching the default.

The message is still present and is now clearer about how to complain at us, if people are inspired to complain by no longer having the link present.

/cc @spiffxp @fejta 