### PR TITLE
fix: tekton pipeline run

### DIFF
--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -603,14 +603,14 @@ func makePipelineRun(pj prowjobv1.ProwJob, pr *pipelinev1alpha1.PipelineResource
 		Name:  "build_id",
 		Value: buildID,
 	})
-	rb := pipelinev1alpha1.PipelineResourceBinding{
-		Name: pr.Name,
-		ResourceRef: pipelinev1alpha1.PipelineResourceRef{
-			Name:       pr.Name,
-			APIVersion: pr.APIVersion,
-		},
+	for _, res := range p.Spec.Resources {
+		if res.Name == "repo-source" {
+			res.ResourceRef = pipelinev1alpha1.PipelineResourceRef{
+				Name:       pr.Name,
+				APIVersion: pr.APIVersion,
+			}
+		}
 	}
-	p.Spec.Resources = append(p.Spec.Resources, rb)
 
 	return &p, nil
 }

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -1003,14 +1003,6 @@ func TestMakePipelineRun(t *testing.T) {
 				Name:  "build_id",
 				Value: randomPipelineRunID,
 			})
-			rb := pipelinev1alpha1.PipelineResourceBinding{
-				Name: pr.Name,
-				ResourceRef: pipelinev1alpha1.PipelineResourceRef{
-					Name:       pr.Name,
-					APIVersion: pr.APIVersion,
-				},
-			}
-			expected.Spec.Resources = append(expected.Spec.Resources, rb)
 
 			if !equality.Semantic.DeepEqual(actual, &expected) {
 				t.Errorf("pipelineruns do not match:\n%s", diff.ObjectReflectDiff(&expected, actual))

--- a/prow/cmd/pipeline/dev.yaml
+++ b/prow/cmd/pipeline/dev.yaml
@@ -31,9 +31,10 @@ metadata:
   name: prow-pipeline
 rules:
 - apiGroups:
-  - pipeline.tekton.dev
+  - tekton.dev
   resources:
   - pipelineruns
+  - pipelineresource
   verbs:
   - create
   - delete


### PR DESCRIPTION
Added tekton resources for clusterrole.
When pipelineresource create via command we set name to UUID and it's expected error on tekton side "InvalidPipelineResourceBindings" because this resource is unexpected. I propouse use some hard code name for that (simple way) or we can find first git resource in pipeline and put our new resource to it dynamically via pipelinerun (it's harder and we should read pipeline resource before that)