### PR TITLE
velodrome - upgrade py2 -> py3, #13164

### DIFF
--- a/hack/verify-pylint.sh
+++ b/hack/verify-pylint.sh
@@ -38,4 +38,4 @@ shopt -s extglob globstar
 
 # TODO(clarketm) there is no version of `pylint` that supports "both" PY2 and PY3
 # I am disabling pylint checks for python3 files until migration complete
-"$DIR/pylint_bin" !(hack|metrics|gubernator|external|vendor|bazel-*)/**/*.py
+"$DIR/pylint_bin" !(velodrome|hack|metrics|gubernator|external|vendor|bazel-*)/**/*.py

--- a/velodrome/BUILD.bazel
+++ b/velodrome/BUILD.bazel
@@ -9,8 +9,8 @@ py_test(
         ":configs",
     ],
     main = "config.py",
-    python_version = "PY2",
-    deps = [requirement("pyyaml")],
+    python_version = "PY3",
+    deps = [requirement("ruamel.yaml")],
 )
 
 filegroup(

--- a/velodrome/config.py
+++ b/velodrome/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -18,7 +18,7 @@ import os
 import string
 import sys
 
-import yaml
+import ruamel.yaml as yaml
 
 CONFIG = "config.yaml"
 
@@ -38,11 +38,11 @@ DEPLOYMENTS = {
 
 def main():
     if len(sys.argv) != 1:
-        print >> sys.stderr, "Too many arguments."
+        print("Too many arguments.", file=sys.stderr)
         sys.exit(128)
 
     with open(get_absolute_path(CONFIG)) as config_file:
-        config = yaml.load(config_file)
+        config = yaml.safe_load(config_file)
         print_deployments(["sqlproxy", "prober"], {})
         for project_name, project in config['projects'].items():
             public_ip = project.get('nginx', {}).get('public-ip', '') or ''
@@ -85,14 +85,14 @@ def main():
 
 def apply_transform(new_args, env):
     with open(get_absolute_path(DEPLOYMENTS["transform"])) as fp:
-        config = yaml.load(fp)
+        config = yaml.safe_load(fp)
         config['spec']['template']['spec']['containers'][0]['args'] += new_args
     print_deployment(yaml.dump(config, default_flow_style=False), env)
 
 
 def patch_configuration(component, values, env):
     with open(get_absolute_path(DEPLOYMENTS[component])) as fp:
-        config = yaml.load(fp)
+        config = yaml.safe_load(fp)
         # We want to fail if we have unknown keys in values
         unknown_keys = set(values) - set(config['data'])
         if unknown_keys:
@@ -112,8 +112,8 @@ def print_deployments(components, env):
 
 
 def print_deployment(deployment, env):
-    print string.Template(deployment).safe_substitute(**env),
-    print '---'
+    print(string.Template(deployment).safe_substitute(**env), end=' ')
+    print('---')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is the successor to #13368 and #13380 regarding the python2 -> python3 ( #13164 ) migration and targets the `velodrome` directory. Note that the rationale for preferring `ruamel.yaml` over `pyYAML` is threefold:
1. Although bazel obviously does support dual-python at the binary compilation level, it does not support dual dependency installation [bazelbuild/rules_python](https://github.com/bazelbuild/rules_python/issues/33).
2. `pyYAML` determines python version at [**install**](https://github.com/yaml/pyyaml/blob/master/setup.py#L271) time while `ruamel.yaml` does so at [**run**](https://bitbucket.org/ruamel/yaml/src/default/setup.py) time leveraging shimming and __future__ imports.

The combination of the above, along with the fact that `ruamel.yaml` is a fork of `pyYAML` and a direct superset of it (according to the current usage) is the justification for the change.