### PR TITLE
Update Bug state only when necessary

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -325,7 +325,7 @@ Once a valid bug is referenced in the title of this pull request, request a bug 
 			log.Debug("Valid bug found.")
 			response = fmt.Sprintf(`This pull request references a valid `+bugLink+`.`, bc.Endpoint(), e.bugId)
 			// if configured, move the bug to the new state
-			if options.StatusAfterValidation != nil {
+			if options.StatusAfterValidation != nil && bug.Status != *options.StatusAfterValidation {
 				if err := bc.UpdateBug(e.bugId, bugzilla.BugUpdate{Status: *options.StatusAfterValidation}); err != nil {
 					log.WithError(err).Warn("Unexpected error updating Bugzilla bug.")
 					return comment(fmt.Sprintf(`An error was encountered updating the bug to the %s state on the Bugzilla server at %s for bug %d:

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -547,6 +547,25 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 			expectedBug: &bugzilla.Bug{ID: 123, Status: "UPDATED"},
 		},
+		{
+			name:           "valid bug with status update removes invalid label, adds valid label, comments and does not update status when it is already correct",
+			bug:            &bugzilla.Bug{ID: 123, Status: updated},
+			options:        plugins.BugzillaBranchOptions{StatusAfterValidation: &updated}, // no requirements --> always valid
+			labels:         []string{"bugzilla/invalid-bug"},
+			expectedLabels: []string{"bugzilla/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references a valid [Bugzilla bug](www.bugzilla/show_bug.cgi?id=123).
+
+<details>
+
+In response to [this](http.com):
+
+>Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedBug: &bugzilla.Bug{ID: 123, Status: "UPDATED"},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
The API call to update a Bugzilla bug state is only necessary when the
state does not already match what we want to move it to. The API call
succeeds either way but making it conditionally helps message better to
the developers.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cblecker 
/cc @petr-muller @bbguimaraes @cjwagner @fejta 