### PR TITLE
support @user -> user in github client, repoowners, etc.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -161,7 +161,9 @@ type User struct {
 }
 
 // NormLogin normalizes GitHub login strings
-var NormLogin = strings.ToLower
+func NormLogin(login string) string {
+	return strings.TrimPrefix(strings.ToLower(login), "@")
+}
 
 // PullRequestEventAction enumerates the triggers for this
 // webhook payload type. See also:

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -50,7 +50,7 @@ labels:
 - bob
 reviewers:
 - alice
-- CJWagner
+- "@CJWagner"
 - jakub
 required_reviewers:
 - ben
@@ -223,7 +223,7 @@ labels:
 				"OWNERS": []byte(`approvers:
 - cjwagner
 reviewers:
-- Alice
+- "@Alice"
 - bob
 
 required_reviewers:


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/issues/10065#issuecomment-509850018

with this we can have OWNERS files like:
```yaml
reviewers:
- '@CjWaGnEr'
- some-user-hostile-alias
```
and you can tell which one is the alias (if we start doing something like this consistently)