### PR TITLE
Add cluster-api-aws to image promoter configs

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -15,6 +15,7 @@ presubmits:
         args:
         - /app/cip-docker-image.binary
         - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+        - k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
         - k8s.gcr.io/k8s-staging-coredns/manifest.yaml
         - k8s.gcr.io/k8s-staging-csi/manifest.yaml
         env:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -533,6 +533,7 @@ postsubmits:
         args:
         - /app/cip-docker-image.binary
         - k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
+        - k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
         - k8s.gcr.io/k8s-staging-coredns/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
         - k8s.gcr.io/k8s-staging-csi/manifest.yaml,/etc/k8s-artifacts-prod-service-account/service-account.json
         env:


### PR DESCRIPTION
Adds the cluster-api-aws staging repo to the image promoter configs

/assign @dims 
/cc @spiffxp @amy @listx 

Related to kubernetes/k8s.io#300