### PR TITLE
Add support for linking to log lines in spyglass

### DIFF
--- a/prow/cmd/deck/static/spyglass/common.ts
+++ b/prow/cmd/deck/static/spyglass/common.ts
@@ -34,6 +34,7 @@ export interface UpdateHash extends BaseMessage {
 export interface ShowOffset extends BaseMessage {
   type: 'showOffset';
   top: number;
+  left: number;
 }
 
 export interface Response extends BaseMessage {

--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -41,6 +41,14 @@ export interface Spyglass {
    *                 be assumed.
    */
   makeFragmentLink(fragment: string): string;
+
+  /**
+   * Scrolls the parent window so that the specified coordinates are visible.
+   *
+   * @param x The x coordinate relative to the lens document to scroll to.
+   * @param y The y coordinate relative to the lens document to scroll to.
+   */
+  scrollTo(x: number, y: number): Promise<void>;
 }
 
 class SpyglassImpl implements Spyglass {
@@ -98,6 +106,10 @@ class SpyglassImpl implements Spyglass {
       fragment = '#' + fragment;
     }
     return `${topURL}#${serialiseHashes({[lensIndex]: fragment})}`;
+  }
+
+  public async scrollTo(x: number, y: number): Promise<void> {
+    await this.postMessage({type: 'showOffset', left: x, top: y});
   }
 
   private updateHeight(): void {
@@ -174,7 +186,7 @@ class SpyglassImpl implements Spyglass {
       }
     }
     const top = el.getBoundingClientRect().top + window.pageYOffset;
-    this.postMessage({type: 'showOffset', top}).then();
+    this.scrollTo(0, top).then();
   }
 
   // We need to fix up anchor links (i.e. links that only set the fragment)

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -114,12 +114,13 @@ window.addEventListener('message', async (e) => {
       }
       case "showOffset": {
         const container = document.getElementsByTagName('main')[0]!;
-        let containerOffset = 0;
+        const containerOffset = {left: 0, top: 0};
         let parent: HTMLElement = frame;
         // figure out our cumulative offset from the root container <main> by
         // looping through our parents until we get to it or run out of parents.
         while (parent) {
-          containerOffset += parent.offsetTop;
+          containerOffset.top += parent.offsetTop;
+          containerOffset.left += parent.offsetLeft;
           if (parent.offsetParent instanceof HTMLElement && parent.offsetParent !== container) {
             parent = parent.offsetParent;
           } else {
@@ -129,7 +130,8 @@ window.addEventListener('message', async (e) => {
         if (!parent) {
           console.error("Couldn't find parent for frame!", container, frame);
         }
-        container.scrollTop = containerOffset + message.top;
+        container.scrollTop = containerOffset.top + message.top;
+        container.scrollLeft = containerOffset.left + message.left;
         break;
       }
       default:

--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -39,7 +39,7 @@ html {
     user-select: none;
     -moz-user-select: none; /* for Firefox pre-69 */
     -webkit-user-select: none; /* for Safari, Opera, and Edge (pre-Blink) */
-    color: rgba(255,255,2552,0.6);
+    color: rgba(255,255,255,0.6);
     text-align: right;
     vertical-align: top;
     width: 50px;
@@ -47,10 +47,23 @@ html {
     position: absolute;
 }
 
+.linenum a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.linenum a:hover {
+    color: rgba(255,255,255,0.4);
+}
+
 .linetext {
     width: calc(100% - 55px);
     margin-left: 55px;
     min-height: 20px;
+}
+
+.highlighted-line {
+    background-color: #555;
 }
 
 /* ansi colors from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors */

--- a/prow/spyglass/lenses/buildlog/buildlog.ts
+++ b/prow/spyglass/lenses/buildlog/buildlog.ts
@@ -46,16 +46,13 @@ function ansiToHTML(orig: string): string {
   });
 }
 
-async function handleShowSkipped(this: HTMLDivElement, e: MouseEvent) {
-  // Don't do anything unless they actually clicked the button.
-  if (!(e.target instanceof HTMLButtonElement)) {
-    return;
-  }
-  const {artifact, offset, length, startLine} = this.dataset;
+async function replaceElementWithContent(element: HTMLDivElement) {
+  const {artifact, offset, length, startLine} = element.dataset;
   const content = await spyglass.request(JSON.stringify({
     artifact, length: +length!, offset: +offset!, startLine: +startLine!}));
-  this.innerHTML = ansiToHTML(content);
-  showElem(this);
+  element.innerHTML = ansiToHTML(content);
+  fixLinks(element);
+  showElem(element);
 
   // Remove the "show all" button if we no longer need it.
   const log = document.getElementById(`${artifact}-content`)!;
@@ -65,6 +62,14 @@ async function handleShowSkipped(this: HTMLDivElement, e: MouseEvent) {
     button.parentNode!.removeChild(button);
   }
   spyglass.contentUpdated();
+}
+
+async function handleShowSkipped(this: HTMLDivElement, e: MouseEvent): Promise<void> {
+  // Don't do anything unless they actually clicked the button.
+  if (!(e.target instanceof HTMLButtonElement)) {
+    return;
+  }
+  await replaceElementWithContent(this);
 }
 
 async function handleShowAll(this: HTMLButtonElement) {
@@ -79,6 +84,73 @@ async function handleShowAll(this: HTMLButtonElement) {
   spyglass.contentUpdated();
 }
 
+function handleLineLink(e: MouseEvent): void {
+  if (!e.target) {
+    return;
+  }
+  const el = e.target as HTMLElement;
+  if (!el.dataset.lineNumber) {
+    return;
+  }
+  location.hash = `#${el.dataset.artifact}:${el.dataset.lineNumber}`;
+  e.preventDefault();
+}
+
+function highlightLine(element: HTMLElement): void {
+  for (const oldEl of Array.from(document.querySelectorAll('.highlighted-line'))) {
+    oldEl.classList.remove('highlighted-line');
+  }
+  element.classList.add('highlighted-line');
+}
+
+function fixLinks(parent: HTMLElement): void {
+  const links = parent.querySelectorAll<HTMLAnchorElement>('a[data-artifact][data-line-number]');
+  for (const link of Array.from(links)) {
+    link.href = spyglass.makeFragmentLink(`${link.dataset.artifact}:${link.dataset.lineNumber}`);
+  }
+}
+
+async function loadLine(artifact: string, line: number): Promise<boolean> {
+  const showers = document.querySelectorAll<HTMLDivElement>(`.show-skipped[data-artifact="${artifact}"]`);
+  for (const shower of Array.from(showers)) {
+    if (line >= Number(shower.dataset.startLine) && line < Number(shower.dataset.endLine)) {
+      await replaceElementWithContent(shower);
+      return true;
+    }
+  }
+  return false;
+}
+
+async function handleHash(): Promise<void> {
+  const hash = location.hash.substr(1);
+  const colonPos = hash.lastIndexOf(':');
+  if (colonPos === -1) {
+    return;
+  }
+  const artifact = hash.substring(0, colonPos);
+  const lineNum = Number(hash.substring(colonPos + 1));
+  if (isNaN(lineNum)) {
+    return;
+  }
+  const lineId = `${artifact}:${lineNum}`;
+  let lineEl = document.getElementById(lineId);
+  if (!lineEl) {
+    if (await loadLine(artifact, lineNum)) {
+      lineEl = document.getElementById(lineId);
+      if (!lineEl) {
+        return;
+      }
+    } else {
+      return;
+    }
+  }
+  const top = lineEl.getBoundingClientRect().top + window.pageYOffset;
+  highlightLine(lineEl);
+  spyglass.scrollTo(0, top).then();
+}
+
+window.addEventListener('hashchange', () => handleHash());
+
 window.addEventListener('load', () => {
   const shown = document.getElementsByClassName("shown");
   for (const child of Array.from(shown)) {
@@ -92,4 +164,11 @@ window.addEventListener('load', () => {
   for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>("button.show-all-button"))) {
     button.addEventListener('click', handleShowAll);
   }
+
+  for (const container of Array.from(document.querySelectorAll<HTMLElement>('.loglines'))) {
+    container.addEventListener('click', handleLineLink, {capture: true});
+  }
+  fixLinks(document.documentElement);
+
+  handleHash();
 });

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -172,7 +172,7 @@ func TestGroupLines(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := groupLines(highlightLines(test.lines, 0, defaultErrRE))
+			got := groupLines(highlightLines(test.lines, 0, "", defaultErrRE))
 			if len(got) != len(test.groups) {
 				t.Fatalf("Expected %d groups, got %d", len(test.groups), len(got))
 			}

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -11,7 +11,7 @@
     <div class="loglines" id="{{$log.ArtifactName}}-content" style="font-family: monospace; margin-top: 15px;">
       {{range $g := $log.LineGroups}}
         {{if $g.Skip}}
-          <div class="show-skipped" data-artifact="{{$log.ArtifactName}}" data-offset="{{$g.ByteOffset}}" data-length="{{$g.ByteLength}}" data-start-line="{{$g.Start}}">
+          <div class="show-skipped" data-artifact="{{$log.ArtifactName}}" data-offset="{{$g.ByteOffset}}" data-length="{{$g.ByteLength}}" data-start-line="{{$g.Start}}" data-end-line="{{$g.End}}">
             <div>
               <div class="linenum"></div>
               <div class="linetext"><button> skipped {{$g.LinesSkipped}} lines <i class="material-icons" style="font-size: 1em; vertical-align: middle;">unfold_more</i></button></div>
@@ -31,8 +31,8 @@
 
 {{define "line group"}}
   {{range .}}
-    <div>
-      <div class="linenum">{{.Number}}</div>
+    <div id="{{.ArtifactName}}:{{.Number}}">
+      <div class="linenum"><a href="#{{.ArtifactName}}:{{.Number}}" data-artifact="{{.ArtifactName}}" data-line-number="{{.Number}}">{{.Number}}</a></div>
       <div class="linetext">
         <span {{if .Highlighted}}class="line-highlighted"{{end}}>
           {{- range .SubLines -}}<span {{if .Highlighted}}class="match-highlighted"{{end}}>{{.Text}}</span>{{- end -}}


### PR DESCRIPTION
This PR adds support for linking to log lines in spyglass, with the following behaviour:

* The line numbers are links to the appropriate line. You can click and copy from the address bar or right click -> copy link
* When a line number is linked to (or clicked on), that line is highlighted
* If the line that is linked to is hidden behind a fold, the relevant section is unfolded and the line then jumped to.

Almost all of the complexity here comes from that last bullet.

The first commit makes `spyglass.scrollTo` (which was previously only available internally) available to lenses. The second implements log line linking.

Fixes #12766.

/cc @michelle192837 