### PR TITLE
cluster-api-bootstrap-provider-kubeadm: add presubmit job + OWNERS file

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- chuckha
+- detiber
+- justinsb
+- vincepri
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
@@ -1,0 +1,15 @@
+# sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm presubmits
+presubmits:
+  kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm:
+  - name: pull-cluster-api-bootstrap-provider-kubeadm-verify
+    path_alias: "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm"
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190626-f0c7a9f-master
+        command:
+        - "./hack/verify-all.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
+      testgrid-tab-name: pr-verify

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -633,6 +633,9 @@ plugins:
   kubernetes-sigs/cluster-api-provider-docker:
   - milestone
 
+  kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm:
+  - milestone
+
   kubernetes-sigs/contributor-playground:
   - require-sig
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4165,6 +4165,8 @@ dashboards:
   - name: pr-verify
     test_group_name: pull-cluster-api-provider-docker-verify
 
+- name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
+
 - name: sig-multicluster-kubemci
   dashboard_tab:
   - name: kubemci-image-push


### PR DESCRIPTION
includes:
- OWNERS file
- a presubmit job
- milestone plugin
- testgrid entries

xref: https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/issues/2

/sig cluster-lifecycle
/kind feature
/priority important-soon

/assign @chuckha 