### PR TITLE
Automatically build/push slack-infra images

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -18,6 +18,8 @@ presubmits:
     branches:
     - ^master$
     run_if_changed: '^communication/slack-config'
+    annotations:
+      testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
         - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -553,6 +553,10 @@ postsubmits:
     branches:
       - ^master$
     run_if_changed: '^communication/slack-config'
+    annotations:
+      testgrid-num-failures-to-alert: "1"
+      testgrid-alert-email: ktbry@google.com
+      testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
         - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
@@ -575,6 +579,10 @@ postsubmits:
   - name: post-slack-infra-push-images
     cluster: test-infra-trusted
     run_if_changed: '^(slack|tempelis)'
+    annotations:
+      testgrid-num-failures-to-alert: "1"
+      testgrid-alert-email: ktbry@google.com
+      testgrid-dashboards: sig-contribex-slack-infra
     decorate: true
     branches:
       - ^master$

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -571,6 +571,32 @@ postsubmits:
         - name: tempelis-creds
           secret:
             secretName: slack-tempelis-auth
+  kubernetes-sigs/slack-infra:
+  - name: post-slack-infra-push-images
+    cluster: test-infra-trusted
+    run_if_changed: '^(slack|tempelis)'
+    decorate: true
+    branches:
+      - ^master$
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20190619-47630b6
+          command:
+            - /run.sh
+          args:
+            - --scratch-bucket=gs://kubernetes-tools-scratch
+            - --project=kubernetes-tools
+            - .
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /creds/service-account.json
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: deployer-service-account
 
 
 periodics:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2000,11 +2000,6 @@ test_groups:
   alert_stale_results_hours: 24
   num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
 
-- name: pull-community-tempelis-check
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-community-tempelis-check
-- name: post-community-tempelis-apply
-  gcs_prefix: kubernetes-jenkins/logs/post-community-tempelis-apply
-  num_failures_to_alert: 1
 - name: pull-community-verify
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-community-verify
 
@@ -3198,15 +3193,6 @@ dashboards:
   dashboard_tab:
   - name: pull-verify
     test_group_name: pull-community-verify
-
-- name: sig-contribex-tempelis
-  dashboard_tab:
-  - name: presubmit
-    test_group_name: pull-community-tempelis-check
-  - name: postsubmit
-    test_group_name: post-community-tempelis-apply
-    alert_options:
-      alert_mail_to_addresses: ktbry@google.com
 
 - name: sig-release-1.12-all
   dashboard_tab:
@@ -6671,6 +6657,8 @@ dashboards:
     test_group_name: pull-release-notes-test
     base_options: width=10
 
+- name: sig-contribex-slack-infra
+
 #
 # Start dashboard groups
 #
@@ -6777,7 +6765,7 @@ dashboard_groups:
 - name: sig-contribex
   dashboard_names:
   - sig-contribex-community
-  - sig-contribex-tempelis
+  - sig-contribex-slack-infra
 
 - name: sig-multicluster
   dashboard_names:


### PR DESCRIPTION
Use the image builder to use GCB to automatically build and push the slack-infra images when PRs merge.