### PR TITLE
Update kubekins image for cluster-api-provider-aws jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
       command:
       - "./scripts/ci-aws-cred-test.sh"
 - name: periodic-cluster-api-provider-aws-bazel-e2e
@@ -32,7 +32,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
       command: ["runner.sh"]
       args: ["make", "e2e"]
       env:
@@ -59,7 +59,7 @@ postsubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command: ["runner.sh"]
         args: ["make", "e2e"]
         env:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./hack/verify-bazel.sh"
   - name: pull-cluster-api-provider-aws-bazel-test
@@ -17,7 +17,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./scripts/ci-bazel-test.sh"
   - name: pull-cluster-api-provider-aws-bazel-build
@@ -27,7 +27,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./scripts/ci-bazel-build.sh"
   - name: pull-cluster-api-provider-aws-bazel-integration
@@ -68,6 +68,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-experimental
         command:
         - "./hack/verify_boilerplate.py"


### PR DESCRIPTION
We need to use a kubekins-e2e image with Bazel >= 0.25

/assign @vincepri 