### PR TITLE
hack - upgrade py2 -> py3, #13164

### DIFF
--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -10,14 +10,14 @@ py_test(
         "coalesce.py",
         "coalesce_test.py",
     ],
-    python_version = "PY2",
+    python_version = "PY3",
 )
 
 py_test(
     name = "verify_boilerplate",
     srcs = ["verify_boilerplate.py"],
     data = ["//:all-srcs"],
-    python_version = "PY2",
+    python_version = "PY3",
     tags = ["lint"],
 )
 

--- a/hack/coalesce.py
+++ b/hack/coalesce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright 2016 The Kubernetes Authors.
 #
@@ -66,7 +66,7 @@ def result(pkg):
                 if status.tag == 'error' or status.tag == 'failure':
                     failure = ET.Element('failure')
                     with open(pkg + '/test.log') as fp:
-                        text = fp.read().decode('UTF-8', 'ignore')
+                        text = fp.read()
                         failure.text = sanitize(text)
                     elem.append(failure)
     return elem
@@ -85,7 +85,7 @@ def main():
     except OSError:
         pass
     with open(os.path.join(artifacts_dir, 'junit_bazel.xml'), 'w') as fp:
-        fp.write(ET.tostring(root, 'UTF-8'))
+        fp.write(ET.tostring(root, 'unicode'))
 
 
 if __name__ == '__main__':

--- a/hack/coalesce_test.py
+++ b/hack/coalesce_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2016 The Kubernetes Authors.
 #
@@ -49,8 +49,8 @@ class TestCoalesce(unittest.TestCase):
         return pkg
 
     def test_utf8(self):
-        uni_string = u'\u8a66\u3057'
-        pkg = self.make_result(name='coal', error=uni_string.encode('utf8'))
+        uni_string = '\u8a66\u3057'
+        pkg = self.make_result(name='coal', error=uni_string)
         result = coalesce.result(pkg)
         self.assertEqual(result.find('failure').text, uni_string)
 

--- a/hack/verify-pylint.sh
+++ b/hack/verify-pylint.sh
@@ -38,4 +38,4 @@ shopt -s extglob globstar
 
 # TODO(clarketm) there is no version of `pylint` that supports "both" PY2 and PY3
 # I am disabling pylint checks for python3 files until migration complete
-"$DIR/pylint_bin" !(metrics|gubernator|external|vendor|bazel-*)/**/*.py
+"$DIR/pylint_bin" !(hack|metrics|gubernator|external|vendor|bazel-*)/**/*.py

--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #
@@ -16,8 +16,6 @@
 
 # Verifies that all source files contain the necessary copyright boilerplate
 # snippet.
-
-from __future__ import print_function
 
 import argparse
 import datetime
@@ -98,7 +96,7 @@ def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
         (data, found) = con.subn("", data, 1)
 
     # remove shebang from the top of shell files
-    if extension == "sh" or extension == "py":
+    if extension in ("sh", "py"):
         she = regexs["shebang"]
         (data, found) = she.subn("", data, 1)
 


### PR DESCRIPTION
This is the successor to #13368 regarding the python2 -> python3 ( #13164 ) migration and targets the **hack** directory (excluding `pylint` upgrade which is to be performed **last**).