### PR TITLE
sig-release: Update images for deb/rpm verify jobs

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -92,7 +92,7 @@ periodics:
     path_alias: k8s.io/release
   spec:
     containers:
-    - image: ubuntu:latest
+    - image: quay.io/k8s/release-tools:latest
       imagePullPolicy: Always
       command:
       - make
@@ -111,7 +111,7 @@ periodics:
     path_alias: k8s.io/release
   spec:
     containers:
-    - image: centos:latest
+    - image: quay.io/k8s/release-tools-centos:latest
       imagePullPolicy: Always
       command:
       - make


### PR DESCRIPTION
The verify-package jobs[1](https://testgrid.k8s.io/sig-release-master-informing#verify-packages-debs)[2](https://testgrid.k8s.io/sig-release-master-informing#verify-packages-rpms) that were recently created (#13348) are failing because the container images were missing some dependencies, like `make`, `curl`, and `jq`.

This switches them to some lightweight images that can do the checks.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>