### PR TITLE
Add Jenkins X agent to the configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/influxdata/influxdb v0.0.0-20161215172503-049f9b42e9a5
 	github.com/jinzhu/gorm v0.0.0-20170316141641-572d0a0ab1eb
 	github.com/jinzhu/inflection v0.0.0-20190603042836-f5c5f50e6090 // indirect
-	github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3 // indirect
+	github.com/jinzhu/now v1.0.1 // indirect
 	github.com/klauspost/compress v1.4.1 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect
 	github.com/klauspost/pgzip v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/jinzhu/gorm v0.0.0-20170316141641-572d0a0ab1eb h1:0D5F4qAGJbRqzyCIHsw
 github.com/jinzhu/gorm v0.0.0-20170316141641-572d0a0ab1eb/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20190603042836-f5c5f50e6090 h1:LIwA5USOJ9W/0hwiRH1MugeThGBHGqv+USXcDKWHIVY=
 github.com/jinzhu/inflection v0.0.0-20190603042836-f5c5f50e6090/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3 h1:xvj06l8iSwiWpYgm8MbPp+naBg+pwfqmdXabzqPCn/8=
-github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
+github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
+github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -75,7 +75,9 @@ const (
 	// KnativeBuildAgent means prow will schedule the job via a build-crd resource.
 	KnativeBuildAgent ProwJobAgent = "knative-build"
 	// TektonAgent means prow will schedule the job via a tekton PipelineRun CRD resource.
-	TektonAgent = "tekton-pipeline"
+	TektonAgent ProwJobAgent = "tekton-pipeline"
+	// JenkinsXAgent means prow will schedule the jobs via JenkinsX pipeline.
+	JenkinsXAgent ProwJobAgent = "jenkins-x"
 )
 
 const (

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//prow/pod-utils/decorate:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//vendor/github.com/knative/build/pkg/apis/build/v1alpha1:go_default_library",
+        "//vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1226,7 +1226,8 @@ func validateAgent(v JobBase, podNamespace string) error {
 	b := string(prowapi.KnativeBuildAgent)
 	j := string(prowapi.JenkinsAgent)
 	p := string(prowapi.TektonAgent)
-	agents := sets.NewString(k, b, j, p)
+	x := string(prowapi.JenkinsXAgent)
+	agents := sets.NewString(k, b, j, p, x)
 	agent := v.Agent
 	switch {
 	case !agents.Has(agent):

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1244,6 +1244,12 @@ func validateAgent(v JobBase, podNamespace string) error {
 		return fmt.Errorf("job pipeline_run_spec require agent: %s (found %q)", p, agent)
 	case agent == p && v.PipelineRunSpec == nil:
 		return fmt.Errorf("agent: %s jobs require a pipeline_run_spec", p)
+	case agent == x && v.Spec != nil:
+		return fmt.Errorf("agent: %s does not require a spec", agent)
+	case agent == x && v.BuildSpec != nil:
+		return fmt.Errorf("agent: %s does not require a build_spec", agent)
+	case agent == x && v.PipelineRunSpec != nil:
+		return fmt.Errorf("agent: %s does not require a pipeline_run_spec", agent)
 	case v.DecorationConfig != nil && agent != k && agent != b:
 		// TODO(fejta): only source decoration supported...
 		return fmt.Errorf("decoration requires agent: %s or %s (found %q)", k, b, agent)

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -439,6 +440,7 @@ func TestValidateAgent(t *testing.T) {
 	b := string(prowjobv1.KnativeBuildAgent)
 	jenk := string(prowjobv1.JenkinsAgent)
 	k := string(prowjobv1.KubernetesAgent)
+	x := string(prowjobv1.JenkinsXAgent)
 	ns := "default"
 	base := JobBase{
 		Agent:     k,
@@ -562,6 +564,43 @@ func TestValidateAgent(t *testing.T) {
 				j.ErrorOnEviction = true
 			},
 			pass: true,
+		},
+		{
+			name: "accept jenkins-x agent without any spec",
+			base: func(j *JobBase) {
+				j.Agent = x
+				j.Spec = nil
+				j.DecorationConfig = nil
+			},
+			pass: true,
+		},
+		{
+			name: "reject jenkins-x agent with spec",
+			base: func(j *JobBase) {
+				j.Agent = x
+				j.DecorationConfig = nil
+			},
+			pass: false,
+		},
+		{
+			name: "reject jenkins-x agent with build_spec",
+			base: func(j *JobBase) {
+				j.Agent = x
+				j.Spec = nil
+				j.BuildSpec = &buildv1alpha1.BuildSpec{}
+				j.DecorationConfig = nil
+			},
+			pass: false,
+		},
+		{
+			name: "reject jenkins-x agent with pipeline_run_spec",
+			base: func(j *JobBase) {
+				j.Agent = x
+				j.Spec = nil
+				j.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{}
+				j.DecorationConfig = nil
+			},
+			pass: false,
 		},
 	}
 

--- a/repos.bzl
+++ b/repos.bzl
@@ -600,8 +600,8 @@ def go_repositories():
     go_repository(
         name = "com_github_jinzhu_now",
         importpath = "github.com/jinzhu/now",
-        sum = "h1:xvj06l8iSwiWpYgm8MbPp+naBg+pwfqmdXabzqPCn/8=",
-        version = "v0.0.0-20181116074157-8ec929ed50c3",
+        sum = "h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=",
+        version = "v1.0.1",
     )
     go_repository(
         name = "com_github_jmespath_go_jmespath",


### PR DESCRIPTION
I am adding the Jenkins X agent to the configuration as agreed in https://github.com/kubernetes/test-infra/pull/11888 and in the design document review. This will allow us to use our custom pipeline controller to trigger Jenkins X pipeline execution. This controller is planned to be maintained by Jenkins X team in a stand-alone repository.

cc @fejta @cjwagner @wbrefvem @abayer