### PR TITLE
Increasing c-jobs kubemark logs size

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -45,6 +45,11 @@ presets:
     value: "true"
   - name: KUBE_MASTER_NODE_LABELS
     value: "node.kubernetes.io/node-exporter-ready=true"
+  # Keep all logrotated files (not just 5 latest which is a default)
+  - name: LOGROTATE_FILES_MAX_COUNT
+    value: 1000
+  - name: LOGROTATE_MAX_SIZE
+    value: "5G"
 ### kubemark-gce-big
 - labels:
     preset-e2e-kubemark-gce-big: "true"


### PR DESCRIPTION
Adding `LOGROTATE_FILES_MAX_COUNT` and `LOGROTATE_MAX_SIZE` flags to kubemark common preset, so we keep all of the run logs.