### PR TITLE
Janitor log includes timestamp with verbose mode

### DIFF
--- a/boskos/janitor/gcp_janitor.py
+++ b/boskos/janitor/gcp_janitor.py
@@ -65,7 +65,8 @@ DEMOLISH_ORDER = [
 def log(message):
     """ print a message if --verbose is set. """
     if ARGS.verbose:
-        print message + '\n'
+        tss = "[" + str(datetime.datetime.now()) + "] "
+        print tss + message + '\n'
 
 
 def base_command(resource):


### PR DESCRIPTION
Helps debugging where time is spent when Janitor takes too long

Part of: https://github.com/knative/test-infra/issues/946