### PR TITLE
pull-release-verify Job Failing #756

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -58,6 +58,8 @@ presubmits:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20190604-3070529-master
           command:
             - runner.sh
-            - make verify
+          args:
+            - make
+            - verify
       securityContext:
         privileged: true


### PR DESCRIPTION
Fixes https://github.com/kubernetes/release/issues/756

See https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/release/742/pull-release-verify/1144645322690007040 for reference, specifically:

```
 Done setting up docker in docker.
+ 'make verify'
/usr/local/bin/runner.sh: line 117: make verify: command not found
+ EXIT_VALUE=127
+ set +o xtrace
Cleaning up after docker in docker. 
```