### PR TITLE
Update CI jobs for 1.15 and only have alpha jobs for 1.15 and master

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -171,7 +171,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -218,78 +218,6 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-13-on-kubernetes-1-13
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.13.3"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.13"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-14-on-kubernetes-1-14
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.14.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.14"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-15-on-kubernetes-1-15
     always_run: false
     optional: true
@@ -315,7 +243,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -326,6 +254,42 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-15-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
     always_run: true
     decorate: true
@@ -427,6 +391,46 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.14"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.13"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-13-on-kubernetes-1-15
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: 1.13-on-1.15
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.15 and 1.13 sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.15"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
@@ -560,6 +564,46 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
+  name: ci-kubernetes-csi-1-14-on-kubernetes-1-15
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: 1.14-on-1.15
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.15 and 1.14 sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.15"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.14"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
   name: ci-kubernetes-csi-1-14-on-kubernetes-master
   decorate: true
   extra_refs:
@@ -600,7 +644,7 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-alpha-1-13-on-kubernetes-1-13
+  name: ci-kubernetes-csi-1-15-on-kubernetes-1-13
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -613,9 +657,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi
-    testgrid-tab-name: alpha-1.13-on-1.13
+    testgrid-tab-name: 1.15-on-1.13
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: Kubernetes-CSI alpha tests with Kubernetes 1.13 and 1.13 sidecars
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.13 and 1.15 sidecars
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -630,9 +674,9 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.13"
+        value: "kubernetes-1.15"
       - name: CSI_PROW_TESTS
-        value: "serial-alpha parallel-alpha"
+        value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -640,7 +684,7 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-alpha-1-14-on-kubernetes-1-14
+  name: ci-kubernetes-csi-1-15-on-kubernetes-1-14
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -653,9 +697,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi
-    testgrid-tab-name: alpha-1.14-on-1.14
+    testgrid-tab-name: 1.15-on-1.14
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: Kubernetes-CSI alpha tests with Kubernetes 1.14 and 1.14 sidecars
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.14 and 1.15 sidecars
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -670,7 +714,127 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.14"
+        value: "kubernetes-1.15"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-15-on-kubernetes-1-15
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: 1.15-on-1.15
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.15 and 1.15 sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.15"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.15"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-15-on-kubernetes-master
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: 1.15-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes master and 1.15 sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.15"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-alpha-1-15-on-kubernetes-1-15
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: alpha-1.15-on-1.15
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI alpha tests with Kubernetes 1.15 and 1.15 sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.15"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.15"
       - name: CSI_PROW_TESTS
         value: "serial-alpha parallel-alpha"
       # docker-in-docker needs privileged mode
@@ -753,6 +917,52 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.14.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-canary-on-kubernetes-1-15
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi
+    testgrid-tab-name: canary-on-1.15
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: Kubernetes-CSI non-alpha tests with Kubernetes 1.15 and canary sidecars
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.15"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       # Replace images....

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -171,7 +171,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -218,78 +218,6 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-attacher-alpha-1-13-on-kubernetes-1-13
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.13.3"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.13"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-attacher-alpha-1-14-on-kubernetes-1-14
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|saad-ali-patch-3|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.14.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.14"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-alpha-1-15-on-kubernetes-1-15
     always_run: false
     optional: true
@@ -315,7 +243,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -326,6 +254,42 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-external-attacher-alpha-1-15-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -171,7 +171,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -218,78 +218,6 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-provisioner-alpha-1-13-on-kubernetes-1-13
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.13.3"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.13"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-provisioner-alpha-1-14-on-kubernetes-1-14
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(lpabon-patch-1|release-0.2.0|release-0.3.0|release-0.4|release-1.0|saad-ali-patch-1|saad-ali-patch-2|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.14.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.14"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-15-on-kubernetes-1-15
     always_run: false
     optional: true
@@ -315,7 +243,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -326,6 +254,42 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-external-provisioner-alpha-1-15-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -21,6 +21,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel"
         # docker-in-docker needs privileged mode
@@ -48,6 +50,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "unit"
         # docker-in-docker needs privileged mode
@@ -75,6 +79,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -21,6 +21,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel"
         # docker-in-docker needs privileged mode
@@ -48,6 +50,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "unit"
         # docker-in-docker needs privileged mode
@@ -75,6 +79,8 @@ presubmits:
         args:
         - ./.prow.sh
         env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.15.0"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -171,7 +171,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -218,78 +218,6 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-13-on-kubernetes-1-13
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.13.3"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.13"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-14-on-kubernetes-1-14
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.14.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.14"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-15-on-kubernetes-1-15
     always_run: false
     optional: true
@@ -315,7 +243,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.15"
+          value: "1.15.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.15"
         - name: CSI_PROW_TESTS
@@ -326,6 +254,42 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-15-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190703-1f4d616-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-unit
     always_run: true
     decorate: true


### PR DESCRIPTION
This should allow us to update prow in external-snapshotter