### PR TITLE
Add KUBE_MASTER_NODE_LABELS to scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -45,6 +45,8 @@ presets:
     value: 1
   - name: ENABLE_PROMETHEUS_SERVER
     value: "true"
+  - name: KUBE_MASTER_NODE_LABELS
+    value: "kubernetes.io/node-exporter=true"
 ### kubemark-gce-big
 - labels:
     preset-e2e-kubemark-gce-big: "true"
@@ -119,6 +121,8 @@ presets:
     value: 1000
   - name: ENABLE_PROMETHEUS_SERVER
     value: "true"
+  - name: KUBE_MASTER_NODE_LABELS
+    value: "kubernetes.io/node-exporter=true"
 
 ###### Scalability Envs
 ### Common env variables for all scalability-related suites.


### PR DESCRIPTION
It will be used by https://github.com/kubernetes/perf-tests/pull/596 to schedule node exporter on master nodes.

/assign @mm4tt 