### PR TITLE
Removing unneeded flags

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -283,14 +283,12 @@ presubmits:
       containers:
       - args:
         - --root=/go/src
-        - --repo=k8s.io/kubernetes=master
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=120
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100
@@ -338,7 +336,6 @@ presubmits:
       containers:
         - args:
             - --root=/go/src
-            - --repo=k8s.io/kubernetes=master
             - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
             - --repo=k8s.io/release
             - --service-account=/etc/service-account/service-account.json
@@ -346,7 +343,6 @@ presubmits:
             - --timeout=120
             - --scenario=kubernetes_e2e
             - --
-            - --build=bazel
             - --cluster=
             - --extract=ci/latest
             - --gcp-master-size=n1-standard-4


### PR DESCRIPTION
Removing `build` and `repo=k8s.io/kubernetes` flags which should be unneeded when we extract specific k8s image.

ref #13460