### PR TITLE
Ghproxy request metrics for token usage and token requests

### DIFF
--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -53,6 +53,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//ghproxy/ghcache:all-srcs",
+        "//ghproxy/ghmetrics:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/test-infra/ghproxy/ghcache",
     visibility = ["//visibility:public"],
     deps = [
+        "//ghproxy/ghmetrics:go_default_library",
         "//vendor/github.com/gomodule/redigo/redis:go_default_library",
         "//vendor/github.com/gregjones/httpcache:go_default_library",
         "//vendor/github.com/gregjones/httpcache/diskcache:go_default_library",

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -27,9 +27,11 @@ package ghcache
 
 import (
 	"context"
+	"crypto/sha256"
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/gregjones/httpcache"
@@ -39,6 +41,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
+	"k8s.io/test-infra/ghproxy/ghmetrics"
 )
 
 type CacheResponseMode string
@@ -154,12 +157,24 @@ type upstreamTransport struct {
 
 func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	etag := req.Header.Get("if-none-match")
+
+	// get authorization header to convert to sha256
+	authHeader := req.Header.Get("Authorization")
+	hasher := sha256.New()
+	hasher.Write([]byte(authHeader))
+	authHeaderHash := string(hasher.Sum(nil))
+	if authHeader == "" {
+		logrus.Warnf("Couldn't retrieve 'Authorization' header, %s is the hash of an empty string", authHeaderHash)
+	}
+
+	reqStartTime := time.Now()
 	// Don't modify request, just pass to delegate.
 	resp, err := u.delegate.RoundTrip(req)
 	if err != nil {
 		logrus.WithField("cache-key", req.URL.String()).WithError(err).Error("Error from upstream (GitHub).")
 		return nil, err
 	}
+	responseTime := time.Now()
 
 	if resp.StatusCode >= 400 {
 		// Don't store errors. They can't be revalidated to save API tokens.
@@ -170,6 +185,14 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if etag != "" {
 		resp.Header.Set("X-Conditional-Request", etag)
 	}
+
+	apiVersion := "v3"
+	if strings.HasPrefix(req.URL.Path, "search") || strings.HasPrefix(req.URL.Path, "/search") {
+		apiVersion = "v4"
+	}
+
+	ghmetrics.CollectGitHubTokenMetrics(authHeaderHash, apiVersion, resp.Header, reqStartTime, responseTime)
+
 	return resp, nil
 }
 

--- a/ghproxy/ghmetrics/BUILD.bazel
+++ b/ghproxy/ghmetrics/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ghmetrics.go"],
+    importpath = "k8s.io/test-infra/ghproxy/ghmetrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghmetrics
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// ghTokenUntilResetGaugeVec provides the 'github_token_reset' gauge that
+// enables keeping track of GitHub reset times.
+var ghTokenUntilResetGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "github_token_reset",
+		Help: "Last reported GitHub token reset time.",
+	},
+	[]string{"token_hash", "api_version"},
+)
+
+// ghTokenUsageGaugeVec provides the 'github_token_usage' gauge that
+// enables keeping track of GitHub calls and quotas.
+var ghTokenUsageGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "github_token_usage",
+		Help: "How many GitHub token requets are remaining for the current hour.",
+	},
+	[]string{"token_hash", "api_version"},
+)
+
+var muxTokenUsage, muxRequestMetrics sync.Mutex
+var lastGitHubResponse time.Time
+
+func init() {
+	prometheus.MustRegister(ghTokenUntilResetGaugeVec)
+	prometheus.MustRegister(ghTokenUsageGaugeVec)
+}
+
+// CollectGitHubTokenMetrics publishes the rate limits of the github api to
+// `github_token_usage` as well as `github_token_reset` on prometheus.
+func CollectGitHubTokenMetrics(tokenHash, apiVersion string, headers http.Header, reqStartTime, responseTime time.Time) {
+	remaining := headers.Get("X-RateLimit-Remaining")
+	timeUntilReset := timestampStringToTime(headers.Get("X-RateLimit-Reset"))
+	durationUntilReset := timeUntilReset.Sub(reqStartTime)
+
+	remainingFloat, err := strconv.ParseFloat(remaining, 64)
+	if err != nil {
+		logrus.WithError(err).Infof("Couldn't convert number of remaining token requests into gauge value (float)")
+	}
+
+	muxTokenUsage.Lock()
+	isAfter := lastGitHubResponse.After(responseTime)
+	if !isAfter {
+		lastGitHubResponse = responseTime
+	}
+	muxTokenUsage.Unlock()
+	if isAfter {
+		logrus.WithField("last-github-response", lastGitHubResponse).WithField("response-time", responseTime).Debug("Previously pushed metrics of a newer response, skipping old metrics")
+	} else {
+		ghTokenUntilResetGaugeVec.With(prometheus.Labels{"token_hash": tokenHash, "api_version": apiVersion}).Set(float64(durationUntilReset.Nanoseconds()))
+		ghTokenUsageGaugeVec.With(prometheus.Labels{"token_hash": tokenHash, "api_version": apiVersion}).Set(remainingFloat)
+	}
+}
+
+// timestampStringToTime takes a unix timestamp and returns a `time.Time`
+// from the given time.
+func timestampStringToTime(tstamp string) time.Time {
+	timestamp, err := strconv.ParseInt(tstamp, 10, 64)
+	if err != nil {
+		logrus.WithField("timestamp", tstamp).Info("Couldn't convert unix timestamp")
+	}
+	return time.Unix(timestamp, 0)
+}

--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	clientset "k8s.io/test-infra/prow/client/clientset/versioned"
 	pjinformers "k8s.io/test-infra/prow/client/informers/externalversions/prowjobs/v1"
 )


### PR DESCRIPTION
As proposed by @stevekuznetsov in [PR #13182](https://github.com/kubernetes/test-infra/pull/13182) I've removed the path metrics on this branch, so we can work on the path logic a bit more but already start tracking token usage.