### PR TITLE
Allow defining jobs as hidden

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -165,6 +165,13 @@ type ProwJobSpec struct {
 
 	// RerunAuthConfig holds information about which users can rerun the job
 	RerunAuthConfig RerunAuthConfig `json:"rerun_auth_config,omitempty"`
+
+	// Hidden specifies if the Job is considered hidden.
+	// Hidden jobs are only shown by deck instances that have the
+	// `--hiddenOnly=true` or `--show-hidden=true` flag set.
+	// Presubmits and Postsubmits can also be set to hidden by
+	// adding their repository in Decks `hidden_repo` setting.
+	Hidden bool `json:"hidden,omitempty"`
 }
 
 type GitHubTeamSlug struct {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -421,17 +421,15 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 
 	var filtered []prowapi.ProwJob
 	for _, item := range prowJobList.Items {
-		if item.Spec.Refs == nil && len(item.Spec.ExtraRefs) == 0 {
-			// periodic jobs with no refs cannot be filtered
-			filtered = append(filtered, item)
-			continue
-		}
-
 		refs := item.Spec.Refs
 		if refs == nil {
-			refs = &item.Spec.ExtraRefs[0]
+			if len(item.Spec.ExtraRefs) > 0 {
+				refs = &item.Spec.ExtraRefs[0]
+			} else {
+				refs = &prowapi.Refs{}
+			}
 		}
-		shouldHide := c.hiddenRepos.HasAny(fmt.Sprintf("%s/%s", refs.Org, refs.Repo), refs.Org)
+		shouldHide := c.hiddenRepos.HasAny(fmt.Sprintf("%s/%s", refs.Org, refs.Repo), refs.Org) || item.Spec.Hidden
 		if shouldHide && c.showHidden {
 			filtered = append(filtered, item)
 		} else if shouldHide == c.hiddenOnly {

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -826,6 +826,21 @@ func TestListProwJobs(t *testing.T) {
 			expected:    sets.NewString("first", "second"),
 			showHidden:  true,
 		},
+		{
+			name: "setting pj.Spec.Hidden hides it",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden"
+					in.Spec.Hidden = true
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "shown"
+					return in
+				},
+			},
+			expected: sets.NewString("shown"),
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -113,6 +113,11 @@ type JobBase struct {
 	ReporterConfig *prowapi.ReporterConfig `json:"reporter_config,omitempty"`
 	// RerunAuthConfig specifies who can rerun the job
 	RerunAuthConfig *prowapi.RerunAuthConfig `json:"rerun_auth_config,omitempty"`
+	// Hidden defines if the job is hidden. If set to `true`, only Deck instances
+	// that have the flag `--hiddenOnly=true or `--show-hidden=true` set will show it.
+	// Presubmits and Postsubmits can also be set to hidden by
+	// adding their repository in Decks `hidden_repo` setting.
+	Hidden bool `json:"hidden,omitempty"`
 
 	UtilityConfig
 }

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -177,6 +177,7 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 
 		ReporterConfig:  jb.ReporterConfig,
 		RerunAuthConfig: rerunAuthConfig,
+		Hidden:          jb.Hidden,
 	}
 }
 

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -799,6 +799,18 @@ func TestSpecFromJobBase(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "Verify hidden property gets copied",
+			jobBase: config.JobBase{
+				Hidden: true,
+			},
+			verify: func(pj prowapi.ProwJobSpec) error {
+				if !pj.Hidden {
+					return errors.New("hidden property didnt get copied")
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Periodics may have no repository association at all. Having to add a
repository that is set to `hidden` to them just to hide them in a public
Deck instance is unintuitive.

/assign @Katharine 