### PR TITLE
Sketch out structure and signatures for inrepoconfig

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -182,7 +182,7 @@ func (p *protector) protect() {
 	}
 
 	// Some repos with presubmits might not be listed in the branch-protection
-	for repo := range p.cfg.Presubmits {
+	for repo := range p.cfg.GetStaticPresubmitsForAllRepos() {
 		if p.completedRepos[repo] == true {
 			continue
 		}

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -427,7 +427,7 @@ func getJSONTagName(field reflect.StructField, i int) string {
 
 func validateJobRequirements(c config.JobConfig) error {
 	var validationErrs []error
-	for repo, jobs := range c.Presubmits {
+	for repo, jobs := range c.GetStaticPresubmitsForAllRepos() {
 		for _, job := range jobs {
 			validationErrs = append(validationErrs, validatePresubmitJob(repo, job))
 		}
@@ -818,7 +818,7 @@ func verifyOwnersPlugin(cfg *plugins.Configuration) error {
 
 func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 	configuredRepos := sets.NewString()
-	for orgRepo := range cfg.JobConfig.Presubmits {
+	for orgRepo := range cfg.GetStaticPresubmitsForAllRepos() {
 		configuredRepos.Insert(orgRepo)
 	}
 	for orgRepo := range cfg.JobConfig.Postsubmits {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -719,7 +719,7 @@ func setPeriodicDecorationDefaults(c *Config, ps *Periodic) {
 }
 
 func finalizePresubmits(c *Config, presubmits []Presubmit) error {
-	c.defaultPresubmitFields(vs)
+	c.defaultPresubmitFields(presubmits)
 	if err := SetPresubmitRegexes(vs); err != nil {
 		return fmt.Errorf("could not set regex: %v", err)
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -719,7 +719,6 @@ func setPeriodicDecorationDefaults(c *Config, ps *Periodic) {
 }
 
 func finalizePresubmits(c *Config, presubmits []Presubmit) error {
-	setPresubmitDecorationDefaults(c, presubmits)
 	c.defaultPresubmitFields(vs)
 	if err := SetPresubmitRegexes(vs); err != nil {
 		return fmt.Errorf("could not set regex: %v", err)
@@ -727,6 +726,7 @@ func finalizePresubmits(c *Config, presubmits []Presubmit) error {
 
 	for i := range presubmits {
 		ps := presubmits[i]
+		setPresubmitDecorationDefaults(c, ps)
 		if err := resolvePresets(ps.Name, ps.Labels, ps.Spec, ps.BuildSpec, c.Presets); err != nil {
 			return err
 		}
@@ -751,12 +751,6 @@ func (c *Config) finalizeJobConfig() error {
 			return errors.New("no default GCS credentials secret provided for plank")
 		}
 
-		for _, vs := range c.presubmits {
-			if err := finalizePresubmits(c, vs); err != nil {
-				return err
-			}
-		}
-
 		for _, js := range c.Postsubmits {
 			for i := range js {
 				setPostsubmitDecorationDefaults(c, &js[i])
@@ -765,6 +759,12 @@ func (c *Config) finalizeJobConfig() error {
 
 		for i := range c.Periodics {
 			setPeriodicDecorationDefaults(c, &c.Periodics[i])
+		}
+	}
+
+	for _, vs := range c.presubmits {
+		if err := finalizePresubmits(c, vs); err != nil {
+			return err
 		}
 	}
 

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -1,0 +1,60 @@
+// We need to put the inrepoconfig code into the config package to not cause an import cycle,
+// because inrepoconfigs types import types from the config package and the config package needs
+// the inrepoconfig types in `GetPresubmits`
+package config
+
+import (
+	"k8s.io/test-infra/prow/git"
+)
+
+type InrepoconfigConfiguration struct {
+	Enabled bool `json:"enabled"`
+}
+
+type Inrepoconfig struct {
+	Presubmits []Presubmit `json:"presubmit,omitempty"`
+}
+
+func (c *ProwConfig) InRepoConfigConfiguration(org, repo string) InrepoconfigConfiguration {
+	// Check on repo, org and global level
+}
+
+// This is for callers who want the Presubmits for all repos and don't know which
+// repos exist. Even if inrepoconfig is enabled, this wont return presubmits
+// in prow.yaml. This should only be used by components that do something with
+// Presubmits but do not get triggered by PullRequests, e.G. Branchprotector and
+// the config parsing
+func (c *Config) GetStaticPresubmitsForAllRepos() map[string][]Presubmit {
+	return c.presubmits
+}
+
+// This has to be used when not using GitHub, as the git.Client only supports Github.
+// If your component uses Github, use Presubmits instead
+func (c *Config) GetStaticPresubmits(identifier string) []Presumit {
+	return c.presubmits[identifier]
+}
+
+// Used for all consumers of the Presubmits config that get triggered on pull requests.
+// It can only be used with Github, as the *git.Client only works with GitHub
+func (c *Config) Presubmits(gc *git.Client, org, repo, baseSHA string, headRefs []string) ([]Presubmit, error) {
+	if !c.InRepoConfigConfiguration(org, repo).Enabled {
+		return c.presubmits[org+"/"+repo], nil
+	}
+
+	inrepoconfig, err := c.GetInrepoconfig(gc, org, repo, baseRef, headRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(c.presubmits[org+"/"+repo], inrepoconfig.Presubmits...), nil
+}
+
+func (c *Config) getInrepoconfig(gc *git.Client, org, repo, baseRef string, headRefs []string) (*Inrepoconfig, error) {
+	// * use git.Client to clone the repo and checkout baseRef
+	// * if len(headRefs) > 0, merge them onto baseRef in order, using the
+	//   mergeStrategy configured on tide
+	// * check if prow.yaml exists, if not return
+	// * read prow.yaml
+	// * unmarshal prow.yaml
+	// * default and validate presubmits in prow.yaml
+}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -20,10 +20,10 @@ func (c *ProwConfig) InRepoConfigConfiguration(org, repo string) InrepoconfigCon
 }
 
 // This is for callers who want the Presubmits for all repos and don't know which
-// repos exist. Even if inrepoconfig is enabled, this wont return presubmits
-// in prow.yaml. This should only be used by components that do something with
-// Presubmits but do not get triggered by PullRequests, e.G. Branchprotector and
-// the config parsing
+// repos exist. If anyhow possible, this should not be used because it will not
+// return all Presubmits if `inrepoconfig` is enabled/prow.yaml
+// This is needed for some components that do need Presubmits but do not have a
+// Pull Request at hand, e.G. `branchprotector`.
 func (c *Config) GetStaticPresubmitsForAllRepos() map[string][]Presubmit {
 	return c.presubmits
 }

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -281,8 +281,8 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 			}
 		}
 	case client.New:
-		presubmits := c.config().Presubmits[cloneURI.String()]
-		presubmits = append(presubmits, c.config().Presubmits[cloneURI.Host+"/"+cloneURI.Path]...)
+		presubmits := c.config().GetStaticPresubmits[cloneURI.String()]
+		presubmits = append(presubmits, c.config().GetStaticPresubmits[cloneURI.Host+"/"+cloneURI.Path]...)
 
 		var filters []pjutil.Filter
 		var latestReport *reporter.JobReport

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -110,11 +110,16 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 		}
 	}
 
-	toTest, toSkip, err := FilterPresubmits(HonorOkToTest(trigger), c.GitHubClient, gc.Body, pr, c.Config.Presubmits[gc.Repo.FullName], c.Logger)
+	baseSHA, presubmits, err := c.Presubmits(c, pr)
 	if err != nil {
 		return err
 	}
-	return RunAndSkipJobs(c, pr, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
+
+	toTest, toSkip, err := FilterPresubmits(HonorOkToTest(trigger), c.GitHubClient, gc.Body, pr, presubmits, c.Logger)
+	if err != nil {
+		return err
+	}
+	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
 }
 
 func HonorOkToTest(trigger plugins.Trigger) bool {

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -159,21 +159,21 @@ func (c *Controller) Run(stop <-chan os.Signal, changes <-chan config.Delta) {
 
 func (c *Controller) reconcile(delta config.Delta) error {
 	var errors []error
-	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.GetStaticPresubmitsForAllRepos(), delta.After.GetStaticPresubmitsForAllRepos())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.GetStaticPresubmitsForAllRepos(), delta.After.GetStaticPresubmitsForAllRepos())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.GetStaticPresubmitsForAllRepos(), delta.After.GetStaticPresubmitsForAllRepos())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1159,7 +1159,7 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 	if err != nil {
 		return nil, err
 	}
-	for _, ps := range c.config().GetPresubmits(c.gc, sp.org, sp.repo, sp.sha, headRefs) {
+	for _, ps := range presubmits {
 		if !ps.ContextRequired() {
 			continue
 		}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1151,7 +1151,15 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 		}
 	}
 
-	for _, ps := range c.config().Presubmits[sp.org+"/"+sp.repo] {
+	var headRefs []string
+	for _, pr := range sp.prs {
+		headRefs = append(headRefs, string(pr.HeadRefOID))
+	}
+	presubmits, err := c.config().GetPresubmits(c.gc, sp.org, sp.repo, sp.sha, headRefs)
+	if err != nil {
+		return nil, err
+	}
+	for _, ps := range c.config().GetPresubmits(c.gc, sp.org, sp.repo, sp.sha, headRefs) {
 		if !ps.ContextRequired() {
 			continue
 		}


### PR DESCRIPTION
This pr demonstrates the structure and function signature I have in mind to use for inrepoconfig. Its purpose at this stage is demonstration only/basis for further discussion as agreed on the meeting on june 27th. Hence, several parts are not actually implemented and the whole thing wont build.

Included are:

* Required refactorings in `prow/config` to make the presubmit defaulting and validation usable after startup
* Getter funcs in `prow/config`, replacing the existing public `Presubmit` field which was made private
* A sample of a simple plugin using the new getter (`skip`)
* A sample of a component that can not use the dynamic Presubmits, as its not github-based (`prow/gerrit/adapter`)
* Adjustments for the `trigger` plugin
* Adjustments for `tide`
* Adjustments for the `status-reconciler` and `branchprotector` which have no/limited functionality when used in conjunction with `inrepoconfig`
* Sample adjustments in `Deck`

/assign @cjwagner @stevekuznetsov 