### PR TITLE
Removal of kube-storage-version-migrator from blacklist

### DIFF
--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -60,7 +60,7 @@ var (
 	// gcs prefixes populated by the kubernetes prow instance
 	prowGcsPrefixes = []string{
 		"kubernetes-jenkins/logs/",
-		"kubernetes-jenkins/pr-logs/directory/",
+		"kubernetes-jenkins/pr-logs/",
 	}
 )
 
@@ -371,7 +371,6 @@ var noPresubmitsInTestgridPrefixes = []string{
 	"kubernetes-sigs/gcp-compute-persistent-disk-csi-driver",
 	"kubernetes-sigs/gcp-filestore-csi-driver",
 	"kubernetes-sigs/kind",
-	"kubernetes-sigs/kube-storage-version-migrator",
 	"kubernetes-sigs/kubebuilder-declarative-pattern",
 	"kubernetes-sigs/service-catalog",
 	"kubernetes-sigs/sig-storage-local-static-provisioner",


### PR DESCRIPTION
TestGrid Jobs appear to have been added for [kube-storage-version-migrator](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kube-storage-version-migrator)

However, since their gcs_prefix is `kubernetes-jenkins/pr-logs/<job-name>`, in [config.yaml](https://github.com/kubernetes/test-infra/blob/3ce030d42897b8957c273eb93c17a66d8c72862c/testgrid/config.yaml#L1868-L1876), both the TestGrid test group AND the Prow Job were blacklisted, leading to no checking being done.

I'm not certain if the gcs_prefix in config.yaml is incorrect, or the prowGcsPrefixes the test code is looking for. I assumed the latter, since I think kubernetes-jenkins/* is still a bucket under kubernetes-prow control.