### PR TITLE
decorate: Configure workDir for container from refs.

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -546,6 +546,12 @@ type Refs struct {
 	// set, <root-dir>/src/github.com/org/repo will be
 	// used as the default.
 	PathAlias string `json:"path_alias,omitempty"`
+
+	// WorkDir defines if the location of the cloned
+	// repository will be used as the default working
+	// directory.
+	WorkDir bool `json:"workdir,omitempty"`
+
 	// CloneURI is the URI that is used to clone the
 	// repository. If unset, will default to
 	// `https://github.com/org/repo.git`.

--- a/prow/pod-utilities.md
+++ b/prow/pod-utilities.md
@@ -80,7 +80,7 @@ Additional fields may be required for some use cases:
 - Repos requiring a non-standard clone path can use the `path_alias` field
 to clone the repo to different go import path than the default of `/home/prow/go/src/github.com/{{.Org}}/{{.Repo}}/` (e.g. `path_alias: k8s.io/test-infra` -> `/home/prow/go/src/k8s.io/test-infra`).
 - Jobs that require additional repos to be checked out can arrange for that with
-the `exta_refs` field.
+the `exta_refs` field. If the cloned path of this repo must be used as a default working dir the `workdir: true` must be specified.
 - Jobs that do not want submodules to be cloned should set `skip_submodules` to `true`
 - Jobs that want to perform shallow cloning can use `clone_depth` field. It can be set to desired clone depth. By default, clone_depth get set to 0 which results in full clone of repo.
 
@@ -95,6 +95,7 @@ the `exta_refs` field.
   - org: kubernetes
     repo: other-repo
     base_ref: master
+    workdir: false
   skip_submodules: true
   clone_depth: 0
   spec:

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -553,12 +553,21 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 	spec.Volumes = append(spec.Volumes, logVolume, toolsVolume, gcsVol)
 
 	if len(refs) > 0 {
-		spec.Containers[0].WorkingDir = clone.PathForRefs(codeMount.MountPath, refs[0])
+		spec.Containers[0].WorkingDir = determineWorkDir(codeMount.MountPath, refs)
 		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, codeMount)
 		spec.Volumes = append(spec.Volumes, append(cloneVolumes, codeVolume)...)
 	}
 
 	return nil
+}
+
+func determineWorkDir(baseDir string, refs []prowapi.Refs) string {
+	for _, ref := range refs {
+		if ref.WorkDir {
+			return clone.PathForRefs(baseDir, ref)
+		}
+	}
+	return clone.PathForRefs(baseDir, refs[0])
 }
 
 const (


### PR DESCRIPTION
Currently we force the working directory for the container from the `refs[0]`.

This PR adds the ability to choose the working directory from a specify `ref` or `extra_ref`.