### PR TITLE
Update experimental bazel version to 0.28.0

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -3,7 +3,7 @@ variants:
     CONFIG: experimental
     GO_VERSION: 1.12.1
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.26.0
+    BAZEL_VERSION: 0.28.0
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master


### PR DESCRIPTION
0.28.0 is the most recent bazel release, as of today; update experimental for this release.