### PR TITLE
Force host to use PY2 for rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,11 @@ run --workspace_status_command=./hack/print-workspace-status.sh
 # https://github.com/kubernetes/test-infra/issues/13140
 build --incompatible_disable_deprecated_attr_params=false
 
+# https://github.com/kubernetes/test-infra/issues/13239
+# https://github.com/bazelbuild/rules_docker/issues/842
+# https://github.com/bazelbuild/bazel/issues/7899
+build --host_force_python=PY2
+
 # enable data race detection
 test --features=race --test_output=errors
 


### PR DESCRIPTION
ref #13140 https://github.com/kubernetes/test-infra/issues/13239 https://github.com/bazelbuild/bazel/issues/7899 

/assign @michelle192837 @Katharine @spiffxp 

`bazel run //prow:release-push` works with this, doesn't without it :sigh:

This **should** just be for building stuff. Any `py_test() py_binary()` targets that declare `python_version = "PY3"` should use the right version at test/run time still