### PR TITLE
Add CAPV fmt, lint, vet, and markdown pre-submits

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -60,6 +60,71 @@ presets:
 
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
+  - name: pull-cluster-api-provider-vsphere-verify-fmt
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - hack/check-format.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-fmt
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the Golang sources have been formatted
+
+  - name: pull-cluster-api-provider-vsphere-verify-lint
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - hack/check-lint.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-lint
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the Golang sources are linted
+
+  - name: pull-cluster-api-provider-vsphere-verify-vet
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - hack/check-vet.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-vet
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Vets the Golang sources have been vetted
+
+  - name: pull-cluster-api-provider-vsphere-verify-markdown
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0
+        command:
+        - /nodejs/bin/node
+        args:
+        - /md/lint
+        - -i
+        - vendor
+        - .
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-markdown
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the markdown has been linted
+
   - name: pull-cluster-api-provider-vsphere-verify-crds
     always_run: true
     decorate: true
@@ -69,12 +134,12 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
         command:
         - hack/verify-crds.sh
-
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-verify-crds
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Verifies the CRDs
+      description: Verifies the CRDs have been updated
+
   - name: pull-cluster-api-provider-vsphere-test
     always_run: true
     decorate: true
@@ -91,12 +156,12 @@ presubmits:
         - runner.sh
         args:
         - ./scripts/ci-test.sh
-
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Runs unit tests
+
   - name: pull-cluster-api-provider-vsphere-e2e
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This patch adds support for three new CAPV pre-submits for verifying that the project's sources are formatted, linted, and vetted.

Please see https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/422 for more information.

cc @frapposelli @figo @codenrhoden 