### PR TITLE
kops pr e2e: tell kops to deploy the 1.15 version

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -76,6 +76,7 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.15.txt
         - --extract=ci/latest-1.15
         - --ginkgo-parallel
         - --kops-build


### PR DESCRIPTION
Following on to #13320, it looks like we are using the 1.15 branch of
k8s for the e2e tests, but we are still telling kops to deploy the
latest version.  KOPS_DEPLOY_LATEST_URL seems to be the magic env var.