### PR TITLE
Enforce dashboard foo-bar should be in group foo

### DIFF
--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -323,6 +323,18 @@ func TestConfig(t *testing.T) {
 				t.Errorf("Dashboard %v in group %v must have the group name as a prefix", dashboard, dashboardGroup.Name)
 			}
 		}
+
+		// Dashboards that match this dashboard group's prefix should be a part of it
+		for dashboard := range dashboardmap {
+			if strings.HasPrefix(dashboard, dashboardGroup.Name+"-") {
+				group, ok := tabs[dashboard]
+				if !ok {
+					t.Errorf("Dashboard %v should be in dashboard_group %v", dashboard, dashboardGroup.Name)
+				} else if group != dashboardGroup.Name {
+					t.Errorf("Dashboard %v should be in dashboard_group %v instead of dashboard_group %v", dashboard, dashboardGroup.Name, group)
+				}
+			}
+		}
 	}
 
 	// All Testgroup should be mapped to one or more tabs

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -6728,6 +6728,8 @@ dashboard_groups:
   - presubmits-poseidon
   - presubmits-kube-batch
   - presubmits-misc
+  - presubmits-release-notes-master
+  - presubmits-cloud-provider-alibaba
 
 - name: sig-api-machinery
   dashboard_names:
@@ -6762,6 +6764,8 @@ dashboard_groups:
   - sig-cluster-lifecycle-cluster-api-provider-gcp
   - sig-cluster-lifecycle-cluster-api-provider-ibmcloud
   - sig-cluster-lifecycle-cluster-api-provider-openstack
+  - sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
+  - sig-cluster-lifecycle-cluster-api-provider-docker
   - sig-cluster-lifecycle-kops
 
 - name: sig-contribex
@@ -6888,14 +6892,6 @@ dashboard_groups:
   - redhat-openshift-release-blocking
   - redhat-osd-stage
   - redhat-osd-prod
-
-- name: presubmits-cloud-provider
-  dashboard_names:
-  - presubmits-cloud-provider-alibaba
-
-- name: presubmits-release-notes
-  dashboard_names:
-  - presubmits-release-notes-master
 
 - name: gardener
   dashboard_names:


### PR DESCRIPTION
This was intended to catch sig-cluster-lifecycle-foo dashboards
that were top level that should have been grouped.

It ended up catching a number of presubmits. I don't think we
should allow multiple top-level presubmit dashboards, and moved
everything under presubmits.