### PR TITLE
Enable blockade plugin for k/release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -496,6 +496,7 @@ plugins:
   - override
 
   kubernetes/release:
+  - blockade
   - milestone
   - override
 


### PR DESCRIPTION
Configured in https://github.com/kubernetes/test-infra/pull/13328, but we forgot to enable it. :neutral_face: 

/assign @justaugustus @cblecker 