### PR TITLE
Allow configuring the Bugzilla plugin to validate by default

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1011,6 +1011,10 @@ type BugzillaRepoOptions struct {
 
 // BugzillaBranchOptions describes how to check if a Bugzilla bug is valid or not.
 type BugzillaBranchOptions struct {
+	// ValidateByDefault determines whether a validation check is run for all pull
+	// requests by default
+	ValidateByDefault *bool `json:"validate_by_default,omitempty"`
+
 	// IsOpen determines whether a bug needs to be open to be valid
 	IsOpen *bool `json:"is_open,omitempty"`
 	// TargetRelease determines which release a bug needs to target to be valid
@@ -1028,6 +1032,8 @@ type BugzillaBranchOptions struct {
 }
 
 func (o BugzillaBranchOptions) matches(other BugzillaBranchOptions) bool {
+	validateByDefaultMatch := o.ValidateByDefault == nil && other.ValidateByDefault == nil ||
+		(o.ValidateByDefault != nil && other.ValidateByDefault != nil && *o.ValidateByDefault == *other.ValidateByDefault)
 	isOpenMatch := o.IsOpen == nil && other.IsOpen == nil ||
 		(o.IsOpen != nil && other.IsOpen != nil && *o.IsOpen == *other.IsOpen)
 	targetReleaseMatch := o.TargetRelease == nil && other.TargetRelease == nil ||
@@ -1038,7 +1044,7 @@ func (o BugzillaBranchOptions) matches(other BugzillaBranchOptions) bool {
 		(o.StatusAfterValidation != nil && other.StatusAfterValidation != nil && *o.StatusAfterValidation == *other.StatusAfterValidation)
 	addExternalLinkMatch := o.AddExternalLink == nil && other.AddExternalLink == nil ||
 		(o.AddExternalLink != nil && other.AddExternalLink != nil && *o.AddExternalLink == *other.AddExternalLink)
-	return isOpenMatch && targetReleaseMatch && statusesMatch && statusesAfterValidationMatch && addExternalLinkMatch
+	return validateByDefaultMatch && isOpenMatch && targetReleaseMatch && statusesMatch && statusesAfterValidationMatch && addExternalLinkMatch
 }
 
 const BugzillaOptionsWildcard = `*`
@@ -1056,6 +1062,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	output := BugzillaBranchOptions{}
 
 	// populate with the parent
+	if parent.ValidateByDefault != nil {
+		output.ValidateByDefault = parent.ValidateByDefault
+	}
 	if parent.IsOpen != nil {
 		output.IsOpen = parent.IsOpen
 	}
@@ -1073,6 +1082,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	}
 
 	//override with the child
+	if child.ValidateByDefault != nil {
+		output.ValidateByDefault = child.ValidateByDefault
+	}
 	if child.IsOpen != nil {
 		output.IsOpen = child.IsOpen
 	}


### PR DESCRIPTION
In general we don't want the plugin to post to every pull request
created that does not reference a bug but it is possible that the tide
requirements for a branch require valid bugs, in which case we want the
plugin to validate all PRs for that branch by default.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller 
/cc @jwforres 