### PR TITLE
Migrate Cluster API to podutils

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -1,6 +1,8 @@
 presubmits:
   kubernetes-sigs/cluster-api:
   - name: pull-cluster-api-build
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
@@ -8,15 +10,13 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
-        args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./scripts/ci-build.sh"
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
   - name: pull-cluster-api-make
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
@@ -25,22 +25,19 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=90"
-        - "--scenario=execute"
-        - "--"
-        - "./scripts/ci-make.sh"
+      - command:
+        - runner.sh
+        - ./scripts/ci-make.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         resources:
           requests:
             memory: "6Gi"
   - name: pull-cluster-api-test
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
@@ -48,19 +45,17 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./scripts/ci-test.sh"
+        - runner.sh
+        - ./scripts/ci-test.sh
         resources:
           requests:
             cpu: 3
             memory: "6Gi"
   - name: pull-cluster-api-vendor-in-sync
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
@@ -68,28 +63,23 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
-        args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./scripts/ci-is-vendor-in-sync.sh"
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        - ./scripts/ci-is-vendor-in-sync.sh
   - name: pull-cluster-api-integration
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
       preset-kind-volume-mounts: "true"
-    always_run: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
+    always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         command:
         - runner.sh
-        args:
         - ./scripts/ci-integration.sh
         # we need privileged mode in order to do docker in docker
         securityContext:


### PR DESCRIPTION
This PR migrates the Cluster API presubmits jobs to use podutils and newer images.

Signed-off-by: Vince Prignano <vincepri@vmware.com>