### PR TITLE
Allow an unknown agent to be configured in prow

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1228,7 +1228,8 @@ func validateAgent(v JobBase, podNamespace string) error {
 	agent := v.Agent
 	switch {
 	case !agents.Has(agent):
-		return fmt.Errorf("agent must be one of %s (found %q)", strings.Join(agents.List(), ", "), agent)
+		logrus.Warningf("agent %s is unknown and cannot be validated: use at your own risk", agent)
+		return nil
 	case v.Spec != nil && agent != k:
 		return fmt.Errorf("job specs require agent: %s (found %q)", k, agent)
 	case agent == k && v.Spec == nil:

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -455,10 +455,11 @@ func TestValidateAgent(t *testing.T) {
 		pass bool
 	}{
 		{
-			name: "reject unknown agent",
+			name: "accept unknown agent",
 			base: func(j *JobBase) {
 				j.Agent = "random-agent"
 			},
+			pass: true,
 		},
 		{
 			name: "spec requires kubernetes agent",


### PR DESCRIPTION
This PR is intended to address issues raised in the review of https://github.com/kubernetes/test-infra/pull/13199. Instead of returning an error when an unknown agent is configured, this change causes prow to emit a warning and return nil. This means that prow can support any agent the user cares to configure without having to know about all potential agents in advance.

cc @stevekuznetsov @fejta @ccojocar @abayer