### PR TITLE
Parse out JSONRPC errors, comment conditionally on update

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -43,6 +43,7 @@ if find -L . -type f -not \( \
     -o -path '*/node_modules/*' \
     -o -path '*/localdata/*' \
     -o -path '*/gubernator/*' \
+    -o -path '*/prow/bugzilla/client_test.go' \
     \) -prune \
     \) -exec grep -Hn 'Git'hub '{}' '+' ; then
   false

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -226,7 +226,7 @@ func (c *client) AddPullRequestAsExternalBug(id int, org, repo string, num int) 
 	if response.Result != nil {
 		for _, bug := range response.Result.Bugs {
 			if bug.ID == id {
-				changed = strings.Contains(bug.Changes.ExternalBugs.Added, pullIdentifier)
+				changed = changed || strings.Contains(bug.Changes.ExternalBugs.Added, pullIdentifier)
 			}
 		}
 	}

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -30,7 +31,7 @@ type Client interface {
 	Endpoint() string
 	GetBug(id int) (*Bug, error)
 	UpdateBug(id int, update BugUpdate) error
-	AddPullRequestAsExternalBug(id int, org, repo string, num int) error
+	AddPullRequestAsExternalBug(id int, org, repo string, num int) (bool, error)
 }
 
 func NewClient(getAPIKey func() []byte, endpoint string) Client {
@@ -151,11 +152,13 @@ func IsNotFound(err error) bool {
 
 // AddPullRequestAsExternalBug attempts to add a PR to the external tracker list.
 // External bugs are assumed to fall under the type identified by their hostname,
-// so we will provide https://github.com/ here for the URL identifier.
+// so we will provide https://github.com/ here for the URL identifier. We return
+// any error as well as whether a change was actually made.
 // This will be done via JSONRPC:
 // https://bugzilla.redhat.com/docs/en/html/integrating/api/Bugzilla/Extension/ExternalBugs/WebService.html#add-external-bug
-func (c *client) AddPullRequestAsExternalBug(id int, org, repo string, num int) error {
+func (c *client) AddPullRequestAsExternalBug(id int, org, repo string, num int) (bool, error) {
 	logger := c.logger.WithFields(logrus.Fields{"method": "AddExternalBug", "id": id, "org": org, "repo": repo, "num": num})
+	pullIdentifier := fmt.Sprintf("%s/%s/pull/%d", org, repo, num)
 	rpcPayload := struct {
 		// Version is the version of JSONRPC to use. All Bugzilla servers
 		// support 1.0. Some support 1.1 and some support 2.0
@@ -174,20 +177,58 @@ func (c *client) AddPullRequestAsExternalBug(id int, org, repo string, num int) 
 			BugIDs: []int{id},
 			ExternalBugs: []NewExternalBugIdentifier{{
 				Type: "https://github.com/",
-				ID:   fmt.Sprintf("%s/%s/pull/%d", org, repo, num),
+				ID:   pullIdentifier,
 			}},
 		}},
 	}
 	body, err := json.Marshal(rpcPayload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSONRPC payload: %v", err)
+		return false, fmt.Errorf("failed to marshal JSONRPC payload: %v", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/jsonrpc.cgi", c.endpoint), bytes.NewBuffer(body))
 	if err != nil {
-		return err
+		return false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	_, err = c.request(req, logger)
-	return err
+	resp, err := c.request(req, logger)
+	if err != nil {
+		return false, err
+	}
+	var response struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+		ID     string `json:"id"`
+		Result *struct {
+			Bugs []struct {
+				ID      int `json:"id"`
+				Changes struct {
+					ExternalBugs struct {
+						Added   string `json:"added"`
+						Removed string `json:"removed"`
+					} `json:"ext_bz_bug_map.ext_bz_bug_id"`
+				} `json:"changes"`
+			} `json:"bugs"`
+		} `json:"result,omitempty"`
+	}
+	if err := json.Unmarshal(resp, &response); err != nil {
+		return false, fmt.Errorf("failed to unmarshal JSONRPC response: %v", err)
+	}
+	if response.Error != nil {
+		return false, fmt.Errorf("JSONRPC error %d: %v", response.Error.Code, response.Error.Message)
+	}
+	if response.ID != rpcPayload.ID {
+		return false, fmt.Errorf("JSONRPC returned mismatched identifier, expected %s but got %s", rpcPayload.ID, response.ID)
+	}
+	changed := false
+	if response.Result != nil {
+		for _, bug := range response.Result.Bugs {
+			if bug.ID == id {
+				changed = strings.Contains(bug.Changes.ExternalBugs.Added, pullIdentifier)
+			}
+		}
+	}
+	return changed, nil
 }

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -189,6 +189,14 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 			expectedChanged: true,
 		},
 		{
+			name:            "update succeeds, makes a change as part of multiple changes reported",
+			id:              1705243,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705243],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"bugs":[{"alias":[],"changes":{"ext_bz_bug_map.ext_bz_bug_id":{"added":"Github org/repo/pull/1","removed":""}},"id":1705243},{"alias":[],"changes":{"ext_bz_bug_map.ext_bz_bug_id":{"added":"Github org/repo/pull/2","removed":""}},"id":1705243}]}}`,
+			expectedError:   false,
+			expectedChanged: true,
+		},
+		{
 			name:            "update succeeds, makes no change",
 			id:              1705244,
 			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705244],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -172,6 +172,47 @@ func TestUpdateBug(t *testing.T) {
 }
 
 func TestAddPullRequestAsExternalBug(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		id              int
+		expectedPayload string
+		response        string
+		expectedError   bool
+		expectedChanged bool
+	}{
+		{
+			name:            "update succeeds, makes a change",
+			id:              1705243,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705243],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"bugs":[{"alias":[],"changes":{"ext_bz_bug_map.ext_bz_bug_id":{"added":"Github org/repo/pull/1","removed":""}},"id":1705243}]}}`,
+			expectedError:   false,
+			expectedChanged: true,
+		},
+		{
+			name:            "update succeeds, makes no change",
+			id:              1705244,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705244],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"bugs":[]}}`,
+			expectedError:   false,
+			expectedChanged: false,
+		},
+		{
+			name:            "update fails, makes no change",
+			id:              1705246,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705246],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":{"code": 100400,"message":"Invalid params for JSONRPC 1.0."},"id":"identifier","result":null}`,
+			expectedError:   true,
+			expectedChanged: false,
+		},
+		{
+			name:            "get unrelated JSONRPC response",
+			id:              1705247,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705247],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"oops","result":{"bugs":[]}}`,
+			expectedError:   true,
+			expectedChanged: false,
+		},
+	}
 	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Error("did not correctly set content-type header for JSON")
@@ -209,27 +250,45 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if payload.Parameters[0].BugIDs[0] == 1705243 {
-			if actual, expected := string(raw), `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705243],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`; actual != expected {
-				t.Errorf("got incorrect JSONRPC payload: %v", diff.ObjectReflectDiff(expected, actual))
+		for _, testCase := range testCases {
+			if payload.Parameters[0].BugIDs[0] == testCase.id {
+				if actual, expected := string(raw), testCase.expectedPayload; actual != expected {
+					t.Errorf("%s: got incorrect JSONRPC payload: %v", testCase.name, diff.ObjectReflectDiff(expected, actual))
+				}
+				if _, err := w.Write([]byte(testCase.response)); err != nil {
+					t.Fatalf("%s: failed to send JSONRPC response: %v", testCase.name, err)
+				}
+				return
 			}
-		} else {
-			http.Error(w, "404 Not Found", http.StatusNotFound)
 		}
+		http.Error(w, "404 Not Found", http.StatusNotFound)
 	}))
 	defer testServer.Close()
 	client := clientForUrl(testServer.URL)
 
-	// this should run an update
-	if err := client.AddPullRequestAsExternalBug(1705243, "org", "repo", 1); err != nil {
-		t.Errorf("expected no error, but got one: %v", err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			changed, err := client.AddPullRequestAsExternalBug(testCase.id, "org", "repo", 1)
+			if !testCase.expectedError && err != nil {
+				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)
+			}
+			if testCase.expectedError && err == nil {
+				t.Errorf("%s: expected an error, but got none", testCase.name)
+			}
+			if testCase.expectedChanged != changed {
+				t.Errorf("%s: got incorrect state change", testCase.name)
+			}
+		})
 	}
 
 	// this should 404
-	err := client.AddPullRequestAsExternalBug(1, "org", "repo", 1)
+	changed, err := client.AddPullRequestAsExternalBug(1, "org", "repo", 1)
 	if err == nil {
 		t.Error("expected an error, but got none")
 	} else if !IsNotFound(err) {
 		t.Errorf("expected a not found error, got %v", err)
+	}
+	if changed {
+		t.Error("expected not to change state, but did")
 	}
 }

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -45,9 +45,8 @@ func (c *Fake) GetBug(id int) (*Bug, error) {
 	}
 	if bug, exists := c.Bugs[id]; exists {
 		return &bug, nil
-	} else {
-		return nil, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 	}
+	return nil, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 }
 
 // UpdateBug updates the bug, if registered, or an error, if set,
@@ -60,9 +59,8 @@ func (c *Fake) UpdateBug(id int, update BugUpdate) error {
 		bug.Status = update.Status
 		c.Bugs[id] = bug
 		return nil
-	} else {
-		return &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 	}
+	return &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 }
 
 // AddPullRequestAsExternalBug adds an external bug to the Bugzilla bug,
@@ -73,21 +71,20 @@ func (c *Fake) AddPullRequestAsExternalBug(id int, org, repo string, num int) (b
 		return false, errors.New("injected error adding external bug to bug")
 	}
 	if _, exists := c.Bugs[id]; exists {
-		pullIdenfitier := fmt.Sprintf("%s/%s/pull/%d", org, repo, num)
+		pullIdentifier := fmt.Sprintf("%s/%s/pull/%d", org, repo, num)
 		for _, bug := range c.ExternalBugs[id] {
-			if bug.BugzillaBugID == id && bug.ExternalBugID == pullIdenfitier {
+			if bug.BugzillaBugID == id && bug.ExternalBugID == pullIdentifier {
 				return false, nil
 			}
 		}
 		c.ExternalBugs[id] = append(c.ExternalBugs[id], ExternalBug{
 			TrackerID:     0, // impl detail of each bz server
 			BugzillaBugID: id,
-			ExternalBugID: pullIdenfitier,
+			ExternalBugID: pullIdentifier,
 		})
 		return true, nil
-	} else {
-		return false, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 	}
+	return false, &requestError{statusCode: http.StatusNotFound, message: "bug not registered in the fake"}
 }
 
 // the Fake is a Client

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -354,14 +354,17 @@ Please contact an administrator to resolve this issue, then request a bug refres
 				response += fmt.Sprintf(" The bug has been moved to the %s state.", *options.StatusAfterValidation)
 			}
 			if options.AddExternalLink != nil && *options.AddExternalLink {
-				if err := bc.AddPullRequestAsExternalBug(e.bugId, e.org, e.repo, e.number); err != nil {
+				changed, err := bc.AddPullRequestAsExternalBug(e.bugId, e.org, e.repo, e.number)
+				if err != nil {
 					log.WithError(err).Warn("Unexpected error adding external tracker bug to Bugzilla bug.")
 					return comment(fmt.Sprintf(`An error was encountered adding this pull request to the external tracker bugs on the Bugzilla server at %s for bug %d:
 > %v
 Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.`,
 						bc.Endpoint(), e.bugId, err))
 				}
-				response += " The bug has been updated to refer to the pull request using the external bug tracker."
+				if changed {
+					response += " The bug has been updated to refer to the pull request using the external bug tracker."
+				}
 			}
 		} else {
 			log.Debug("Invalid bug found.")


### PR DESCRIPTION
Even when the JSONRPC server returns a 200, it can return errors in the
payload coming back to the client. We should parse those out and return
them as errors in the request.

Parsing out the JSONRPC response also allows us to conditionally comment
when we are updating the external bug trackers so we don't mislead users
into thinking we made changes that we did not.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller 
/cc @cjwagner @fejta 