### PR TITLE
fix-kubeadm-kinder-1-13-on-1-12

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-1.13
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"


### PR DESCRIPTION
This PR tries to fìx errors on the kubeadm-kinder-1-13-on-1-12 by switching to the same kubekins image that we are currently using in [kubeadm-kinder-upgrade-1-12-1-13](https://github.com/kubernetes/test-infra/blob/f62c9248fe8d5af81e10a31e8a3865aa562663a0/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml#L151) job

/assign @neolit123 
