### PR TITLE
Use MIME-type text/yaml for yaml

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1178,7 +1178,7 @@ func marshalJob(w http.ResponseWriter, pj prowapi.ProwJob, l *logrus.Entry) {
 		l.WithError(err).Error("Error marshaling job.")
 		return
 	}
-	w.Header().Set("Content-Type", "application/x-yaml")
+	w.Header().Set("Content-Type", "text/plain")
 	if _, err := w.Write(b); err != nil {
 		l.WithError(err).Error("Error writing log.")
 	}
@@ -1269,7 +1269,7 @@ func handleConfig(cfg config.Getter) http.HandlerFunc {
 			http.Error(w, "Failed to marhshal config.", http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/x-yaml")
+		w.Header().Set("Content-Type", "text/plain")
 		buff := bytes.NewBuffer(b)
 		_, err = buff.WriteTo(w)
 		if err != nil {

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -972,8 +972,8 @@ func TestHandleConfig(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("Bad error code: %d", rr.Code)
 	}
-	if h := rr.Header().Get("Content-Type"); h != "application/x-yaml" {
-		t.Fatalf("Bad Content-Type, expected: 'application/x-yaml', got: %v", h)
+	if h := rr.Header().Get("Content-Type"); h != "text/plain" {
+		t.Fatalf("Bad Content-Type, expected: 'text/plain', got: %v", h)
 	}
 	resp := rr.Result()
 	defer resp.Body.Close()


### PR DESCRIPTION
`application/x-yaml`, while arguably more correct, does not display in browsers. use `text/plain` instead, which does.

`text/yaml` works in Chrome, but not Firefox :(