### PR TITLE
Copy annotations from Jobs to Pods

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1166,7 +1166,7 @@ func handleRerun(prowJobClient prowv1.ProwJobInterface, createProwJob bool) http
 			}
 			return
 		}
-		newPJ := pjutil.NewProwJob(pj.Spec, pj.ObjectMeta.Labels)
+		newPJ := pjutil.NewProwJob(pj.Spec, pj.ObjectMeta.Labels, pj.ObjectMeta.Annotations)
 		// Be very careful about this on publicly accessible Prow instances. Even after we have authentication
 		// for the handler, we need CSRF protection.
 		// On Prow instances that require auth even for viewing Deck this is okayish, because the Prowjob UUID

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -146,7 +146,7 @@ func sync(prowJobClient prowJobClient, cfg *config.Config, cr cronClient, now ti
 			shouldTrigger := j.Complete() && now.Sub(j.Status.StartTime.Time) > p.GetInterval()
 			logger = logger.WithField("should-trigger", shouldTrigger)
 			if !previousFound || shouldTrigger {
-				prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels)
+				prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels, p.Annotations)
 				logger.WithFields(pjutil.ProwJobFields(&prowJob)).Info("Triggering new run of interval periodic.")
 				if _, err := prowJobClient.Create(&prowJob); err != nil {
 					errs = append(errs, err)
@@ -156,7 +156,7 @@ func sync(prowJobClient prowJobClient, cfg *config.Config, cr cronClient, now ti
 			shouldTrigger := j.Complete()
 			logger = logger.WithField("should-trigger", shouldTrigger)
 			if !previousFound || shouldTrigger {
-				prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels)
+				prowJob := pjutil.NewProwJob(pjutil.PeriodicSpec(p), p.Labels, p.Annotations)
 				logger.WithFields(pjutil.ProwJobFields(&prowJob)).Info("Triggering new run of cron periodic.")
 				if _, err := prowJobClient.Create(&prowJob); err != nil {
 					errs = append(errs, err)

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -189,6 +189,7 @@ func main() {
 
 	var pjs prowapi.ProwJobSpec
 	var labels map[string]string
+	var annotations map[string]string
 	var found bool
 	var needsBaseRef bool
 	var needsPR bool
@@ -212,6 +213,7 @@ func main() {
 					}},
 				})
 				labels = p.Labels
+				annotations = p.Annotations
 				found = true
 				needsBaseRef = true
 				needsPR = true
@@ -235,6 +237,7 @@ func main() {
 					BaseSHA: o.baseSha,
 				})
 				labels = p.Labels
+				annotations = p.Annotations
 				found = true
 				needsBaseRef = true
 				o.org = org
@@ -246,6 +249,7 @@ func main() {
 		if p.Name == o.jobName {
 			pjs = pjutil.PeriodicSpec(p)
 			labels = p.Labels
+			annotations = p.Annotations
 			found = true
 		}
 	}
@@ -262,7 +266,7 @@ func main() {
 			logrus.WithError(err).Fatal("Failed to default base ref")
 		}
 	}
-	pj := pjutil.NewProwJob(pjs, labels)
+	pj := pjutil.NewProwJob(pjs, labels, annotations)
 	b, err := yaml.Marshal(&pj)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error marshalling YAML.")

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -344,7 +344,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 			labels[client.GerritReportLabel] = client.CodeReview
 		}
 
-		pj := pjutil.NewProwJobWithAnnotation(jSpec.spec, labels, annotations)
+		pj := pjutil.NewProwJob(jSpec.spec, labels, annotations)
 		if _, err := c.kc.CreateProwJob(pj); err != nil {
 			logger.WithError(err).Errorf("fail to create prowjob %v", pj)
 		} else {

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -608,7 +608,7 @@ func TestBatch(t *testing.T) {
 				SHA:    "qwe",
 			},
 		},
-	}), nil)
+	}), nil, nil)
 	pj.ObjectMeta.Name = "known_name"
 	pj.ObjectMeta.Namespace = "prowjobs"
 	fakeProwJobClient := fake.NewSimpleClientset(&pj)

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -36,17 +36,8 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
-// NewProwJobWithAnnotation initializes a ProwJob out of a ProwJobSpec with annotations.
-func NewProwJobWithAnnotation(spec prowapi.ProwJobSpec, labels, annotations map[string]string) prowapi.ProwJob {
-	return newProwJob(spec, labels, annotations)
-}
-
 // NewProwJob initializes a ProwJob out of a ProwJobSpec.
-func NewProwJob(spec prowapi.ProwJobSpec, labels map[string]string) prowapi.ProwJob {
-	return newProwJob(spec, labels, nil)
-}
-
-func newProwJob(spec prowapi.ProwJobSpec, extraLabels, extraAnnotations map[string]string) prowapi.ProwJob {
+func NewProwJob(spec prowapi.ProwJobSpec, extraLabels, extraAnnotations map[string]string) prowapi.ProwJob {
 	labels, annotations := decorate.LabelsAndAnnotationsForSpec(spec, extraLabels, extraAnnotations)
 
 	return prowapi.ProwJob{
@@ -101,8 +92,12 @@ func NewPresubmit(pr github.PullRequest, baseSHA string, job config.Presubmit, e
 	for k, v := range job.Labels {
 		labels[k] = v
 	}
+	annotations := make(map[string]string)
+	for k, v := range job.Annotations {
+		annotations[k] = v
+	}
 	labels[github.EventGUID] = eventGUID
-	return NewProwJob(PresubmitSpec(job, refs), labels)
+	return NewProwJob(PresubmitSpec(job, refs), labels, annotations)
 }
 
 // PresubmitSpec initializes a ProwJobSpec for a given presubmit job.

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -430,10 +430,12 @@ func TestGetLatestProwJobs(t *testing.T) {
 
 func TestNewProwJob(t *testing.T) {
 	var testCases = []struct {
-		name           string
-		spec           prowapi.ProwJobSpec
-		labels         map[string]string
-		expectedLabels map[string]string
+		name                string
+		spec                prowapi.ProwJobSpec
+		labels              map[string]string
+		expectedLabels      map[string]string
+		annotations         map[string]string
+		expectedAnnotations map[string]string
 	}{
 		{
 			name: "periodic job, no extra labels",
@@ -446,6 +448,9 @@ func TestNewProwJob(t *testing.T) {
 				kube.CreatedByProw:     "true",
 				kube.ProwJobAnnotation: "job",
 				kube.ProwJobTypeLabel:  "periodic",
+			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job",
 			},
 		},
 		{
@@ -462,6 +467,9 @@ func TestNewProwJob(t *testing.T) {
 				kube.ProwJobAnnotation: "job",
 				kube.ProwJobTypeLabel:  "periodic",
 				"extra":                "stuff",
+			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job",
 			},
 		},
 		{
@@ -486,6 +494,9 @@ func TestNewProwJob(t *testing.T) {
 				kube.RepoLabel:         "repo",
 				kube.PullLabel:         "1",
 			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job",
+			},
 		},
 		{
 			name: "non-github presubmit job",
@@ -509,6 +520,9 @@ func TestNewProwJob(t *testing.T) {
 				kube.RepoLabel:         "repo",
 				kube.PullLabel:         "1",
 			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job",
+			},
 		}, {
 			name: "job with name too long to fit in a label",
 			spec: prowapi.ProwJobSpec{
@@ -531,16 +545,44 @@ func TestNewProwJob(t *testing.T) {
 				kube.RepoLabel:         "repo",
 				kube.PullLabel:         "1",
 			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job-created-by-someone-who-loves-very-very-very-long-names-so-long-that-it-does-not-fit-into-the-Kubernetes-label-so-it-needs-to-be-truncated-to-63-characters",
+			},
+		},
+		{
+			name: "periodic job, extra labels, extra annotations",
+			spec: prowapi.ProwJobSpec{
+				Job:  "job",
+				Type: prowapi.PeriodicJob,
+			},
+			labels: map[string]string{
+				"extra": "stuff",
+			},
+			annotations: map[string]string{
+				"extraannotation": "foo",
+			},
+			expectedLabels: map[string]string{
+				kube.CreatedByProw:     "true",
+				kube.ProwJobAnnotation: "job",
+				kube.ProwJobTypeLabel:  "periodic",
+				"extra":                "stuff",
+			},
+			expectedAnnotations: map[string]string{
+				kube.ProwJobAnnotation: "job",
+				"extraannotation":      "foo",
+			},
 		},
 	}
-
 	for _, testCase := range testCases {
-		pj := NewProwJob(testCase.spec, testCase.labels)
+		pj := NewProwJob(testCase.spec, testCase.labels, testCase.annotations)
 		if actual, expected := pj.Spec, testCase.spec; !equality.Semantic.DeepEqual(actual, expected) {
 			t.Errorf("%s: incorrect ProwJobSpec created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 		}
 		if actual, expected := pj.Labels, testCase.expectedLabels; !reflect.DeepEqual(actual, expected) {
 			t.Errorf("%s: incorrect ProwJob labels created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
+		}
+		if actual, expected := pj.Annotations, testCase.expectedAnnotations; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: incorrect ProwJob annotations created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 		}
 	}
 }

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -580,7 +580,7 @@ func TestNewProwJobWithAnnotations(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pj := NewProwJobWithAnnotation(testCase.spec, nil, testCase.annotations)
+		pj := NewProwJob(testCase.spec, nil, testCase.annotations)
 		if actual, expected := pj.Spec, testCase.spec; !equality.Semantic.DeepEqual(actual, expected) {
 			t.Errorf("%s: incorrect ProwJobSpec created: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 		}

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -1208,7 +1208,7 @@ func TestPeriodic(t *testing.T) {
 	totServ := httptest.NewServer(http.HandlerFunc(handleTot))
 	defer totServ.Close()
 	fc := &fkc{
-		prowjobs: []prowapi.ProwJob{pjutil.NewProwJob(pjutil.PeriodicSpec(per), nil)},
+		prowjobs: []prowapi.ProwJob{pjutil.NewProwJob(pjutil.PeriodicSpec(per), nil, nil)},
 	}
 	log := logrus.NewEntry(logrus.StandardLogger())
 	c := Controller{

--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -72,7 +72,7 @@ func handlePE(c Client, pe github.PushEvent) error {
 			labels[k] = v
 		}
 		labels[github.EventGUID] = pe.GUID
-		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels)
+		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels, j.Annotations)
 		c.Logger.WithFields(pjutil.ProwJobFields(&pj)).Info("Creating a new prowjob.")
 		if _, err := c.ProwJobClient.Create(&pj); err != nil {
 			return err

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -137,8 +137,12 @@ func LabelsAndAnnotationsForJob(pj prowapi.ProwJob) (map[string]string, map[stri
 	if extraLabels = pj.ObjectMeta.Labels; extraLabels == nil {
 		extraLabels = map[string]string{}
 	}
+	var extraAnnotations map[string]string
+	if extraAnnotations = pj.ObjectMeta.Annotations; extraAnnotations == nil {
+		extraAnnotations = map[string]string{}
+	}
 	extraLabels[kube.ProwJobIDLabel] = pj.ObjectMeta.Name
-	return LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, nil)
+	return LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
 }
 
 // ProwJobToPod converts a ProwJob to a Pod that will run the tests.

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -181,7 +181,7 @@ func (s *Subscriber) handlePeriodicJob(l *logrus.Entry, msg messageInterface, su
 	if periodicJob == nil {
 		err := fmt.Errorf("failed to find associated periodic job %q", pe.Name)
 		l.WithError(err).Errorf("failed to create job %q", pe.Name)
-		prowJob = pjutil.NewProwJobWithAnnotation(prowapi.ProwJobSpec{}, nil, pe.Annotations)
+		prowJob = pjutil.NewProwJob(prowapi.ProwJobSpec{}, nil, pe.Annotations)
 		reportProwJobFailure(&prowJob, err)
 		return err
 	}
@@ -192,7 +192,7 @@ func (s *Subscriber) handlePeriodicJob(l *logrus.Entry, msg messageInterface, su
 	}
 
 	// Adds annotations
-	prowJob = pjutil.NewProwJobWithAnnotation(prowJobSpec, periodicJob.Labels, pe.Annotations)
+	prowJob = pjutil.NewProwJob(prowJobSpec, periodicJob.Labels, pe.Annotations)
 	// Adds / Updates Environments to containers
 	if prowJob.Spec.PodSpec != nil {
 		for _, c := range prowJob.Spec.PodSpec.Containers {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1022,7 +1022,7 @@ func (c *Controller) trigger(sp subpool, presubmits map[int][]config.Presubmit, 
 			} else {
 				spec = pjutil.BatchSpec(ps, refs)
 			}
-			pj := pjutil.NewProwJob(spec, ps.Labels)
+			pj := pjutil.NewProwJob(spec, ps.Labels, ps.Annotations)
 			start := time.Now()
 			if _, err := c.prowJobClient.Create(&pj); err != nil {
 				c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")


### PR DESCRIPTION
This PR copies annotations from ProwJobs to pods run by them.

As suggested by @cjwagner on slack, the only `NewProwJob` constructor we should be using is the one that accepts annotations, so I extended the old implementation / merged it with `NewProwJobWithAnnotation`.
