### PR TITLE
Use bazelbuild for trusted push jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -57,7 +57,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190626-f0c7a9f-experimental # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190627-9413fcb-0.27.0 # whatever image you use here must have bash 4.4+
         command:
         - prow/push.sh
         env:
@@ -109,7 +109,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190626-f0c7a9f-master # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190627-9413fcb-0.27.0 # whatever image you use here must have bash 4.4+
         command:
         - boskos/push.sh
         env:


### PR DESCRIPTION
/assign @Katharine @stevekuznetsov 

ref #13204 #13218


```console
$ docker run --rm=true --entrypoint=bash gcr.io/k8s-testimages/bazelbuild:v20190627-9413fcb-0.27.0 --version
GNU bash, version 4.4.19(1)-release (x86_64-pc-linux-gnu)
```