### PR TITLE
allow gke support release channels

### DIFF
--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -133,6 +133,16 @@ func TestExtractStrategies(t *testing.T) {
 			"v1.2.3+abcde",
 		},
 		{
+			"ci/gke-latest-1.13",
+			"https://storage.googleapis.com/kubernetes-release-gke/release",
+			"v1.2.3+abcde",
+		},
+		{
+			"ci/gke-channel-rapid",
+			"https://storage.googleapis.com/kubernetes-release-gke/release",
+			"v1.2.3+abcde",
+		},
+		{
 			"gs://whatever-bucket/ci/latest.txt",
 			"https://storage.googleapis.com/whatever-bucket/ci",
 			"v1.2.3+abcde",

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -52,6 +52,7 @@ var (
 	gkeCommandGroup                = flag.String("gke-command-group", "", "(gke only) Use a different gcloud track (e.g. 'alpha') for all 'gcloud container' commands. Note: This is added to --gke-create-command on create. You should only use --gke-command-group if you need to change the gcloud track for *every* gcloud container command.")
 	gkeCreateCommand               = flag.String("gke-create-command", defaultCreate, "(gke only) gcloud subcommand used to create a cluster. Modify if you need to pass arbitrary arguments to create.")
 	gkeCustomSubnet                = flag.String("gke-custom-subnet", "", "(gke only) if specified, we create a custom subnet with the specified options and use it for the gke cluster. The format should be '<subnet-name> --region=<subnet-gcp-region> --range=<subnet-cidr> <any other optional params>'.")
+	gkeReleaseChannel              = flag.String("gke-release-channel", "", "(gke only) if specified, bring up GKE clusters from that release channel.")
 	gkeSingleZoneNodeInstanceGroup = flag.Bool("gke-single-zone-node-instance-group", true, "(gke only) Add instance groups from a single zone to the NODE_INSTANCE_GROUP env variable.")
 
 	// poolRe matches instance group URLs of the form `https://www.googleapis.com/compute/v1/projects/some-project/zones/a-zone/instanceGroupManagers/gke-some-cluster-some-pool-90fcb815-grp`. Match meaning:
@@ -330,11 +331,17 @@ func (g *gkeDeployer) Up() error {
 			}
 		}
 	}
-	// TODO(zmerlynn): The version should be plumbed through Extract
-	// or a separate flag rather than magic env variables.
-	if v := os.Getenv("CLUSTER_API_VERSION"); v != "" {
-		args = append(args, "--cluster-version="+v)
+
+	if *gkeReleaseChannel != "" {
+		args = append(args, "--release-channel="+*gkeReleaseChannel)
+	} else {
+		// TODO(zmerlynn): The version should be plumbed through Extract
+		// or a separate flag rather than magic env variables.
+		if v := os.Getenv("CLUSTER_API_VERSION"); v != "" {
+			args = append(args, "--cluster-version="+v)
+		}
 	}
+
 	args = append(args, g.cluster)
 	if err := control.FinishRunning(exec.Command("gcloud", args...)); err != nil {
 		return fmt.Errorf("error creating cluster: %v", err)

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -334,6 +334,9 @@ func (g *gkeDeployer) Up() error {
 
 	if *gkeReleaseChannel != "" {
 		args = append(args, "--release-channel="+*gkeReleaseChannel)
+		if strings.EqualFold(*gkeReleaseChannel, "rapid") {
+			args = append(args, "--enable-autorepair")
+		}
 	} else {
 		// TODO(zmerlynn): The version should be plumbed through Extract
 		// or a separate flag rather than magic env variables.


### PR DESCRIPTION
I think this is good enough for now, we can `--extract=ci/latest-1.14` and `--gke-release-channel=rapid`

/assign @yujuhong @sebastienvas @RonWeber @losipiuk 