### PR TITLE
Add new lens API spyglass.makeFragmentLink()

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -173,6 +173,7 @@ ts_library(
     name = "spyglass_lens",
     srcs = ["spyglass/lens.ts"],
     deps = [
+        ":common",
         ":spyglass_common",
     ],
 )

--- a/prow/cmd/deck/static/spyglass/common.ts
+++ b/prow/cmd/deck/static/spyglass/common.ts
@@ -59,3 +59,7 @@ export function isTransitMessage(data: any): data is TransitMessage {
 export function isUpdateHashMessage(data: any): data is UpdateHash {
   return isBaseMessage(data) && data.type === 'updateHash';
 }
+
+export function serialiseHashes(hashes: {[index: string]: string}): string {
+  return Object.keys(hashes).map((i) => `${i}:${escape(hashes[i].substr(1))}`).join(';');
+}

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,4 +1,4 @@
-import { isTransitMessage } from "./common";
+import {isTransitMessage, serialiseHashes} from "./common";
 
 declare const src: string;
 declare const lensArtifacts: {[index: string]: string[]};
@@ -10,6 +10,7 @@ function loadLenses(): void {
   for (const lensIndex of lensIndexes) {
     const frame = document.querySelector<HTMLIFrameElement>(`#iframe-${lensIndex}`)!;
     let url = urlForLensRequest(frame.dataset.lensName!, Number(frame.dataset.lensIndex!), 'iframe');
+    url += `&topURL=${escape(location.href.split('#')[0])}&lensIndex=${lensIndex}`;
     const hash = hashes[lensIndex];
     if (hash) {
       url += hash;
@@ -61,10 +62,6 @@ function parseHash(): {[index: string]: string} {
     result[index] = '#' + unescape(hash);
   }
   return result;
-}
-
-function serialiseHashes(hashes: {[index: string]: string}): string {
-  return Object.keys(hashes).map((i) => `${i}:${escape(hashes[i].substr(1))}`).join(';');
 }
 
 window.addEventListener('message', async (e) => {


### PR DESCRIPTION
Add the new lens API `spyglass.makeFragmentLink()`. This enables a lens to generate a fragment link that can be directly copy/pasted or similar to get back a link that will return the specified fragment to the lens when that link is loaded.

This is not necessary and should not be used when using fragments internally, but is useful when inviting a user to copy/paste a link.

The link is passed via query parameters because it needs to be immediately available synchronously and the only other avenue (the URL fragment) belongs to the lens code and is not available for our use.

This PR depends on #13411 and is a prerequisite for #12766 (or, at least, for making it so you can right click -> copy link and have something sane happen). 

/cc @michelle192837 