### PR TITLE
Set pull-release-verify to optional, due to k/r revert

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -48,6 +48,7 @@ presubmits:
             - ./...
   - name: pull-release-verify
     always_run: true
+    optional: true
     decorate: true
     path_alias: k8s.io/release
     labels:


### PR DESCRIPTION
/cc @pswica 
ref: https://github.com/kubernetes/release/pull/814
Signed-off-by: Stephen Augustus <saugustus@vmware.com>