### PR TITLE
Use latest 1.15 k8s in kops e2e aws test instead of k8s master

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -76,7 +76,7 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --extract=ci/latest
+        - --extract=ci/latest-1.15
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws


### PR DESCRIPTION
It seems that current k/k master is not working with kops e2e aws tests because of PR https://github.com/kubernetes/kubernetes/pull/79305 

Example log

```
F0627 21:23:33.060643    2873 server.go:187] unknown 'kubernetes.io' or 'k8s.io' labels specified with --node-labels: [kops.k8s.io/instancegroup kubernetes.io/role node-role.kubernetes.io/master]
--node-labels in the 'kubernetes.io' namespace must begin with an allowed prefix (kubelet.kubernetes.io, node.kubernetes.io) or be in the specifically allowed set (beta.kubernetes.io/arch, beta.kubernetes.io/instance-type, beta.kubernetes.io/os, failure-domain.beta.kubernetes.io/region, failure-domain.beta.kubernetes.io/zone, failure-domain.kubernetes.io/region, failure-domain.kubernetes.io/zone, kubernetes.io/arch, kubernetes.io/hostname, kubernetes.io/instance-type, kubernetes.io/os)
```

This means that kops master is kind of stuck because PR tests will always fail. That is why I am kind of asking to change testjob `pull-kops-e2e-kubernetes-aws` from latest kubernetes master against latest release-1.15 (which is current kops master kubernetes version as well)

cc @justinsb @BenTheElder 