### PR TITLE
Support anchor links in lenses

### DIFF
--- a/prow/cmd/deck/static/spyglass/common.ts
+++ b/prow/cmd/deck/static/spyglass/common.ts
@@ -2,7 +2,7 @@ export interface BaseMessage {
   type: string;
 }
 
-function isBaseMessage(data: any): data is BaseMessage {
+export function isBaseMessage(data: any): data is BaseMessage {
   return typeof data.type === 'string';
 }
 
@@ -26,6 +26,16 @@ export interface UpdatePageMessage extends BaseMessage {
   data: string;
 }
 
+export interface UpdateHash extends BaseMessage {
+  type: 'updateHash';
+  hash: string;
+}
+
+export interface ShowOffset extends BaseMessage {
+  type: 'showOffset';
+  top: number;
+}
+
 export interface Response extends BaseMessage {
   type: 'response';
   data: string;
@@ -35,7 +45,7 @@ export function isResponse(data: any): data is Response {
   return isBaseMessage(data) && data.type === 'response';
 }
 
-export type Message = ContentUpdatedMessage | RequestMessage | RequestPageMessage | UpdatePageMessage | Response;
+export type Message = ContentUpdatedMessage | RequestMessage | RequestPageMessage | UpdatePageMessage | UpdateHash | ShowOffset | Response;
 
 export interface TransitMessage {
   id: number;
@@ -44,4 +54,8 @@ export interface TransitMessage {
 
 export function isTransitMessage(data: any): data is TransitMessage {
   return typeof data.id === 'number' && data.message && typeof data.message.type === 'string';
+}
+
+export function isUpdateHashMessage(data: any): data is UpdateHash {
+  return isBaseMessage(data) && data.type === 'updateHash';
 }

--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -1,4 +1,4 @@
-import {isResponse, isTransitMessage, Message, Response} from './common';
+import {isBaseMessage, isResponse, isTransitMessage, isUpdateHashMessage, Message, Response, UpdateHash} from './common';
 
 export interface Spyglass {
   /**
@@ -38,9 +38,28 @@ class SpyglassImpl implements Spyglass {
   private pendingRequests = new Map<number, (v: Response) => void>();
   private messageId = 0;
   private pendingUpdateTimer = 0;
+  private currentHash = '';
+  private observer: MutationObserver;
 
   constructor() {
+    this.currentHash = location.hash;
+    this.observer = new MutationObserver((mutations) => this.handleMutations(mutations));
+
     window.addEventListener('message', (e) => this.handleMessage(e));
+    window.addEventListener('hashchange', (e) => this.handleHashChange(e));
+    window.addEventListener('DOMContentLoaded', () => {
+      this.fixAnchorLinks(document.documentElement);
+      this.observer.observe(document.documentElement, {attributeFilter: ['href'], childList: true, subtree: true});
+    });
+    window.addEventListener('load', () => {
+      this.contentUpdated();
+      // this needs a delay but I'm not sure what (if anything) we're racing.
+      setTimeout(() => {
+        if (location.hash !== '') {
+          this.tryMoveToHash(location.hash);
+        }
+      }, 100);
+    });
   }
 
   public async updatePage(data: string): Promise<void> {
@@ -75,7 +94,7 @@ class SpyglassImpl implements Spyglass {
     });
   }
 
-  private handleMessage(e: MessageEvent) {
+  private handleMessage(e: MessageEvent): void {
     if (e.origin !== document.location.origin) {
       console.warn(`Got MessageEvent from unexpected origin ${e.origin}; expected ${document.location.origin}`, e);
       return;
@@ -88,14 +107,74 @@ class SpyglassImpl implements Spyglass {
           this.pendingRequests.delete(data.id);
         }
       }
+    } else if (isUpdateHashMessage(data)) {
+      location.hash = data.hash;
     }
+  }
+
+  // When any links on the page are added or mutated, we fix them up if they
+  // were anchor links to avoid developer confusion.
+  private handleMutations(mutations: MutationRecord[]): void {
+    for (const mutation of mutations) {
+      if (!(mutation.target instanceof HTMLElement)) {
+        continue;
+      }
+      if (mutation.type === 'childList') {
+        this.fixAnchorLinks(mutation.target);
+      } else if (mutation.type === 'attributes') {
+        if (mutation.target instanceof HTMLAnchorElement && mutation.attributeName === 'href') {
+          const href = mutation.target.getAttribute('href');
+          if (href && href[0] === '#') {
+            this.fixAnchorLink(mutation.target);
+          }
+        }
+      }
+    }
+  }
+
+  private handleHashChange(e: HashChangeEvent): void {
+    if (location.hash === this.currentHash) {
+      return;
+    }
+    this.currentHash = location.hash;
+    this.postMessage({type: 'updateHash', hash: location.hash}).then();
+    this.tryMoveToHash(location.hash);
+  }
+
+  // Because we're in an iframe that is exactly our height, anchor links don't
+  // actually do anything (and even if they did, it would not be something
+  // useful). We implement their intended behaviour manually by looking up the
+  // element referred to and requesting that our parent jump to that offset.
+  private tryMoveToHash(hash: string): void {
+    hash = hash.substr(1);
+    let el = document.getElementById(hash);
+    if (!el) {
+      el = document.getElementsByName(hash)[0];
+      if (!el) {
+        return;
+      }
+    }
+    const top = el.getBoundingClientRect().top + window.pageYOffset;
+    this.postMessage({type: 'showOffset', top}).then();
+  }
+
+  // We need to fix up anchor links (i.e. links that only set the fragment)
+  // because we use <base> to make asset references Just Work, but that also
+  // applies to anchor links, which is surprising to developers.
+  // In order to mitigate this surprise, we find all the links that were
+  // supposed to be anchor links and fix them by adding the absolute URL
+  // of the current page.
+  private fixAnchorLinks(parent: Element): void {
+    for (const a of Array.from(parent.querySelectorAll<HTMLAnchorElement>('a[href^="#"]'))) {
+      this.fixAnchorLink(a);
+    }
+  }
+
+  private fixAnchorLink(a: HTMLAnchorElement): void {
+    a.href = location.href.split('#')[0] + a.getAttribute('href');
+    a.target = "_self";
   }
 }
 
 const spyglass = new SpyglassImpl();
-
-window.addEventListener('load', () => {
-  spyglass.contentUpdated();
-});
-
 (window as any).spyglass = spyglass;


### PR DESCRIPTION
This adds support for anchor links or other fragment manipulation in spyglass lenses, and muxes any fragments from multiple lenses into the final URL. Additionally, fragments that link to actual elements will cause the page to jump to the expected place. All of this is handled transparently to the lenses.

The muxing approach is to use the lens indexes (from the spyglass lens config) as keys and whatever content was in the lens's expected hash as the value, which results in hashes like `#0:l1234;2:something` if lens 0 had the fragment `#l1234`, lens 2 had the fragment `#something`, and no others had any.

To make this happen, the library we inject into lenses now listens for the `hashchange` event and sends it to the main spyglass page to handle. Additionally, the library looks for an element matching the fragment and, if found, determines the position of that element and asks the main page to scroll to it. Going the other way, the root page also listens for `hashchange` and propagates changes to the lenses, where the libraries then update the fragments. On page load, the fragments are injected directly into the iframe URLs, so they are available immediately. If multiple lenses have independently defined fragments that would directly jump to a position, which one you end up with is undefined (the actual effect is that you'll jump to them in sequence as the lenses finish loading).

A wrinkle in lens developers doing this the simple way (i.e. `<a href="#whatever">`) is that we use a `<base>` element in lenses to change the root URL in order to enable seamless references to assets. Unfortunately, this caused `href="#whatever"` to be interpreted as `/static/spyglass/lenses/buildlog/#whatever` or similar. To avoid this surprising developers, the lens library now rewrites `a` elements pointing to an anchor to work correctly. This occurs both during page load and when the developer adds new DOM nodes (e.g. loading more of a log).

The upshot of all this is that standard fragment manipulation APIs and HTML anchor links now work as expected without any lens developer effort.

This PR is a prerequisite for #12766. 