### PR TITLE
 mkpj: stop when first job is found

### DIFF
--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -92,9 +92,6 @@ func (o *options) defaultPR(pjs *prowapi.ProwJobSpec) error {
 }
 
 func (o *options) defaultBaseRef(pjs *prowapi.ProwJobSpec) error {
-	if pjs.Refs == nil {
-		return nil
-	}
 	if pjs.Refs.BaseRef == "" {
 		if o.pullNumber != 0 {
 			pr, err := o.getPullRequest()
@@ -191,8 +188,6 @@ func main() {
 	var labels map[string]string
 	var annotations map[string]string
 	var found bool
-	var needsBaseRef bool
-	var needsPR bool
 	for fullRepoName, ps := range conf.Presubmits {
 		org, repo, err := splitRepoName(fullRepoName)
 		if err != nil {
@@ -215,8 +210,6 @@ func main() {
 				labels = p.Labels
 				annotations = p.Annotations
 				found = true
-				needsBaseRef = true
-				needsPR = true
 			}
 		}
 	}
@@ -237,7 +230,6 @@ func main() {
 				labels = p.Labels
 				annotations = p.Annotations
 				found = true
-				needsBaseRef = true
 			}
 		}
 	}
@@ -255,13 +247,11 @@ func main() {
 	if pjs.Refs != nil {
 		o.org = pjs.Refs.Org
 		o.repo = pjs.Refs.Repo
-	}
-	if needsPR {
-		if err := o.defaultPR(&pjs); err != nil {
-			logrus.WithError(err).Fatal("Failed to default PR")
+		if len(pjs.Refs.Pulls) != 0 {
+			if err := o.defaultPR(&pjs); err != nil {
+				logrus.WithError(err).Fatal("Failed to default PR")
+			}
 		}
-	}
-	if needsBaseRef {
 		if err := o.defaultBaseRef(&pjs); err != nil {
 			logrus.WithError(err).Fatal("Failed to default base ref")
 		}

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -217,8 +217,6 @@ func main() {
 				found = true
 				needsBaseRef = true
 				needsPR = true
-				o.org = org
-				o.repo = repo
 			}
 		}
 	}
@@ -240,8 +238,6 @@ func main() {
 				annotations = p.Annotations
 				found = true
 				needsBaseRef = true
-				o.org = org
-				o.repo = repo
 			}
 		}
 	}
@@ -255,6 +251,10 @@ func main() {
 	}
 	if !found {
 		logrus.Fatalf("Job %s not found.", o.jobName)
+	}
+	if pjs.Refs != nil {
+		o.org = pjs.Refs.Org
+		o.repo = pjs.Refs.Repo
 	}
 	if needsPR {
 		if err := o.defaultPR(&pjs); err != nil {


### PR DESCRIPTION
Other than eliminating the unnecessary iterations, this removes at least one bug (fixes #13280).

Targeting a specific job when its name is not unique is still a problem, but at least now the right set of actions will be performed after one of the potential candidates is chosen.