### PR TITLE
testgrid/config.md: use quotes for numbers in annotations

### DIFF
--- a/testgrid/config.md
+++ b/testgrid/config.md
@@ -25,17 +25,17 @@ Simply add this to your prowjob:
 
 ```yaml
 annotations:
-  testgrid-dashboards: dashboard-name    # a dashboard defined in config.yaml.
-  testgrid-tab-name: some-short-name     # optionally, a shorter name for the tab. If omitted, just uses the job name.
-  testgrid-alert-email: me@me.com        # optionally, an alert email that will be applied to the tab created in the
-                                         # first dashboard specified in testgrid-dashboards.
-  description: Words about your job.     # optionally, a description of your job. If omitted, just uses the job name.
-  
-  testgrid-num-columns-recent: 10        # optionally, the number of runs a row can be omitted from before it is
-                                         # considered stale. Currently defaults to 10.
-  testgrid-num-failures-to-alert: 3      # optionally, the number of continuous failures before sending an email.
-                                         # Currently defaults to 3.
-  testgrid-alert-stale-results-hours: 12 # optionally, send an email if this many hours pass with no results at all.
+  testgrid-dashboards: dashboard-name      # a dashboard defined in config.yaml.
+  testgrid-tab-name: some-short-name       # optionally, a shorter name for the tab. If omitted, just uses the job name.
+  testgrid-alert-email: me@me.com          # optionally, an alert email that will be applied to the tab created in the
+                                           # first dashboard specified in testgrid-dashboards.
+  description: Words about your job.       # optionally, a description of your job. If omitted, just uses the job name.
+
+  testgrid-num-columns-recent: "10"        # optionally, the number of runs a row can be omitted from before it is
+                                           # considered stale. Currently defaults to 10.
+  testgrid-num-failures-to-alert: "3"      # optionally, the number of continuous failures before sending an email.
+                                           # Currently defaults to 3.
+  testgrid-alert-stale-results-hours: "12" # optionally, send an email if this many hours pass with no results at all.
 
 ```
 


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/blob/master/prow/config/jobs.go#L111

The annotations use a `map[string]string`, thus not quoting the
number values will fail unmarshal.

```
./hack/verify-config.sh
...
2019/06/28 01:56:06 Failed to read config file: error unmarshaling config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field Presubmit.annotations of type string
Target //hack:verify-config failed to build
```

found here:
https://github.com/kubernetes/test-infra/pull/13208#issuecomment-506542262

/kind documentation
/priority important-longterm
