### PR TITLE
Validate if earlier build was successful by spot checking for additional files

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -73,9 +73,12 @@ def check_build_exists(gcs, suffix):
         gcs = os.path.join(gcs, mode, version)
         try:
             check_no_stdout('gsutil', 'ls', gcs)
+            check_no_stdout('gsutil', 'ls', gcs + "/kubernetes.tar.gz")
+            check_no_stdout('gsutil', 'ls', gcs + "/bin")
             return True
         except subprocess.CalledProcessError as exc:
-            print >>sys.stderr, 'gcs path %s does not exist yet, continue' % gcs
+            print >>sys.stderr, (
+                'gcs path %s (or some files under it) does not exist yet, continue' % gcs)
     return False
 
 


### PR DESCRIPTION
if you look at the following log:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1146091040474664960/

you will see that we check for the existence of a directory and consider
that the earlier build was successful:
```
W0702 16:20:39.891] Run: ('gsutil', 'ls', 'gs://kubernetes-release-dev/ci/v1.16.0-alpha.0.1795+6b5f5514a8e638')
W0702 16:20:41.281] build already exists, exit
```

We need to look for some additional files and directories as well. As
sometimes the build fails with things like:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1146059582565519363/