### PR TITLE
Add instructions for checking bug validity again

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -342,7 +342,8 @@ Please contact an administrator to resolve this issue, then request a bug refres
 				formattedReasons += fmt.Sprintf(" - %s\n", reason)
 			}
 			response = fmt.Sprintf(`This pull request references an invalid `+bugLink+`:
-%s`, bc.Endpoint(), e.bugId, formattedReasons)
+%s
+Comment <code>/bugzilla refresh</code> to re-evaluate validity if changes to the Bugzilla bug are made, or edit the title of this pull request to link to a different bug.`, bc.Endpoint(), e.bugId, formattedReasons)
 		}
 	}
 

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -499,6 +499,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			expectedComment: `org/repo#1:@user: This pull request references an invalid [Bugzilla bug](www.bugzilla/show_bug.cgi?id=123):
  - expected the bug to be open, but it isn't
 
+Comment <code>/bugzilla refresh</code> to re-evaluate validity if changes to the Bugzilla bug are made, or edit the title of this pull request to link to a different bug.
 
 <details>
 


### PR DESCRIPTION
When a bug is invalid, a user will either choose a new bug to link to
or update the bug in Bugzilla. This update helps users know what action
to take next.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cblecker @cjwagner 
/cc @bparees 