### PR TITLE
Add 0.27.0 to bazelbuild variants

### DIFF
--- a/images/bazelbuild/variants.yaml
+++ b/images/bazelbuild/variants.yaml
@@ -1,15 +1,9 @@
 variants:
+  0.27.0:
+    BAZEL_VERSION: 0.27.0
   0.26.0:
     BAZEL_VERSION: 0.26.0
   0.24.0:
     BAZEL_VERSION: 0.24.0
   0.23.2:
     BAZEL_VERSION: 0.23.2
-  0.10.0:
-    BAZEL_VERSION: 0.10.0
-  0.8.1:
-    BAZEL_VERSION: 0.8.1
-  0.7.0:
-    BAZEL_VERSION: 0.7.0
-  0.6.1:
-    BAZEL_VERSION: 0.6.1


### PR DESCRIPTION
/assign @Katharine @stevekuznetsov 

ref https://github.com/kubernetes/test-infra/pull/13204

autobump job is still using 0.26.0: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow/1144336356562964482