### PR TITLE
Give presubmits a minimum of num_columns_recent = 20

### DIFF
--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -73,6 +73,20 @@ func applySingleProwjobAnnotations(c *Config, pc *prowConfig.Config, j prowConfi
 			ReconcileTestGroup(testGroup, c.defaultConfig.DefaultTestGroup)
 			c.config.TestGroups = append(c.config.TestGroups, testGroup)
 		}
+	} else {
+		testGroup = c.config.FindTestGroup(testGroupName)
+	}
+
+	if testGroup == nil {
+		for _, a := range []string{testgridNumColumnsRecentAnnotation, testgridAlertStaleResultsHoursAnnotation,
+			testgridNumFailuresToAlertAnnotation, testgridTabNameAnnotation, testgridEmailAnnotation} {
+			_, ok := j.Annotations[a]
+			if ok {
+				return fmt.Errorf("no testgroup exists for job %q, but annotation %q implies one should exist", j.Name, a)
+			}
+		}
+		// exit early: with no test group, there's nothing else for us to usefully do with the job.
+		return nil
 	}
 
 	if ncr, ok := j.Annotations[testgridNumColumnsRecentAnnotation]; ok {

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -37,6 +37,7 @@ const testgridNumColumnsRecentAnnotation = "testgrid-num-columns-recent"
 const testgridAlertStaleResultsHoursAnnotation = "testgrid-alert-stale-results-hours"
 const testgridNumFailuresToAlertAnnotation = "testgrid-num-failures-to-alert"
 const descriptionAnnotation = "description"
+const minPresubmitNumColumnsRecent = 20
 
 // Talk to @michelle192837 if you're thinking about adding more of these!
 
@@ -95,6 +96,8 @@ func applySingleProwjobAnnotations(c *Config, pc *prowConfig.Config, j prowConfi
 			return fmt.Errorf("%s value %q is not a valid integer", testgridNumColumnsRecentAnnotation, ncr)
 		}
 		testGroup.NumColumnsRecent = int32(ncrInt)
+	} else if jobType == prowapi.PresubmitJob && testGroup.NumColumnsRecent < minPresubmitNumColumnsRecent {
+		testGroup.NumColumnsRecent = minPresubmitNumColumnsRecent
 	}
 
 	if srh, ok := j.Annotations[testgridAlertStaleResultsHoursAnnotation]; ok {


### PR DESCRIPTION
The default default is 10, which fails tests, which is _super intuitive_.

For presubmits with associated prowjobs, make the minimum 20.

Also, don't panic if a presubmit specifies a meaningless set of annotations (this fix is actually most of the change).

/cc @michelle192837 