### PR TITLE
Clean up pods whose ProwJob is in aborted state

### DIFF
--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -207,6 +207,19 @@ func TestClean(t *testing.T) {
 				StartTime: startTime(time.Now().Add(-maxPodAge).Add(-time.Second)),
 			},
 		},
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prowjob-aborted",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw: "true",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodRunning,
+				StartTime: startTime(time.Now().Add(-10 * time.Second)),
+			},
+		},
 	}
 	deletedPods := sets.NewString(
 		"new-running-no-pj",
@@ -214,6 +227,7 @@ func TestClean(t *testing.T) {
 		"old-succeeded",
 		"old-pending-abort",
 		"old-running",
+		"prowjob-aborted",
 	)
 	setComplete := func(d time.Duration) *metav1.Time {
 		completed := metav1.NewTime(time.Now().Add(d))
@@ -355,6 +369,16 @@ func TestClean(t *testing.T) {
 			Status: prowv1.ProwJobStatus{
 				StartTime:      metav1.NewTime(time.Now().Add(-maxProwJobAge).Add(-time.Second)),
 				CompletionTime: setComplete(-time.Second),
+			},
+		},
+		&prowv1.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prowjob-aborted",
+				Namespace: "ns",
+			},
+			Status: prowv1.ProwJobStatus{
+				State:     prowv1.AbortedState,
+				StartTime: metav1.NewTime(time.Now().Add(-time.Second)),
 			},
 		},
 	}


### PR DESCRIPTION
We do not care about the result anymore, so free the resources the Pod
is occupying.

On a semi-related note, I find it a bit confusing that logic related to kubernetes-type Prowjobs is partly in sinker and partly in Plank. IMHO it would be much more logical to reduce sinker to only clean up old ProwJobs and do everything related to kubernetes-type Prowjobs in Plank.

On another semi-related note: The cost we are paying in terms of
* De-/Serialization by having multiple cron-like binaries that re-list everything regularly
* Code complexity by having to resync everything in one func

is huge. 