### PR TITLE
Use pip to import ruamel_yaml, resolves #13162

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -16,7 +16,7 @@ py_binary(
         "//prow:configs",
         "//testgrid:config-yaml",
     ],
-    deps = ["@ruamel_yaml//ruamel/yaml:ruamel.yaml"],
+    deps = [requirement("ruamel.yaml")],
 )
 
 py_binary(
@@ -25,7 +25,7 @@ py_binary(
     data = [
         "//testgrid:config-yaml",
     ],
-    deps = ["@ruamel_yaml//ruamel/yaml:ruamel.yaml"],
+    deps = [requirement("ruamel.yaml")],
 )
 
 py_binary(
@@ -44,7 +44,7 @@ py_binary(
         "//experiment/config-rotator",
     ],
     deps = [
-        "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
+        requirement("ruamel.yaml"),
         requirement("sh"),
     ],
 )

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -301,7 +301,7 @@ py_binary(
         requirement("singledispatch"),
         requirement("six"),
         requirement("wrapt"),
-        "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
+        requirement("ruamel.yaml"),
     ],
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-dateutil==2.8.0
 pytz==2019.1
 PyYAML==5.1.1
 requests==2.22.0
+ruamel.yaml==0.15.97
 setuptools==41.0.1
 sh==1.12.14
 singledispatch==3.4.0.3


### PR DESCRIPTION
Leverage `pip` and the `requirement()` directive for adding the `ruamel.yaml` python dependency to the project.