### PR TITLE
flipped to report both presubmit and postsubmit jobs by default

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,8 @@
 # Announcements
 
 New features added to each component:
+ - *July 2, 2019* prow defaults to report status for both presubmit and postsubmit
+   jobs on GitHub now.
  - *June 17, 2019* It is now possible to configure the channel for the Slack reporter
    directly on jobs via the `.reporter_config.slack.channel` config option
  - *May 13, 2019* New `plank` config `pod_running_timeout` is added and

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -261,8 +261,7 @@ type GitHubReporter struct {
 	// JobTypesToReport is used to determine which type of prowjob
 	// should be reported to github
 	//
-	// defaults to presubmit job only.
-	// Will default to both presubmit and postsubmit jobs by April.1st.2019
+	// defaults to both presubmit and postsubmit jobs.
 	JobTypesToReport []prowapi.ProwJobType `json:"job_types_to_report,omitempty"`
 }
 
@@ -955,8 +954,7 @@ func parseProwConfig(c *Config) error {
 	}
 
 	if len(c.GitHubReporter.JobTypesToReport) == 0 {
-		// TODO(krzyzacy): The default will be changed to presubmit + postsubmit by April.
-		c.GitHubReporter.JobTypesToReport = append(c.GitHubReporter.JobTypesToReport, prowapi.PresubmitJob)
+		c.GitHubReporter.JobTypesToReport = append(c.GitHubReporter.JobTypesToReport, prowapi.PresubmitJob, prowapi.PostsubmitJob)
 	}
 
 	// validate entries are valid job types

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1819,9 +1819,9 @@ func TestValidGitHubReportType(t *testing.T) {
 		expectTypes []prowapi.ProwJobType
 	}{
 		{
-			name:        "empty config should default to report for presubmit only",
+			name:        "empty config should default to report for both presubmit and postsubmit",
 			prowConfig:  ``,
-			expectTypes: []prowapi.ProwJobType{prowapi.PresubmitJob},
+			expectTypes: []prowapi.ProwJobType{prowapi.PresubmitJob, prowapi.PostsubmitJob},
 		},
 		{
 			name: "reject unsupported job types",


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/pull/11168

/cc @krzyzacy 
/cc @fejta 