### PR TITLE
LSC: Migration of Testgrid Tabs to Prow Jobs

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml
@@ -19,6 +19,8 @@ presubmits:
       volumes:
       - name: empty-workspace
         emptyDir: {}
+    annotations:
+      testgrid-dashboards: presubmits-misc
 postsubmits:
   GoogleCloudPlatform/k8s-cluster-bundle:
   - name: post-k8s-cluster-bundle-bazel-test
@@ -39,3 +41,5 @@ postsubmits:
       volumes:
       - name: empty-workspace
         emptyDir: {}
+    annotations:
+      testgrid-dashboards: presubmits-misc

--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -59,6 +59,9 @@ postsubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: sig-multicluster-kubemci
+      test-tab-name: kubemci-image-push
 periodics:
 - interval: 6h
   name: ci-kubernetes-multicluster-ingress-test
@@ -93,6 +96,9 @@ periodics:
       secret:
         secretName: k8s-multicluster-ingress-coveralls-token
 
+  annotations:
+    testgrid-dashboards: sig-multicluster-kubemci
+    test-tab-name: ci-kubemci-unit-tests
 - interval: 60m
   name: ci-kubemci-ingress-conformance
   labels:
@@ -116,3 +122,6 @@ periodics:
       - --timeout=90m
       image: gcr.io/k8s-testimages/e2e-kubemci:latest
       imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: sig-multicluster-kubemci
+    test-tab-name: kubemci-ingress-conformance

--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -35,6 +35,9 @@ periodics:
           cpu: 6
           memory: "8Gi"
 
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic builds and testing of Apache Spark on default version of GKE.
 - interval: 2h
   name: spark-periodic-latest-gke
   labels:
@@ -70,3 +73,6 @@ periodics:
         requests:
           cpu: 6
           memory: "8Gi"
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic builds and testing of Apache Spark running on the newest stable GKE.

--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -26,3 +26,5 @@ presubmits:
       - name: service-account
         secret:
           secretName: service-account
+    annotations:
+      testgrid-dashboards: google-rules_k8s

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -45,6 +45,9 @@ presubmits:
         - --test_args=--nodes=1--flakeAttempts=2
         - --timeout=10m
 
+    annotations:
+      testgrid-dashboards: presubmits-misc
+      test-tab-name: cadvisor
 periodics:
 - interval: 24h
   name: ci-cadvisor-canarypush
@@ -68,6 +71,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-node-cadvisor
+    test-tab-name: cadvisor-push
 - name: ci-cadvisor-e2e
   interval: 8h
   labels:
@@ -97,3 +103,6 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+  annotations:
+    testgrid-dashboards: sig-node-cadvisor
+    test-tab-name: cadvisor-e2e

--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -34,6 +34,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-alpha-cluster
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster
   labels:
@@ -62,6 +65,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.14-alpha-cluster
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster-features
   labels:
@@ -89,6 +95,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.14-alpha-cluster-features
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta
   labels:
@@ -117,6 +126,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.14
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1
   labels:
@@ -145,6 +157,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.13
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster
   labels:
@@ -173,6 +188,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.13-alpha-cluster
 - interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster-features
   labels:
@@ -201,6 +219,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-containerd-gke-1.13-alpha-cluster-features
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster
   labels:
@@ -228,6 +249,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-gke-1.14-alpha-cluster
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster-features
   labels:
@@ -254,6 +278,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-gke-1.14-alpha-cluster-features
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster
   labels:
@@ -281,6 +308,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-gke-1.13-alpha-cluster
 - interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster-features
   labels:
@@ -308,6 +338,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: cos-gke-1.13-alpha-cluster-features
 - interval: 12h
   name: ci-kubernetes-soak-gke-cos-containerd
   labels:
@@ -339,3 +372,6 @@ periodics:
       - --timeout=800m
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-soak
+    test-tab-name: gke-cos-containerd

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -21,6 +21,9 @@ presubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: presubmits-misc
+      test-tab-name: charts
 periodics:
 - interval: 1h
   name: ci-kubernetes-charts-gce
@@ -45,3 +48,6 @@ periodics:
       - --test=false
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-apps
+    test-tab-name: charts-gce

--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -14,6 +14,9 @@ periodics:
         value: kubeflow
       - name: BRANCH_NAME
         value: v0.5-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-5 release branch.
 - name: kubeflow-periodic-0-4-branch
   interval: 8h
   labels:
@@ -29,6 +32,9 @@ periodics:
         value: kubeflow
       - name: BRANCH_NAME
         value: v0.4-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-4 release branch.
 - name: kubeflow-periodic-0-3-branch
   interval: 8h
   labels:
@@ -44,6 +50,9 @@ periodics:
         value: kubeflow
       - name: BRANCH_NAME
         value: v0.3-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-3 release branch.
 - name: kubeflow-periodic-master
   interval: 4h
   labels:
@@ -59,6 +68,9 @@ periodics:
         value: kubeflow
       - name: BRANCH_NAME
         value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the latest master branch.
 - name: kubeflow-periodic-examples
   interval: 8h
   labels:
@@ -74,3 +86,6 @@ periodics:
         value: examples
       - name: BRANCH_NAME
         value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow examples

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -10,6 +10,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/examples.
   kubeflow/kubeflow:
   - name: kubeflow-postsubmit
     labels:
@@ -19,6 +22,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for Kubeflow.
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-postsubmit
     branches:
@@ -30,6 +36,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/pytorch-operator.
   kubeflow/reporting:
   - name: kubeflow-reporting-postsubmit
     branches:
@@ -41,6 +50,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/reporting.
   kubeflow/website:
   - name: kubeflow-website-postsubmit
     labels:
@@ -50,6 +62,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/website.
   kubeflow/testing:
   - name: kubeflow-testing-postsubmit
     branches:
@@ -61,6 +76,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/testing.
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-postsubmit
     labels:
@@ -70,6 +88,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/tf-operator.
   kubeflow/katib:
   - name: kubeflow-katib-postsubmit
     labels:
@@ -79,6 +100,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/katib.
   kubeflow/experimental-kvc:
   - name: kubeflow-experimental-kvc-postsubmit
     labels:
@@ -88,6 +112,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-kvc.
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-postsubmit
     labels:
@@ -97,6 +124,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-seldon.
   kubeflow/experimental-beagle:
   - name: kubeflow-experimental-beagle-postsubmit
     labels:
@@ -106,6 +136,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-beagle.
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-postsubmit
     labels:
@@ -115,6 +148,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/caffe2-operator.
   kubeflow/kubebench:
   - name: kubeflow-kubebench-postsubmit
     branches:
@@ -126,6 +162,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/kubebench.
   kubeflow/mpi-operator:
   - name: kubeflow-mpi-operator-postsubmit
     branches:
@@ -137,6 +176,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/mpi-operator.
   kubeflow/chainer-operator:
   - name: kubeflow-chainer-operator-postsubmit
     branches:
@@ -148,6 +190,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/chainer-operator.
   kubeflow/mxnet-operator:
   - name: kubeflow-mxnet-operator-postsubmit
     branches:
@@ -159,6 +204,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/mxnet-operator.
   kubeflow/arena:
   - name: kubeflow-arena-postsubmit
     branches:
@@ -170,6 +218,9 @@ postsubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/arena.
   kubeflow/pipelines:
   - name: kubeflow-pipeline-postsubmit
     decorate: true
@@ -189,3 +240,6 @@ postsubmits:
         - sample_test
         - --timeout
         - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -11,6 +11,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/examples.
   kubeflow/kubeflow:
   - name: kubeflow-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -21,6 +24,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for Kubeflow.
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -33,6 +39,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/pytorch-operator.
   kubeflow/reporting:
   - name: kubeflow-reporting-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -45,6 +54,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/reporting.
   kubeflow/website:
   - name: kubeflow-website-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -57,6 +69,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/website.
   kubeflow/testing:
   - name: kubeflow-testing-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -69,6 +84,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/testing.
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -79,6 +97,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/tf-operator.
   kubeflow/katib:
   - name: kubeflow-katib-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -91,6 +112,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/katib.
   kubeflow/experimental-kvc:
   - name: kubeflow-experimental-kvc-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -103,6 +127,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-kvc.
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -115,6 +142,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-seldon.
   kubeflow/experimental-beagle:
   - name: kubeflow-experimental-beagle-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -127,6 +157,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-beagle.
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -139,6 +172,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/caffe2-operator.
   kubeflow/kubebench:
   - name: kubeflow-kubebench-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -151,6 +187,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/kubebench.
   kubeflow/mpi-operator:
   - name: kubeflow-mpi-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -163,6 +202,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/mpi-operator.
   kubeflow/chainer-operator:
   - name: kubeflow-chainer-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -175,6 +217,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/chainer-operator.
   kubeflow/mxnet-operator:
   - name: kubeflow-mxnet-operator-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -187,6 +232,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/mxnet-operator.
   kubeflow/arena:
   - name: kubeflow-arena-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -199,6 +247,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/arena.
   kubeflow/fairing:
   - name: kubeflow-fairing-presubmit
     always_run: true
@@ -211,6 +262,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/fairing.
   kubeflow/metadata:
   - name: kubeflow-metadata-presubmit
     always_run: true
@@ -223,6 +277,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/metadata.
   kubeflow/kfserving:
   - name: kubeflow-kfserving-presubmit
     always_run: true
@@ -235,6 +292,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/kfserving.
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit
     always_run: true         # Run for every PR, or only when requested.
@@ -247,6 +307,9 @@ presubmits:
       - image: gcr.io/kubeflow-ci/test-worker:latest
         imagePullPolicy: Always
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/manifests.
   kubeflow/pipelines:
   - name: kubeflow-pipeline-e2e-test
     always_run: true

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -286,6 +286,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-13-on-1-13
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.13 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-1-13-on-kubernetes-1-14
   decorate: true
@@ -321,6 +326,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-13-on-1-14
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.13 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-1-13-on-kubernetes-master
   decorate: true
@@ -356,6 +366,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-13-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.13 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-1-14-on-kubernetes-1-13
   decorate: true
@@ -391,6 +406,10 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-14-on-1-13
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-1-14-on-kubernetes-1-14
   decorate: true
@@ -426,6 +445,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-14-on-1-14
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-1-14-on-kubernetes-master
   decorate: true
@@ -461,6 +485,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: 1-14-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
   decorate: true
@@ -496,6 +525,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: alpha-1-13-on-1-13
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI alpha tests with Kubernetes 1.13.x and 1.13 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
   decorate: true
@@ -531,6 +565,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: alpha-1-14-on-1-14
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI alpha tests with Kubernetes 1.14.x and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-13
   decorate: true
@@ -572,6 +611,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: canary-on-1-13
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-1-14
   decorate: true
@@ -613,6 +657,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: canary-on-1-14
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-canary-on-kubernetes-master
   decorate: true
@@ -654,6 +703,11 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: canary-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.14 sidecars
 - interval: 6h
   name: ci-kubernetes-csi-alpha-canary-on-kubernetes-master
   decorate: true
@@ -695,3 +749,8 @@ periodics:
         resources:
           requests:
             cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    test-tab-name: alpha-canary-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI alpha tests with Kubernetes master and 1.14 sidecars

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -13,6 +13,10 @@ presubmits:
         args:
         - make
         - lint
+    annotations:
+      testgrid-dashboards: sig-aws-alb-ingress-controller
+      test-tab-name: lint
+      description: aws alb ingress controller code lint
   - name: pull-aws-alb-ingress-controller-unit-test
     always_run: true
     decorate: true
@@ -34,6 +38,10 @@ presubmits:
       - name: coveralls
         secret:
           secretName: k8s-aws-alb-ingress-coveralls-token
+    annotations:
+      testgrid-dashboards: sig-aws-alb-ingress-controller
+      test-tab-name: unit test
+      description: aws alb ingress controller unit tests
   - name: pull-aws-alb-ingress-controller-e2e-test
     always_run: true
     decorate: true
@@ -52,3 +60,7 @@ presubmits:
         - e2e-test
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-aws-alb-ingress-controller
+      test-tab-name: e2e test
+      description: aws alb ingress controller e2e tests

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -13,6 +13,10 @@ presubmits:
         args:
         - make
         - verify
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: verify
+      description: aws ebs csi driver basic code verification
   - name: pull-aws-ebs-csi-driver-unit
     always_run: true
     decorate: true
@@ -26,6 +30,10 @@ presubmits:
         args:
         - make
         - test
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: unit-test
+      description: aws ebs csi driver unit test
   - name: pull-aws-ebs-csi-driver-sanity
     always_run: true
     decorate: true
@@ -39,6 +47,10 @@ presubmits:
         args:
         - make
         - test-sanity
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: sanity-test
+      description: aws ebs csi driver sanity test
   - name: pull-aws-ebs-csi-driver-integration
     always_run: true
     decorate: true
@@ -53,6 +65,10 @@ presubmits:
         args:
         - make
         - test-integration
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: integration-test
+      description: aws ebs csi driver integration test
   - name: pull-aws-ebs-csi-driver-e2e-single-az
     always_run: true
     decorate: true
@@ -70,6 +86,10 @@ presubmits:
         - test-e2e-single-az
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: e2e-test-single-az
+      description: aws ebs csi driver e2e test on single az
   - name: pull-aws-ebs-csi-driver-e2e-multi-az
     always_run: true
     decorate: true
@@ -87,3 +107,7 @@ presubmits:
         - test-e2e-multi-az
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      test-tab-name: e2e-test-multi-az
+      description: aws ebs csi driver e2e test on mutiple AZs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -16,6 +16,9 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
       command:
       - "./scripts/ci-aws-cred-test.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    test-tab-name: test-creds
 - name: periodic-cluster-api-provider-aws-bazel-e2e
   decorate: true
   interval: 1h
@@ -42,6 +45,9 @@ periodics:
         value: "us-west-2"
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    test-tab-name: bazel-periodic-e2e
 postsubmits:
   kubernetes-sigs/cluster-api-provider-aws:
   - name: ci-cluster-api-provider-aws-bazel-e2e
@@ -69,3 +75,6 @@ postsubmits:
           value: "us-west-2"
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: bazel-ci-e2e

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -10,6 +10,9 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./hack/verify-bazel.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: bazel-pr-verify
   - name: pull-cluster-api-provider-aws-bazel-test
     always_run: true
     optional: false
@@ -20,6 +23,9 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./scripts/ci-bazel-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: bazel-pr-test
   - name: pull-cluster-api-provider-aws-bazel-build
     always_run: true
     optional: false
@@ -30,6 +36,9 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./scripts/ci-bazel-build.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: bazel-pr-build
   - name: pull-cluster-api-provider-aws-bazel-integration
     always_run: true
     optional: true
@@ -61,6 +70,9 @@ presubmits:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: bazel-pr-integration
   - name: pull-cluster-api-provider-aws-verify-boilerplate
     always_run: true
     optional: false
@@ -71,3 +83,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./hack/verify_boilerplate.py"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      test-tab-name: verify-boilerplate

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -11,6 +11,10 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./hack/verify-bazel.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      test-tab-name: bazel-pr-verify
+      testgrid-alert-email: foo+k8s-azure@agst.us
   - name: pull-cluster-api-provider-azure-bazel-test
     always_run: true
     optional: false
@@ -22,6 +26,10 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      test-tab-name: bazel-pr-test
+      testgrid-alert-email: foo+k8s-azure@agst.us
   - name: pull-cluster-api-provider-azure-bazel-build
     always_run: true
     optional: false
@@ -33,6 +41,10 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-build.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      test-tab-name: bazel-pr-build
+      testgrid-alert-email: foo+k8s-azure@agst.us
   - name: pull-cluster-api-provider-azure-verify-boilerplate
     always_run: true
     optional: false
@@ -44,3 +56,7 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "./hack/verify_boilerplate.py"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      test-tab-name: verify-boilerplate
+      testgrid-alert-email: foo+k8s-azure@agst.us

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -11,6 +11,9 @@ presubmits:
         - make
         args:
         - compile
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      test-tab-name: build
   - name: pull-cluster-api-provider-digitalocean-test
     always_run: true
     decorate: true
@@ -22,6 +25,9 @@ presubmits:
         - make
         args:
         - test-unit
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      test-tab-name: test
   - name: pull-cluster-api-provider-digitalocean-verify
     always_run: true
     decorate: true
@@ -33,6 +39,9 @@ presubmits:
         - make
         args:
         - verify
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      test-tab-name: verify
   - name: pull-cluster-api-provider-digitalocean-lint
     always_run: true
     decorate: true
@@ -44,3 +53,6 @@ presubmits:
         - make
         args:
         - lint
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      test-tab-name: lint

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -11,3 +11,6 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         command:
         - "./hack/verify-all.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-docker
+      test-tab-name: pr-verify

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -13,6 +13,9 @@ periodics:
       - "--scenario=execute"
       - "--"
       - "./scripts/ci-build.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+    test-tab-name: build
 - name: ci-cluster-api-provider-gcp-test
   interval: 1h
   labels:
@@ -27,3 +30,6 @@ periodics:
       - "--scenario=execute"
       - "--"
       - "./scripts/ci-test.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+    test-tab-name: unit tests

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -14,6 +14,9 @@ presubmits:
         - "--scenario=execute"
         - "--"
         - "./scripts/ci-build.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      test-tab-name: pr-build
   - name: pull-cluster-api-provider-gcp-make
     always_run: true
     labels:
@@ -36,6 +39,9 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      test-tab-name: pr-make
   - name: pull-cluster-api-provider-gcp-test
     always_run: true
     labels:
@@ -50,3 +56,6 @@ presubmits:
         - "--scenario=execute"
         - "--"
         - "./scripts/ci-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      test-tab-name: pr-test

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -22,6 +22,9 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      test-tab-name: pr-make
   - name: pull-cluster-api-provider-ibmcloud-test
     always_run: true
     decorate: true
@@ -37,6 +40,9 @@ presubmits:
         args:
         - make
         - test
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      test-tab-name: pr-test
   - name: pull-cluster-api-provider-ibmcloud-check
     always_run: true
     decorate: true
@@ -54,3 +60,6 @@ presubmits:
         args:
         - make
         - check
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
+      test-tab-name: pr-check

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -21,6 +21,9 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      test-tab-name: pr-make
   - name: pull-cluster-api-provider-openstack-test
     always_run: true
     decorate: true
@@ -35,6 +38,9 @@ presubmits:
         args:
         - make
         - test
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      test-tab-name: pr-test
   - name: pull-cluster-api-provider-openstack-check
     always_run: true
     decorate: true
@@ -51,3 +57,6 @@ presubmits:
         args:
         - make
         - check
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      test-tab-name: pr-check

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -1,24 +1,29 @@
 periodics:
-  - name: ci-cluster-api-provider-vsphere-ova-e2e
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-      preset-cluster-api-provider-vsphere-e2e-creds: "true"
-    decorate: true
-    interval: 24h
-    extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-vsphere
-      base_ref: master
-      path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/e2e/e2e.sh
-        - "ova"
+- name: ci-cluster-api-provider-vsphere-ova-e2e
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+    preset-cluster-api-provider-vsphere-e2e-creds: "true"
+  decorate: true
+  interval: 24h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-vsphere
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/e2e/e2e.sh
+      - "ova"
         # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    test-tab-name: periodic-e2e
+    testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@vmware.co
+    description: Runs periodic e2e tests

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -70,6 +70,11 @@ presubmits:
         command:
         - hack/verify-crds.sh
 
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      test-tab-name: pr-verify-crds
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the CRDs
   - name: pull-cluster-api-provider-vsphere-test
     always_run: true
     decorate: true
@@ -87,6 +92,11 @@ presubmits:
         args:
         - ./scripts/ci-test.sh
 
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      test-tab-name: pr-test
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs unit tests
   - name: pull-cluster-api-provider-vsphere-e2e
     labels:
       preset-dind-enabled: "true"
@@ -106,3 +116,8 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      test-tab-name: pr-e2e
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs e2e tests

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -14,6 +14,9 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
       command:
       - "./scripts/ci-build.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    test-tab-name: build
 - name: ci-cluster-api-test
   interval: 1h
   decorate: true
@@ -33,3 +36,6 @@ periodics:
         requests:
           cpu: 3
           memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    test-tab-name: unit tests

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -14,6 +14,9 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-build.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      test-tab-name: pr-build
   - name: pull-cluster-api-make
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
@@ -35,6 +38,9 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      test-tab-name: pr-make
   - name: pull-cluster-api-test
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
@@ -53,6 +59,9 @@ presubmits:
           requests:
             cpu: "6000m"
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      test-tab-name: pr-test
   - name: pull-cluster-api-vendor-in-sync
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
@@ -67,6 +76,9 @@ presubmits:
         command:
         - runner.sh
         - ./scripts/ci-is-vendor-in-sync.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      test-tab-name: pr-vendor
   - name: pull-cluster-api-integration
     labels:
       preset-dind-enabled: "true"
@@ -88,3 +100,6 @@ presubmits:
           requests:
             cpu: "4000m"
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      test-tab-name: pr-integration

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -24,6 +24,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Kubernetes Master Driver Release 0.3
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.3
 - name: ci-gcp-compute-persistent-disk-csi-driver-release-0-4-k8s-master-integration
   interval: 4h
   labels:
@@ -49,6 +53,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Kubernetes Master Driver Release 0.4
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.4
 - name: ci-gcp-compute-persistent-disk-csi-driver-release-0-5-k8s-master-integration
   interval: 4h
   labels:
@@ -74,6 +82,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Kubernetes Master Driver Release 0.5
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.5
 - name: ci-gcp-compute-persistent-disk-csi-driver-release-0-4-k8s-1-13-5-integration
   interval: 4h
   labels:
@@ -101,6 +113,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Kubernetes v1.13.5 Driver Release 0.4
+    description: Kubernetes Integration tests for Kubernetes 1.13.5 and Driver Release 0.4
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration
   interval: 4h
   labels:
@@ -126,6 +142,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Kubernetes Master Driver Latest
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest build
 - name: ci-gcp-compute-persistent-disk-csi-driver-stable-k8s-master-migration
   interval: 4h
   labels:
@@ -152,12 +172,16 @@ periodics:
       securityContext:
         privileged: true
     resources:
-        requests:
+      requests:
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: "9000Mi"
+        memory: "9000Mi"
           # during the tests more like 3-20m is used
-          cpu: 2000m
+        cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Migration Kubernetes Master Driver Stable
+    description: Kubernetes in-tree E2E tests with CSIMigration on for Kubernetes Master branch and Driver Stable
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-migration
   interval: 4h
   labels:
@@ -184,9 +208,13 @@ periodics:
       securityContext:
         privileged: true
     resources:
-        requests:
+      requests:
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: "9000Mi"
+        memory: "9000Mi"
           # during the tests more like 3-20m is used
-          cpu: 2000m
+        cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-gcp-compute-persistent-disk-csi-driver
+    test-tab-name: Migration Kubernetes Master Driver Latest
+    description: Kubernetes in-tree E2E tests with CSIMigration on for Kubernetes Master branch and Driver latest build

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -14,5 +14,10 @@ postsubmits:
       # TODO(bentheelder): consider setting this at the cluster level instead
       dnsConfig:
         options:
-          - name: ndots
-            value: "1"
+        - name: ndots
+          value: "1"
+    annotations:
+      testgrid-dashboards: sig-testing-kind
+      test-tab-name: ci build
+      testgrid-alert-email: bentheelder@google.com
+      description: kind CI build

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -47,6 +47,11 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 # conformance test against kubernetes master branch with `kind` ipv6
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: conformance, master (dev)
+    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
+    testgrid-alert-email: bentheelder@google.com
 - interval: 1h
   name: ci-kubernetes-kind-conformance-ipv6
   labels:
@@ -95,6 +100,11 @@ periodics:
           cpu: 2000m
 # conformance test against kubernetes master branch with `kind`, skipping
 # serial tests so it runs in ~20m
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: kind (IPv6), master (dev)
+    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
+    testgrid-alert-email: bentheelder@google.com
 - interval: 20m
   name: ci-kubernetes-kind-conformance-parallel
   labels:
@@ -131,6 +141,11 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 # conformance test against kubernetes master branch with `kind` ipv6
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: conformance, master (dev) [non-serial]
+    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
+    testgrid-alert-email: bentheelder@google.com
 - interval: 20m
   name: ci-kubernetes-kind-conformance-parallel-ipv6
   labels:
@@ -181,6 +196,11 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 # conformance test against kubernetes release-1.12 branch with `kind`
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: kind (IPv6), master (dev) [non-serial]
+    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster, skipping [Serial] tests
+    testgrid-alert-email: bentheelder@google.com
 - interval: 1h
   name: ci-kubernetes-kind-conformance-latest-1-12
   labels:
@@ -213,6 +233,11 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 # conformance test against kubernetes release-1.13 branch with `kind`
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: kind, v1.12 (dev)
+    description: Runs conformance tests using kubetest against latest kubernetes release-1.12 with a kubernetes-in-docker cluster
+    testgrid-alert-email: bentheelder@google.com
 - interval: 1h
   name: ci-kubernetes-kind-conformance-latest-1-13
   labels:
@@ -245,6 +270,11 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 # conformance test against kubernetes release-1.14 branch with `kind`
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: kind, v1.13 (dev)
+    description: Runs conformance tests using kubetest against latest kubernetes release-1.13 with a kubernetes-in-docker cluster
+    testgrid-alert-email: bentheelder@google.com
 - interval: 1h
   name: ci-kubernetes-kind-conformance-latest-1-14
   labels:
@@ -276,3 +306,8 @@ periodics:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: kind, v1.14 (dev)
+    description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster
+    testgrid-alert-email: bentheelder@google.com

--- a/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-batch/kube-batch-config.yaml
@@ -19,3 +19,6 @@ presubmits:
         - --
         - make
         - verify
+    annotations:
+      testgrid-dashboards: presubmits-kube-batch
+      test-tab-name: verify

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -30,3 +30,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      test-tab-name: ci-disruptive

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -10,6 +10,9 @@ presubmits:
         - make
         - test
 
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      test-tab-name: pr-test
   - name: pull-kube-storage-version-migrator-manually-launched-e2e
     decorate: true
     always_run: true
@@ -37,6 +40,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      test-tab-name: pr-e2e-manually-launched
   - name: pull-kube-storage-version-migrator-fully-automated-e2e
     decorate: true
     always_run: true
@@ -67,3 +73,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      test-tab-name: pr-e2e-fully-automated

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -27,3 +27,7 @@ periodics:
       - --test-cmd=../examples/integration_tests.sh
       - --test-cmd-name=kustomize-integration
       - --timeout=120m
+  annotations:
+    testgrid-dashboards: sig-cli-misc
+    test-tab-name: kustomize-periodic-default-gke
+    description: Periodic integration testing of kustomize.

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -28,6 +28,9 @@ presubmits:
         - --timeout=60m
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: presubmits-poseidon
+      test-tab-name: e2e
   - name: pull-poseidon-bazel
     always_run: true
     labels:
@@ -52,6 +55,9 @@ presubmits:
         resources:
           requests:
             memory: "2Gi"
+    annotations:
+      testgrid-dashboards: presubmits-poseidon
+      test-tab-name: bazel
   - name: pull-poseidon-verify
     branches:
     - master
@@ -71,3 +77,6 @@ presubmits:
         - --
         - make
         - verify
+    annotations:
+      testgrid-dashboards: presubmits-poseidon
+      test-tab-name: verify

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -38,6 +38,11 @@ postsubmits:
         secret:
           secretName: sig-storage-local-static-provisioner-pusher
   # A postsubmit job to build release image on release tags.
+    annotations:
+      testgrid-dashboards: sig-storage-local-static-provisioner
+      test-tab-name: master-canary-build
+      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+      description: Canary image build against latest master
   - name: post-sig-storage-local-static-provisioner-build-release
     branches:
     - ^v\d+\.\d+\.\d+$ # stable
@@ -74,3 +79,7 @@ postsubmits:
       - name: pusher-docker-config
         secret:
           secretName: sig-storage-local-static-provisioner-pusher
+    annotations:
+      testgrid-dashboards: sig-storage-local-static-provisioner
+      test-tab-name: release-build
+      description: Release image build against tagged releases

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -84,6 +84,10 @@ presubmits:
           privileged: true
 
 
+    annotations:
+      testgrid-dashboards: sig-windows
+      test-tab-name: aks-engine-azure-windows-presubmit
+      description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 periodics:
 - interval: 6h
   name: ci-kubernetes-e2e-aks-engine-azure-master-windows
@@ -125,6 +129,10 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-windows
+    test-tab-name: aks-engine-azure-windows-master
+    description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 - interval: 12h
   name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   labels:
@@ -165,6 +173,10 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all, sig-windows
+    test-tab-name: aks-engine-azure-1-14-windows
+    description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
 - interval: 6h
   name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
   labels:
@@ -205,6 +217,10 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-release-1.15-all, sig-windows
+    test-tab-name: aks-engine-azure-1-15-windows
+    description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
 - interval: 3h
   name: ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
   labels:
@@ -245,3 +261,7 @@ periodics:
       - "--timeout=450m"
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows
+    test-tab-name: aks-engine-azure-windows-master-staging
+    description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -17,6 +17,9 @@ periodics:
       args:
       - test
       - ./...
+  annotations:
+    testgrid-dashboards: sig-api-machinery-structured-merge-diff
+    test-tab-name: ci-test
 - name: ci-structured-merge-diff-gofmt
   interval: 12h
   labels:
@@ -34,3 +37,6 @@ periodics:
       - bash
       - -c
       - test -z "$({ find . -name "*.go" | grep -v "\\/vendor\\/" | xargs gofmt -s -d | tee /dev/stderr; })"
+  annotations:
+    testgrid-dashboards: sig-api-machinery-structured-merge-diff
+    test-tab-name: ci-gofmt

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -14,6 +14,9 @@ presubmits:
         args:
         - test
         - ./...
+    annotations:
+      testgrid-dashboards: sig-api-machinery-structured-merge-diff
+      test-tab-name: pr-test
   - name: pull-structured-merge-diff-gofmt
     labels:
       preset-service-account: "true"
@@ -27,3 +30,6 @@ presubmits:
         - bash
         - -c
         - test -z "$({ find . -name "*.go" | grep -v "\\/vendor\\/" | xargs gofmt -s -d | tee /dev/stderr; })"
+    annotations:
+      testgrid-dashboards: sig-api-machinery-structured-merge-diff
+      test-tab-name: pr-gofmt

--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/cloud-provider-alibaba-cloud-config.yaml
@@ -14,6 +14,10 @@ presubmits:
         args:
         - check
 
+    annotations:
+      testgrid-dashboards: presubmits-cloud-provider-alibaba
+      test-tab-name: check
+      description: alibaba cloud provider checks
   - name: pull-cloud-provider-alibaba-cloud-unit-test
     always_run: true
     branches:
@@ -27,3 +31,7 @@ presubmits:
         - make
         args:
         - unit-test
+    annotations:
+      testgrid-dashboards: presubmits-cloud-provider-alibaba
+      test-tab-name: unit-test
+      description: alibaba cloud provider unit test

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -15,6 +15,10 @@ presubmits:
         - make
         - check
 
+    annotations:
+      testgrid-dashboards: sig-aws-cloud-provider-aws
+      test-tab-name: check
+      description: aws cloud provider checks
   - name: pull-cloud-provider-aws-test
     always_run: true
     decorate: true
@@ -29,3 +33,7 @@ presubmits:
         args:
         - make
         - test
+    annotations:
+      testgrid-dashboards: sig-aws-cloud-provider-aws
+      test-tab-name: test
+      description: aws cloud provider tests

--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -46,6 +46,10 @@ presubmits:
         - test-check
 
   # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
+    annotations:
+      testgrid-dashboards: sig-azure-master
+      test-tab-name: pr-cloud-provider-check
+      description: Run lint check tests for cloud-provider-azure
   - name: pull-cloud-provider-azure-e2e
     # Disable always_run because of https://github.com/kubernetes/test-infra/pull/11887
     # TODO(feiskyer): enable the tests after it's fixed and published in the image
@@ -95,6 +99,10 @@ presubmits:
           privileged: true
 
   # pull-cloud-provider-azure-e2e-ccm runs Azure specific e2e tests.
+    annotations:
+      testgrid-dashboards: sig-azure-master
+      test-tab-name: pr-cloud-provider-e2e
+      description: Run Kubernetes e2e tests for cloud-provider-azure
   - name: pull-cloud-provider-azure-e2e-ccm
     always_run: true
     branches:
@@ -140,6 +148,10 @@ presubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: sig-azure-master
+      test-tab-name: pr-cloud-provider-e2e-ccm
+      description: Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
   - name: pull-cloud-provider-azure-unit
     always_run: true
     branches:
@@ -158,6 +170,10 @@ presubmits:
         - make
         - test-unit
 
+    annotations:
+      testgrid-dashboards: sig-azure-master
+      test-tab-name: pr-cloud-provider-unit
+      description: Run unit tests for cloud-provider-azure
 periodics:
 - interval: 8h
   # ci-cloud-provider-azure-master runs Azure specific tests periodically.
@@ -213,6 +229,10 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
 
+  annotations:
+    testgrid-dashboards: sig-azure-master
+    test-tab-name: cloud-provider-azure-master
+    description: Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
 - interval: 8h
   # ci-cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
   name: ci-cloud-provider-azure-autoscaling
@@ -269,6 +289,10 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
 
+  annotations:
+    testgrid-dashboards: sig-azure-master
+    test-tab-name: cloud-provider-azure-autoscaling
+    description: Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
 - interval: 8h
   # ci-cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
   name: ci-cloud-provider-azure-conformance
@@ -324,6 +348,10 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
 
+  annotations:
+    testgrid-dashboards: sig-azure-master
+    test-tab-name: cloud-provider-azure-conformance
+    description: Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
 - interval: 8h
   # ci-cloud-provider-azure-slow runs Kubernetes slow tests periodically.
   name: ci-cloud-provider-azure-slow
@@ -378,3 +406,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: cloud-provider-azure
+  annotations:
+    testgrid-dashboards: sig-azure-master
+    test-tab-name: cloud-provider-azure-slow
+    description: Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -160,6 +160,11 @@ periodics:
         value: "dryrun"
       - name: LOG_LEVEL
         value: "5"
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-cloud-provider-vsphere, vmware-conformance-cloud-provider
+    test-tab-name: periodic-latest
+    description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere
+    testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 - name: ci-cloud-provider-vsphere-conformance-stable-1-14
   interval: 12h
   decorate: true
@@ -190,6 +195,11 @@ periodics:
         value: "dryrun"
       - name: LOG_LEVEL
         value: "5"
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-cloud-provider-vsphere, vmware-conformance-cloud-provider
+    test-tab-name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with cloud-provider-vsphere
+    testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 - name: ci-cloud-provider-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
@@ -220,6 +230,11 @@ periodics:
         value: "dryrun"
       - name: LOG_LEVEL
         value: "5"
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-cloud-provider-vsphere, vmware-conformance-cloud-provider
+    test-tab-name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with cloud-provider-vsphere
+    testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 - name: ci-cloud-provider-vsphere-conformance-stable-1-12
   interval: 12h
   decorate: true
@@ -253,6 +268,11 @@ periodics:
 # Runs the e2e conformance suite against a cluster turned up with the
 # in-tree vSphere cloud provider. This job is duplicated for multiple versions
 # of Kubernetes.
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-cloud-provider-vsphere, vmware-conformance-cloud-provider
+    test-tab-name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with cloud-provider-vsphere
+    testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 - name: ci-vsphere-conformance-latest
   interval: 12h
   decorate: true
@@ -281,6 +301,11 @@ periodics:
         value: vsphere
       - name: K8S_VERSION
         value: ci/latest.txt
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-vsphere, vmware-conformance
+    test-tab-name: periodic-latest
+    description: Runs conformance tests using kubetest against latest kubernetes master with the in-tree vSphere cloud provider
+    testgrid-alert-email: k8s-testing-vsphere+alerts@groups.vmware.com
 - name: ci-vsphere-conformance-stable-1-14
   interval: 12h
   decorate: true
@@ -309,6 +334,11 @@ periodics:
         value: vsphere
       - name: K8S_VERSION
         value: release/stable-1.14.txt
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-vsphere, vmware-conformance
+    test-tab-name: periodic-v1.14
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with the in-tree vSphere cloud provider
+    testgrid-alert-email: k8s-testing-vsphere+alerts@groups.vmware.com
 - name: ci-vsphere-conformance-stable-1-13
   interval: 12h
   decorate: true
@@ -337,6 +367,11 @@ periodics:
         value: vsphere
       - name: K8S_VERSION
         value: release/stable-1.13.txt
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-vsphere, vmware-conformance
+    test-tab-name: periodic-v1.13
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with the in-tree vSphere cloud provider
+    testgrid-alert-email: k8s-testing-vsphere+alerts@groups.vmware.com
 - name: ci-vsphere-conformance-stable-1-12
   interval: 12h
   decorate: true
@@ -365,3 +400,8 @@ periodics:
         value: vsphere
       - name: K8S_VERSION
         value: release/stable-1.12.txt
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-vsphere, vmware-conformance
+    test-tab-name: periodic-v1.12
+    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with the in-tree vSphere cloud provider
+    testgrid-alert-email: k8s-testing-vsphere+alerts@groups.vmware.com

--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -13,6 +13,9 @@ presubmits:
         - "-c"
         # Add GOPATH/bin back to PATH to workaround #9469
         - "export PATH=$PATH:$GOPATH/bin && make verify"
+    annotations:
+      testgrid-dashboards: sig-contribex-community
+      test-tab-name: pull-verify
   - name: pull-community-tempelis-check
     decorate: true
     branches:
@@ -22,18 +25,18 @@ presubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-        - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
-          command:
-          - /tempelis
-          args:
-          - --config=communication/slack-config/
-          - --restrictions=communication/slack-config/restrictions.yaml
-          - --auth=/etc/slack-auth/auth.json
-          volumeMounts:
-            - name: tempelis-readonly-creds
-              mountPath: /etc/slack-auth
-              readOnly: true
-      volumes:
+      - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+        command:
+        - /tempelis
+        args:
+        - --config=communication/slack-config/
+        - --restrictions=communication/slack-config/restrictions.yaml
+        - --auth=/etc/slack-auth/auth.json
+        volumeMounts:
         - name: tempelis-readonly-creds
-          secret:
-            secretName: slack-tempelis-auth
+          mountPath: /etc/slack-auth
+          readOnly: true
+      volumes:
+      - name: tempelis-readonly-creds
+        secret:
+          secretName: slack-tempelis-auth

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -25,6 +25,9 @@ presubmits:
           requests:
             memory: "2Gi"
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: bazel-build
   - name: pull-kops-bazel-test
     branches:
     - master
@@ -50,6 +53,9 @@ presubmits:
           requests:
             memory: "2Gi"
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: bazel-test
   - name: pull-kops-e2e-kubernetes-aws
     branches:
     - master
@@ -90,6 +96,9 @@ presubmits:
           requests:
             memory: "6Gi"
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: e2e
   - name: pull-kops-verify-bazel
     branches:
     - master
@@ -107,6 +116,9 @@ presubmits:
         - --
         - ./hack/verify-bazel.sh
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: verify-bazel
   - name: pull-kops-verify-boilerplate
     branches:
     - master
@@ -124,6 +136,9 @@ presubmits:
         - --
         - ./hack/verify-boilerplate.sh
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: verify-boilerplate
   - name: pull-kops-verify-gofmt
     branches:
     - master
@@ -147,6 +162,9 @@ presubmits:
           requests:
             memory: "2Gi"
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: verify-gofmt
   - name: pull-kops-verify-govet
     branches:
     - master
@@ -165,6 +183,9 @@ presubmits:
         - make
         - govet
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: verify-govet
   - name: pull-kops-verify-packages
     branches:
     - master
@@ -182,6 +203,9 @@ presubmits:
         - --
         - ./hack/verify-packages.sh
 
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      test-tab-name: verify-packages
 periodics:
 - interval: 30m
   name: ci-kops-build
@@ -205,6 +229,10 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-release-misc
+    test-tab-name: kops-build
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
 postsubmits:
   kubernetes/kops:
   - name: kops-postsubmit
@@ -231,3 +259,5 @@ postsubmits:
         resources:
           requests:
             memory: "2Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-kops

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -23,6 +23,9 @@ periodics:
         privileged: true
 
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-test
   interval: 2h
   decorate: true
@@ -45,6 +48,9 @@ periodics:
         ./test/build.sh install-lib &&
         make test
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-e2e-node
   interval: 2h
   decorate: true
@@ -86,6 +92,9 @@ periodics:
         '--test_args=--nodes=8 --focus=NodeProblemDetector'
         --timeout=60m
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-e2e-kubernetes-gce-gci
   interval: 2h
   decorate: true
@@ -118,6 +127,9 @@ periodics:
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
   interval: 2h
   decorate: true
@@ -150,6 +162,9 @@ periodics:
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-e2e-kubernetes-gce-ubuntu
   interval: 2h
   decorate: true
@@ -182,6 +197,9 @@ periodics:
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
 
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com
 - name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
   interval: 2h
   decorate: true
@@ -213,3 +231,6 @@ periodics:
         --ginkgo-parallel=30
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: zhenw@google.com,lantaol@google.com

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
           privileged: true
 
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-test
     branches:
     - master
@@ -45,6 +47,8 @@ presubmits:
           ./test/build.sh install-lib &&
           make test
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-e2e-node
     branches:
     - master
@@ -90,6 +94,8 @@ presubmits:
           privileged: true
 
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-e2e-kubernetes-gce-gci
     branches:
     - master
@@ -124,6 +130,8 @@ presubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
     branches:
     - master
@@ -158,6 +166,8 @@ presubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
     branches:
     - master
@@ -192,6 +202,8 @@ presubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
     branches:
     - master
@@ -225,3 +237,5 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector

--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -9,25 +9,31 @@ presubmits:
       - image: golang:1.11
         command:
         - make
+    annotations:
+      testgrid-dashboards: sig-release-publishing-bot
+      test-tab-name: build
   kubernetes/kubernetes:
-    - name: pull-publishing-bot-validate
-      always_run: false
-      decorate: true
-      path_alias: k8s.io/kubernetes
-      skip_report: false
-      optional: true
-      run_if_changed: '^staging/publishing.*$'
-      extra_refs:
-        - org: kubernetes
-          repo: publishing-bot
-          base_ref: master
-          path_alias: k8s.io/publishing-bot
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-            command:
-              - go
-            args:
-              - run
-              - k8s.io/publishing-bot/cmd/validate-rules
-              - /home/prow/go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+  - name: pull-publishing-bot-validate
+    always_run: false
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    skip_report: false
+    optional: true
+    run_if_changed: '^staging/publishing.*$'
+    extra_refs:
+    - org: kubernetes
+      repo: publishing-bot
+      base_ref: master
+      path_alias: k8s.io/publishing-bot
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - go
+        args:
+        - run
+        - k8s.io/publishing-bot/cmd/validate-rules
+        - /home/prow/go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+    annotations:
+      testgrid-dashboards: sig-release-publishing-bot
+      test-tab-name: validate

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -34,18 +34,26 @@ presubmits:
           requests:
             memory: "6Gi"
 
+    annotations:
+      testgrid-dashboards: sig-release-misc
+      test-tab-name: release-cluster-up
+      testgrid-alert-email: kubernetes-patch-release-team@googlegroups.com
   - name: pull-release-unit
     always_run: true
     decorate: true
     path_alias: k8s.io/release
     spec:
       containers:
-        - image: golang:1.12
-          command:
-            - go
-          args:
-            - test
-            - ./...
+      - image: golang:1.12
+        command:
+        - go
+        args:
+        - test
+        - ./...
+    annotations:
+      testgrid-dashboards: sig-release-misc
+      test-tab-name: release-unit
+      testgrid-alert-email: kubernetes-patch-release-team@googlegroups.com
   - name: pull-release-verify
     always_run: true
     optional: true
@@ -55,16 +63,20 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-          command:
-            - runner.sh
-          args:
-            - make
-            - verify
-          securityContext:
-            privileged: true
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify
+        securityContext:
+          privileged: true
 
 # package tests
+    annotations:
+      testgrid-dashboards: sig-release-misc
+      test-tab-name: release-verify
+      testgrid-alert-email: kubernetes-patch-release-team@googlegroups.com
 periodics:
 - name: periodic-release-verify-packages-debs
   interval: 6h

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -21,3 +21,6 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-proto

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -34,6 +34,9 @@ periodics:
           cpu: 6
           memory: "8Gi"
 
+  annotations:
+    testgrid-dashboards: sig-apps
+    description: Periodic builds and testing of the Application Type on GKE.
 - interval: 30m
   name: ci-kubernetes-e2e-gce-taint-evict
   labels:
@@ -57,6 +60,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-taint-evict
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-statefulset
   labels:
@@ -76,3 +82,6 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -27,6 +27,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-vpa
+    test-tab-name: autoscaling-vpa-actuation
 - name: ci-kubernetes-e2e-autoscaling-vpa-admission-controller
   interval: 2h
   labels:
@@ -55,6 +58,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-vpa
+    test-tab-name: autoscaling-vpa-admission-controller
 - name: ci-kubernetes-e2e-autoscaling-vpa-full
   interval: 2h
   labels:
@@ -83,6 +89,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-vpa
+    test-tab-name: autoscaling-vpa-full
 - name: ci-kubernetes-e2e-autoscaling-vpa-recommender
   interval: 3h
   labels:
@@ -111,6 +120,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-vpa
+    test-tab-name: autoscaling-vpa-recommender
 - name: ci-kubernetes-e2e-autoscaling-vpa-updater
   interval: 2h
   labels:
@@ -139,6 +151,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-vpa
+    test-tab-name: autoscaling-vpa-updater
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling
   labels:
@@ -171,6 +186,9 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gce-autoscaling
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
   labels:
@@ -193,6 +211,9 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-hpa
+    test-tab-name: gci-gce-autoscaling-hpa
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
   labels:
@@ -225,6 +246,9 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gce-autoscaling-migs
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
   labels:
@@ -247,6 +271,9 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-hpa
+    test-tab-name: gci-gce-autoscaling-migs-hpa
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling
   labels:
@@ -273,6 +300,9 @@ periodics:
       - --timeout=600m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gke-autoscaling
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
   labels:
@@ -299,6 +329,9 @@ periodics:
       - --timeout=420m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-hpa
+    test-tab-name: gci-gke-autoscaling-hpa
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
   labels:
@@ -325,3 +358,6 @@ periodics:
       - --test_args=--gce-multizone=true --ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=400m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gke-autoscaling-regional

--- a/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/eks-periodics.yaml
@@ -25,6 +25,9 @@ periodics:
       - --timeout=180m
 
 # Kubernetes conformance e2e tests against EKS 1.11 build.
+  annotations:
+    testgrid-dashboards: sig-aws-eks-periodics
+    description: Kubernetes e2e correctness tests against EKS 1.11 build
 - interval: 3h
   name: ci-kubernetes-e2e-aws-eks-1-11-conformance
   labels:
@@ -50,6 +53,9 @@ periodics:
       - --timeout=180m
 
 # Kubernetes performance e2e tests against EKS 1.11 build.
+  annotations:
+    testgrid-dashboards: sig-aws-eks-periodics
+    description: Kubernetes conformance e2e tests against EKS 1.11 build
 - interval: 1h
   name: ci-kubernetes-e2e-aws-eks-1-11-scalability
   labels:
@@ -73,3 +79,6 @@ periodics:
       - --eks-nodes=100
       - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8
       - --timeout=300m
+  annotations:
+    testgrid-dashboards: sig-aws-eks-periodics
+    description: Kubernetes performance e2e tests against EKS 1.11 build

--- a/config/jobs/kubernetes/sig-aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-aws/eks/eks-presubmits.yaml
@@ -16,20 +16,24 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         imagePullPolicy: Always
         args:
-          - --root=/go/src
-          - --repo=k8s.io/kubernetes=$(PULL_REFS)
-          - --repo=k8s.io/release
-          - --upload=gs://kubernetes-jenkins/pr-logs
-          - --timeout=200
-          - --scenario=kubernetes_e2e
-          - --
-          - --build=bazel
-          - --cluster=
-          - --check-version-skew=false
-          - --deployment=eks
-          - --provider=eks
-          - --gce-ssh=
-          - --extract=local
-          - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8
-          - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-correctness
-          - --timeout=180m
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=200
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --check-version-skew=false
+        - --deployment=eks
+        - --provider=eks
+        - --gce-ssh=
+        - --extract=local
+        - --test_args=--ginkgo.focus=\[Feature:Performance\] --minStartupPods=8
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-11-correctness
+        - --timeout=180m
+    annotations:
+      testgrid-dashboards: sig-aws-eks-presubmits
+      test-tab-name: k8s-eks-1-11-correctness
+      description: Kubernetes e2e correctness tests against EKS 1.11 build

--- a/config/jobs/kubernetes/sig-aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-aws/kops/kops-periodics.yaml
@@ -23,6 +23,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-beta
   labels:
@@ -47,6 +50,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-release-1.14-all, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-1.14
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
   labels:
@@ -73,6 +79,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-channelalpha
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-ena-nvme
   labels:
@@ -100,6 +109,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-ena-nvme
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-ha-uswest2
   labels:
@@ -127,6 +139,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-ha-uswest2
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-imagecentos7
   labels:
@@ -155,6 +170,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-imagecentos7
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
   labels:
@@ -182,6 +200,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-imageubuntu1604
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan
   labels:
@@ -208,6 +229,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-networking-kopeio-vxlan
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-newrunner
   labels:
@@ -233,6 +257,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-newrunner
 - interval: 2h
   name: ci-kubernetes-e2e-kops-aws-stable1
   labels:
@@ -257,6 +284,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-1.13
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-stable2
   labels:
@@ -281,6 +311,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-release-1.13-all, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-1.12
 - interval: 6h
   name: ci-kubernetes-e2e-kops-aws-stable3
   labels:
@@ -305,6 +338,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-1.11
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-updown
   labels:
@@ -330,6 +366,9 @@ periodics:
       - --timeout=30m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-updown
 - interval: 24h
   name: ci-kubernetes-e2e-kops-aws-weave
   labels:
@@ -355,6 +394,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-weave
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce
   labels:
@@ -379,6 +421,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    test-tab-name: kops-gce
 - interval: 1h
   name: ci-kubernetes-e2e-kops-gce-channelalpha
   labels:
@@ -403,6 +448,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    test-tab-name: kops-gce-channelalpha
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce-ha
   labels:
@@ -426,3 +474,6 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    test-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/sig-azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-azure/sig-azure-config.yaml
@@ -73,3 +73,7 @@ presubmits:
         - "--timeout=420m"
         securityContext:
           privileged: true
+    annotations:
+      testgrid-dashboards: sig-azure-master
+      test-tab-name: pr-k8s-e2e
+      description: Run e2e tests

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -20,6 +20,11 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: gce-serial
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    description: kubectl gce serial e2e tests for master branch
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gce-sig-cli
   labels:
@@ -44,6 +49,11 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: gce
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    description: kubectl gce e2e tests for master branch
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gke-sig-cli
   labels:
@@ -70,6 +80,11 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: gke
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    description: kubectl gke e2e tests for master branch
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
   labels:
@@ -94,6 +109,11 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: gke-serial
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    description: kubectl gke serial e2e tests for master branch
 - interval: 2h
   name: ci-kubernetes-e2e-kops-aws-sig-cli
   labels:
@@ -118,6 +138,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
 # kubectl skew tests
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: aws
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   labels:
@@ -143,6 +167,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.14-1.13-gci-kubectl-skew
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
   labels:
@@ -167,6 +194,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.14-1.13-gci-kubectl-skew-serial
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
   labels:
@@ -192,6 +222,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-latest-kubectl-stable1-gce
+    description: stable1 e2e tests run against a master gce cluster using a stable1 kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   labels:
@@ -216,6 +250,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-latest-kubectl-stable1-gce-serial
+    description: stable1 serial tests run against a master gce cluster using a stable1 kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
   labels:
@@ -240,6 +278,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-stable1-kubectl-latest-gce
+    description: stable1 e2e tests run against a stable1 gce cluster using a master kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
   labels:
@@ -263,6 +305,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-stable1-kubectl-latest-gce-serial
+    description: stable1 serial tests run against a stable1 gce cluster using a master kubectl binary
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
   labels:
@@ -287,6 +333,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-gci-kubectl-skew
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
   labels:
@@ -310,6 +359,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
   labels:
@@ -335,6 +387,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.13-1.12-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
   labels:
@@ -359,6 +414,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.13-1.12-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
   labels:
@@ -383,6 +441,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.12-1.13-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
   labels:
@@ -406,6 +467,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.12-1.13-gci-kubectl-skew-serial
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
   labels:
@@ -434,6 +498,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.14-1.13-gci-kubectl-skew
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
   labels:
@@ -461,6 +528,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.14-1.13-gci-kubectl-skew-serial
 - interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
   labels:
@@ -489,6 +559,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-latest-kubectl-stable1-gke
+    description: stable1 e2e tests run against a master gke cluster using a stable1 kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
   labels:
@@ -516,6 +590,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-latest-kubectl-stable1-gke-serial
+    description: stable1 serial tests run against a master gke cluster using a stable1 kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
   labels:
@@ -543,6 +621,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-stable1-kubectl-latest-gke
+    description: stable1 e2e tests run against a stable1 gke cluster using a master kubectl binary
 - interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
   labels:
@@ -569,6 +651,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cli-master
+    test-tab-name: skew-cluster-stable1-kubectl-latest-gke-serial
+    description: stable1 serial tests run against a stable1 gke cluster using a master kubectl binary
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
   labels:
@@ -597,6 +683,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.13-1.14-gci-kubectl-skew
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
   labels:
@@ -624,6 +713,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.13-1.14-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
   labels:
@@ -652,6 +744,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-1.13-1.12-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
   labels:
@@ -679,6 +774,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-1.13-1.12-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
   labels:
@@ -707,6 +805,9 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-1.12-1.13-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
   labels:
@@ -733,3 +834,6 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-1.12-1.13-gci-kubectl-skew-serial

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gce.yaml
@@ -24,6 +24,9 @@ periodics:
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-cluster
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
   labels:
@@ -50,6 +53,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-cluster-parallel
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
   labels:
@@ -75,6 +81,9 @@ periodics:
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-cluster-new
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel
   labels:
@@ -102,6 +111,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-cluster-new-parallel
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
   labels:
@@ -126,6 +138,9 @@ periodics:
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master-parallel
   labels:
@@ -153,6 +168,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.13-1.14-upgrade-master-parallel
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster
   labels:
@@ -179,6 +197,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.13-1.12-downgrade-cluster
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster-parallel
   labels:
@@ -206,6 +227,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.13-1.12-downgrade-cluster-parallel
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
   labels:
@@ -231,6 +255,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.12-1.13-upgrade-cluster
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
   labels:
@@ -256,6 +283,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.12-1.13-upgrade-cluster-new
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
   labels:
@@ -281,6 +311,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-1.12-1.13-upgrade-master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster
   labels:
@@ -313,6 +346,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-master-new-downgrade-cluster
+    description: Downgrade master and node, in gce(gci), from master to 1.14
 - interval: 2h
   name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster-parallel
   labels:
@@ -346,6 +383,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-master-new-downgrade-cluster-parallel
+    description: Downgrade master and node, in gce(gci), from master to 1.14, run parallel tests only
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
   labels:
@@ -373,6 +414,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.14-1.13-downgrade-cluster
 - interval: 2h
   name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
   labels:
@@ -401,6 +445,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gce-1.14-1.13-downgrade-cluster-parallel
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster
   labels:
@@ -435,6 +482,10 @@ periodics:
 
 # ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new has a -parallel form for the parallel-safe tests,
 # and the non-parallel form runs the Serial & Disruptive tests (only)
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-cluster
+    description: Upgrade master and node, in gce(gci), from 1.14 to master
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new
   labels:
@@ -461,6 +512,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-cluster-new
+    description: Upgrade master and node, in gce(gci), from 1.14 to master, and run skewed e2e tests.  We only run the serial & disruptive tests; the others are run in the -parallel test.
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new-parallel
   labels:
@@ -488,6 +543,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-cluster-new-parallel
+    description: Upgrade master and node, in gce(gci), from 1.14 to master, and run skewed e2e tests.  We skip the serial & disruptive tests; those are run in the non-parallel test.
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-parallel
   labels:
@@ -520,6 +579,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-cluster-parallel
+    description: Upgrade master and node, in gce(gci), from 1.14 to master, run parallel tests only
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-master
   labels:
@@ -546,6 +609,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-master
+    description: 'OWNER: kube-up-owners; Upgrade master only, in gce(gci), from 1.14 to master, run non-parallel-safe tests only'
 - interval: 2h
   name: ci-kubernetes-e2e-gce-new-master-upgrade-master-parallel
   labels:
@@ -572,3 +639,7 @@ periodics:
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    test-tab-name: gce-new-master-upgrade-master-parallel
+    description: 'OWNER: kube-upowners; Upgrade master only, in gce(gci), from 1.14 to master, run parallel tests only'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
@@ -30,6 +30,10 @@ periodics:
 # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
 # The non -parallel form of the test includes Serial and Disruptive, so it must run serially;
 # we skip Slow tests though so that the runtime is reasonable.
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-new-gci-master-upgrade-cluster
+    description: Upgrade master and node, in gke(gci), from 1.14 to master
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
   labels:
@@ -58,6 +62,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-new-gci-master-upgrade-cluster-new
+    description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping slow tests as we run serially
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new-parallel
   labels:
@@ -87,6 +95,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-new-gci-master-upgrade-cluster-new-parallel
+    description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping serial and disruptive tests as we run in parallel
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-parallel
   labels:
@@ -115,6 +127,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-new-gci-master-upgrade-cluster-parallel
+    description: Upgrade master and node, in gke(gci), from 1.14 to master, run parallel tests only
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master
   labels:
@@ -142,6 +158,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-new-gci-master-upgrade-master
+    description: Upgrade master only, in gke(gci), from 1.14 to master
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
   labels:
@@ -169,6 +189,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-stable-gci-master-upgrade-master
+    description: Upgrade master only, in gke, from gci 1.13 to gci master
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
   labels:
@@ -197,6 +221,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gke-gci-1.13-gci-1.12-downgrade-cluster
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
   labels:
@@ -226,6 +253,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gke-gci-1.13-gci-1.12-downgrade-cluster-parallel
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
   labels:
@@ -254,6 +284,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.12-gci-1.13-upgrade-cluster
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
   labels:
@@ -282,6 +315,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.12-gci-1.13-upgrade-cluster-new
 - interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
   labels:
@@ -310,6 +346,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.12-gci-1.13-upgrade-master
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
   labels:
@@ -338,6 +377,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.11-gci-1.13-upgrade-cluster
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
   labels:
@@ -367,6 +409,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.11-gci-1.13-upgrade-cluster-new
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
   labels:
@@ -395,6 +440,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew, sig-gcp-release-1.11
+    test-tab-name: gke-gci-1.11-gci-1.13-upgrade-master
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
   labels:
@@ -423,6 +471,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.13-1.14-upgrade-cluster
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
   labels:
@@ -451,6 +502,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.13-1.14-upgrade-cluster-new
 - interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
   labels:
@@ -479,6 +533,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.13-1.14-upgrade-master
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
   labels:
@@ -507,6 +564,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.14-1.13-downgrade-cluster
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
   labels:
@@ -536,6 +596,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-1.14-1.13-downgrade-cluster-parallel
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster
   labels:
@@ -564,6 +627,10 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-master-gci-new-downgrade-cluster
+    description: Downgrade master and node, in gke(gci), from master to 1.14
 - interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
   labels:
@@ -592,3 +659,7 @@ periodics:
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gke-upgrade
+    test-tab-name: gke-gci-master-gci-new-downgrade-cluster-parallel
+    description: Downgrade master and node, in gke(gci), from master to 1.14, run parallel tests only

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -15,3 +15,6 @@ periodics:
       - ./tests/e2e/manifests/verify_manifest_lists.sh
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-all
+    test-tab-name: periodic-manifest-lists

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/sig-cluster-lifecycle-misc.yaml
@@ -21,6 +21,9 @@ periodics:
       - --timeout=220m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-ha-master
 - interval: 24h
   name: ci-kubernetes-e2e-gce-min-node-permissions
   labels:
@@ -45,3 +48,6 @@ periodics:
       - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-min-node-permissions

--- a/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gce-conformance.yaml
@@ -48,6 +48,10 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
 
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-gce
+    test-tab-name: GCE, v1.12 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on GCE
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-13
   labels:
@@ -69,6 +73,10 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
 
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-gce
+    test-tab-name: GCE, v1.13 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on GCE
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-14
   labels:
@@ -91,6 +99,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
 
 
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-gce
+    test-tab-name: GCE, v1.14 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on GCE
 - interval: 6h
   name: ci-kubernetes-gce-conformance-stable-1-15
   labels:
@@ -98,16 +110,20 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - args:
-          - --timeout=220
-          - --bare
-          - --scenario=kubernetes_e2e
-          - --
-          - --extract=release/stable-1.15
-          - --gcp-master-image=gci
-          - --gcp-node-image=gci
-          - --gcp-zone=us-west1-b
-          - --provider=gce
-          - --test_args=--ginkgo.focus=\[Conformance\]
-          - --timeout=200m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+    - args:
+      - --timeout=220
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --extract=release/stable-1.15
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Conformance\]
+      - --timeout=200m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-gce
+    test-tab-name: GCE, v1.15 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.15 stable tag on GCE

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-autoscaling.yaml
@@ -26,6 +26,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gke-autoscaling-gpu-k80
 - cron: "0 2-23/4 * * *"
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-p100
   labels:
@@ -53,6 +56,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gke-autoscaling-gpu-p100
 - interval: 4h
   name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-v100
   labels:
@@ -79,3 +85,6 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingGpu\] --ginkgo.skip=\[Flaky\]
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+    test-tab-name: gci-gke-autoscaling-gpu-v100

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gce.yaml
@@ -20,7 +20,7 @@ periodics:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
     fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
-    testgrid-dashboards: sig-release-master-blocking
+    testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-device-plugin-gpu-master
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     description: "Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-gke.yaml
@@ -25,6 +25,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-device-plugin-gpu
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
   cron: "30 0-23/2 * * *"
   labels:
@@ -51,6 +54,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-device-plugin-gpu-1.14
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-monitoring
   cron: "30 0-23/3 * * *"
   labels:
@@ -103,6 +109,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-device-plugin-gpu-p100
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
   cron: "30 8-23/12 * * *" #expensive test
   labels:
@@ -129,6 +138,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: gke-device-plugin-gpu-p100-1.14
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable1
   cron: "0 0-23/12 * * *" #expensive test
   labels:
@@ -181,6 +193,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-release-1.12-all
+    test-tab-name: gke-device-plugin-gpu-p100-1.12
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
   cron: "0 1-23/6 * * *"
   labels:
@@ -207,6 +222,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-gcp-release-1.11
+    test-tab-name: gke-device-plugin-gpu-1.13
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
   cron: "0 2-23/12 * * *"
   labels:
@@ -233,6 +251,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all, sig-release-1.12-all
+    test-tab-name: gke-device-plugin-gpu-1.12
 - name: ci-kubernetes-e2e-gke-device-plugin-gpu-ubuntu
   cron: "0 1-23/2 * * *"
   labels:

--- a/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-gcp/gpu/sig-gcp-gpu-upgrade-downgrade.yaml
@@ -26,6 +26,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.12-1.13-cluster-upgrade
 - cron: "0 5-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
   labels:
@@ -53,6 +56,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.12-1.13-master-upgrade
 - cron: "0 1-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
   labels:
@@ -80,6 +86,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.13-1.14-cluster-upgrade
 - cron: "0 7-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
   labels:
@@ -107,6 +116,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.13-1.14-master-upgrade
 - cron: "0 3-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
   labels:
@@ -134,6 +146,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.13-master-cluster-upgrade
 - cron: "0 9-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
   labels:
@@ -161,6 +176,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.13-master-master-upgrade
 - cron: "0 10-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
   labels:
@@ -189,6 +207,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-1.14-1.13-cluster-downgrade
 - cron: "0 11-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
   labels:
@@ -216,3 +237,6 @@ periodics:
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    test-tab-name: gce-gpu-master-1.13-cluster-downgrade

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml
@@ -162,6 +162,11 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
+    test-tab-name: gce-cos-master-default
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
   labels:
@@ -188,6 +193,9 @@ periodics:
       - --timeout=70m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-alpha-enabled-default
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-alpha-features
   labels:
@@ -213,6 +221,11 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-gce
+    test-tab-name: gce-cos-master-alpha-features
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-flaky
   labels:
@@ -234,6 +247,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-flaky
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
   labels:
@@ -257,6 +273,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-single-flake-attempt
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-reboot
   labels:
@@ -279,6 +298,10 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-informing, google-gce
+    test-tab-name: gce-cos-master-reboot
+    description: Uses kubetest to run a subset of e2e tests (+Feature:Reboot) against a cluster created with cluster/kube-up.sh
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial
   labels:
@@ -302,6 +325,11 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
+    test-tab-name: gce-cos-master-serial
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-slow
   labels:
@@ -325,6 +353,11 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
+    test-tab-name: gce-cos-master-slow
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
 - interval: 30m
   name: ci-kubernetes-e2e-gce-multizone
   labels:
@@ -352,6 +385,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-multizone
 - interval: 12h
   name: ci-kubernetes-soak-gce-gci
   labels:
@@ -379,6 +415,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-soak
+    test-tab-name: gce-gci
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-beta
   labels:
@@ -406,6 +445,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.15-all
+    test-tab-name: soak-gci-gce-1.15
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable1
   labels:
@@ -433,6 +475,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: soak-gci-gce-1.14
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable2
   labels:
@@ -459,6 +504,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-1.13-all
+    test-tab-name: soak-gci-gce-1.13
 - interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable3
   labels:
@@ -484,3 +532,6 @@ periodics:
       - --timeout=1400m
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-release-1.12-all
+    test-tab-name: soak-gci-gce-1.12

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-gke-config.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-gke-config.yaml
@@ -69,6 +69,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-features
   labels:
@@ -95,6 +98,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-alpha-features
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-enabled-default
   labels:
@@ -122,6 +128,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-alpha-enabled-default
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-flaky
   labels:
@@ -147,6 +156,9 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-flaky
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-multizone
   labels:
@@ -174,6 +186,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-multizone
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-reboot
   labels:
@@ -199,6 +214,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-reboot
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-serial
   labels:
@@ -224,6 +242,9 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-serial
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-slow
   labels:
@@ -250,6 +271,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-slow
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-updown
   labels:
@@ -275,6 +299,9 @@ periodics:
       - --timeout=30m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gci-gke-updown
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional
   labels:
@@ -301,6 +328,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-regional
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional-serial
   labels:
@@ -325,6 +355,9 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-regional-serial
 - interval: 1h
   name: ci-kubernetes-e2e-gke-regional-slow
   labels:
@@ -350,6 +383,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-regional-slow
 - interval: 1h
   name: ci-kubernetes-e2e-gke-gci-ci-master
   labels:
@@ -375,6 +411,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gci
+    test-tab-name: ci-gke-master
 - interval: 12h
   name: ci-kubernetes-soak-gke-gci
   labels:
@@ -404,6 +443,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-soak
+    test-tab-name: gke-gci
 - interval: 2h
   name: istio-periodic-e2e-gke-addon
   labels:
@@ -437,3 +479,6 @@ periodics:
       - --test-cmd-args=simple
       - --test-cmd-name=istio-addon
       - --timeout=60m
+  annotations:
+    testgrid-dashboards: istio-gke
+    test-tab-name: istio-gke-addon

--- a/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-gcp/sig-gcp-windows.yaml
@@ -64,6 +64,9 @@ periodics:
         requests:
           memory: "8Gi"
 
+  annotations:
+    testgrid-dashboards: google-windows
+    test-tab-name: windows-prototype
 - name: ci-kubernetes-e2e-windows-gce
   decorate: true
   extra_refs:
@@ -96,6 +99,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-windows, sig-windows
+    test-tab-name: gce-windows-master
+    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
 - name: ci-kubernetes-e2e-windows-gce-k8sbeta
   decorate: true
   extra_refs:
@@ -128,6 +135,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-windows, sig-windows
+    test-tab-name: gce-windows-1.15
+    description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE"
 - name: ci-kubernetes-e2e-windows-gce-k8sstable1
   decorate: true
   extra_refs:
@@ -161,6 +172,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
 
+  annotations:
+    testgrid-dashboards: google-windows, sig-release-1.14-all, sig-windows
+    test-tab-name: gce-windows-1.14
+    description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE"
 - name: ci-kubernetes-e2e-windows-gce-alpha-features
   decorate: true
   extra_refs:
@@ -196,6 +211,10 @@ periodics:
         value: "WindowsGMSA=true"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-windows, sig-windows
+    test-tab-name: gce-windows-master-alpha-features
+    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled"
 - name: ci-kubernetes-e2e-windows-gce-serial
   decorate: true
   extra_refs:
@@ -228,6 +247,9 @@ periodics:
       - --timeout=240m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-windows
+    test-tab-name: windows-gce-serial
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-windows-gce
@@ -271,3 +293,6 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: google-windows
+      test-tab-name: pull-windows-gce

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -20,6 +20,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-influxdb
 - interval: 30m
   name: ci-kubernetes-e2e-gce-prometheus
   labels:
@@ -40,6 +43,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-prometheus
 - interval: 30m
   name: ci-kubernetes-e2e-gce-stackdriver
   labels:
@@ -63,6 +69,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gce-stackdriver
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-es-logging
   labels:
@@ -86,6 +95,9 @@ periodics:
       - --timeout=90m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-es-logging
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-sd-logging
   labels:
@@ -109,6 +121,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce
+    test-tab-name: gci-gce-sd-logging
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
   labels:
@@ -133,6 +148,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-gci-1.14
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
   labels:
@@ -157,6 +175,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-gci-latest
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
   labels:
@@ -181,6 +202,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-gci-1.13
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
   labels:
@@ -205,6 +229,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-ubuntu-1.14
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
   labels:
@@ -229,6 +256,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-ubuntu-latest
 - interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
   labels:
@@ -253,6 +283,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-sd-logging-ubuntu-1.13
 - interval: 30m
   name: ci-kubernetes-e2e-gke-stackdriver
   labels:
@@ -277,3 +310,6 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gke-stackdriver
+    test-tab-name: gke-stackdriver

--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -7,7 +7,7 @@ presets:
     # remove this after https://github.com/kubernetes/kubernetes/pull/69051
   - name: KUBE_CUSTOM_NETD_YAML
     # we want to keep extra spaces for the yaml file.
-    value: |2+
+    value: |2
         kind: ClusterRole
         apiVersion: rbac.authorization.k8s.io/v1
         metadata:
@@ -196,7 +196,7 @@ presets:
     # remove this after https://github.com/kubernetes/kubernetes/pull/69051
   - name: KUBE_CUSTOM_NETD_YAML
     # we want to keep extra spaces for the yaml file.
-    value: |2+
+    value: |2
         kind: ClusterRole
         apiVersion: rbac.authorization.k8s.io/v1
         metadata:
@@ -377,7 +377,7 @@ presets:
   - name: KUBE_ENABLE_NETD
     value: true
   - name: KUBE_CUSTOM_CALICO_NODE_DAEMONSET_YAML
-    value: |2+
+    value: |2
         kind: DaemonSet
         apiVersion: extensions/v1beta1
         metadata:
@@ -658,7 +658,7 @@ presets:
   - name: KUBE_UP_AUTOMATIC_CLEANUP
     value: true
   - name: KUBE_CUSTOM_CALICO_NODE_DAEMONSET_YAML
-    value: |2+
+    value: |2
         kind: DaemonSet
         apiVersion: extensions/v1beta1
         metadata:
@@ -840,7 +840,7 @@ presets:
                 - key: CriticalAddonsOnly
                   operator: Exists
   - name: KUBE_CUSTOM_TYPHA_DEPLOYMENT_YAML
-    value: |2+
+    value: |2
         apiVersion: extensions/v1beta1
         kind: Deployment
         metadata:
@@ -940,6 +940,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-gci-gce-netd
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-gci-gce-netd-calico
   labels:
@@ -966,6 +970,10 @@ periodics:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-gci-gce-netd-calico
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-ubuntu-gce-netd
   labels:
@@ -991,6 +999,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-ubuntu-gce-netd
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-ubuntu-gce-netd-calico
   labels:
@@ -1018,6 +1030,10 @@ periodics:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-ubuntu-gce-netd-calico
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-containerd-gce-netd
   labels:
@@ -1047,6 +1063,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-containerd-gce-netd
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-containerd-gce-netd-calico
   labels:
@@ -1079,6 +1099,10 @@ periodics:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
 
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-containerd-gce-netd-calico
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-kubernetes-e2e-containerd-gce-calico
   labels:
@@ -1107,3 +1131,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: sig-network-netd
+    test-tab-name: e2e-containerd-gce-calico
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -128,6 +128,10 @@ postsubmits:
         securityContext:
           privileged: true
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-gce-e2e
+      test-tab-name: ingress-gce-image-push
+      testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 periodics:
 - name: ci-ingress-gce-e2e
   interval: 60m
@@ -156,6 +160,10 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
 
+  annotations:
+    testgrid-dashboards: sig-network-ingress-gce-e2e
+    test-tab-name: ingress-gce-e2e
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - name: ci-ingress-gce-e2e-multi-zone
   interval: 3h
   labels:
@@ -184,6 +192,10 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]
       - --timeout=320m
 
+  annotations:
+    testgrid-dashboards: sig-network-ingress-gce-e2e
+    test-tab-name: ingress-gce-e2e-multi-zone
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - name: ci-ingress-gce-e2e-release-1-6
   interval: 90m
   labels:
@@ -208,6 +220,10 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]
       - --timeout=320m
 
+  annotations:
+    testgrid-dashboards: sig-network-ingress-gce-e2e
+    test-tab-name: ingress-gce-e2e-release-1.6
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - name: ci-ingress-gce-e2e-scale
   interval: 6h
   labels:
@@ -232,3 +248,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:IngressScale\]
       - --timeout=320m
+  annotations:
+    testgrid-dashboards: sig-network-ingress-gce-e2e
+    test-tab-name: ingress-gce-e2e-scale
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com

--- a/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
@@ -14,6 +14,9 @@ presubmits:
         command:
         - ./hack/verify-boilerplate.sh
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: boilerplate
   - name: pull-ingress-nginx-codegen
     always_run: true
     decorate: true
@@ -27,6 +30,9 @@ presubmits:
         command:
         - ./hack/verify-codegen.sh
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: codegen
   - name: pull-ingress-nginx-gofmt
     always_run: true
     decorate: true
@@ -40,6 +46,9 @@ presubmits:
         command:
         - ./hack/verify-gofmt.sh
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: gofmt
   - name: pull-ingress-nginx-golint
     always_run: true
     decorate: true
@@ -53,6 +62,9 @@ presubmits:
         command:
         - ./hack/verify-golint.sh
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: golint
   - name: pull-ingress-nginx-test-lua
     always_run: true
     decorate: true
@@ -67,6 +79,9 @@ presubmits:
         - make
         - lua-test
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: test-lua
   - name: pull-ingress-nginx-test
     always_run: true
     decorate: true
@@ -88,13 +103,16 @@ presubmits:
               name: ingress-nginx-codecov-token
               key: ingress-nginx-codecov-token
     volumes:
-      - name: ingress-nginx-codecov-token
-        secret:
-          secretName: ingress-nginx-codecov-token
-          items:
-          - key: ingress-nginx-codecov-token
-            path: ingress-nginx-codecov-token
+    - name: ingress-nginx-codecov-token
+      secret:
+        secretName: ingress-nginx-codecov-token
+        items:
+        - key: ingress-nginx-codecov-token
+          path: ingress-nginx-codecov-token
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: test
   - name: pull-ingress-nginx-e2e-1-12
     always_run: true
     decorate: true
@@ -125,6 +143,9 @@ presubmits:
           requests:
             cpu: 2
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: e2e-1-12
   - name: pull-ingress-nginx-e2e-1-13
     always_run: true
     decorate: true
@@ -155,6 +176,9 @@ presubmits:
           requests:
             cpu: 2
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: e2e-1-13
   - name: pull-ingress-nginx-e2e-1-14
     always_run: true
     decorate: true
@@ -185,6 +209,9 @@ presubmits:
           requests:
             cpu: 2
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: e2e-1-14
   - name: pull-ingress-nginx-e2e-1-15
     always_run: true
     decorate: true
@@ -215,6 +242,9 @@ presubmits:
           requests:
             cpu: 2
 
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      test-tab-name: e2e-1-15
 periodics:
 
 - name: ci-ingress-nginx-e2e
@@ -244,3 +274,6 @@ periodics:
       resources:
         requests:
           cpu: 2
+  annotations:
+    testgrid-dashboards: sig-network-ingress-nginx
+    test-tab-name: ci-e2e

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -45,6 +45,10 @@ periodics:
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce, sig-network-gce
+    test-tab-name: gce-alpha-api
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance
   labels:
@@ -70,6 +74,9 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    test-tab-name: gce-coredns-performance
 - interval: 6h
   name: ci-kubernetes-e2e-gce-kubedns-performance
   labels:
@@ -95,6 +102,9 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    test-tab-name: gce-kubedns-performance
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-coredns
   labels:
@@ -144,6 +154,9 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    test-tab-name: gce-coredns-performance-nodecache
 - interval: 6h
   name: ci-kubernetes-e2e-gce-kubedns-performance-nodecache
   labels:
@@ -170,6 +183,9 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    test-tab-name: gce-kubedns-performance-nodecache
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-coredns-nodecache
   labels:
@@ -218,6 +234,11 @@ periodics:
       - --timeout=320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
+    test-tab-name: gci-gce-ingress
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
+    description: Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
   labels:
@@ -241,6 +262,10 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    test-tab-name: gci-gce-ingress-manual-network
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ip-alias
   labels:
@@ -267,6 +292,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gce, google-gci
+    test-tab-name: ip-alias
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-ipvs
   labels:
@@ -390,6 +418,10 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: google-gke, sig-network-gke
+    test-tab-name: gci-gke-ingress
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gke-network-policy
   labels:
@@ -416,6 +448,10 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gke
+    test-tab-name: gci-gke-network-policy
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 120m
   name: ci-kubernetes-e2e-gce-lb-finalizer
   labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -55,6 +55,9 @@ periodics:
       - --
       - /go/src/github.com/containerd/cri/test/containerd/build.sh
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-build
 - name: ci-containerd-build-1-1
   interval: 30m
   labels:
@@ -72,6 +75,9 @@ periodics:
       - --env=DEPLOY_DIR=containerd/release-1.1
       - /go/src/github.com/containerd/cri/test/containerd/build.sh
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-build-1.1
 - name: ci-containerd-build-1-2
   interval: 30m
   labels:
@@ -89,6 +95,9 @@ periodics:
       - --env=DEPLOY_DIR=containerd/release-1.2
       - /go/src/github.com/containerd/cri/test/containerd/build.sh
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-build-1.2
 - interval: 1h
   name: ci-containerd-e2e-gci-gce
   labels:
@@ -117,6 +126,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-gci
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-1
   labels:
@@ -146,6 +158,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190513-95c7cbe-1.11
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-gci-1.1
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-2
   labels:
@@ -175,6 +190,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
 
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-gci-1.2
 - interval: 1h
   name: ci-containerd-e2e-ubuntu-gce
   labels:
@@ -203,6 +221,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-ubuntu
 - name: ci-containerd-node-e2e
   interval: 1h
   labels:
@@ -231,6 +252,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd, sig-node-cri
+    test-tab-name: containerd-node-conformance
 - name: ci-containerd-node-e2e-1-1
   interval: 1h
   labels:
@@ -259,6 +283,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-node-e2e-1.1
 - name: ci-containerd-node-e2e-1-2
   interval: 1h
   labels:
@@ -287,6 +314,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-node-e2e-1.2
 - name: ci-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -315,6 +345,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd, sig-node-cri
+    test-tab-name: containerd-node-features
 - name: ci-containerd-node-e2e-features-1-1
   interval: 1h
   labels:
@@ -343,6 +376,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-node-e2e-features-1.1
 - name: ci-containerd-node-e2e-features-1-2
   interval: 1h
   labels:
@@ -371,6 +407,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-node-e2e-features-1.2
 - interval: 12h
   name: ci-containerd-soak-gci-gce
   labels:
@@ -401,6 +440,9 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: soak-gci-gce
 - name: ci-cri-containerd-build
   interval: 30m
   labels:
@@ -416,6 +458,9 @@ periodics:
       - --
       - ./test/build.sh
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: build
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cron: "30 1-23/3 * * *"
   labels:
@@ -441,6 +486,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-device-plugin-gpu
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-multizone
   labels:
@@ -469,6 +517,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-multizone
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-stackdriver
   labels:
@@ -495,6 +546,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-stackdriver
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce
   labels:
@@ -521,6 +575,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-alpha-features
   labels:
@@ -548,6 +605,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-alpha-features
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-es-logging
   labels:
@@ -573,6 +633,9 @@ periodics:
       - --timeout=90m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-es-logging
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-flaky
   labels:
@@ -596,6 +659,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-flaky
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ingress
   labels:
@@ -622,6 +688,10 @@ periodics:
       - --timeout=320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-network-gce, sig-node-containerd
+    test-tab-name: e2e-gci-ingress
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ip-alias
   labels:
@@ -649,6 +719,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-ip-alias
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-proto
   labels:
@@ -674,6 +747,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-proto
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-reboot
   labels:
@@ -697,6 +773,9 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-reboot
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging
   labels:
@@ -722,6 +801,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-sd-logging
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging-k8s-resources
   labels:
@@ -751,6 +833,9 @@ periodics:
       - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-sd-logging-k8s-resources
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-serial
   labels:
@@ -774,6 +859,9 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-serial
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-slow
   labels:
@@ -798,6 +886,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-slow
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-statefulset
   labels:
@@ -820,6 +911,9 @@ periodics:
       - --timeout=90m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-gci-statefulset
 - interval: 1h
   name: ci-cri-containerd-e2e-ubuntu-gce
   labels:
@@ -846,6 +940,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: e2e-ubuntu
 - name: ci-cri-containerd-node-e2e
   interval: 1h
   labels:
@@ -874,6 +971,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: node-e2e
 - name: ci-cri-containerd-node-e2e-benchmark
   interval: 2h
   labels:
@@ -902,6 +1002,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: node-e2e-benchmark
 - name: ci-cri-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -930,6 +1033,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: node-e2e-features
 - name: ci-cri-containerd-node-e2e-flaky
   interval: 2h
   labels:
@@ -958,6 +1064,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: node-e2e-flaky
 - name: ci-cri-containerd-node-e2e-serial
   interval: 4h30m
   labels:
@@ -986,6 +1095,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: node-e2e-serial
 - interval: 1h
   name: ci-containerd-e2e-shielded-gci-gce-1-2
   labels:
@@ -1016,6 +1128,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-shielded-gci-1.2
 - interval: 1h
   name: ci-containerd-e2e-shielded-gci-gce-slow-1-2
   labels:
@@ -1044,6 +1159,9 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-shielded-gci-slow-1.2
 - interval: 1h
   name: ci-containerd-e2e-shielded-gci-gce-serial-1-2
   labels:
@@ -1071,6 +1189,9 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: containerd-e2e-shielded-gci-serial-1.2
 - interval: 1h
   name: ci-cos-containerd-e2e-gci-gce
   labels:
@@ -1099,6 +1220,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: image-validation-cos-e2e
 - interval: 1h
   name: ci-cos-containerd-e2e-ubuntu-gce
   labels:
@@ -1124,6 +1248,9 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: image-validation-ubuntu-e2e
 - name: ci-cos-containerd-node-e2e
   interval: 1h
   labels:
@@ -1151,6 +1278,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: image-validation-node-e2e
 - name: ci-cos-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -1177,3 +1307,6 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    test-tab-name: image-validation-node-features

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -25,6 +25,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-cri
+    test-tab-name: docker-node-conformance
 - name: ci-docker-node-features
   interval: 4h
   labels:
@@ -51,6 +54,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-cri
+    test-tab-name: docker-node-features
 - name: ci-docker-node-legacy
   interval: 2h
   labels:
@@ -75,3 +81,6 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+  annotations:
+    testgrid-dashboards: sig-node-cri
+    test-tab-name: docker-node-legacy

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -61,6 +61,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-alpha
 - name: ci-kubernetes-node-kubelet-benchmark
   interval: 2h
   labels:
@@ -88,6 +91,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-benchmark
 - name: ci-kubernetes-node-kubelet-conformance
   interval: 2h
   labels:
@@ -119,6 +125,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-conformance
 - name: ci-kubernetes-node-kubelet-features
   interval: 1h
   labels:
@@ -127,6 +136,8 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-features
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
@@ -176,6 +187,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-flaky
 - name: ci-kubernetes-node-kubelet-orphans
   interval: 12h
   labels:
@@ -203,6 +217,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-orphans
 - name: ci-kubernetes-node-kubelet-serial
   interval: 4h30m
   labels:
@@ -230,6 +247,9 @@ periodics:
       - name: GOPATH
         value: /go
 
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    test-tab-name: node-kubelet-serial
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h
   labels:
@@ -256,3 +276,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+  annotations:
+    testgrid-dashboards: wg-resource-management
+    test-tab-name: kubelet-serial-gce-e2e-cpu-manager
+    testgrid-alert-email: balaji.warft@gmail.com, connor.p.d@gmail.com

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -25,3 +25,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+  annotations:
+    testgrid-dashboards: google-gce, sig-storage-kubernetes
+    test-tab-name: gce-containerd
+    description: node gce e2e tests for master branch using containerd

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -53,6 +53,11 @@ periodics:
           cpu: 4
           memory: "8Gi"
 
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, google-unit
+    test-tab-name: build-master-fast
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    description: 'Ends up running: make quick-release'
 - interval: 4h
   name: ci-kubernetes-build-debian-unstable
   labels:
@@ -75,6 +80,10 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  annotations:
+    testgrid-dashboards: sig-release-misc
+    test-tab-name: debian-unstable
+    testgrid-alert-email: kubernetes-patch-release-team@googlegroups.com
 - interval: 1h
   name: ci-kubernetes-build
   labels:
@@ -89,25 +98,25 @@ periodics:
     testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190703-1f4d616
-        args:
-          - --repo=k8s.io/kubernetes
-          - --repo=k8s.io/release
-          - --root=/go/src
-          - --timeout=180
-          - --scenario=kubernetes_build
-          - --
-          - --allow-dup
-          - --extra-publish-file=k8s-master
-          - --hyperkube
-          - --registry=gcr.io/kubernetes-ci-images
+    - image: gcr.io/k8s-testimages/bootstrap:v20190703-1f4d616
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=180
+      - --scenario=kubernetes_build
+      - --
+      - --allow-dup
+      - --extra-publish-file=k8s-master
+      - --hyperkube
+      - --registry=gcr.io/kubernetes-ci-images
         # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 4
-            memory: "8Gi"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
 - interval: 1h
   name: ci-kubernetes-cross-build
   labels:
@@ -133,3 +142,7 @@ periodics:
         requests:
           cpu: 7
           memory: "41Gi"
+  annotations:
+    testgrid-dashboards: sig-release-misc
+    test-tab-name: cross-build
+    testgrid-alert-email: kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -1,9 +1,7 @@
 periodics:
 - annotations:
-    description: Runs conformance tests using kubetest against kubernetes release
-      1.12 branch on GCE
-    testgrid-dashboards: sig-release-1.12-informing, sig-release-1.12-all, conformance-all,
-      conformance-gce
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 branch on GCE
+    testgrid-dashboards: sig-release-1.12-informing, sig-release-1.12-all, conformance-all, conformance-gce
     testgrid-tab-name: GCE, v1.12 (dev)
   interval: 6h
   labels:
@@ -60,7 +58,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all
+    testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, google-unit
     testgrid-tab-name: build-1.12
   interval: 1h
   labels:
@@ -235,8 +233,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-cron: ""
-    testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, sig-scalability-gce,
-      google-gce
+    testgrid-dashboards: sig-release-1.12-blocking, sig-release-1.12-all, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-1.12-scalability-100
   cron: 0 8-20/12 * * *
   labels:
@@ -374,8 +371,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
         name: ""
@@ -415,8 +411,7 @@ presubmits:
         - --provider=gke
         - --stage=gs://kubernetes-release-dev/ci
         - --stage-suffix=pull-kubernetes-e2e-gke
-        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
         name: ""
@@ -532,8 +527,7 @@ presubmits:
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          --flakeAttempts=2
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -1,9 +1,7 @@
 periodics:
 - annotations:
-    description: Runs conformance tests using kubetest against kubernetes release
-      1.13 branch on GCE
-    testgrid-dashboards: sig-release-1.13-informing, sig-release-1.13-all, conformance-all,
-      conformance-gce
+    description: Runs conformance tests using kubetest against kubernetes release 1.13 branch on GCE
+    testgrid-dashboards: sig-release-1.13-informing, sig-release-1.13-all, conformance-all, conformance-gce
     testgrid-tab-name: GCE, v1.13 (dev)
   interval: 6h
   labels:
@@ -60,7 +58,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
+    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
     testgrid-tab-name: build-1.13
   interval: 1h
   labels:
@@ -235,8 +233,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-cron: 0 8-20/12 * * *
-    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, sig-scalability-gce,
-      google-gce
+    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-1.13-scalability-100
   cron: 0 4-16/12 * * *
   labels:
@@ -375,8 +372,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
         name: ""
@@ -416,8 +412,7 @@ presubmits:
         - --provider=gke
         - --stage=gs://kubernetes-release-dev/ci
         - --stage-suffix=pull-kubernetes-e2e-gke
-        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
         name: ""
@@ -533,8 +528,7 @@ presubmits:
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          --flakeAttempts=2
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -1,9 +1,7 @@
 periodics:
 - annotations:
-    description: Runs conformance tests using kubetest against kubernetes release
-      1.14 branch on GCE
-    testgrid-dashboards: sig-release-1.14-informing, sig-release-1.14-all, conformance-all,
-      conformance-gce
+    description: Runs conformance tests using kubetest against kubernetes release 1.14 branch on GCE
+    testgrid-dashboards: sig-release-1.14-informing, sig-release-1.14-all, conformance-all, conformance-gce
     testgrid-tab-name: GCE, v1.14 (dev)
   interval: 6h
   labels:
@@ -29,8 +27,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-periodic-interval: 6h 24h
-    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-node-kubelet,
-      sig-node-cri-1.12
+    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-node-kubelet, sig-node-cri-1.12
     testgrid-tab-name: node-kubelet-1.14
   interval: 2h
   labels:
@@ -93,7 +90,7 @@ periodics:
     testgrid-dashboards: sig-release-1.15-all
     testgrid-tab-name: node-kubetlet-features-1.15
 - annotations:
-    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
+    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
     testgrid-tab-name: build-1.14
   interval: 1h
   labels:
@@ -222,6 +219,9 @@ periodics:
       resources:
         requests:
           memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-release-1.14-all
+    test-tab-name: periodic-bazel-test-1.14
 - annotations:
     fork-per-release-periodic-interval: 6h 24h
     testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
@@ -278,8 +278,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
-    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-scalability-gce,
-      google-gce
+    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-cos-1.14-scalability-100
   cron: 0 0/12 * * *
   labels:
@@ -416,8 +415,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
         name: ""
@@ -457,8 +455,7 @@ presubmits:
         - --provider=gke
         - --stage=gs://kubernetes-release-dev/ci
         - --stage-suffix=pull-kubernetes-e2e-gke
-        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
         name: ""
@@ -574,8 +571,7 @@ presubmits:
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          --flakeAttempts=2
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -122,7 +122,7 @@ periodics:
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking
+    testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: build-1.15
   interval: 1h
   labels:
@@ -556,8 +556,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
         name: ""
@@ -599,8 +598,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
@@ -640,8 +638,7 @@ presubmits:
         - --provider=gke
         - --stage=gs://kubernetes-release-dev/ci
         - --stage-suffix=pull-kubernetes-e2e-gke
-        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
         name: ""
@@ -673,8 +670,7 @@ presubmits:
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          --flakeAttempts=2
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
@@ -715,8 +711,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
-          --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
         name: ""

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -33,6 +33,9 @@ periodics:
       - --use-logexporter
 
 #kubemark
+  annotations:
+    testgrid-dashboards: sig-scalability-node
+    test-tab-name: node-throughput
 - name: ci-kubernetes-kubemark-100-gce
   tags:
   - "perfDashPrefix: kubemark-100Nodes"
@@ -83,6 +86,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    test-tab-name: kubemark-100
 - name: ci-kubernetes-kubemark-500-gce
   tags:
   - "perfDashPrefix: kubemark-500Nodes"
@@ -132,6 +138,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    test-tab-name: kubemark-500
 - name: ci-kubernetes-kubemark-gce-scale
   tags:
   - "perfDashPrefix: kubemark-5000Nodes"
@@ -184,6 +193,9 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    test-tab-name: kubemark-5000
 - name: ci-kubernetes-kubemark-high-density-100-gce
   tags:
   - "perfDashPrefix: kubemark-100Nodes-highDensity"
@@ -231,6 +243,9 @@ periodics:
       securityContext:
         privileged: true
 
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    test-tab-name: kubemark-100-high-density
 - name: ci-perf-tests-kubemark-100-benchmark
   interval: 2h
   labels:
@@ -247,6 +262,9 @@ periodics:
       - --
       - ./benchmark/runner.sh
 
+  annotations:
+    testgrid-dashboards: sig-scalability-perf-tests
+    test-tab-name: kubemark-100-benchmark
 - name: ci-benchmark-scheduler-master
   tags:
   - "perfDashPrefix: scheduler-benchmark"
@@ -272,6 +290,9 @@ periodics:
       - name: KUBE_TIMEOUT
         value: --timeout 40m
 
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    test-tab-name: scheduler
 - name: ci-benchmark-kube-dns-master
   interval: 2h
   tags:
@@ -304,6 +325,9 @@ periodics:
       - --test-cmd-name=KubeDnsBenchmark
       - --timeout=120m
 
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    test-tab-name: kube-dns
 - name: ci-benchmark-microbenchmarks
   interval: 20m
   decorate: true
@@ -334,6 +358,9 @@ periodics:
       - ../kubernetes/vendor/k8s.io/client-go/...
 
 # Experimental config for testing private gce clusters.
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    test-tab-name: microbenchmarks
 - name: ci-kubernetes-e2e-gce-private-cluster-correctness
   # TODO(mm4tt): Lower the timeout once we know how long the test takes.
   interval: 6h
@@ -343,22 +370,25 @@ periodics:
     preset-e2e-scalability-common: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        args:
-          - --timeout=300
-          - --bare
-          - --scenario=kubernetes_e2e
-          - --
-          - --cluster=private-gce-test
-          - --env=KUBE_GCE_PRIVATE_CLUSTER=true
-          - --extract=ci/latest
-          - --gcp-master-image=gci
-          - --gcp-node-image=gci
-          - --gcp-nodes=5
-          - --gcp-ssh-proxy-instance-name=private-gce-test-master
-          - --gcp-zone=us-east1-b
-          - --ginkgo-parallel=5
-          - --provider=gce
-          - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
-          - --timeout=240m
-          - --use-logexporter
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      args:
+      - --timeout=300
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=private-gce-test
+      - --env=KUBE_GCE_PRIVATE_CLUSTER=true
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-nodes=5
+      - --gcp-ssh-proxy-instance-name=private-gce-test-master
+      - --gcp-zone=us-east1-b
+      - --ginkgo-parallel=5
+      - --provider=gce
+      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
+      - --timeout=240m
+      - --use-logexporter
+  annotations:
+    testgrid-dashboards: sig-scalability-experiments
+    test-tab-name: gce-private-cluster-correctness

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -108,7 +108,7 @@ periodics:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
-    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce
+    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com,cloud-kubernetes-scalability-oncall@google.com
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with cluster/kube-up.sh"

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -105,16 +105,20 @@ postsubmits:
         args:
         - -c
         - |
-                set -o errexit
-                gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
-                ../test-infra/scenarios/kubernetes_bazel.py \
-                    --config=ci \
-                    "--build=//... -//vendor/..." \
-                    --release=//build/release-tars \
-                    --gcs=gs://kubernetes-release-dev/ci \
-                    --version-suffix=-bazel-rbe \
-                    --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-rbe.txt
+          set -o errexit
+          gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+          ../test-infra/scenarios/kubernetes_bazel.py \
+              --config=ci \
+              "--build=//... -//vendor/..." \
+              --release=//build/release-tars \
+              --gcs=gs://kubernetes-release-dev/ci \
+              --version-suffix=-bazel-rbe \
+              --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-rbe.txt
 
+    annotations:
+      testgrid-dashboards: sig-release-master-informing
+      test-tab-name: bazel-build-master
+      description: 'OWNER: sig-testing; Builds kubernetes at each bommit using bazel with RBE'
   - name: ci-kubernetes-bazel-test # TODO(fejta): delete after 1m (dup of post-kubernetes-bazel-test)
     decorate: true
     labels:
@@ -154,6 +158,9 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: sig-release-master-informing
+      test-tab-name: bazel-test-master
+      description: 'OWNER: sig-testing; Runs kubernetes unit tests using bazel'
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -188,6 +195,8 @@ periodics:
     fork-per-release: "true"
     fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
     fork-per-release-periodic-interval: 6h
+    testgrid-dashboards: google-unit
+    test-tab-name: periodic-bazel-build-master
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -203,15 +212,15 @@ periodics:
       args:
       - -c
       - |
-              set -o errexit
-              gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
-              ../test-infra/scenarios/kubernetes_bazel.py \
-                  --config=ci \
-                  "--build=//... -//vendor/..." \
-                  --release=//build/release-tars \
-                  --gcs=gs://kubernetes-release-dev/ci \
-                  --version-suffix=-bazel \
-                  --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
+        set -o errexit
+        gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+        ../test-infra/scenarios/kubernetes_bazel.py \
+            --config=ci \
+            "--build=//... -//vendor/..." \
+            --release=//build/release-tars \
+            --gcs=gs://kubernetes-release-dev/ci \
+            --version-suffix=-bazel \
+            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
 
 - name: periodic-kubernetes-bazel-build-canary
   interval: 1h
@@ -236,17 +245,21 @@ periodics:
       args:
       - -c
       - |
-              set -o errexit
-              gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
-              ../test-infra/scenarios/kubernetes_bazel.py \
-                  --config=ci \
-                  "--build=//... -//vendor/..." \
-                  --release=//build/release-tars \
-                  --gcs=gs://kubernetes-release-dev/ci \
-                  --version-suffix=-bazel \
-                  --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
+        set -o errexit
+        gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+        ../test-infra/scenarios/kubernetes_bazel.py \
+            --config=ci \
+            "--build=//... -//vendor/..." \
+            --release=//build/release-tars \
+            --gcs=gs://kubernetes-release-dev/ci \
+            --version-suffix=-bazel \
+            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
 
 # periodic bazel test jobs
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    test-tab-name: bazel-build
+    description: run kubernetes-bazel-build with latest image
 - interval: 5m
   name: periodic-kubernetes-bazel-test-master
   decorate: true
@@ -256,6 +269,8 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 6h
+    testgrid-dashboards: google-unit
+    test-tab-name: periodic-bazel-test-master
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -306,3 +321,7 @@ periodics:
       - --
       - -//build/...
       - -//vendor/...
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    test-tab-name: bazel-test
+    description: run kubernetes-bazel-test with latest image

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -3,7 +3,7 @@ presubmits:
   # conformance test using image against kubernetes master branch with `kind`
   - name: pull-kubernetes-conformance-image-test
     branches:
-      - master
+    - master
     always_run: false
     skip_report: false
     max_concurrency: 8
@@ -17,102 +17,112 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-          args:
-            - "--job=$(JOB_NAME)"
-            - "--root=/go/src"
-            - "--repo=k8s.io/test-infra=master"
-            - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
-            - "--service-account=/etc/service-account/service-account.json"
-            - "--upload=gs://kubernetes-jenkins/pr-logs"
-            - "--scenario=execute"
-            - "--"
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--root=/go/src"
+        - "--repo=k8s.io/test-infra=master"
+        - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
             # the script must run from kubernetes, but we're checking out kind
-            - "bash"
-            - "--"
-            - "-c"
-            - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+        - "bash"
+        - "--"
+        - "-c"
+        - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
           # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
+        securityContext:
+          privileged: true
+        resources:
+          requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
-              memory: "9000Mi"
+            memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+            cpu: 2000m
 
 periodics:
   # conformance test using image against kubernetes master branch with `kind`
-  - interval: 1h
-    name: ci-kubernetes-conformance-image-test
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-          args:
-            - "--job=$(JOB_NAME)"
-            - "--root=/go/src"
-            - "--repo=k8s.io/test-infra=master"
-            - "--repo=k8s.io/kubernetes=master"
-            - "--service-account=/etc/service-account/service-account.json"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            - "--scenario=execute"
-            - "--"
+- interval: 1h
+  name: ci-kubernetes-conformance-image-test
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/test-infra=master"
+      - "--repo=k8s.io/kubernetes=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
             # the script must run from kubernetes, but we're checking out kind
-            - "bash"
-            - "--"
-            - "-c"
-            - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+      - "bash"
+      - "--"
+      - "-c"
+      - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
           # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
+      securityContext:
+        privileged: true
+      resources:
+        requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
-              memory: "9000Mi"
+          memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+          cpu: 2000m
   # conformance test using image against kubernetes 1.14 branch with `kind`
-  - interval: 1h
-    name: ci-kubernetes-conformance-image-1-14-test
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-          args:
-            - "--job=$(JOB_NAME)"
-            - "--root=/go/src"
-            - "--repo=k8s.io/test-infra=master"
-            - "--repo=k8s.io/kubernetes=release-1.14"
-            - "--service-account=/etc/service-account/service-account.json"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            - "--scenario=execute"
-            - "--"
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: conformance-image, master (dev)
+    description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
+    testgrid-alert-email: davanum@gmail.com
+- interval: 1h
+  name: ci-kubernetes-conformance-image-1-14-test
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/test-infra=master"
+      - "--repo=k8s.io/kubernetes=release-1.14"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
             # the script must run from kubernetes, but we're checking out kind
-            - "bash"
-            - "--"
-            - "-c"
-            - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+      - "bash"
+      - "--"
+      - "-c"
+      - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
           # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
+      securityContext:
+        privileged: true
+      resources:
+        requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
-              memory: "9000Mi"
+          memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    test-tab-name: conformance-image, 1.14 (dev)
+    description: Runs conformance tests using image against kubernetes 1.14 branch with a kubernetes-in-docker cluster
+    testgrid-alert-email: davanum@gmail.com

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -58,6 +58,9 @@ periodics:
       securityContext:
         privileged: true
 # coverage for same tests that run in ci-kubernetes-e2e-gci-gce
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    description: build instrumented kubernetes, run conformance tests, generate line coverage using gopherage
 - interval: 1h
   name: ci-kubernetes-coverage-e2e-gci-gce
   decorate: true
@@ -121,3 +124,6 @@ periodics:
         value: "n"
       securityContext:
         privileged: true
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    description: build instrumented kubernetes, run (non-slow/serial/disruptive/flaky/feature) e2e tests, generate line coverage using gopherage

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -58,6 +58,8 @@ presubmits:
           requests:
             cpu: 4
 
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
 periodics:
 - interval: 1h
   name: ci-kubernetes-integration-master

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -24,6 +24,9 @@ presubmits:
           requests:
             memory: "6Gi"
 
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+      test-tab-name: pull-bazel-build
   - name: pull-kubernetes-bazel-test-canary
     always_run: false
     labels:
@@ -48,6 +51,9 @@ presubmits:
           requests:
             memory: "6Gi"
 
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+      test-tab-name: pull-bazel-test
   - name: pull-kubernetes-bazel-test-integration-canary
     always_run: false
     labels:
@@ -72,6 +78,9 @@ presubmits:
           requests:
             memory: "6Gi"
 
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+      test-tab-name: pull-bazel-test-integration
 periodics:
 - name: ci-kubernetes-e2e-prow-canary
   interval: 1h
@@ -176,6 +185,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-gke
+    test-tab-name: gke-canary
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-canary
   labels:
@@ -206,6 +218,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    test-tab-name: kops-aws-canary
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce-canary
   labels:
@@ -232,6 +247,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
 
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    test-tab-name: kops-gce-canary
 - name: ci-kubernetes-e2e-node-canary
   interval: 1h
   labels:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -73,3 +73,7 @@ periodics:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-hack-local-up-cluster
+    test-tab-name: local-up-cluster, master (dev)
+    description: Runs conformance tests using kubetest with hack/local-up-cluster.sh

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -21,31 +21,39 @@ presubmits:
 
 # Testing to make sure things still update.
 periodics:
-  - interval: 10m
-    name: ci-test-infra-canary-echo-test
-    decorate: true
-    spec:
-      containers:
-        - image: alpine
-          command: ["/bin/date"]
+- interval: 10m
+  name: ci-test-infra-canary-echo-test
+  decorate: true
+  spec:
+    containers:
+    - image: alpine
+      command: ["/bin/date"]
 
-  - name: ci-test-infra-benchmark-demo
-    interval: 20m
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: golang:latest
-        command:
-        - go
-        args:
-        - run
-        - ./pkg/benchmarkjunit
-        - --log-file=$(ARTIFACTS)/benchmark-log.txt
-        - --output=$(ARTIFACTS)/junit_benchmarks.xml
-        - --pass-on-error
-        - ./experiment/dummybenchmarks/...
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    test-tab-name: echo-test
+    description: temporarily echoing things.
+- name: ci-test-infra-benchmark-demo
+  interval: 20m
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: golang:latest
+      command:
+      - go
+      args:
+      - run
+      - ./pkg/benchmarkjunit
+      - --log-file=$(ARTIFACTS)/benchmark-log.txt
+      - --output=$(ARTIFACTS)/junit_benchmarks.xml
+      - --pass-on-error
+      - ./experiment/dummybenchmarks/...
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    test-tab-name: benchmark-demo
+    description: Demoing JUnit golang benchmark results.

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -78,26 +78,26 @@ postsubmits:
       testgrid-tab-name: "velodrome"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - velodrome/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - velodrome/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-boskos
     cluster: test-infra-trusted
     run_if_changed: '^boskos/'
@@ -130,26 +130,26 @@ postsubmits:
     run_if_changed: '^kettle/'
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - kettle/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - kettle/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-planter
     cluster: test-infra-trusted
     annotations:
@@ -158,26 +158,26 @@ postsubmits:
     run_if_changed: '^planter/'
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - planter/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - planter/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-triage
     cluster: test-infra-trusted
     run_if_changed: '^triage/'
@@ -186,26 +186,26 @@ postsubmits:
       testgrid-tab-name: "triage"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - triage/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - triage/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-bazelbuild
     cluster: test-infra-trusted
     run_if_changed: '^images/bazelbuild/'
@@ -214,26 +214,26 @@ postsubmits:
       testgrid-tab-name: "bazelbuild"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/bazelbuild/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/bazelbuild/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-bazel-krte
     cluster: test-infra-trusted
     run_if_changed: '^images/bazel-krte/'
@@ -242,26 +242,26 @@ postsubmits:
       testgrid-tab-name: "bazel-krte"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/bazel-krte/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/bazel-krte/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-bigquery
     cluster: test-infra-trusted
     run_if_changed: '^images/bigquery/'
@@ -270,26 +270,26 @@ postsubmits:
       testgrid-tab-name: "bigquery"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/bigquery/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/bigquery/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-bootstrap
     cluster: test-infra-trusted
     run_if_changed: '^(images/bootstrap|scenarios)/'
@@ -298,26 +298,26 @@ postsubmits:
       testgrid-tab-name: "bootstrap"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/bootstrap/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/bootstrap/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-cluster-api
     cluster: test-infra-trusted
     run_if_changed: '^images/cluster-api/'
@@ -326,26 +326,26 @@ postsubmits:
       testgrid-tab-name: "cluster-api"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/cluster-api/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/cluster-api/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-gcloud
     cluster: test-infra-trusted
     run_if_changed: '^images/gcloud/'
@@ -354,26 +354,26 @@ postsubmits:
       testgrid-tab-name: "gcloud"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/gcloud/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/gcloud/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-kubekins-e2e
     cluster: test-infra-trusted
     run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
@@ -382,26 +382,26 @@ postsubmits:
       testgrid-tab-name: "kubekins-e2e"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/kubekins-e2e/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/kubekins-e2e/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-kubekins-test
     cluster: test-infra-trusted
     run_if_changed: '^images/kubekins-test/'
@@ -410,26 +410,26 @@ postsubmits:
       testgrid-tab-name: "kubekins-test"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/kubekins-test/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/kubekins-test/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-kubemci
     cluster: test-infra-trusted
     run_if_changed: '^images/kubemci/'
@@ -438,26 +438,26 @@ postsubmits:
       testgrid-tab-name: "kubemci"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/kubemci/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/kubemci/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-test-gubernator
     cluster: test-infra-trusted
     run_if_changed: '^images/pull-test-infra-gubernator/'
@@ -466,26 +466,26 @@ postsubmits:
       testgrid-tab-name: "gubernator"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/pull-test-infra-gubernator/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/pull-test-infra-gubernator/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-image-builder
     cluster: test-infra-trusted
     run_if_changed: '^images/builder/'
@@ -494,26 +494,26 @@ postsubmits:
       testgrid-tab-name: "image-builder"
     decorate: true
     branches:
-      - master
+    - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
-          command:
-            - images/builder/ci-runner.sh
-          args:
-            - --scratch-bucket=gs://k8s-testimages-scratch
-            - --project=k8s-testimages
-            - images/builder/
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20190627-v0.1-98-gdda7ab9
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/builder/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   kubernetes/k8s.io:
   - name: post-k8sio-cip
     cluster: test-infra-trusted
@@ -546,12 +546,14 @@ postsubmits:
       - name: k8s-artifacts-prod-service-account-creds
         secret:
           secretName: k8s-artifacts-prod-service-account
+    annotations:
+      testgrid-dashboards: sig-release-misc
   kubernetes/community:
   - name: post-community-tempelis-apply
     cluster: test-infra-trusted
     decorate: true
     branches:
-      - ^master$
+    - ^master$
     run_if_changed: '^communication/slack-config'
     annotations:
       testgrid-num-failures-to-alert: "1"
@@ -559,22 +561,22 @@ postsubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-        - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
-          command:
-            - /tempelis
-          args:
-            - --config=communication/slack-config/
-            - --restrictions=communication/slack-config/restrictions.yaml
-            - --auth=/etc/slack-auth/auth.json
-            - --dry-run=false
-          volumeMounts:
-            - name: tempelis-creds
-              mountPath: /etc/slack-auth
-              readOnly: true
-      volumes:
+      - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+        command:
+        - /tempelis
+        args:
+        - --config=communication/slack-config/
+        - --restrictions=communication/slack-config/restrictions.yaml
+        - --auth=/etc/slack-auth/auth.json
+        - --dry-run=false
+        volumeMounts:
         - name: tempelis-creds
-          secret:
-            secretName: slack-tempelis-auth
+          mountPath: /etc/slack-auth
+          readOnly: true
+      volumes:
+      - name: tempelis-creds
+        secret:
+          secretName: slack-tempelis-auth
   kubernetes-sigs/slack-infra:
   - name: post-slack-infra-push-images
     cluster: test-infra-trusted
@@ -585,26 +587,26 @@ postsubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     decorate: true
     branches:
-      - ^master$
+    - ^master$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/image-builder:v20190619-47630b6
-          command:
-            - /run.sh
-          args:
-            - --scratch-bucket=gs://kubernetes-tools-scratch
-            - --project=kubernetes-tools
-            - .
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /creds/service-account.json
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
+      - image: gcr.io/k8s-testimages/image-builder:v20190619-47630b6
+        command:
+        - /run.sh
+        args:
+        - --scratch-bucket=gs://kubernetes-tools-scratch
+        - --project=kubernetes-tools
+        - .
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
         - name: creds
-          secret:
-            secretName: deployer-service-account
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
 
 
 periodics:
@@ -639,6 +641,10 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
+  annotations:
+    testgrid-dashboards: sig-testing-org
+    test-tab-name: ci-peribolos
+    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com
 - cron: "05 15 1-7 * 1"  # Run at 7:05 PST (15:05 UTC) on first monthly monday.
   name: ci-test-infra-autoupdate-minor
   cluster: test-infra-trusted
@@ -672,6 +678,10 @@ periodics:
       secret:
         secretName: k8s-ci-robot-ssh-keys
         defaultMode: 0400
+  annotations:
+    testgrid-dashboards: sig-testing-maintenance
+    test-tab-name: autoupdate-minor
+    description: Monthly module update to latest minor versions
 - cron: "05 15 * * 1"  # Run at 7:05 PST (15:05 UTC) every Monday
   name: ci-test-infra-autoupdate-patch
   cluster: test-infra-trusted
@@ -705,6 +715,10 @@ periodics:
       secret:
         secretName: k8s-ci-robot-ssh-keys
         defaultMode: 0400
+  annotations:
+    testgrid-dashboards: sig-testing-maintenance
+    test-tab-name: autoupdate-patch
+    description: Weekly module update to latest patched versions
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
   name: ci-test-infra-autobump-prow
   cluster: test-infra-trusted
@@ -745,9 +759,9 @@ periodics:
   cluster: test-infra-trusted
   decorate: true
   extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
   spec:
     containers:
     - image: launcher.gcr.io/google/bazel:0.27.0
@@ -915,3 +929,5 @@ periodics:
     - name: k8s-artifacts-prod-service-account-creds
       secret:
         secretName: k8s-artifacts-prod-service-account
+  annotations:
+    testgrid-dashboards: sig-release-misc

--- a/config/jobs/tensorflow/minigo/minigo.yaml
+++ b/config/jobs/tensorflow/minigo/minigo.yaml
@@ -15,6 +15,9 @@ presubmits:
         # Copy prebuilt tensorflow into repo, check clang-format, test with board_size 9 and 19.
         - "./testing/setup.sh && ./cc/test.sh"
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: C++ presubmit tests for Minigo.
   - name: tf-minigo-presubmit
     always_run: true         # Run for every PR, or only when requested.
     branches:
@@ -26,6 +29,9 @@ presubmits:
         command:
         - ./test.sh
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Python presumbit tests for Minigo.
 postsubmits:
   tensorflow/minigo:
   - name: tf-minigo-postsubmit
@@ -38,6 +44,9 @@ postsubmits:
         command:
         - ./test.sh
 
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for Minigo.
 periodics:
 - name: tf-minigo-periodic
   interval: 8h
@@ -51,3 +60,6 @@ periodics:
     - image: gcr.io/minigo-testing/minigo-prow-harness-v2:latest
       command:
       - ./test.sh
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Minigo.

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2112,51 +2112,9 @@ dashboards:
 - name: conformance-all
   # entries are named $PROVIDER, $KUBERNETES_RELEASE
   dashboard_tab:
-  - name: GCE, v1.15 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.15 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-15
-  - name: GCE, v1.14 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-14
-  - name: GCE, v1.13 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-13
-  - name: GCE, v1.12 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-12
-  - name: kind, master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance
-  - name: kind (IPv6), master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-ipv6
-  - name: kind (IPv6), master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel-ipv6
-  - name: kind-image, master (dev)
-    description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-test
-  - name: kind-image, 1.14 (dev)
-    description: Runs conformance tests using image against kubernetes 1.14 branch with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-1-14-test
-  - name: kind, master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel
-  - name: kind, v1.14 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-14
-  - name: kind, v1.13 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.13 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-13
-  - name: kind, v1.12 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.12 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-12
   - name: kind, v1.14 (dev, ARM64)
     description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster on ARM64 platform
     test_group_name: ci-kubernetes-kind-conformance-latest-1-14-arm64
-  - name: local-up-cluster, master (dev)
-    description: Runs conformance tests using kubetest with hack/local-up-cluster.sh
-    test_group_name: ci-kubernetes-local-e2e
   - name: OpenStack, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
@@ -2167,33 +2125,6 @@ dashboards:
     description: Runs conformance tests using kubetest against kubernetes from the release-1.15 branch with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15
 
-  - name: vSphere-cloud-provider, master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-latest
-  - name: vSphere-cloud-provider, v1.14 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
-  - name: vSphere-cloud-provider, v1.13 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
-  - name: vSphere-cloud-provider, v1.12 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
-
-  - name: vSphere, master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-latest
-  - name: vSphere, v1.14 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.14 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-stable-1-14
-  - name: vSphere, v1.13 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.13 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-stable-1-13
-  - name: vSphere, v1.12 (dev)
-    description: Runs conformance tests using kubetest against kubernetes from the release-1.12 branch with the in-tree vSphere cloud provider
-    test_group_name: ci-vsphere-conformance-stable-1-12
-
-# Gardener conformance-all Dashboard
   - name: Gardener, v1.15 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.15
@@ -2308,115 +2239,19 @@ dashboards:
       alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
 
 - name: conformance-gce
-  dashboard_tab:
-  - name: GCE, v1.15 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.15 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-15
-  - name: GCE, v1.14 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-14
-  - name: GCE, v1.13 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-13
-  - name: GCE, v1.12 (release)
-    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on GCE
-    test_group_name: ci-kubernetes-gce-conformance-stable-1-12
-
+  dashboard_tab: []
 - name: conformance-kind
   dashboard_tab:
-  - name: kind, master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind (IPv6), master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-ipv6
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind, master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind (IPv6), master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel-ipv6
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind, v1.14 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-14
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind, v1.13 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.13 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-13
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind, v1.12 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.12 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-12
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: kind-image, master (dev)
-    description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-test
-    alert_options:
-      alert_mail_to_addresses: davanum@gmail.com
-  - name: kind-image, 1.14 (dev)
-    description: Runs conformance tests using image against kubernetes 1.14 branch with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-1-14-test
-    alert_options:
-      alert_mail_to_addresses: davanum@gmail.com
   - name: kind, v1.14 (dev, ARM64)
     description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster on ARM64 platform
     test_group_name: ci-kubernetes-kind-conformance-latest-1-14-arm64
 
 - name: conformance-hack-local-up-cluster
-  dashboard_tab:
-  - name: local-up-cluster, master (dev)
-    description: Runs conformance tests using kubetest with local-up-cluster
-    test_group_name: ci-kubernetes-local-e2e
-
+  dashboard_tab: []
 - name: conformance-vsphere
-  dashboard_tab:
-  - name: periodic-latest
-    description: Runs conformance tests using kubetest against kubernetes ci/latest with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-latest
-  - name: periodic-v1.14
-    description: Runs conformance tests using kubetest against kubernetes v1.14 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-14
-  - name: periodic-v1.13
-    description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-13
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-12
-
+  dashboard_tab: []
 - name: vmware-conformance
-  dashboard_tab:
-  - name: periodic-latest
-    description: Runs conformance tests using kubetest against kubernetes ci/latest with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-latest
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.14
-    description: Runs conformance tests using kubetest against kubernetes v1.14 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-14
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.13
-    description: Runs conformance tests using kubetest against kubernetes v1.13 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-13
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with in-tree vSphere components
-    test_group_name: ci-vsphere-conformance-stable-1-12
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-vsphere+alerts@groups.vmware.com
-
+  dashboard_tab: []
 - name: conformance-cloud-provider-openstack
   dashboard_tab:
   - name: presubmit-master
@@ -2451,67 +2286,11 @@ dashboards:
       alert_mail_to_addresses: davanum+testgrid@gmail.com
 
 - name: conformance-cloud-provider-vsphere
-  dashboard_tab:
-  - name: periodic-latest
-    description: Runs conformance tests using kubetest against kubernetes ci/latest with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-latest
-  - name: periodic-v1.14
-    description: Runs conformance tests using kubetest against kubernetes v1.14 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
-  - name: periodic-v1.13
-    description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
-
+  dashboard_tab: []
 - name: vmware-conformance-cloud-provider
-  dashboard_tab:
-  - name: periodic-latest
-    description: Runs conformance tests using kubetest against kubernetes ci/latest with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-latest
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.14
-    description: Runs conformance tests using kubetest against kubernetes v1.14 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-14
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.13
-    description: Runs conformance tests using kubetest against kubernetes v1.13 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-13
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-  - name: periodic-v1.12
-    description: Runs conformance tests using kubetest against kubernetes v1.12 with cloud-provider-vsphere
-    test_group_name: ci-cloud-provider-vsphere-conformance-stable-1-12
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
-
+  dashboard_tab: []
 - name: vmware-cluster-api-provider-vsphere
-  dashboard_tab:
-  - name: pr-verify-crds
-    description: Verifies the CRDs
-    test_group_name: pull-cluster-api-provider-vsphere-verify-crds
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-  - name: pr-test
-    description: Runs unit tests
-    test_group_name: pull-cluster-api-provider-vsphere-test
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-  - name: pr-e2e
-    description: Runs e2e tests
-    test_group_name: pull-cluster-api-provider-vsphere-e2e
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-  - name: periodic-e2e
-    description: Runs periodic e2e tests
-    test_group_name: ci-cluster-api-provider-vsphere-ova-e2e
-    alert_options:
-      alert_mail_to_addresses: k8s-testing-clusterapi-vsphere+alerts@vmware.co
-
-# Alibaba Cloud Provider Dashboard
+  dashboard_tab: []
 - name: conformance-alibaba-cloud-provider
   dashboard_tab:
   - name: Alibaba Cloud Provider, v1.12
@@ -2523,36 +2302,36 @@ dashboards:
 
 - name: conformance-oracle-cloud-infrastructure
   dashboard_tab:
-    - name: OCI, v1.14 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure
-      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.14
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OCI, v1.13 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure
-      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OCI, v1.12 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure
-      test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.12
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OKE, v1.12 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
-      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OKE, v1.11 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.11 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
-      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.11
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OKE, v1.10 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
-      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.10
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OCI, v1.14 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.14
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OCI, v1.13 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OCI, v1.12 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure
+    test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.12
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.12 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.11 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.11 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.11
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+  - name: OKE, v1.10 (release)
+    description: Runs conformance tests using kubetest against kubernetes release 1.10 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+    test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.10
+    alert_options:
+      alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
 
 - name: canonical-ubuntu1-k8sbeta
 - name: canonical-ubuntu1-k8sstable1
@@ -2577,89 +2356,9 @@ dashboards:
 - name: cos-cos2-k8sstable3
 
 - name: google-aws
-  dashboard_tab:
-  - name: kops-aws
-    test_group_name: ci-kubernetes-e2e-kops-aws
-  - name: kops-aws-canary
-    test_group_name: ci-kubernetes-e2e-kops-aws-canary
-  - name: kops-aws-1.11
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable3
-  - name: kops-aws-1.12
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable2
-  - name: kops-aws-1.13
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable1
-  - name: kops-aws-1.14
-    test_group_name: ci-kubernetes-e2e-kops-aws-beta
-  - name: kops-aws-updown
-    test_group_name: ci-kubernetes-e2e-kops-aws-updown
-  - name: kops-aws-networking-kopeio-vxlan
-    test_group_name: ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan
-  - name: kops-aws-weave
-    test_group_name: ci-kubernetes-e2e-kops-aws-weave
-  - name: kops-aws-channelalpha
-    test_group_name: ci-kubernetes-e2e-kops-aws-channelalpha
-  - name: kops-aws-ena-nvme
-    test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
-  - name: kops-aws-ha-uswest2
-    test_group_name: ci-kubernetes-e2e-kops-aws-ha-uswest2
-  - name: kops-aws-newrunner
-    test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
-  - name: kops-aws-imagecentos7
-    test_group_name: ci-kubernetes-e2e-kops-aws-imagecentos7
-  - name: kops-aws-imageubuntu1604
-    test_group_name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
-
+  dashboard_tab: []
 - name: google-gce
-  dashboard_tab:
-  - name: gci-gce
-    test_group_name: ci-kubernetes-e2e-gci-gce
-  - name: gci-gce-alpha-enabled-default
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
-  - name: gci-gce-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-  - name: gce-stackdriver
-    test_group_name: ci-kubernetes-e2e-gce-stackdriver
-  - name: gce-prometheus
-    test_group_name: ci-kubernetes-e2e-gce-prometheus
-  - name: gce-influxdb
-    test_group_name: ci-kubernetes-e2e-gce-influxdb
-  - name: gci-gce-es-logging
-    test_group_name: ci-kubernetes-e2e-gci-gce-es-logging
-  - name: gci-gce-sd-logging
-    test_group_name: ci-kubernetes-e2e-gci-gce-sd-logging
-  - name: gci-gce-flaky
-    test_group_name: ci-kubernetes-e2e-gci-gce-flaky
-  - name: gci-gce-single-flake-attempt
-    test_group_name: ci-kubernetes-e2e-gci-gce-single-flake-attempt
-  - name: gci-gce-containerd
-    test_group_name: ci-kubernetes-e2e-gci-gce-containerd
-  - name: gci-gce-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-  - name: gce-multizone
-    test_group_name: ci-kubernetes-e2e-gce-multizone
-  - name: gci-gce-statefulset
-    test_group_name: ci-kubernetes-e2e-gci-gce-statefulset
-  - name: gci-gce-proto
-    test_group_name: ci-kubernetes-e2e-gci-gce-proto
-  - name: gci-gce-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-  - name: gci-gce-ip-alias
-    test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
-  - name: gce-alpha-api
-    test_group_name: ci-kubernetes-e2e-gce-alpha-api
-  - name: gci-gce-serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-  - name: gci-gce-slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
-  - name: gce-ha-master
-    test_group_name: ci-kubernetes-e2e-gce-ha-master
-  - name: gce-taint-evict
-    test_group_name: ci-kubernetes-e2e-gce-taint-evict
-  - name: gce-device-plugin-gpu
-    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu
-  - name: gce-min-node-permissions
-    test_group_name: ci-kubernetes-e2e-gce-min-node-permissions
-
+  dashboard_tab: []
 - name: google-gce-compute-image-tools
   dashboard_tab:
   - name: ci-daisy-e2e
@@ -2754,68 +2453,11 @@ dashboards:
         value: <test-url>
 
 - name: google-kops-gce
-  dashboard_tab:
-  - name: kops-gce
-    test_group_name: ci-kubernetes-e2e-kops-gce
-  - name: kops-gce-canary
-    test_group_name: ci-kubernetes-e2e-kops-gce-canary
-  - name: kops-gce-channelalpha
-    test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
-  - name: kops-gce-ha
-    test_group_name: ci-kubernetes-e2e-kops-gce-ha
-
+  dashboard_tab: []
 - name: google-gci
-  dashboard_tab:
-  - name: gci-gce
-    test_group_name: ci-kubernetes-e2e-gci-gce
-  - name: ip-alias
-    test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
-  - name: scalability
-    test_group_name: ci-kubernetes-e2e-gci-gce-scalability
-  - name: serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-  - name: slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
-  - name: ci-gke-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-ci-master
-
+  dashboard_tab: []
 - name: google-gke
   dashboard_tab:
-  - name: gci-gke-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gke-alpha-features
-  - name: gci-gke-alpha-enabled-default
-    test_group_name: ci-kubernetes-e2e-gci-gke-alpha-enabled-default
-  - name: gci-gke-flaky
-    test_group_name: ci-kubernetes-e2e-gci-gke-flaky
-  - name: gci-gke
-    test_group_name: ci-kubernetes-e2e-gci-gke
-  - name: gci-gke-serial
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial
-  - name: gci-gke-slow
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow
-  - name: gci-gke-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gke-ingress
-  - name: gci-gke-multizone
-    test_group_name: ci-kubernetes-e2e-gci-gke-multizone
-  - name: gke-regional
-    test_group_name: ci-kubernetes-e2e-gke-regional
-  - name: gke-regional-serial
-    test_group_name: ci-kubernetes-e2e-gke-regional-serial
-  - name: gke-regional-slow
-    test_group_name: ci-kubernetes-e2e-gke-regional-slow
-  - name: gci-gke-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: gci-gke-updown
-    test_group_name: ci-kubernetes-e2e-gci-gke-updown
-  - name: gke-device-plugin-gpu
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu
-  - name: gke-device-plugin-gpu-p100
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100
-  - name: gke-canary
-    test_group_name: ci-kubernetes-e2e-gke-canary
-  - name: cos-containerd-gke-alpha-cluster
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-alpha-cluster
-  # K8S stable3 branch on GKE
   - name: gke-cos-1.11-ingress
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable3-ingress
   - name: gke-cos-1.11-reboot
@@ -2848,437 +2490,50 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable1-serial
   - name: gke-cos-1.13-slow
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable1-slow
-  - name: cos-containerd-gke-1.13-alpha-cluster
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster
-  - name: cos-gke-1.13-alpha-cluster
-    test_group_name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster
-  - name: cos-containerd-gke-1.13-alpha-cluster-features
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster-features
-  - name: cos-gke-1.13-alpha-cluster-features
-    test_group_name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster-features
-  - name: cos-containerd-gke-1.13
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1
-  - name: cos-containerd-gke-1.14
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta
-  - name: cos-containerd-gke-1.14-alpha-cluster
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster
-  - name: cos-gke-1.14-alpha-cluster
-    test_group_name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster
-  - name: cos-containerd-gke-1.14-alpha-cluster-features
-    test_group_name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster-features
-  - name: cos-gke-1.14-alpha-cluster-features
-    test_group_name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster-features
-
 - name: google-gke-stackdriver
-  dashboard_tab:
-  - name: gke-stackdriver
-    test_group_name: ci-kubernetes-e2e-gke-stackdriver
-  - name: gke-sd-logging-gci-latest
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
-  - name: gke-sd-logging-ubuntu-latest
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
-  - name: gke-sd-logging-gci-1.14
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
-  - name: gke-sd-logging-ubuntu-1.14
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
-  - name: gke-sd-logging-gci-1.13
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
-  - name: gke-sd-logging-ubuntu-1.13
-    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
-
+  dashboard_tab: []
 - name: google-gke-upgrade
-  dashboard_tab:
-  - name: gke-gci-stable-gci-master-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
-    description: Upgrade master only, in gke, from gci 1.13 to gci master
-  - name: gke-gci-new-gci-master-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master
-    description: Upgrade master only, in gke(gci), from 1.14 to master
-  - name: gke-gci-new-gci-master-upgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-parallel
-    description: Upgrade master and node, in gke(gci), from 1.14 to master, run parallel tests only
-  - name: gke-gci-new-gci-master-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster
-    description: Upgrade master and node, in gke(gci), from 1.14 to master
-  - name: gke-gci-master-gci-new-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster
-    description: Downgrade master and node, in gke(gci), from master to 1.14
-  - name: gke-gci-master-gci-new-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
-    description: Downgrade master and node, in gke(gci), from master to 1.14, run parallel tests only
-  - name: gke-gci-new-gci-master-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
-    description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping slow tests as we run serially
-  - name: gke-gci-new-gci-master-upgrade-cluster-new-parallel
-    test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new-parallel
-    description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping serial and disruptive tests as we run in parallel
-
+  dashboard_tab: []
 - name: google-soak
-  dashboard_tab:
-  - name: gce-gci
-    test_group_name: ci-kubernetes-soak-gce-gci
-  - name: gke-gci
-    test_group_name: ci-kubernetes-soak-gke-gci
-  - name: gke-cos-containerd
-    test_group_name: ci-kubernetes-soak-gke-cos-containerd
-
+  dashboard_tab: []
 - name: google-unit
-  dashboard_tab:
-  - name: build
-    test_group_name: ci-kubernetes-build-fast
-  - name: build-1.11
-    test_group_name: ci-kubernetes-build-stable3
-  - name: build-1.12
-    test_group_name: ci-kubernetes-build-stable2
-  - name: build-1.13
-    test_group_name: ci-kubernetes-build-stable1
-  - name: build-1.14
-    test_group_name: ci-kubernetes-build-beta
-  - name: periodic-bazel-build-master
-    test_group_name: periodic-kubernetes-bazel-build-master
-  - name: periodic-bazel-test-master
-    test_group_name: periodic-kubernetes-bazel-test-master
-
+  dashboard_tab: []
 - name: google-windows
-  dashboard_tab:
-  - name: windows-prototype
-    test_group_name: ci-kubernetes-e2e-windows-gce-poc
-  - name: windows-gce
-    test_group_name: ci-kubernetes-e2e-windows-gce
-  - name: windows-gce-serial
-    test_group_name: ci-kubernetes-e2e-windows-gce-serial
-  - name: windows-gce-alpha-features
-    test_group_name: ci-kubernetes-e2e-windows-gce-alpha-features
-  - name: windows-gce-1.15
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sbeta
-  - name: windows-gce-1.14
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sstable1
-  - name: pull-windows-gce
-    test_group_name: pull-kubernetes-e2e-windows-gce
-
-# These are the master *blocking* tests.  These provide a valid binary signal
-# to gate releases (alpha, beta, official).
-# This list is used by kubernetes/release/lib/releaselib.sh to provide go/nogo
-# signal for releases.
-# The first test/suite in the list is the primary suite for release purposes
-# Blocking tests for the next release
-# Only tests that do not exist on release branches are listed here.
-# For other tests, search config/jobs for "sig-release-master-blocking"
+  dashboard_tab: []
 - name: sig-release-master-blocking
-  dashboard_tab:
-  - name: build-master-fast
-    test_group_name: ci-kubernetes-build-fast
-    description: "Ends up running: make quick-release"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: gce-cos-master-default
-    test_group_name: ci-kubernetes-e2e-gci-gce
-    description: "Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: gce-cos-master-slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
-    description: "Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: gce-cos-master-serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-    description: "Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: gce-cos-master-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-    description: "Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: gce-cos-master-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-    description: "Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh"
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-
+  dashboard_tab: []
 - name: sig-release-master-informing
   dashboard_tab:
-  - name: bazel-build-master
-    test_group_name: post-kubernetes-bazel-build
-    description: "OWNER: sig-testing; Builds kubernetes at each bommit using bazel with RBE"
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
     description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
-  - name: bazel-test-master
-    test_group_name: post-kubernetes-bazel-test
-    description: "OWNER: sig-testing; Runs kubernetes unit tests using bazel"
-  - name: gce-new-master-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-master
-    description: "OWNER: kube-up-owners; Upgrade master only, in gce(gci), from 1.14 to master, run non-parallel-safe tests only"
-  - name: gce-new-master-upgrade-master-parallel
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-master-parallel
-    description: "OWNER: kube-upowners; Upgrade master only, in gce(gci), from 1.14 to master, run parallel tests only"
-  - name: gce-new-master-upgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-parallel
-    description: Upgrade master and node, in gce(gci), from 1.14 to master, run parallel tests only
-  - name: gce-new-master-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster
-    description: Upgrade master and node, in gce(gci), from 1.14 to master
-  - name: gce-master-new-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster
-    description: Downgrade master and node, in gce(gci), from master to 1.14
-  - name: gce-master-new-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-master-new-downgrade-cluster-parallel
-    description: Downgrade master and node, in gce(gci), from master to 1.14, run parallel tests only
-  - name: gce-new-master-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new
-    description: Upgrade master and node, in gce(gci), from 1.14 to master, and run skewed e2e tests.  We only run the serial & disruptive tests; the others are run in the -parallel test.
-  - name: gce-new-master-upgrade-cluster-new-parallel
-    test_group_name: ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new-parallel
-    description: Upgrade master and node, in gce(gci), from 1.14 to master, and run skewed e2e tests.  We skip the serial & disruptive tests; those are run in the non-parallel test.
-  - name: gce-cos-master-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-    description: "Uses kubetest to run a subset of e2e tests (+Feature:Reboot) against a cluster created with cluster/kube-up.sh"
-
 - name: sig-release-misc
-  dashboard_tab:
-  - name: cross-build
-    test_group_name: ci-kubernetes-cross-build
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: kops-build
-    test_group_name: ci-kops-build
-    alert_options:
-      alert_mail_to_addresses: kubernetes-release-team@googlegroups.com
-  - name: debian-unstable
-    test_group_name: ci-kubernetes-build-debian-unstable
-    alert_options:
-      alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
-  - name: post-k8sio-cip
-    test_group_name: post-k8sio-cip
-  - name: ci-k8sio-cip
-    test_group_name: ci-k8sio-cip
-  - name: release-cluster-up
-    test_group_name: pull-release-cluster-up
-    alert_options:
-      alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
-  - name: release-unit
-    test_group_name: pull-release-unit
-    alert_options:
-      alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
-  - name: release-verify
-    test_group_name: pull-release-verify
-    alert_options:
-      alert_mail_to_addresses: kubernetes-patch-release-team@googlegroups.com
-
+  dashboard_tab: []
 - name: sig-release-1.15-blocking
 - name: sig-release-1.15-informing
 - name: sig-release-1.15-all
-  dashboard_tab:
-  # TODO(Katharine): fork this job.
-  - name: soak-gci-gce-1.15
-    test_group_name: ci-kubernetes-soak-gci-gce-beta
-  - name: aks-engine-azure-1-15-windows-release
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
-
+  dashboard_tab: []
 - name: sig-release-1.14-all
-  dashboard_tab:
-  - name: soak-gci-gce-1.14
-    test_group_name: ci-kubernetes-soak-gci-gce-stable1
-  - name: gce-1.14-1.13-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster
-  - name: gce-1.14-1.13-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-downgrade-cluster-parallel
-  - name: gce-1.13-1.14-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster
-  - name: gce-1.13-1.14-upgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-parallel
-  - name: gce-1.13-1.14-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new
-  - name: gce-1.13-1.14-upgrade-cluster-new-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-cluster-new-parallel
-  - name: gce-1.13-1.14-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master
-  - name: gce-1.13-1.14-upgrade-master-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-upgrade-master-parallel
-  - name: gce-1.14-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
-  - name: gce-1.14-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
-  - name: gce-1.13-1.14-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
-  - name: gce-1.13-1.14-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
-  - name: gke-1.14-1.13-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
-  - name: gke-1.14-1.13-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
-  - name: gke-1.13-1.14-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
-  - name: gke-1.13-1.14-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
-  - name: gke-1.13-1.14-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
-  - name: gke-1.14-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
-  - name: gke-1.14-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
-  - name: gke-1.13-1.14-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
-  - name: gke-1.13-1.14-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
-  - name: gke-device-plugin-gpu-1.14
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-beta
-  - name: gke-device-plugin-gpu-p100-1.14
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-beta
-  - name: kops-aws-1.14
-    test_group_name: ci-kubernetes-e2e-kops-aws-beta
-  - name: periodic-bazel-test-1.14
-    test_group_name: periodic-kubernetes-bazel-test-1-14
-  - name: aks-engine-azure-1-14-windows-release
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
-  - name: gce-windows-1.14
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sstable1
-
-
+  dashboard_tab: []
 - name: sig-release-1.14-blocking
 - name: sig-release-1.14-informing
 
 - name: sig-release-1.13-all
-  dashboard_tab:
-  - name: soak-gci-gce-1.13
-    test_group_name: ci-kubernetes-soak-gci-gce-stable2
-  - name: kops-aws-1.13
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable2
-  - name: gke-gci-1.11-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
-  - name: gke-gci-1.12-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
-  - name: gce-1.12-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
-  - name: gce-1.13-1.12-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
-  - name: gke-1.13-1.12-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
-  - name: gke-1.12-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
-  - name: gce-1.12-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
-  - name: gce-1.13-1.12-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
-  - name: gke-1.13-1.12-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
-  - name: gke-1.12-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
-  - name: gce-1.12-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
-  - name: gce-1.12-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
-  - name: gce-1.12-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
-    # TODO(Katharine): Fork these two
-  - name: gke-device-plugin-gpu-1.13
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
-  - name: gke-device-plugin-gpu-p100-1.13
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2
-
+  dashboard_tab: []
 - name: sig-release-1.13-blocking
 - name: sig-release-1.13-informing
 
 - name: sig-cluster-lifecycle-upgrade-skew
-  dashboard_tab:
-  - name: gke-gci-1.11-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
-  - name: gke-gci-1.12-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
-  - name: gce-1.12-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
-  - name: gce-1.13-1.12-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
-  - name: gke-1.13-1.12-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
-  - name: gke-1.12-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
-  - name: gce-1.12-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
-  - name: gce-1.13-1.12-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
-  - name: gke-1.13-1.12-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
-  - name: gke-1.12-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
-  - name: gce-1.12-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
-  - name: gce-1.12-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
-  - name: gce-1.12-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
-  - name: gce-gpu-1.12-1.13-master-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
-  - name: gce-gpu-1.12-1.13-cluster-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-cluster-upgrade
-  - name: gce-gpu-1.13-1.14-master-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
-  - name: gce-gpu-1.13-1.14-cluster-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
-  - name: gce-gpu-1.13-master-master-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
-  - name: gce-gpu-1.13-master-cluster-upgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
-  - name: gce-gpu-1.14-1.13-cluster-downgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
-  - name: gce-gpu-master-1.13-cluster-downgrade
-    test_group_name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
-  - name: gce-1.13-1.12-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster
-  - name: gce-1.13-1.12-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-downgrade-cluster-parallel
-  - name: gke-gci-1.13-gci-1.12-downgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
-  - name: gke-gci-1.13-gci-1.12-downgrade-cluster-parallel
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
-
+  dashboard_tab: []
 - name: sig-contribex-community
-  dashboard_tab:
-  - name: pull-verify
-    test_group_name: pull-community-verify
-
+  dashboard_tab: []
 - name: sig-release-1.12-all
-  dashboard_tab:
-  - name: soak-gci-gce-1.12
-    test_group_name: ci-kubernetes-soak-gci-gce-stable3
-  - name: gke-device-plugin-gpu-1.12
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable2
-  - name: gke-device-plugin-gpu-p100-1.12
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100-stable2
-
-# These are the release *blocking* tests.  These provide a valid binary signal
-# to gate releases (alpha, beta, official).
-# This list is used by kubernetes/release/lib/releaselib.sh to provide go/nogo
-# signal for releases.
-# The first test/suite in the list is the primary suite for release purposes
+  dashboard_tab: []
 - name: sig-release-1.12-blocking
 - name: sig-release-1.12-informing
 
 - name: sig-release-publishing-bot
-  dashboard_tab:
-  - name: build
-    test_group_name: pull-publishing-bot-build
-  - name: validate
-    test_group_name: pull-publishing-bot-validate
-
+  dashboard_tab: []
 - name: wg-resource-management
   dashboard_tab:
   - name: gce-device-plugin-gpu
@@ -3389,11 +2644,6 @@ dashboards:
   - name: kubelet-serial-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-serial
     base_options: include-filter-by-regex=GPU|DevicePlugin
-  - name: kubelet-serial-gce-e2e-cpu-manager
-    test_group_name: ci-kubernetes-node-kubelet-serial-cpu-manager
-    alert_options:
-      alert_mail_to_addresses: balaji.warft@gmail.com, connor.p.d@gmail.com
-
 - name: sig-api-machinery-gce-gke
   dashboard_tab:
   - name: gce
@@ -3467,12 +2717,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-statefulset
     base_options: include-filter-by-regex=sig-apps
     description: apps gce statefulset e2e tests for master branch
-  - name: charts-gce
-    test_group_name: ci-kubernetes-charts-gce
-  - name: application-periodic-default-gke
-    description: Periodic builds and testing of the Application Type on GKE.
-    test_group_name: application-periodic-default-gke
-
 - name: sig-auth
   dashboard_tab:
   - name: gce
@@ -3501,174 +2745,9 @@ dashboards:
     description: apps gke serial e2e tests for master branch
 
 - name: sig-big-data
-  dashboard_tab:
-  - name: kubeflow-periodic-0-5-branch
-    description: Periodic testing of Kubeflow on the 0-5 release branch.
-    test_group_name: kubeflow-periodic-0-5-branch
-  - name: kubeflow-periodic-0-4-branch
-    description: Periodic testing of Kubeflow on the 0-4 release branch.
-    test_group_name: kubeflow-periodic-0-4-branch
-  - name: kubeflow-periodic-0-3-branch
-    description: Periodic testing of Kubeflow on the 0-3 release branch.
-    test_group_name: kubeflow-periodic-0-3-branch
-  - name: kubeflow-periodic-master
-    description: Periodic testing of Kubeflow on the latest master branch.
-    test_group_name: kubeflow-periodic-master
-  - name: kubeflow-periodic-examples
-    description: Periodic testing of Kubeflow examples
-    test_group_name: kubeflow-periodic-examples
-  - name: kubeflow-postsubmit
-    description: Postsubmit tests for Kubeflow.
-    test_group_name: kubeflow-postsubmit
-  - name: kubeflow-presubmit
-    description: Presubmit tests for Kubeflow.
-    test_group_name: kubeflow-presubmit
-  - name: kubeflow-examples-postsubmit
-    description: Postsubmit kubeflow/examples.
-    test_group_name: kubeflow-examples-postsubmit
-  - name: kubeflow-examples-presubmit
-    description: Presubmits for kubeflow/examples.
-    test_group_name: kubeflow-examples-presubmit
-  - name: kubeflow-pytorch-operator-postsubmit
-    description: Postsubmit kubeflow/pytorch-operator.
-    test_group_name: kubeflow-pytorch-operator-postsubmit
-  - name: kubeflow-pytorch-operator-presubmit
-    description: Presubmits for kubeflow/pytorch-operator.
-    test_group_name: kubeflow-pytorch-operator-presubmit
-  - name: kubeflow-mxnet-operator-postsubmit
-    description: Postsubmit kubeflow/mxnet-operator.
-    test_group_name: kubeflow-mxnet-operator-postsubmit
-  - name: kubeflow-mxnet-operator-presubmit
-    description: Presubmits for kubeflow/mxnet-operator.
-    test_group_name: kubeflow-mxnet-operator-presubmit
-  - name: kubeflow-website-postsubmit
-    description: Postsubmit kubeflow/website.
-    test_group_name: kubeflow-website-postsubmit
-  - name: kubeflow-website-presubmit
-    description: Presubmits for kubeflow/website.
-    test_group_name: kubeflow-website-presubmit
-  - name: kubeflow-reporting-postsubmit
-    description: Postsubmit kubeflow/reporting.
-    test_group_name: kubeflow-reporting-postsubmit
-  - name: kubeflow-reporting-presubmit
-    description: Presubmits for kubeflow/reporting.
-    test_group_name: kubeflow-reporting-presubmit
-  - name: kubeflow-testing-postsubmit
-    description: Postsubmit kubeflow/testing.
-    test_group_name: kubeflow-testing-postsubmit
-  - name: kubeflow-testing-presubmit
-    description: Presubmits for kubeflow/testing.
-    test_group_name: kubeflow-testing-presubmit
-  - name: kubeflow-tf-operator-postsubmit
-    description: Postsubmit kubeflow/tf-operator.
-    test_group_name: kubeflow-tf-operator-postsubmit
-  - name: kubeflow-tf-operator-presubmit
-    description: Presubmits for kubeflow/tf-operator.
-    test_group_name: kubeflow-tf-operator-presubmit
-  - name: kubeflow-katib-postsubmit
-    description: Postsubmit kubeflow/katib.
-    test_group_name: kubeflow-katib-postsubmit
-  - name: kubeflow-katib-presubmit
-    description: Presubmits for kubeflow/katib.
-    test_group_name: kubeflow-katib-presubmit
-  - name: kubeflow-kfserving-presubmit
-    description: Presubmits for kubeflow/kfserving.
-    test_group_name: kubeflow-kfserving-presubmit
-  - name: kubeflow-manifests-presubmit
-    description: Presubmits for kubeflow/manifests.
-    test_group_name: kubeflow-manifests-presubmit
-  - name: kubeflow-experimental-kvc-postsubmit
-    description: Postsubmit kubeflow/experimental-kvc.
-    test_group_name: kubeflow-experimental-kvc-postsubmit
-  - name: kubeflow-experimental-kvc-presubmit
-    description: Presubmits for kubeflow/experimental-kvc.
-    test_group_name: kubeflow-experimental-kvc-presubmit
-  - name: kubeflow-experimental-seldon-postsubmit
-    description: Postsubmit kubeflow/experimental-seldon.
-    test_group_name: kubeflow-experimental-seldon-postsubmit
-  - name: kubeflow-experimental-seldon-presubmit
-    description: Presubmits for kubeflow/experimental-seldon.
-    test_group_name: kubeflow-experimental-seldon-presubmit
-  - name: kubeflow-experimental-beagle-postsubmit
-    description: Postsubmit kubeflow/experimental-beagle.
-    test_group_name: kubeflow-experimental-beagle-postsubmit
-  - name: kubeflow-experimental-beagle-presubmit
-    description: Presubmits for kubeflow/experimental-beagle.
-    test_group_name: kubeflow-experimental-beagle-presubmit
-  - name: kubeflow-caffe2-operator-postsubmit
-    description: Postsubmit kubeflow/caffe2-operator.
-    test_group_name: kubeflow-caffe2-operator-postsubmit
-  - name: kubeflow-caffe2-operator-presubmit
-    description: Presubmits for kubeflow/caffe2-operator.
-    test_group_name: kubeflow-caffe2-operator-presubmit
-  - name: kubeflow-kubebench-postsubmit
-    description: Postsubmit tests for kubeflow/kubebench.
-    test_group_name: kubeflow-kubebench-postsubmit
-  - name: kubeflow-kubebench-presubmit
-    description: Presubmit tests for kubeflow/kubebench.
-    test_group_name: kubeflow-kubebench-presubmit
-  - name: kubeflow-mpi-operator-postsubmit
-    description: Postsubmit tests for kubeflow/mpi-operator.
-    test_group_name: kubeflow-mpi-operator-postsubmit
-  - name: kubeflow-mpi-operator-presubmit
-    description: Presubmit tests for kubeflow/mpi-operator.
-    test_group_name: kubeflow-mpi-operator-presubmit
-  - name: kubeflow-chainer-operator-postsubmit
-    description: Postsubmit tests for kubeflow/chainer-operator.
-    test_group_name: kubeflow-chainer-operator-postsubmit
-  - name: kubeflow-chainer-operator-presubmit
-    description: Presubmit tests for kubeflow/chainer-operator.
-    test_group_name: kubeflow-chainer-operator-presubmit
-  - name: kubeflow-arena-postsubmit
-    description: Postsubmit tests for kubeflow/arena.
-    test_group_name: kubeflow-arena-postsubmit
-  - name: kubeflow-arena-presubmit
-    description: Presubmit tests for kubeflow/arena.
-    test_group_name: kubeflow-arena-presubmit
-  - name: kubeflow-fairing-presubmit
-    description: Presubmit tests for kubeflow/fairing.
-    test_group_name: kubeflow-fairing-presubmit
-  - name: kubeflow-metadata-presubmit
-    description: Presubmit tests for kubeflow/metadata.
-    test_group_name: kubeflow-metadata-presubmit
-  - name: kubeflow-pipeline-postsubmit
-    description: Postsubmit tests for kubeflow/pipeline.
-    test_group_name: kubeflow-pipeline-postsubmit
-  - name: spark-periodic-default-gke
-    description: Periodic builds and testing of Apache Spark on default version of GKE.
-    test_group_name: spark-periodic-default-gke
-  - name: spark-periodic-latest-gke
-    description: Periodic builds and testing of Apache Spark running on the newest stable GKE.
-    test_group_name: spark-periodic-latest-gke
-  - name: tf-minigo-periodic
-    description: Periodic testing of Minigo.
-    test_group_name: tf-minigo-periodic
-  - name: tf-minigo-postsubmit
-    description: Postsubmit tests for Minigo.
-    test_group_name: tf-minigo-postsubmit
-  - name: tf-minigo-presubmit
-    description: Python presumbit tests for Minigo.
-    test_group_name: tf-minigo-presubmit
-  - name: pull-tf-minigo-cc
-    description: C++ presubmit tests for Minigo.
-    test_group_name: pull-tf-minigo-cc
-
+  dashboard_tab: []
 - name: sig-autoscaling-cluster-autoscaler
   dashboard_tab:
-  - name: gci-gce-autoscaling
-    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling
-  - name: gci-gce-autoscaling-migs
-    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
-  - name: gci-gke-autoscaling
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling
-  - name: gci-gke-autoscaling-gpu-k80
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-k80
-  - name: gci-gke-autoscaling-gpu-p100
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-p100
-  - name: gci-gke-autoscaling-gpu-v100
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-gpu-v100
-  - name: gci-gke-autoscaling-regional
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-regional
   - name: gke-ubuntu1-k8sbeta-autoscaling
     test_group_name: ci-kubernetes-e2e-gke-ubuntu1-k8sbeta-autoscaling
   - name: gke-ubuntu1-k8sstable1-autoscaling
@@ -3687,123 +2766,23 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-ubuntu2-k8sstable3-autoscaling
 
 - name: sig-autoscaling-hpa
-  dashboard_tab:
-  - name: gci-gce-autoscaling-hpa
-    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa
-  - name: gci-gce-autoscaling-migs-hpa
-    test_group_name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
-  - name: gci-gke-autoscaling-hpa
-    test_group_name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa
-
+  dashboard_tab: []
 - name: sig-autoscaling-vpa
-  dashboard_tab:
-  - name: autoscaling-vpa-recommender
-    test_group_name: ci-kubernetes-e2e-autoscaling-vpa-recommender
-  - name: autoscaling-vpa-updater
-    test_group_name: ci-kubernetes-e2e-autoscaling-vpa-updater
-  - name: autoscaling-vpa-actuation
-    test_group_name: ci-kubernetes-e2e-autoscaling-vpa-actuation
-  - name: autoscaling-vpa-admission-controller
-    test_group_name: ci-kubernetes-e2e-autoscaling-vpa-admission-controller
-  - name: autoscaling-vpa-full
-    test_group_name: ci-kubernetes-e2e-autoscaling-vpa-full
-
+  dashboard_tab: []
 - name: sig-aws-alb-ingress-controller
-  dashboard_tab:
-  - name: lint
-    test_group_name: pull-aws-alb-ingress-controller-lint
-    description: "aws alb ingress controller code lint"
-  - name: unit test
-    test_group_name: pull-aws-alb-ingress-controller-unit-test
-    description: "aws alb ingress controller unit tests"
-  - name: e2e test
-    test_group_name: pull-aws-alb-ingress-controller-e2e-test
-    description: "aws alb ingress controller e2e tests"
-
+  dashboard_tab: []
 - name: sig-aws-cloud-provider-aws
-  dashboard_tab:
-  - name: check
-    test_group_name: pull-cloud-provider-aws-check
-    description: aws cloud provider checks
-  - name: test
-    test_group_name: pull-cloud-provider-aws-test
-    description: aws cloud provider tests
-
+  dashboard_tab: []
 - name: presubmits-cloud-provider-alibaba
-  dashboard_tab:
-  - name: check
-    test_group_name: pull-cloud-provider-alibaba-cloud-check
-    description: alibaba cloud provider checks
-  - name: unit-test
-    test_group_name: pull-cloud-provider-alibaba-cloud-unit-test
-    description: alibaba cloud provider unit test
-
+  dashboard_tab: []
 - name: sig-aws-ebs-csi-driver
-  dashboard_tab:
-  - name: verify
-    test_group_name: pull-aws-ebs-csi-driver-verify
-    description: aws ebs csi driver basic code verification
-  - name: unit-test
-    test_group_name: pull-aws-ebs-csi-driver-unit
-    description: aws ebs csi driver unit test
-  - name: sanity-test
-    test_group_name: pull-aws-ebs-csi-driver-sanity
-    description: aws ebs csi driver sanity test
-  - name: integration-test
-    test_group_name: pull-aws-ebs-csi-driver-integration
-    description: aws ebs csi driver integration test
-  - name: e2e-test-single-az
-    test_group_name: pull-aws-ebs-csi-driver-e2e-single-az
-    description: aws ebs csi driver e2e test on single az
-  - name: e2e-test-multi-az
-    test_group_name: pull-aws-ebs-csi-driver-e2e-multi-az
-    description: aws ebs csi driver e2e test on mutiple AZs
-
-
+  dashboard_tab: []
 - name: sig-aws-eks-presubmits
-  dashboard_tab:
-  - name: k8s-eks-1-11-correctness
-    test_group_name: pull-kubernetes-e2e-aws-eks-1-11-correctness
-    description: Kubernetes e2e correctness tests against EKS 1.11 build
+  dashboard_tab: []
 - name: sig-aws-eks-periodics
-  dashboard_tab:
-  # TODO(shyamjvs): Move these jobs out to the right dashboards later.
-  - name: ci-kubernetes-e2e-aws-eks-1-11-correctness
-    test_group_name: ci-kubernetes-e2e-aws-eks-1-11-correctness
-    description: Kubernetes e2e correctness tests against EKS 1.11 build
-  - name: ci-kubernetes-e2e-aws-eks-1-11-conformance
-    test_group_name: ci-kubernetes-e2e-aws-eks-1-11-conformance
-    description: Kubernetes conformance e2e tests against EKS 1.11 build
-  - name: ci-kubernetes-e2e-aws-eks-1-11-scalability
-    test_group_name: ci-kubernetes-e2e-aws-eks-1-11-scalability
-    description: Kubernetes performance e2e tests against EKS 1.11 build
-
+  dashboard_tab: []
 - name: sig-cli-master
   dashboard_tab:
-  - name: gce
-    test_group_name: ci-kubernetes-e2e-gci-gce-sig-cli
-    description: kubectl gce e2e tests for master branch
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
-  - name: gke
-    test_group_name: ci-kubernetes-e2e-gci-gke-sig-cli
-    description: kubectl gke e2e tests for master branch
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
-  - name: gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
-    description: kubectl gce serial e2e tests for master branch
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
-  - name: gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
-    description: kubectl gke serial e2e tests for master branch
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
-  - name: aws
-    test_group_name: ci-kubernetes-e2e-kops-aws-sig-cli
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cli-oncall@gmail.com
   - name: soak-gce-gci
     test_group_name: ci-kubernetes-soak-gce-gci
     base_options: include-filter-by-regex=Kubectl%7Ckubectl
@@ -3814,43 +2793,10 @@ dashboards:
     test_group_name: ci-kubernetes-integration-master
     base_options: include-filter-by-regex=kubectl%7COverall
     description: unit, integration and cmd tests for master branch
-  - name: skew-cluster-stable1-kubectl-latest-gce
-    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
-    description: stable1 e2e tests run against a stable1 gce cluster using a master kubectl binary
-  - name: skew-cluster-stable1-kubectl-latest-gke
-    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
-    description: stable1 e2e tests run against a stable1 gke cluster using a master kubectl binary
-  - name: skew-cluster-latest-kubectl-stable1-gce
-    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
-    description: stable1 e2e tests run against a master gce cluster using a stable1 kubectl binary
-  - name: skew-cluster-latest-kubectl-stable1-gke
-    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
-    description: stable1 e2e tests run against a master gke cluster using a stable1 kubectl binary
-  - name: skew-cluster-stable1-kubectl-latest-gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
-    description: stable1 serial tests run against a stable1 gce cluster using a master kubectl binary
-  - name: skew-cluster-stable1-kubectl-latest-gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
-    description: stable1 serial tests run against a stable1 gke cluster using a master kubectl binary
-  - name: skew-cluster-latest-kubectl-stable1-gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
-    description: stable1 serial tests run against a master gce cluster using a stable1 kubectl binary
-  - name: skew-cluster-latest-kubectl-stable1-gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
-    description: stable1 serial tests run against a master gke cluster using a stable1 kubectl binary
-
 - name: sig-cli-misc
-  dashboard_tab:
-  - name: kustomize-periodic-default-gke
-    description: Periodic integration testing of kustomize.
-    test_group_name: ci-kustomize-periodic-default-gke
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-all
-  dashboard_tab:
-# manifest list tests
-  - name: periodic-manifest-lists
-    test_group_name: periodic-kubernetes-e2e-manifest-lists
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-kubeadm
 
 - name: sig-cluster-lifecycle-multi-platform
@@ -3865,153 +2811,29 @@ dashboards:
     test_group_name: periodic-multi-platform-kubeadm-packet-arm64
 
 - name: sig-cluster-lifecycle-cluster-api
-  dashboard_tab:
-  - name: build
-    test_group_name: ci-cluster-api-build
-  - name: unit tests
-    test_group_name: ci-cluster-api-test
-  - name: pr-build
-    test_group_name: pull-cluster-api-build
-  - name: pr-make
-    test_group_name: pull-cluster-api-make
-  - name: pr-test
-    test_group_name: pull-cluster-api-test
-  - name: pr-vendor
-    test_group_name: pull-cluster-api-vendor-in-sync
-  - name: pr-integration
-    test_group_name: pull-cluster-api-integration
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
-  dashboard_tab:
-  - name: verify-boilerplate
-    test_group_name: pull-cluster-api-provider-aws-verify-boilerplate
-  - name: bazel-pr-verify
-    test_group_name: pull-cluster-api-provider-aws-bazel-verify
-  - name: bazel-pr-build
-    test_group_name: pull-cluster-api-provider-aws-bazel-build
-  - name: bazel-pr-test
-    test_group_name: pull-cluster-api-provider-aws-bazel-test
-  - name: bazel-pr-integration
-    test_group_name: pull-cluster-api-provider-aws-bazel-integration
-  - name: test-creds
-    test_group_name: periodic-cluster-api-provider-aws-test-creds
-  - name: bazel-periodic-e2e
-    test_group_name: periodic-cluster-api-provider-aws-bazel-e2e
-  - name: bazel-ci-e2e
-    test_group_name: ci-cluster-api-provider-aws-bazel-e2e
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-azure
-  dashboard_tab:
-  - name: verify-boilerplate
-    test_group_name: pull-cluster-api-provider-azure-verify-boilerplate
-    alert_options:
-      alert_mail_to_addresses: foo+k8s-azure@agst.us
-  - name: bazel-pr-verify
-    test_group_name: pull-cluster-api-provider-azure-bazel-verify
-    alert_options:
-      alert_mail_to_addresses: foo+k8s-azure@agst.us
-  - name: bazel-pr-build
-    test_group_name: pull-cluster-api-provider-azure-bazel-build
-    alert_options:
-      alert_mail_to_addresses: foo+k8s-azure@agst.us
-  - name: bazel-pr-test
-    test_group_name: pull-cluster-api-provider-azure-bazel-test
-    alert_options:
-      alert_mail_to_addresses: foo+k8s-azure@agst.us
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-digitalocean
-  dashboard_tab:
-  - name: build
-    test_group_name: pull-cluster-api-provider-digitalocean-build
-  - name: test
-    test_group_name: pull-cluster-api-provider-digitalocean-test
-  - name: verify
-    test_group_name: pull-cluster-api-provider-digitalocean-verify
-  - name: lint
-    test_group_name: pull-cluster-api-provider-digitalocean-lint
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-gcp
-  dashboard_tab:
-  - name: build
-    test_group_name: ci-cluster-api-provider-gcp-build
-  - name: unit tests
-    test_group_name: ci-cluster-api-provider-gcp-test
-  - name: pr-build
-    test_group_name: pull-cluster-api-provider-gcp-build
-  - name: pr-make
-    test_group_name: pull-cluster-api-provider-gcp-make
-  - name: pr-test
-    test_group_name: pull-cluster-api-provider-gcp-test
-
+  dashboard_tab: []
 - name: sig-gcp-compute-persistent-disk-csi-driver
-  dashboard_tab:
-  - name: Kubernetes Master Driver Release 0.3
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-release-0-3-k8s-master-integration
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.3
-  - name: Kubernetes Master Driver Release 0.4
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-release-0-4-k8s-master-integration
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.4
-  - name: Kubernetes Master Driver Release 0.5
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-release-0-5-k8s-master-integration
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.5
-  - name: Kubernetes v1.13.5 Driver Release 0.4
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-release-0-4-k8s-1-13-5-integration
-    description: Kubernetes Integration tests for Kubernetes 1.13.5 and Driver Release 0.4
-  - name: Kubernetes Master Driver Latest
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest build
-  - name: Migration Kubernetes Master Driver Stable
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-stable-k8s-master-migration
-    description: Kubernetes in-tree E2E tests with CSIMigration on for Kubernetes Master branch and Driver Stable
-  - name: Migration Kubernetes Master Driver Latest
-    test_group_name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-migration
-    description: Kubernetes in-tree E2E tests with CSIMigration on for Kubernetes Master branch and Driver latest build
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
-  dashboard_tab:
-  - name: pr-make
-    test_group_name: pull-cluster-api-provider-ibmcloud-make
-  - name: pr-check
-    test_group_name: pull-cluster-api-provider-ibmcloud-check
-  - name: pr-test
-    test_group_name: pull-cluster-api-provider-ibmcloud-test
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
-  dashboard_tab:
-  - name: pr-verify-crds
-    test_group_name: pull-cluster-api-provider-vsphere-verify-crds
-  - name: pr-test
-    test_group_name: pull-cluster-api-provider-vsphere-test
-  - name: pr-e2e
-    test_group_name: pull-cluster-api-provider-vsphere-e2e
-  - name: periodic-e2e
-    test_group_name: ci-cluster-api-provider-vsphere-ova-e2e
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
-  dashboard_tab:
-  - name: pr-make
-    test_group_name: pull-cluster-api-provider-openstack-make
-  - name: pr-check
-    test_group_name: pull-cluster-api-provider-openstack-check
-  - name: pr-test
-    test_group_name: pull-cluster-api-provider-openstack-test
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-provider-docker
-  dashboard_tab:
-  - name: pr-verify
-    test_group_name: pull-cluster-api-provider-docker-verify
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
 
 - name: sig-multicluster-kubemci
-  dashboard_tab:
-  - name: kubemci-image-push
-    test_group_name: ci-kubemci-image-push
-  - name: kubemci-ingress-conformance
-    test_group_name: ci-kubemci-ingress-conformance
-  - name: ci-kubemci-unit-tests
-    test_group_name: ci-kubernetes-multicluster-ingress-test
-
+  dashboard_tab: []
 - name: sig-instrumentation
   dashboard_tab:
   - name: gci-gce
@@ -4097,14 +2919,6 @@ dashboards:
 
 - name: sig-network-gce
   dashboard_tab:
-  - name: gci-gce-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: gci-gce-ingress-manual-network
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gce-cos-1.11-ingress
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
     alert_options:
@@ -4156,10 +2970,6 @@ dashboards:
     description: network gci-gce tests with kube-dns and nodelocaldns cache enabled
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: gce-alpha-api
-    test_group_name: ci-kubernetes-e2e-gce-alpha-api
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gci-gce
     test_group_name: ci-kubernetes-e2e-gci-gce
     base_options: include-filter-by-regex=\[sig-network\]
@@ -4190,18 +3000,6 @@ dashboards:
     description: network gci-gce alpha features e2e tests for master branch
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: containerd-gci-gce-ingress
-    test_group_name: ci-cri-containerd-e2e-gci-gce-ingress
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: gce-coredns-performance
-    test_group_name: ci-kubernetes-e2e-gce-coredns-performance
-  - name: gce-coredns-performance-nodecache
-    test_group_name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
-  - name: gce-kubedns-performance
-    test_group_name: ci-kubernetes-e2e-gce-kubedns-performance
-  - name: gce-kubedns-performance-nodecache
-    test_group_name: ci-kubernetes-e2e-gce-kubedns-performance-nodecache
   - name: gce-lb-finalizer
     test_group_name: ci-kubernetes-e2e-gce-lb-finalizer
     base_options: include-filter-by-regex=\[sig-network\]
@@ -4233,14 +3031,6 @@ dashboards:
     description: network gci-gke alpha features e2e tests for master branch
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: gci-gke-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gke-ingress
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: gci-gke-network-policy
-    test_group_name: ci-kubernetes-e2e-gci-gke-network-policy
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
   - name: gke-cos-1.11-ingress
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable3-ingress
     alert_options:
@@ -4259,84 +3049,11 @@ dashboards:
       alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
 - name: sig-network-ingress-gce-e2e
-  dashboard_tab:
-  - name: ingress-gce-e2e
-    test_group_name: ci-ingress-gce-e2e
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-e2e-multi-zone
-    test_group_name: ci-ingress-gce-e2e-multi-zone
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-e2e-release-1.6
-    test_group_name: ci-ingress-gce-e2e-release-1-6
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-e2e-scale
-    test_group_name: ci-ingress-gce-e2e-scale
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: ingress-gce-image-push
-    test_group_name: ci-ingress-gce-image-push
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-
+  dashboard_tab: []
 - name: sig-network-ingress-nginx
-  dashboard_tab:
-  - name: boilerplate
-    test_group_name: pull-ingress-nginx-boilerplate
-  - name: codegen
-    test_group_name: pull-ingress-nginx-codegen
-  - name: gofmt
-    test_group_name: pull-ingress-nginx-gofmt
-  - name: golint
-    test_group_name: pull-ingress-nginx-golint
-  - name: test-lua
-    test_group_name: pull-ingress-nginx-test-lua
-  - name: test
-    test_group_name: pull-ingress-nginx-test
-  - name: e2e-1-12
-    test_group_name: pull-ingress-nginx-e2e-1-12
-  - name: e2e-1-13
-    test_group_name: pull-ingress-nginx-e2e-1-13
-  - name: e2e-1-14
-    test_group_name: pull-ingress-nginx-e2e-1-14
-  - name: e2e-1-15
-    test_group_name: pull-ingress-nginx-e2e-1-15
-  - name: ci-e2e
-    test_group_name: ci-ingress-nginx-e2e
-
+  dashboard_tab: []
 - name: sig-network-netd
-  dashboard_tab:
-  - name: e2e-gci-gce-netd
-    test_group_name: ci-kubernetes-e2e-gci-gce-netd
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-gci-gce-netd-calico
-    test_group_name: ci-kubernetes-e2e-gci-gce-netd-calico
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-ubuntu-gce-netd
-    test_group_name: ci-kubernetes-e2e-ubuntu-gce-netd
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-ubuntu-gce-netd-calico
-    test_group_name: ci-kubernetes-e2e-ubuntu-gce-netd-calico
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-containerd-gce-netd
-    test_group_name: ci-kubernetes-e2e-containerd-gce-netd
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-containerd-gce-netd-calico
-    test_group_name: ci-kubernetes-e2e-containerd-gce-netd-calico
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-  - name: e2e-containerd-gce-calico
-    test_group_name: ci-kubernetes-e2e-containerd-gce-calico
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-
+  dashboard_tab: []
 - name: sig-node-cri-o
   dashboard_tab:
   - name: crio-e2e-fedora
@@ -4356,139 +3073,20 @@ dashboards:
 
 - name: sig-node-containerd
   dashboard_tab:
-  - name: build
-    test_group_name: ci-cri-containerd-build
-  - name: node-e2e
-    test_group_name: ci-cri-containerd-node-e2e
-  - name: node-e2e-features
-    test_group_name: ci-cri-containerd-node-e2e-features
-  - name: e2e-gci
-    test_group_name: ci-cri-containerd-e2e-gci-gce
-  - name: e2e-ubuntu
-    test_group_name: ci-cri-containerd-e2e-ubuntu-gce
-  - name: containerd-build
-    test_group_name: ci-containerd-build
-  - name: containerd-build-1.1
-    test_group_name: ci-containerd-build-1-1
-  - name: containerd-build-1.2
-    test_group_name: ci-containerd-build-1-2
-  - name: containerd-node-e2e
-    test_group_name: ci-containerd-node-e2e
-  - name: containerd-node-e2e-1.1
-    test_group_name: ci-containerd-node-e2e-1-1
-  - name: containerd-node-e2e-1.2
-    test_group_name: ci-containerd-node-e2e-1-2
-  - name: containerd-node-e2e-features
-    test_group_name: ci-containerd-node-e2e-features
-  - name: containerd-node-e2e-features-1.1
-    test_group_name: ci-containerd-node-e2e-features-1-1
-  - name: containerd-node-e2e-features-1.2
-    test_group_name: ci-containerd-node-e2e-features-1-2
-  - name: containerd-e2e-gci
-    test_group_name: ci-containerd-e2e-gci-gce
-  - name: containerd-e2e-gci-1.1
-    test_group_name: ci-containerd-e2e-gci-gce-1-1
-  - name: containerd-e2e-gci-1.2
-    test_group_name: ci-containerd-e2e-gci-gce-1-2
-  - name: containerd-e2e-shielded-gci-1.2
-    test_group_name: ci-containerd-e2e-shielded-gci-gce-1-2
-  - name: containerd-e2e-shielded-gci-slow-1.2
-    test_group_name: ci-containerd-e2e-shielded-gci-gce-slow-1-2
-  - name: containerd-e2e-shielded-gci-serial-1.2
-    test_group_name: ci-containerd-e2e-shielded-gci-gce-serial-1-2
-  - name: containerd-e2e-ubuntu
-    test_group_name: ci-containerd-e2e-ubuntu-gce
-  - name: e2e-gci-reboot
-    test_group_name: ci-cri-containerd-e2e-gci-gce-reboot
-  - name: e2e-gci-serial
-    test_group_name: ci-cri-containerd-e2e-gci-gce-serial
-  - name: e2e-gci-slow
-    test_group_name: ci-cri-containerd-e2e-gci-gce-slow
-  - name: e2e-gci-flaky
-    test_group_name: ci-cri-containerd-e2e-gci-gce-flaky
-  - name: e2e-gci-alpha-features
-    test_group_name: ci-cri-containerd-e2e-gci-gce-alpha-features
-  - name: e2e-gci-statefulset
-    test_group_name: ci-cri-containerd-e2e-gci-gce-statefulset
-  - name: e2e-gci-proto
-    test_group_name: ci-cri-containerd-e2e-gci-gce-proto
-  - name: e2e-gci-device-plugin-gpu
-    test_group_name: ci-cri-containerd-e2e-gce-device-plugin-gpu
-  - name: e2e-gci-ingress
-    test_group_name: ci-cri-containerd-e2e-gci-gce-ingress
-  - name: e2e-gci-multizone
-    test_group_name: ci-cri-containerd-e2e-gce-multizone
-  - name: e2e-gci-sd-logging
-    test_group_name: ci-cri-containerd-e2e-gci-gce-sd-logging
-  - name: e2e-gci-sd-logging-k8s-resources
-    test_group_name: ci-cri-containerd-e2e-gci-gce-sd-logging-k8s-resources
-  - name: e2e-gci-es-logging
-    test_group_name: ci-cri-containerd-e2e-gci-gce-es-logging
-  - name: e2e-gci-stackdriver
-    test_group_name: ci-cri-containerd-e2e-gce-stackdriver
-  - name: e2e-gci-ip-alias
-    test_group_name: ci-cri-containerd-e2e-gci-gce-ip-alias
-  - name: node-e2e-serial
-    test_group_name: ci-cri-containerd-node-e2e-serial
-  - name: node-e2e-flaky
-    test_group_name: ci-cri-containerd-node-e2e-flaky
-  - name: node-e2e-benchmark
-    test_group_name: ci-cri-containerd-node-e2e-benchmark
   - name: pull-node-e2e
     test_group_name: pull-kubernetes-node-e2e-containerd
     base_options: width=10
   - name: pull-e2e-gci
     test_group_name: pull-kubernetes-e2e-containerd-gce
     base_options: width=10
-  - name: soak-gci-gce
-    test_group_name: ci-containerd-soak-gci-gce
-  - name: image-validation-node-e2e
-    test_group_name: ci-cos-containerd-node-e2e
-  - name: image-validation-node-features
-    test_group_name: ci-cos-containerd-node-e2e-features
-  - name: image-validation-cos-e2e
-    test_group_name: ci-cos-containerd-e2e-gci-gce
-  - name: image-validation-ubuntu-e2e
-    test_group_name: ci-cos-containerd-e2e-ubuntu-gce
-
 - name: sig-node-cri
-  dashboard_tab:
-  - name: docker-node-conformance
-    test_group_name: ci-docker-node-conformance
-  - name: docker-node-features
-    test_group_name: ci-docker-node-features
-  - name: docker-node-legacy
-    test_group_name: ci-docker-node-legacy
-  - name: containerd-node-conformance
-    test_group_name: ci-containerd-node-e2e
-  - name: containerd-node-features
-    test_group_name: ci-containerd-node-e2e-features
-
+  dashboard_tab: []
 - name: sig-node-cri-1.12
 
 - name: sig-node-cadvisor
-  dashboard_tab:
-  - name: cadvisor-push
-    test_group_name: ci-cadvisor-canarypush
-  - name: cadvisor-e2e
-    test_group_name: ci-cadvisor-e2e
-
+  dashboard_tab: []
 - name: sig-node-kubelet
   dashboard_tab:
-  - name: node-kubelet-benchmark
-    test_group_name: ci-kubernetes-node-kubelet-benchmark
-  - name: node-kubelet-features
-    test_group_name: ci-kubernetes-node-kubelet-features
-  - name: node-kubelet-orphans
-    test_group_name: ci-kubernetes-node-kubelet-orphans
-  - name: node-kubelet-serial
-    test_group_name: ci-kubernetes-node-kubelet-serial
-  - name: node-kubelet-flaky
-    test_group_name: ci-kubernetes-node-kubelet-flaky
-  - name: node-kubelet-alpha
-    test_group_name: ci-kubernetes-node-kubelet-alpha
-  - name: node-kubelet-conformance
-    test_group_name: ci-kubernetes-node-kubelet-conformance
   - name: conformance-node-rhel
     test_group_name: ci-kubernetes-conformance-node-e2e-rhel
   - name: conformance-node-containerized-rhel
@@ -4510,75 +3108,19 @@ dashboards:
     description: Runs conformance test by using kubetest against latest version of kubernetes on arm64
 
 - name: sig-node-node-problem-detector
-  dashboard_tab:
-  - name: ci-npd-build
-    test_group_name: ci-npd-build
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-test
-    test_group_name: ci-npd-test
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-e2e-node
-    test_group_name: ci-npd-e2e-node
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-e2e-kubernetes-gce-gci
-    test_group_name: ci-npd-e2e-kubernetes-gce-gci
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
-    test_group_name: ci-npd-e2e-kubernetes-gce-gci-custom-flags
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-e2e-kubernetes-gce-ubuntu
-    test_group_name: ci-npd-e2e-kubernetes-gce-ubuntu
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-  - name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    test_group_name: ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    alert_options:
-      alert_mail_to_addresses: zhenw@google.com,lantaol@google.com
-
-# Move sig-release here
-
+  dashboard_tab: []
 - name: sig-scalability-gce
 
 - name: sig-scalability-kubemark
-  dashboard_tab:
-  - name: kubemark-100
-    test_group_name: ci-kubernetes-kubemark-100-gce
-  - name: kubemark-100-high-density
-    test_group_name: ci-kubernetes-kubemark-high-density-100-gce
-  - name: kubemark-500
-    test_group_name: ci-kubernetes-kubemark-500-gce
-  - name: kubemark-5000
-    test_group_name: ci-kubernetes-kubemark-gce-scale
-
+  dashboard_tab: []
 - name: sig-scalability-node
-  dashboard_tab:
-  - name: node-throughput
-    test_group_name: ci-kubernetes-e2e-gce-node-throughput
-
+  dashboard_tab: []
 - name: sig-scalability-perf-tests
-  dashboard_tab:
-  - name: kubemark-100-benchmark
-    test_group_name: ci-perf-tests-kubemark-100-benchmark
-
+  dashboard_tab: []
 - name: sig-scalability-benchmarks
-  dashboard_tab:
-  - name: scheduler
-    test_group_name: ci-benchmark-scheduler-master
-  - name: kube-dns
-    test_group_name: ci-benchmark-kube-dns-master
-  - name: microbenchmarks
-    test_group_name: ci-benchmark-microbenchmarks
-
+  dashboard_tab: []
 - name: sig-scalability-experiments
-  dashboard_tab:
-  - name: gce-private-cluster-correctness
-    test_group_name: ci-kubernetes-e2e-gce-private-cluster-correctness
-
+  dashboard_tab: []
 - name: sig-scheduling
   dashboard_tab:
   - name: gce
@@ -4634,9 +3176,6 @@ dashboards:
     description: storage gce e2e tests for master branch with reduced flake attempt
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: gce-containerd
-    test_group_name: ci-kubernetes-e2e-gci-gce-containerd
-    description: node gce e2e tests for master branch using containerd
   - name: gke-flaky
     test_group_name: ci-kubernetes-e2e-gci-gke-flaky
     base_options: include-filter-by-regex=Volume%7Cstorage
@@ -4729,76 +3268,8 @@ dashboards:
     test_group_name: ci-sig-storage-local-static-provisioner-master-gke-default
     base_options: include-filter-by-regex=sig-storage
     description: E2E tests against default kubernetes on GKE
-  - name: master-canary-build
-    test_group_name: post-sig-storage-local-static-provisioner-build-canary
-    description: Canary image build against latest master
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: release-build
-    test_group_name: post-sig-storage-local-static-provisioner-build-release
-    description: Release image build against tagged releases
-
 - name: sig-storage-csi
-  dashboard_tab:
-  - name: 1-13-on-1-13
-    test_group_name: ci-kubernetes-csi-1-13-on-kubernetes-1-13
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.13 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: 1-13-on-1-14
-    test_group_name: ci-kubernetes-csi-1-13-on-kubernetes-1-14
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.13 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: 1-13-on-master
-    test_group_name: ci-kubernetes-csi-1-13-on-kubernetes-master
-    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.13 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: 1-14-on-1-13
-    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-1-13
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars
-  - name: 1-14-on-1-14
-    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-1-14
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: 1-14-on-master
-    test_group_name: ci-kubernetes-csi-1-14-on-kubernetes-master
-    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: alpha-1-13-on-1-13
-    test_group_name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
-    description: Kubernetes-CSI alpha tests with Kubernetes 1.13.x and 1.13 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: alpha-1-14-on-1-14
-    test_group_name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
-    description: Kubernetes-CSI alpha tests with Kubernetes 1.14.x and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: canary-on-1-13
-    test_group_name: ci-kubernetes-csi-canary-on-kubernetes-1-13
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13.x and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: canary-on-1-14
-    test_group_name: ci-kubernetes-csi-canary-on-kubernetes-1-14
-    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14.x and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: canary-on-master
-    test_group_name: ci-kubernetes-csi-canary-on-kubernetes-master
-    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-  - name: alpha-canary-on-master
-    test_group_name: ci-kubernetes-csi-alpha-canary-on-kubernetes-master
-    description: Kubernetes-CSI alpha tests with Kubernetes master and 1.14 sidecars
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-
+  dashboard_tab: []
 - name: sig-testing-maintenance
   dashboard_tab:
   - name: boskos-config-upload
@@ -4828,12 +3299,6 @@ dashboards:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
     alert_options:
       alert_mail_to_addresses: kubernetes-sig-testing-alerts@googlegroups.com
-  - name: autoupdate-patch
-    description: Weekly module update to latest patched versions
-    test_group_name: ci-test-infra-autoupdate-patch
-  - name: autoupdate-minor
-    description: Monthly module update to latest minor versions
-    test_group_name: ci-test-infra-autoupdate-minor
 - name: sig-testing-fejtabot
   dashboard_tab:
   - name: retester
@@ -5014,39 +3479,8 @@ dashboards:
     test_group_name: pull-test-infra-bazel-canary
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
-  - name: bazel-build
-    test_group_name: periodic-kubernetes-bazel-build-canary
-    description: run kubernetes-bazel-build with latest image
-  - name: pull-bazel-build
-    test_group_name: pull-kubernetes-bazel-build-canary
-  - name: bazel-test
-    test_group_name: periodic-kubernetes-bazel-test-canary
-    description: run kubernetes-bazel-test with latest image
-  - name: pull-bazel-test
-    test_group_name: pull-kubernetes-bazel-test-canary
-  - name: pull-bazel-test-integration
-    test_group_name: pull-kubernetes-bazel-test-integration-canary
-  - name: pull-kubernetes-integration-podutil
-    test_group_name: pull-kubernetes-integration-podutil
-  - name: ci-kubernetes-coverage-conformance
-    test_group_name: ci-kubernetes-coverage-conformance
-    description: build instrumented kubernetes, run conformance tests, generate line coverage using gopherage
-  - name: ci-kubernetes-coverage-e2e-gci-gce
-    test_group_name: ci-kubernetes-coverage-e2e-gci-gce
-    description: build instrumented kubernetes, run (non-slow/serial/disruptive/flaky/feature) e2e tests, generate line coverage using gopherage
-  - name: echo-test
-    test_group_name: ci-test-infra-canary-echo-test
-    description: temporarily echoing things.
-  - name: benchmark-demo
-    test_group_name: ci-test-infra-benchmark-demo
-    description: Demoing JUnit golang benchmark results.
-
 - name: sig-testing-org
   dashboard_tab:
-  - name: ci-peribolos
-    test_group_name: ci-org-peribolos
-    alert_options:
-      alert_mail_to_addresses: kubernetes-github-managment-alerts@googlegroups.com
   - name: post-peribolos
     test_group_name: post-org-peribolos
     alert_options:
@@ -5063,40 +3497,7 @@ dashboards:
       url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
 
 - name: sig-testing-kind
-  dashboard_tab:
-  - name: ci build
-    description: kind CI build
-    test_group_name: ci-kind-build
-    alert_options:
-      alert_mail_to_addresses: bentheelder@google.com
-  - name: conformance, master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance
-  - name: kind (IPv6), master (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-ipv6
-  - name: conformance, master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel
-  - name: kind (IPv6), master (dev) [non-serial]
-    description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 kubernetes-in-docker cluster, skipping [Serial] tests
-    test_group_name: ci-kubernetes-kind-conformance-parallel-ipv6
-  - name: kind, v1.14 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes relase-1.14 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-14
-  - name: kind, v1.13 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes relase-1.13 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-13
-  - name: kind, v1.12 (dev)
-    description: Runs conformance tests using kubetest against latest kubernetes relase-1.12 with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-12
-  - name: conformance-image, master (dev)
-    description: Runs conformance test using connformance image against latest kubernetes master with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-test
-  - name: conformance-image, 1.14 (dev)
-    description: Runs conformance test using connformance image against kubernetes 1.14 branch with a kubernetes-in-docker cluster
-    test_group_name: ci-kubernetes-conformance-image-1-14-test
-
+  dashboard_tab: []
 - name: sig-gcp-master
   dashboard_tab:
   - name: gci-gke
@@ -5210,29 +3611,6 @@ dashboards:
     - configuration_value: node_os_image
     - configuration_value: Commit
     - configuration_value: infra-commit
-  - name: gke-gci-1.11-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.11-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
-  - name: gke-gci-1.12-gci-1.13-upgrade-master
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
-  - name: gke-gci-1.12-gci-1.13-upgrade-cluster-new
-    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
-  - name: gke-1.13-1.12-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
-  - name: gke-1.12-1.13-gci-kubectl-skew
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
-  - name: gke-1.13-1.12-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
-  - name: gke-1.12-1.13-gci-kubectl-skew-serial
-    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
-  - name: gke-device-plugin-gpu-1.13
-    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
-
 - name: sig-gcp-release-1.12
   dashboard_tab:
   - name: gke-cos-1.12-default
@@ -5465,71 +3843,17 @@ dashboards:
     base_options: width=10
 
 - name: presubmits-misc
-  dashboard_tab:
-  - name: charts
-    test_group_name: pull-charts-e2e
-  - name: cadvisor
-    test_group_name: pull-cadvisor-e2e
-  - name: pull-k8s-cluster-bundle-bazel-test
-    test_group_name: pull-k8s-cluster-bundle-bazel-test
-  - name: post-k8s-cluster-bundle-bazel-test
-    test_group_name: post-k8s-cluster-bundle-bazel-test
-
+  dashboard_tab: []
 - name: presubmits-kops
-  dashboard_tab:
-  - name: e2e
-    test_group_name: pull-kops-e2e-kubernetes-aws
-  - name: verify-bazel
-    test_group_name: pull-kops-verify-bazel
-  - name: bazel-build
-    test_group_name: pull-kops-bazel-build
-  - name: bazel-test
-    test_group_name: pull-kops-bazel-test
-  - name: verify-boilerplate
-    test_group_name: pull-kops-verify-boilerplate
-  - name: verify-govet
-    test_group_name: pull-kops-verify-govet
-  - name: verify-gofmt
-    test_group_name: pull-kops-verify-gofmt
-  - name: verify-packages
-    test_group_name: pull-kops-verify-packages
-
+  dashboard_tab: []
 - name: presubmits-poseidon
-  dashboard_tab:
-  - name: bazel
-    test_group_name: pull-poseidon-bazel
-  - name: verify
-    test_group_name: pull-poseidon-verify
-  - name: e2e
-    test_group_name: ci-poseidon-e2e-gce
-
+  dashboard_tab: []
 - name: presubmits-kube-batch
-  dashboard_tab:
-    - name: verify
-      test_group_name: pull-kube-batch-verify
-
+  dashboard_tab: []
 - name: presubmits-node-problem-detector
-  dashboard_tab:
-  - name: pull-npd-build
-    test_group_name: pull-npd-build
-  - name: pull-npd-test
-    test_group_name: pull-npd-test
-  - name: pull-npd-e2e-node
-    test_group_name: pull-npd-e2e-node
-  - name: pull-npd-e2e-kubernetes-gce-gci
-    test_group_name: pull-npd-e2e-kubernetes-gce-gci
-  - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-    test_group_name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
-  - name: pull-npd-e2e-kubernetes-gce-ubuntu
-    test_group_name: pull-npd-e2e-kubernetes-gce-ubuntu
-  - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-    test_group_name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
-
+  dashboard_tab: []
 - name: google-rules_k8s
-  dashboard_tab:
-  - name: pull-rules-k8s-e2e
-    test_group_name: pull-rules-k8s-e2e
-
+  dashboard_tab: []
 - name: istio-presubmits
   dashboard_tab:
   - name: unit-tests
@@ -6074,86 +4398,41 @@ dashboards:
       alert_mail_to_addresses: istio-oncall@googlegroups.com
 
 - name: istio-gke
-  dashboard_tab:
-  - name: istio-gke-addon
-    test_group_name: istio-periodic-e2e-gke-addon
-
+  dashboard_tab: []
 - name: sig-cluster-lifecycle-kops
-  dashboard_tab:
-  - name: kops-aws
-    test_group_name: ci-kubernetes-e2e-kops-aws
-  - name: kops-aws-canary
-    test_group_name: ci-kubernetes-e2e-kops-aws-canary
-  - name: kops-aws-1.11
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable3
-  - name: kops-aws-1.12
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable2
-  - name: kops-aws-1.13
-    test_group_name: ci-kubernetes-e2e-kops-aws-stable1
-  - name: kops-aws-1.14
-    test_group_name: ci-kubernetes-e2e-kops-aws-beta
-  - name: kops-aws-updown
-    test_group_name: ci-kubernetes-e2e-kops-aws-updown
-  - name: kops-aws-networking-kopeio-vxlan
-    test_group_name: ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan
-  - name: kops-aws-weave
-    test_group_name: ci-kubernetes-e2e-kops-aws-weave
-  - name: kops-aws-channelalpha
-    test_group_name: ci-kubernetes-e2e-kops-aws-channelalpha
-  - name: kops-aws-ena-nvme
-    test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
-  - name: kops-aws-ha-uswest2
-    test_group_name: ci-kubernetes-e2e-kops-aws-ha-uswest2
-  - name: kops-aws-newrunner
-    test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
-  - name: kops-aws-imagecentos7
-    test_group_name: ci-kubernetes-e2e-kops-aws-imagecentos7
-  - name: kops-aws-imageubuntu1604
-    test_group_name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
-  - name: kops-gce
-    test_group_name: ci-kubernetes-e2e-kops-gce
-  - name: kops-gce-canary
-    test_group_name: ci-kubernetes-e2e-kops-gce-canary
-  - name: kops-gce-channelalpha
-    test_group_name: ci-kubernetes-e2e-kops-gce-channelalpha
-  - name: kops-gce-ha
-    test_group_name: ci-kubernetes-e2e-kops-gce-ha
-  - name: kops-postsubmit
-    test_group_name: kops-postsubmit
-
-# Gardener AWS Dashboard
+  dashboard_tab: []
 - name: gardener-aws
   dashboard_tab:
   - name: Gardener, v1.15 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
     test_group_name: ci-gardener-e2e-aws-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 # Gardener GCE Dashboard
 - name: gardener-gce
@@ -6162,32 +4441,32 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
     test_group_name: ci-gardener-e2e-gce-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 # Gardener Alicloud Dashboard
 - name: gardener-alicloud
@@ -6196,17 +4475,17 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
     test_group_name: ci-gardener-e2e-alicloud-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Alicloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
     test_group_name: ci-gardener-e2e-alicloud-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Alicloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
     test_group_name: ci-gardener-e2e-alicloud-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 # Gardener Azure Dashboard
 - name: gardener-azure
@@ -6215,32 +4494,32 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
     test_group_name: ci-gardener-e2e-azure-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 # Gardener OpenStack Dashboard
 - name: gardener-openstack
@@ -6249,32 +4528,32 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
     test_group_name: ci-gardener-e2e-openstack-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 # Gardener Conformance Dashboard
 - name: conformance-gardener
@@ -6283,161 +4562,142 @@ dashboards:
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.15 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.15 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.15 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.15 Alibaba Cloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
     test_group_name: ci-gardener-e2e-conformance-alicloud-v1.15
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.14 Alibaba Cloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
     test_group_name: ci-gardener-e2e-conformance-alicloud-v1.14
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.13 Alibaba Cloud
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
     test_group_name: ci-gardener-e2e-conformance-alicloud-v1.13
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.12 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.12
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.11 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.11
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 AWS
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
     test_group_name: ci-gardener-e2e-conformance-aws-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 GCE
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
     test_group_name: ci-gardener-e2e-conformance-gce-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 OpenStack
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
     test_group_name: ci-gardener-e2e-conformance-openstack-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
   - name: Gardener, v1.10 Azure
     description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
     test_group_name: ci-gardener-e2e-conformance-azure-v1.10
     alert_options:
-      alert_mail_to_addresses:  gardener-oq@listserv.sap.com
+      alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
 - name: sig-api-machinery-kube-storage-version-migrator
-  dashboard_tab:
-  - name: pr-test
-    test_group_name: pull-kube-storage-version-migrator-test
-  - name: pr-e2e-manually-launched
-    test_group_name: pull-kube-storage-version-migrator-manually-launched-e2e
-  - name: pr-e2e-fully-automated
-    test_group_name: pull-kube-storage-version-migrator-fully-automated-e2e
-  - name: ci-disruptive
-    test_group_name: pull-kube-storage-version-migrator-disruptive
-
+  dashboard_tab: []
 - name: sig-api-machinery-structured-merge-diff
-  dashboard_tab:
-  - name: pr-test
-    test_group_name: pull-structured-merge-diff-test
-  - name: ci-test
-    test_group_name: ci-structured-merge-diff-test
-  - name: pr-gofmt
-    test_group_name: pull-structured-merge-diff-gofmt
-  - name: ci-gofmt
-    test_group_name: ci-structured-merge-diff-gofmt
-
-# Arm dashboard
+  dashboard_tab: []
 - name: conformance-arm
   dashboard_tab:
   - name: Periodic Arm64 conformance test on AWS
@@ -6468,34 +4728,6 @@ dashboards:
 # sig-windows dashboard
 - name: sig-windows
   dashboard_tab:
-  - name: aks-engine-azure-windows-master
-    description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-master-windows
-  - name: aks-engine-azure-windows-master-staging
-    description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
-  - name: aks-engine-azure-1-14-windows
-    description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
-  - name: aks-engine-azure-1-15-windows
-    description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
-    test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
-  - name: aks-engine-azure-windows-presubmit
-    description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
-    test_group_name: pull-kubernetes-e2e-aks-engine-azure-windows
-  - name: gce-windows-master
-    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
-    test_group_name: ci-kubernetes-e2e-windows-gce
-  - name: gce-windows-1.14
-    description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE"
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sstable1
-  - name: gce-windows-1.15
-    description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE"
-    test_group_name: ci-kubernetes-e2e-windows-gce-k8sbeta
-  - name: gce-windows-master-alpha-features
-    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled"
-    test_group_name: ci-kubernetes-e2e-windows-gce-alpha-features
-
   - name: cfcr-vsphere-windows-master
     description: Runs Windows verification tests on a master-branch Kubernetes cluster provided by CFCR (https://github.com/cloudfoundry-incubator/kubo-release) on vSphere"
     test_group_name: ci-kubernetes-e2e-windows-cfcr
@@ -6517,36 +4749,7 @@ dashboards:
 
 # sig-azure dashboard
 - name: sig-azure-master
-  dashboard_tab:
-  - name: cloud-provider-azure-master
-    description: Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
-    test_group_name: ci-cloud-provider-azure-master
-  - name: cloud-provider-azure-autoscaling
-    description: Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
-    test_group_name: ci-cloud-provider-azure-autoscaling
-  - name: cloud-provider-azure-conformance
-    description: Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
-    test_group_name: ci-cloud-provider-azure-conformance
-  - name: cloud-provider-azure-slow
-    description: Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
-    test_group_name: ci-cloud-provider-azure-slow
-  - name: pr-cloud-provider-e2e-ccm
-    description: Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)"
-    test_group_name: pull-cloud-provider-azure-e2e-ccm
-  - name: pr-k8s-e2e
-    description: Run e2e tests
-    test_group_name: pull-kubernetes-e2e-aks-engine-azure
-  - name: pr-cloud-provider-e2e
-    description: Run Kubernetes e2e tests for cloud-provider-azure
-    test_group_name: pull-cloud-provider-azure-e2e
-  - name: pr-cloud-provider-unit
-    description: Run unit tests for cloud-provider-azure
-    test_group_name: pull-cloud-provider-azure-unit
-  - name: pr-cloud-provider-check
-    description: Run lint check tests for cloud-provider-azure
-    test_group_name: pull-cloud-provider-azure-check
-
-# openshift dashboard
+  dashboard_tab: []
 - name: redhat-openshift-release-blocking
   dashboard_tab:
   - name: redhat-release-openshift-origin-installer-e2e-aws-4.1


### PR DESCRIPTION
Migrates many annotatable jobs to their respective prow jobs
Skips misconfigured, overconfigured, and one automated dashboard tabs

Partially addresses issues #13057 

/assign @michelle192837 
/cc @spiffxp 