### PR TITLE
kubeadm: update all kind(er) jobs for 1.16

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -219,88 +219,6 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - release-1.12
-    cluster: security
-    context: pull-security-kubernetes-e2e-kind
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: kubernetes-security-prow
-        default_org: kubernetes
-        default_repo: kubernetes
-        path_strategy: legacy
-      gcs_credentials_secret: service-account
-      grace_period: 15s
-      timeout: 40m0s
-    extra_refs:
-    - base_ref: master
-      org: kubernetes
-      path_alias: k8s.io/kubeadm
-      repo: kubeadm
-    - base_ref: master
-      org: kubernetes-sigs
-      path_alias: sigs.k8s.io/kind
-      repo: kind
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-dind-enabled: "true"
-    name: pull-security-kubernetes-e2e-kind
-    optional: true
-    path_alias: k8s.io/kubernetes
-    rerun_command: /test pull-security-kubernetes-e2e-kind
-    spec:
-      containers:
-      - args:
-        - --ssh=/etc/ssh-security/ssh-security
-        - --provider=skeleton
-        - --deployment=kind
-        - --kind-binary-version=stable
-        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
-        - --build=bazel
-        - --up
-        - --test
-        - --check-version-skew=false
-        - --down
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
-        - --ginkgo-parallel
-        - --timeout=30m
-        command:
-        - runner.sh
-        - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: "2"
-            memory: 9000Mi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /etc/ssh-security
-          name: ssh-security
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - name: ssh-security
-        secret:
-          defaultMode: 256
-          secretName: ssh-security
-    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
     - release-1.13
     cluster: security
     context: pull-security-kubernetes-e2e-kind
@@ -349,8 +267,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
-        imagePullPolicy: Always
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
         name: ""
         resources:
           requests:
@@ -419,6 +336,87 @@ presubmits:
         - --provider=skeleton
         - --deployment=kind
         - --kind-binary-version=stable
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - release-1.15
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-security-prow
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15s
+      timeout: 40m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
         - --build=bazel
         - --up
@@ -431,8 +429,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
         name: ""
         resources:
           requests:
@@ -493,9 +490,9 @@ presubmits:
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-e2e-kind
     skip_branches:
+    - release-1.15
     - release-1.14
     - release-1.13
-    - release-1.12
     spec:
       containers:
       - args:
@@ -515,8 +512,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-        imagePullPolicy: Always
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -1,85 +1,6 @@
 # periodic jobs
 
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-kind-1-12
-  interval: 12h
-  decorate: true
-  labels:
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-dind-enabled: "true"
-  decoration_config:
-    timeout: 40m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.12
-    path_alias: k8s.io/kubernetes
-  - org: kubernetes
-    repo: kubeadm
-    base_ref: master
-    path_alias: k8s.io/kubeadm
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
-      imagePullPolicy: Always
-      env:
-      # for bazel caching
-      - name: REPO_OWNER
-        value: kubernetes
-      - name: REPO_NAME
-        value: kubernetes
-      command:
-      - runner.sh
-      - kubetest
-      args:
-      # kind specific args
-      - --provider=skeleton
-      - --deployment=kind
-      - --kind-binary-version=stable
-      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
-      # generic e2e test args
-      - --build=bazel
-      - --up
-      - --test
-      - --check-version-skew=false
-      - --down
-      # specific e2e test args
-      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
-      - --ginkgo-parallel
-      - --timeout=30m
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      # kind needs /lib/modules and cgroups from the host
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-
 - name: ci-kubernetes-e2e-kubeadm-kind-1-13
   interval: 12h
   decorate: true
@@ -87,6 +8,14 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.13-informing
+    testgrid-tab-name: kubeadm-kind-1-13
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kind); Uses kubeadm/kind to create a cluster and run the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -104,8 +33,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
-      imagePullPolicy: Always
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -166,6 +94,14 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.14-informing
+    testgrid-tab-name: kubeadm-kind-1-14
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kind); Uses kubeadm/kind to create a cluster and run the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -183,8 +119,93 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-      imagePullPolicy: Always
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
+      env:
+      # for bazel caching
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # kind specific args
+      - --provider=skeleton
+      - --deployment=kind
+      - --kind-binary-version=build
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
+      # generic e2e test args
+      - --build=bazel
+      - --up
+      - --test
+      - --check-version-skew=false
+      - --down
+      # specific e2e test args
+      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+      - --ginkgo-parallel
+      - --timeout=30m
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
+- name: ci-kubernetes-e2e-kubeadm-kind-1-15
+  interval: 12h
+  decorate: true
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.15-informing
+    testgrid-tab-name: kubeadm-kind-1-15
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kind); Uses kubeadm/kind to create a cluster and run the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.15
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -245,6 +266,14 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
+    testgrid-tab-name: kubeadm-kind-master
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kind); Uses kubeadm/kind to create a cluster and run the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "8"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -262,8 +291,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -326,80 +354,6 @@ presubmits:
     always_run: false
     decorate: true
     branches:
-    - release-1.12
-    labels:
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-    decoration_config:
-      timeout: 40m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: kubeadm
-      base_ref: master
-      path_alias: k8s.io/kubeadm
-    - org: kubernetes-sigs
-      repo: kind
-      base_ref: master
-      path_alias: sigs.k8s.io/kind
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # kind specific args
-        - --provider=skeleton
-        - --deployment=kind
-        - --kind-binary-version=stable
-        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
-        # generic e2e test args
-        - --build=bazel
-        - --up
-        - --test
-        - --check-version-skew=false
-        - --down
-        # specific e2e test args
-        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
-        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
-        - --ginkgo-parallel
-        - --timeout=30m
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        # kind needs /lib/modules and cgroups from the host
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        resources:
-          requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-
-  - name: pull-kubernetes-e2e-kind
-    optional: true
-    always_run: false
-    decorate: true
-    branches:
     - release-1.13
     labels:
       preset-bazel-scratch-dir: "true"
@@ -419,8 +373,7 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
         command:
         - runner.sh
         - kubetest
@@ -493,8 +446,80 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=stable
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/single-cp/single-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
+    branches:
+    - release-1.15
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
         command:
         - runner.sh
         - kubetest
@@ -548,9 +573,9 @@ presubmits:
     always_run: false
     decorate: true
     skip_branches:
+    - release-1.15 # per-release job
     - release-1.14 # per-release job
     - release-1.13 # per-release job
-    - release-1.12 # per-release job
     labels:
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -569,8 +594,7 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-        imagePullPolicy: Always
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -7,6 +7,14 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm
+    testgrid-tab-name: kubeadm-kinder-external-etcd-master
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with external etcd and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "8"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -32,12 +40,61 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-15
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-15
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with external etcd and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.15
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "external-etcd-1.15"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-14
   interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-14
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with external etcd and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -1,12 +1,20 @@
 # periodic jobs
 
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-15-master
   interval: 2h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-15-master
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "8"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -25,19 +33,68 @@ periodics:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
-      - "upgrade-stable-master"
+      - "upgrade-1.15-master"
       securityContext:
         privileged: true
       resources:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-14-1-15
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.15-informing
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-14-1-15
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.15
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-1.14-1.15"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
   interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.14-informing
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-13-1-14
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -51,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -63,12 +120,21 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
   interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.13-informing
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-12-1-13
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -82,43 +148,12 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
       - "upgrade-1.12-1.13"
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9000Mi"
-          cpu: 2000m
-- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
-  interval: 12h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decoration_config:
-    timeout: 40m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.12
-    path_alias: k8s.io/kubernetes
-  - org: kubernetes
-    repo: kubeadm
-    base_ref: master
-    path_alias: k8s.io/kubeadm
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-      command:
-      - runner.sh
-      - "../kubeadm/kinder/ci/kinder-run.sh"
-      args:
-      - "upgrade-1.11-1.12"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -1,12 +1,60 @@
 # periodic jobs
 
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
+- name: ci-kubernetes-e2e-kubeadm-kinder-master-on-1-15
   interval: 2h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
+    testgrid-tab-name: kubeadm-kinder-master-on-1-15
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "4"
+    testgrid-alert-stale-results-hours: "8"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.15
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "skew-master-on-1.15"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-15-on-1-14
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.15-informing
+    testgrid-tab-name: kubeadm-kinder-1-15-on-1-14
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -20,24 +68,33 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.14
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
-      - "skew-master-on-stable"
+      - "skew-1.15-on-1.14"
       securityContext:
         privileged: true
       resources:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
   interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.14-informing
+    testgrid-tab-name: kubeadm-kinder-1-14-on-1-13
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -51,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -63,12 +120,21 @@ periodics:
         requests:
           memory: "9000Mi"
           cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
   interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.13-informing
+    testgrid-tab-name: kubeadm-kinder-1-13-on-1-12
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -82,43 +148,12 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
       - "skew-1.13-on-1.12"
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9000Mi"
-          cpu: 2000m
-- name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
-  interval: 12h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decoration_config:
-    timeout: 40m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.11
-    path_alias: k8s.io/kubernetes
-  - org: kubernetes
-    repo: kubeadm
-    base_ref: master
-    path_alias: k8s.io/kubeadm
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-      command:
-      - runner.sh
-      - "../kubeadm/kinder/ci/kinder-run.sh"
-      args:
-      - "skew-1.12-on-1.11"
       securityContext:
         privileged: true
       resources:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3003,15 +3003,6 @@ dashboards:
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
     description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
-  - name: kubeadm-kind-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
-    description: "OWNER: sig-testing (kind); Uses kubetest to run e2e tests (+Conformance, -Serial|Alpha|Kubectl|Disruptive|Flaky|Feature) against a cluster created with sigs.k8s.io/kind"
-  - name: kubeadm-kinder-master-on-stable
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
-    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to run kubeadm-e2e and e2e tests (+Conformance, -Aggregator|Alpha|Kubectl|Disruptive|Flaky|Feature) against a cluster created using kinder's skew-master-on-stable workflow"
-  - name: kubeadm-kinder-upgrade-stable-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
-    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to run kubeadm-e2e and e2e tests (+Conformance, -Aggregator|Alpha|Kubectl|Disruptive|Flaky|Feature) against a cluster created using kinder's upgrade-stable-master workflow"
   - name: bazel-test-master
     test_group_name: post-kubernetes-bazel-test
     description: "OWNER: sig-testing; Runs kubernetes unit tests using bazel"
@@ -3146,12 +3137,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-beta
   - name: periodic-bazel-test-1.14
     test_group_name: periodic-kubernetes-bazel-test-1-14
-  - name: kubeadm-kind-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
-  - name: kubeadm-kinder-1.14-on-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
-  - name: kubeadm-kinder-upgrade-1.13-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
   - name: aks-engine-azure-1-14-windows-release
     test_group_name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   - name: gce-windows-1.14
@@ -3163,12 +3148,6 @@ dashboards:
 
 - name: sig-release-1.13-all
   dashboard_tab:
-  - name: kubeadm-kind-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
-  - name: kubeadm-kinder-1.13-on-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
-  - name: kubeadm-kinder-upgrade-1.12-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
   - name: soak-gci-gce-1.13
     test_group_name: ci-kubernetes-soak-gci-gce-stable2
   - name: kops-aws-1.13
@@ -3284,12 +3263,6 @@ dashboards:
 
 - name: sig-release-1.12-all
   dashboard_tab:
-  - name: kubeadm-kind-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
-  - name: kubeadm-kinder-1.12-on-1.11
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
-  - name: kubeadm-kinder-upgrade-1.11-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
   - name: soak-gci-gce-1.12
     test_group_name: ci-kubernetes-soak-gci-gce-stable3
   - name: gke-device-plugin-gpu-1.12
@@ -3890,93 +3863,6 @@ dashboards:
     test_group_name: periodic-kubernetes-e2e-manifest-lists
 
 - name: sig-cluster-lifecycle-kubeadm
-  dashboard_tab:
-# kubeadm-kind tests
-  - name: kubeadm-kind-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-12
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-13
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-1-14
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kind-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kind-master
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 8
-    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
-# kubeadm-kinder tests
-  - name: kubeadm-kinder-upgrade-stable-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-stable-master
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 8
-    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
-  - name: kubeadm-kinder-upgrade-1.13-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-13-1-14
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-upgrade-1.12-1.13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-12-1-13
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-upgrade-1.11-1.12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-11-1-12
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-master-on-stable
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-master-on-stable
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 8
-    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
-  - name: kubeadm-kinder-1-14-on-1-13
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-14-on-1-13
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-1-13-on-1-12
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-13-on-1-12
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-1-12-on-1-11
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-1-12-on-1-11
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
-  - name: kubeadm-kinder-external-etcd-master
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-master
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 8
-    num_failures_to_alert: 4 # Runs every 2h. Alert when it's been failing for 8 hours
-  - name: kubeadm-kinder-external-etcd-1.14
-    test_group_name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-14
-    alert_options:
-      alert_mail_to_addresses: kubernetes-sig-cluster-lifecycle@googlegroups.com
-    alert_stale_results_hours: 24
-    num_failures_to_alert: 2 # Runs every 12h. Alert when it's been failing for 24 hours
 
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:


### PR DESCRIPTION
- use prow job annotations
- don't use "latest" kubekins images
- remove 1.12 jobs for kind(er)
- add 1.15 jobs for kind(er)
- don't use "stable" in the names and instead use a version.
existing jobs with "stable" in the name technically should use "ci/latest-x.yy" artifacts
- add kind(er) jobs to release-x.yy-informing dashboards
- update security jobs

/sig cluster-lifecycle
/priority important-longterm
/kind cleanup
/assign @fabriziopandini 
/hold

xref https://github.com/kubernetes/kubeadm/pull/1643
