### PR TITLE
sig-cluster-lifecycle: add presubmits for the etcdadm project

### DIFF
--- a/config/jobs/kubernetes-sigs/etcdadm/OWNERS
+++ b/config/jobs/kubernetes-sigs/etcdadm/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- dlipovetsky
+- justinsb
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -1,0 +1,15 @@
+# sigs.k8s.io/etcdadm presubmits
+presubmits:
+  kubernetes-sigs/etcdadm:
+  - name: pull-etcdadm-verify
+    path_alias: "sigs.k8s.io/etcdadm"
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190702-9adb196-master
+        command:
+        - "./hack/verify-all.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-etcdadm
+      testgrid-tab-name: pr-verify

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -636,6 +636,9 @@ plugins:
   kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm:
   - milestone
 
+  kubernetes-sigs/etcdadm:
+  - milestone
+
   kubernetes-sigs/contributor-playground:
   - require-sig
 

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4045,6 +4045,8 @@ dashboards:
 
 - name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
 
+- name: sig-cluster-lifecycle-etcdadm
+
 - name: sig-multicluster-kubemci
   dashboard_tab:
   - name: kubemci-image-push
@@ -6775,6 +6777,7 @@ dashboard_groups:
   - sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
   - sig-cluster-lifecycle-cluster-api-provider-docker
   - sig-cluster-lifecycle-kops
+  - sig-cluster-lifecycle-etcdadm
 
 - name: sig-contribex
   dashboard_names:


### PR DESCRIPTION
add:
- an OWNERS file
- a dashboard under sig-cluster-lifecycle
- a verify presubmit
- entry in prow/plugins for the milestone plugin

xref https://github.com/kubernetes-sigs/etcdadm/issues/109

/kind feature
/priority important-soon
/assign @justinsb @dlipovetsky 
/hold

waiting on this PR to merge:
https://github.com/kubernetes-sigs/etcdadm/pull/110