### PR TITLE
Optionally add pull requests to Bugzilla external trackers

### DIFF
--- a/prow/bugzilla/OWNERS
+++ b/prow/bugzilla/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- stevekuznetsov
+- petr-muller
+- bbguimaraes

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -18,6 +18,7 @@ package bugzilla
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -163,6 +164,69 @@ func TestUpdateBug(t *testing.T) {
 
 	// this should 404
 	err := client.UpdateBug(1, BugUpdate{Status: "UPDATE"})
+	if err == nil {
+		t.Error("expected an error, but got none")
+	} else if !IsNotFound(err) {
+		t.Errorf("expected a not found error, got %v", err)
+	}
+}
+
+func TestAddPullRequestAsExternalBug(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("did not correctly set content-type header for JSON")
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("incorrect method to use the JSONRPC API: %s", r.Method)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Path != "/jsonrpc.cgi" {
+			t.Errorf("incorrect path to use the JSONRPC API: %s", r.URL.Path)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		var payload struct {
+			// Version is the version of JSONRPC to use. All Bugzilla servers
+			// support 1.0. Some support 1.1 and some support 2.0
+			Version string `json:"jsonrpc"`
+			Method  string `json:"method"`
+			// Parameters must be specified in JSONRPC 1.0 as a structure in the first
+			// index of this slice
+			Parameters []AddExternalBugParameters `json:"parameters"`
+			ID         string                     `json:"id"`
+		}
+		raw, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, "500 Server Error", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Errorf("malformed JSONRPC payload: %s", string(raw))
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if payload.Parameters[0].BugIDs[0] == 1705243 {
+			if actual, expected := string(raw), `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","parameters":[{"api_key":"api-key","bug_ids":[1705243],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`; actual != expected {
+				t.Errorf("got incorrect JSONRPC payload: %v", diff.ObjectReflectDiff(expected, actual))
+			}
+		} else {
+			http.Error(w, "404 Not Found", http.StatusNotFound)
+		}
+	}))
+	defer testServer.Close()
+	client := clientForUrl(testServer.URL)
+
+	// this should run an update
+	if err := client.AddPullRequestAsExternalBug(1705243, "org", "repo", 1); err != nil {
+		t.Errorf("expected no error, but got one: %v", err)
+	}
+
+	// this should 404
+	err := client.AddPullRequestAsExternalBug(1, "org", "repo", 1)
 	if err == nil {
 		t.Error("expected an error, but got none")
 	} else if !IsNotFound(err) {

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -18,6 +18,7 @@ package bugzilla
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -28,6 +29,7 @@ type Fake struct {
 	EndpointString string
 	Bugs           map[int]Bug
 	BugErrors      sets.Int
+	ExternalBugs   map[int][]ExternalBug
 }
 
 // Endpoint returns the endpoint for this fake
@@ -52,11 +54,30 @@ func (c *Fake) GetBug(id int) (*Bug, error) {
 // or responds with an error that matches IsNotFound
 func (c *Fake) UpdateBug(id int, update BugUpdate) error {
 	if c.BugErrors.Has(id) {
-		return errors.New("injected error getting bug")
+		return errors.New("injected error updating bug")
 	}
 	if bug, exists := c.Bugs[id]; exists {
 		bug.Status = update.Status
 		c.Bugs[id] = bug
+		return nil
+	} else {
+		return &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
+	}
+}
+
+// AddPullRequestAsExternalBug adds an external bug to the Bugzilla bug,
+// if registered, or an error, if set, or responds with an error that
+// matches IsNotFound
+func (c *Fake) AddPullRequestAsExternalBug(id int, org, repo string, num int) error {
+	if c.BugErrors.Has(id) {
+		return errors.New("injected error adding external bug to bug")
+	}
+	if _, exists := c.Bugs[id]; exists {
+		c.ExternalBugs[id] = append(c.ExternalBugs[id], ExternalBug{
+			TrackerID:     0, // impl detail of each bz server
+			BugzillaBugID: id,
+			ExternalBugID: fmt.Sprintf("%s/%s/pull/%d", org, repo, num),
+		})
 		return nil
 	} else {
 		return &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -145,3 +145,38 @@ type BugUpdate struct {
 	// Status is the current status of the bug.
 	Status string `json:"status,omitempty"`
 }
+
+// ExternalBug contains details about an external bug linked to a Bugzilla bug.
+// See API documentation at:
+// https://bugzilla.redhat.com/docs/en/html/integrating/api/Bugzilla/Extension/ExternalBugs/WebService.html
+type ExternalBug struct {
+	// TrackerID is an internal field to the Bugzilla server identifying the tracker
+	TrackerID int `json:"ext_bz_id"`
+	// BugzillaBugID is the ID of the Bugzilla bug this external bug is linked to
+	BugzillaBugID int `json:"bug_id"`
+	// ExternalBugID is a unique identifier for the bug under the tracker
+	ExternalBugID string `json:"ext_bz_bug_id"`
+}
+
+// AddExternalBugParameters are the parameters required to add an external
+// tracker bug to a Bugtzilla bug
+type AddExternalBugParameters struct {
+	// APIKey is the API key to use when authenticating with Bugzilla
+	APIKey string `json:"api_key"`
+	// BugIDs are the IDs of Bugzilla bugs to update
+	BugIDs []int `json:"bug_ids"`
+	// ExternalBugs are the external bugs to add
+	ExternalBugs []NewExternalBugIdentifier `json:"external_bugs"`
+}
+
+// NewExternalBugIdentifier holds fields used to identify new external bugs when
+// adding them using the JSONRPC API
+type NewExternalBugIdentifier struct {
+	// Type is the URL prefix that identifies the external bug tracker type.
+	// For GitHub, this is commonly https://github.com/
+	Type string `json:"ext_type_url"`
+	// ID is the identifier of the external bug within the bug tracker type.
+	// For GitHub issues and pull requests, this ID is commonly the path
+	// like `org/repo/pull/number` or `org/repo/issue/number`.
+	ID string `json:"ext_bz_bug_id"`
+}

--- a/prow/plugins/bugzilla/OWNERS
+++ b/prow/plugins/bugzilla/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- stevekuznetsov
+- petr-muller
+- bbguimaraes

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -105,10 +105,28 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 				conditions[len(conditions)-1] = fmt.Sprintf("and %s", conditions[len(conditions)-1])
 				message += strings.Join(conditions, ", ")
 			}
+			var updates []string
 			if opts[branch].StatusAfterValidation != nil {
-				message += fmt.Sprintf(". After being linked to a pull request, bugs will be moved to the %q state.", *opts[branch].StatusAfterValidation)
+				updates = append(updates, fmt.Sprintf("moved to the %q state", *opts[branch].StatusAfterValidation))
 			}
-			configInfoStrings = append(configInfoStrings, "<li>"+message+"</li>")
+			if opts[branch].AddExternalLink != nil && *opts[branch].AddExternalLink {
+				updates = append(updates, "updated to refer to the pull request using the external bug tracker")
+			}
+
+			if len(updates) > 0 {
+				message += ". After being linked to a pull request, bugs will be "
+			}
+			switch len(updates) {
+			case 0:
+			case 1:
+				message += updates[0]
+			case 2:
+				message += fmt.Sprintf("%s and %s", updates[0], updates[1])
+			default:
+				updates[len(updates)-1] = fmt.Sprintf("and %s", updates[len(updates)-1])
+				message += strings.Join(updates, ", ")
+			}
+			configInfoStrings = append(configInfoStrings, "<li>"+message+".</li>")
 		}
 		configInfoStrings = append(configInfoStrings, "</ul>")
 
@@ -334,6 +352,16 @@ Please contact an administrator to resolve this issue, then request a bug refres
 						*options.StatusAfterValidation, bc.Endpoint(), e.bugId, err))
 				}
 				response += fmt.Sprintf(" The bug has been moved to the %s state.", *options.StatusAfterValidation)
+			}
+			if options.AddExternalLink != nil && *options.AddExternalLink {
+				if err := bc.AddPullRequestAsExternalBug(e.bugId, e.org, e.repo, e.number); err != nil {
+					log.WithError(err).Warn("Unexpected error adding external tracker bug to Bugzilla bug.")
+					return comment(fmt.Sprintf(`An error was encountered adding this pull request to the external tracker bugs on the Bugzilla server at %s for bug %d:
+> %v
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.`,
+						bc.Endpoint(), e.bugId, err))
+				}
+				response += " The bug has been updated to refer to the pull request using the external bug tracker."
 			}
 		} else {
 			log.Debug("Invalid bug found.")

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1022,6 +1022,9 @@ type BugzillaBranchOptions struct {
 	// deemed valid and linked to a PR. Will implicitly be considered a part of `statuses`
 	// if others are set.
 	StatusAfterValidation *string `json:"status_after_validation,omitempty"`
+	// AddExternalLink determines whether the pull request will be added to the Bugzilla
+	// bug using the ExternalBug tracker API after being validated
+	AddExternalLink *bool `json:"add_external_link,omitempty"`
 }
 
 func (o BugzillaBranchOptions) matches(other BugzillaBranchOptions) bool {
@@ -1033,7 +1036,9 @@ func (o BugzillaBranchOptions) matches(other BugzillaBranchOptions) bool {
 		(o.Statuses != nil && other.Statuses != nil && sets.NewString(*o.Statuses...).Equal(sets.NewString(*other.Statuses...)))
 	statusesAfterValidationMatch := o.StatusAfterValidation == nil && other.StatusAfterValidation == nil ||
 		(o.StatusAfterValidation != nil && other.StatusAfterValidation != nil && *o.StatusAfterValidation == *other.StatusAfterValidation)
-	return isOpenMatch && targetReleaseMatch && statusesMatch && statusesAfterValidationMatch
+	addExternalLinkMatch := o.AddExternalLink == nil && other.AddExternalLink == nil ||
+		(o.AddExternalLink != nil && other.AddExternalLink != nil && *o.AddExternalLink == *other.AddExternalLink)
+	return isOpenMatch && targetReleaseMatch && statusesMatch && statusesAfterValidationMatch && addExternalLinkMatch
 }
 
 const BugzillaOptionsWildcard = `*`
@@ -1063,6 +1068,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	if parent.StatusAfterValidation != nil {
 		output.StatusAfterValidation = parent.StatusAfterValidation
 	}
+	if parent.AddExternalLink != nil {
+		output.AddExternalLink = parent.AddExternalLink
+	}
 
 	//override with the child
 	if child.IsOpen != nil {
@@ -1076,6 +1084,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	}
 	if child.StatusAfterValidation != nil {
 		output.StatusAfterValidation = child.StatusAfterValidation
+	}
+	if child.AddExternalLink != nil {
+		output.AddExternalLink = child.AddExternalLink
 	}
 
 	return output


### PR DESCRIPTION
There is currently only a one-way link between pull requests and
Bugzilla bugs in the title of the pull request. This change adds an
option to create a reverse link from the Bugzilla bug back to the pull
request by using the external tracker field.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @cjwagner 
/cc @cblecker @fejta 

There is some room here for DRY and refactoring especially for the response messages but I wanted to keep this small, can do in a follow-up.