### PR TITLE
Deck fixes

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -704,7 +704,7 @@ function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob:
 function createViewJobCell(prowjob: string): HTMLTableDataCellElement {
     const c = document.createElement("td");
     const i = icon.create("pageview", "Show job YAML", () => gtag("event", "view_job_yaml", {event_category: "engagement", transport_type: "beacon"}));
-    i.href = `https://${window.location.hostname}/prowjob?prowjob=${prowjob}`;
+    i.href = `/prowjob?prowjob=${prowjob}`;
     c.classList.add("icon-cell");
     c.appendChild(i);
     return c;

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -13,6 +13,11 @@
 
     gtag('config', {{googleAnalytics}});
   </script>
+  {{else}}
+  <!-- Use noop gtag function if analytics are not enabled. -->
+  <script>
+    function gtag() {}
+  </script>
   {{end}}
   {{if .MobileFriendly}}
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Includes 3 small fixes separated by commit:
- Prevent ProwJob YAML button from assuming https.
- Handle `/rerun` even if GH oauth is not configured.
  - Also allows GH oauth to be omitted when direct rerun is enabled if
`allow_anyone: true` is specified.
- Use noop `gtag` function if analytics are not enabled.

/assign @Katharine @clarketm @mirandachrist 
cc @amwat 
/kind bug
/joke