### PR TITLE
Use ubuntu:18.04 for bazelbuild

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Includes git, gcloud, and bazel.
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG


### PR DESCRIPTION
This has bash 4.4, which we need to push reliably. Its the latest LTS release: https://wiki.ubuntu.com/Releases

/assign @Katharine @stevekuznetsov 

This will allow us to use this smaller image for the push jobs, rather than kubekins

ref #13204 #13218