### PR TITLE
sig-release: Add/update jobs for building debs/rpms

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -52,27 +52,30 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
-
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: build-master-fast
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     description: 'Ends up running: make quick-release'
+
 - interval: 4h
-  name: ci-kubernetes-build-debian-unstable
+  name: ci-release-build-packages-debs
+  decorate: true
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: release
+    base_ref: master
+    path_alias: "k8s.io/release"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190703-1f4d616
-      args:
-      - --repo=k8s.io/release
-      - --root=/go/src
-      - --timeout=180
-      - --scenario=execute
-      - --
-      - ./debian/jenkins.sh
+    - image: quay.io/k8s/release-tools:latest
+      imagePullPolicy: Always
+      command:
+      - make
+      - build-debs
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -81,21 +84,45 @@ periodics:
           cpu: 4
           memory: "8Gi"
   annotations:
-    testgrid-dashboards: sig-release-misc
-    testgrid-tab-name: debian-unstable
     testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-tab-name: build-packages-debs
+
+- interval: 4h
+  name: ci-release-build-packages-rpms
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: release
+    base_ref: master
+    path_alias: "k8s.io/release"
+  spec:
+    containers:
+    - image: quay.io/k8s/release-tools:latest
+      imagePullPolicy: Always
+      command:
+      - make
+      - build-rpms
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+  annotations:
+    testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-tab-name: build-packages-rpms
+
 - interval: 1h
   name: ci-kubernetes-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
-    fork-per-release-generic-suffix: "true"
-    testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: build-master
-    testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bootstrap:v20190703-1f4d616
@@ -117,6 +144,14 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-release-master-blocking
+    testgrid-tab-name: build-master
+    testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
+
 - interval: 1h
   name: ci-kubernetes-cross-build
   labels:


### PR DESCRIPTION
Dependent on https://github.com/kubernetes/release/pull/818

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

(for discussion)
/hold
/cc @kubernetes/release-engineering @kubernetes/sig-release-admins