### PR TITLE
Add kubetest flag defining how long it wait on a new Boskos resource

### DIFF
--- a/kubetest/README.md
+++ b/kubetest/README.md
@@ -119,6 +119,9 @@ This makes it easier for developers to add and remove jobs. With boskos they no
 longer need to worry about creating, provisioning, naming, etc a project for
 this new job.
 
+The `--boskos-wait-duration` flag defines how long Kubetest waits on an Boskos resource
+becomes available before quitting the job, default value is 5 minutes.
+
 See the boskos docs for more details.
 
 ### Dump logs

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -119,6 +119,7 @@ type options struct {
 	testCmdArgs             []string
 	up                      bool
 	upgradeArgs             string
+	boskosWaitDuration      int
 }
 
 func defineFlags() *options {
@@ -181,6 +182,7 @@ func defineFlags() *options {
 	flag.DurationVar(&timeout, "timeout", time.Duration(0), "Terminate testing after the timeout duration (s/m/h)")
 	flag.BoolVar(&o.up, "up", false, "If true, start the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
+	flag.IntVar(&o.boskosWaitDuration, "boskos-wait-duration", 5, "Defines how long it waits until quite getting Boskos resoure, default 5 minutes")
 
 	// The "-v" flag was also used by glog, which is used by k8s.io/client-go. Duplicate flags cause panics.
 	// 1. Even if we could convince glog to change, they have too many consumers to ever do so.
@@ -732,7 +734,7 @@ func prepareGcp(o *options) error {
 		log.Printf("provider %v, will acquire project type %v from boskos", o.provider, resType)
 
 		// let's retry 5min to get next available resource
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*(*o.boskosWaitDuration))
 		defer cancel()
 		p, err := boskos.AcquireWait(ctx, resType, "free", "busy")
 		if err != nil {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -119,7 +119,7 @@ type options struct {
 	testCmdArgs             []string
 	up                      bool
 	upgradeArgs             string
-	boskosWaitDuration      int
+	boskosWaitDuration      time.Duration
 }
 
 func defineFlags() *options {
@@ -182,7 +182,7 @@ func defineFlags() *options {
 	flag.DurationVar(&timeout, "timeout", time.Duration(0), "Terminate testing after the timeout duration (s/m/h)")
 	flag.BoolVar(&o.up, "up", false, "If true, start the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
-	flag.IntVar(&o.boskosWaitDuration, "boskos-wait-duration", 5, "Defines how long it waits until quite getting Boskos resoure, default 5 minutes")
+	flag.DurationVar(&o.boskosWaitDuration, "boskos-wait-duration", 5*time.Minute, "Defines how long it waits until quit getting Boskos resoure, default 5 minutes")
 
 	// The "-v" flag was also used by glog, which is used by k8s.io/client-go. Duplicate flags cause panics.
 	// 1. Even if we could convince glog to change, they have too many consumers to ever do so.
@@ -734,7 +734,7 @@ func prepareGcp(o *options) error {
 		log.Printf("provider %v, will acquire project type %v from boskos", o.provider, resType)
 
 		// let's retry 5min to get next available resource
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*(*o.boskosWaitDuration))
+		ctx, cancel := context.WithTimeout(context.Background(), o.boskosWaitDuration)
 		defer cancel()
 		p, err := boskos.AcquireWait(ctx, resType, "free", "busy")
 		if err != nil {


### PR DESCRIPTION
Currently kubetest waits on getting a Boskos in a predefined 5 minutes window, this PR adds a flag to Kubetest to allow it taking a parameter overriding this timeout. This can help alleviate Boskos running out of resources problem when there is a sharp spike of Boskos resources usage

/cc @cjwagner 
/cc @krzyzacy 