### PR TITLE
Make gce-master-scale-(correctness|performance) master-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -9,6 +9,8 @@ periodics:
     preset-e2e-scalability-common: "true"
   annotations:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com,cloud-kubernetes-scalability-oncall@google.com
+    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce
+    testgrid-tab-name: gce-master-scale-correctness
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
@@ -50,6 +52,8 @@ periodics:
     preset-e2e-scalability-common: "true"
   annotations:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com,cloud-kubernetes-scalability-oncall@google.com
+    testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce
+    testgrid-tab-name: gce-master-scale-performance
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2913,12 +2913,6 @@ dashboards:
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
     description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
-  - name: gce-master-scale-correctness
-    test_group_name: ci-kubernetes-e2e-gce-scale-correctness
-    description: "OWNER: sig-scalability; Runs 1000-node performance test once a week and checks that operational results are still all correct at that scale"
-  - name: gce-master-scale-performance
-    test_group_name: ci-kubernetes-e2e-gce-scale-performance
-    description: "OWNER: sig-scalability; 5000-node performance test, runs once a day on weekdays"
   - name: kubeadm-kind-master
     test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
     description: "OWNER: sig-testing (kind); Uses kubetest to run e2e tests (+Conformance, -Serial|Alpha|Kubectl|Disruptive|Flaky|Feature) against a cluster created with sigs.k8s.io/kind"
@@ -4580,11 +4574,6 @@ dashboards:
 # Move sig-release here
 
 - name: sig-scalability-gce
-  dashboard_tab:
-  - name: gce-scale-correctness
-    test_group_name: ci-kubernetes-e2e-gce-scale-correctness
-  - name: gce-scale-performance
-    test_group_name: ci-kubernetes-e2e-gce-scale-performance
 
 - name: sig-scalability-gke
   dashboard_tab:


### PR DESCRIPTION
We're almost certain that they had been in master-blocking a few releases ago, and have no idea how they ended up in master-informing.
These tests should be in the master-blocking.

In addition I'm cleaning up config to make it consitent with a way the gce-cos-master-scalability-100 is configured.