### PR TITLE
Use 0.26.1 bazel version for peribolos

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -6,7 +6,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.27.0
+      - image: launcher.gcr.io/google/bazel:0.26.1
         imagePullPolicy: Always
         command:
         - bazel
@@ -619,7 +619,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.27.0
+    - image: launcher.gcr.io/google/bazel:0.26.1
       imagePullPolicy: Always
       command:
       - bazel


### PR DESCRIPTION
This should fix peribolos. 0.27 broke peribolos. Let's look into supporting 0.27 as a follow up?

/assign @fejta @cblecker 