### PR TITLE
Revert deck to v20190626

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190628-61a858b89
+        image: gcr.io/k8s-prow/deck:v20190626-46a2086f4
         imagePullPolicy: Always
         ports:
           - name: http


### PR DESCRIPTION
Last known good version from https://github.com/kubernetes/test-infra/pull/13201

ref https://github.com/kubernetes/test-infra/issues/13247

/assign @Katharine 