### PR TITLE
Add projects to Prow user list

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -88,6 +88,8 @@ Prow is used by the following organizations and projects:
 - [tensorflow/minigo](https://github.com/tensorflow/minigo#automated-tests)
 - [helm/charts](https://github.com/helm/charts)
 - [Daisy(google compute image tools)](https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/test-infra#prow-and-gubenator)
+- [KubeEdge (Kubernetes Native Edge Computing Framework)](https://github.com/kubeedge/kubeedge)
+- [Volcano (Kubernetes Native Batch System)](https://github.com/volcano-sh/volcano)
 
 [Jenkins X](https://jenkins-x.io/) uses [Prow as part of Serverless Jenkins](https://medium.com/@jdrawlings/serverless-jenkins-with-jenkins-x-9134cbfe6870).
 


### PR DESCRIPTION
The two projects also used Prow:
- [KubeEdge (Kubernetes Native Edge Computing Framework)](https://github.com/kubeedge/kubeedge)
- [Volcano (Kubernetes Native Batch System)](https://github.com/volcano-sh/volcano)