### PR TITLE
sig-release: Blockade changes to critical k/release tooling

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -156,6 +156,17 @@ blockades:
   blockregexps:
   - ^keps/NEXT_KEP_NUMBER$
   explanation: "KEP numbers are obsolete. Please remove any changes to `NEXT_KEP_NUMBER` from this PR and ensure the KEP filename is the draft date and KEP title e.g., `YYYYMMDD-pony-controller.md`"
+# TODO(justaugustus): Remove this blockade after identifying jobs where release tooling is being leveraged and
+#                     reorganizing k/release to be more restrictive about who can approve changes.
+#                     Deadline: 8/8/19
+#                     ref:
+#                       - https://github.com/kubernetes/test-infra/pull/13328
+#                       - https://github.com/kubernetes/release/issues/816
+- repos:
+  - kubernetes/release
+  blockregexps:
+  - ^anago|branchff|build\/|changelog-update|compile-release-tools|debian\/|find_green_build|gcb\/|gcbmgr|lib\/|prin|push-build.sh|release-notify|relnotes|rpm\/
+  explanation: "Changes to certain release tools can affect our ability to test, build, and release Kubernetes. This PR must be explicitly approved by SIG Release repo admins."
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
ref: https://github.com/kubernetes/release/issues/816
Signed-off-by: Stephen Augustus <saugustus@vmware.com>