### PR TITLE
Migration of fejta-bot-periodics to prow annotations

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -3,6 +3,10 @@ periodics:
 - name: periodic-api-review-help
   interval: 1h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Adds API review process description to kind/api-change PRs
+    testgrid-tab-name: api-review-help
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -45,6 +49,10 @@ periodics:
 - name: periodic-test-infra-cla
   interval: 1h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Re-checks CLA context when CLA labels are missing
+    testgrid-tab-name: cla
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -81,6 +89,10 @@ periodics:
 - name: periodic-test-infra-close
   interval: 1h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Closes rotten issues after 30d of inactivity
+    testgrid-tab-name: close
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -164,6 +176,10 @@ periodics:
 - name: periodic-test-infra-rotten
   interval: 1h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    testgrid-tab-name: rotten
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -204,6 +220,10 @@ periodics:
 - name: periodic-test-infra-stale
   interval: 1h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Adds lifecycle/stale to issues after 30d of inactivity
+    testgrid-tab-name: stale
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -272,6 +292,10 @@ periodics:
 - name: periodic-enhancements-unfreeze
   interval: 30m
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: Prevents issues in `k/enhancements` from being marked as `lifecycle/frozen`y
+    testgrid-tab-name: enhancements-unfreeze
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20190716-e6df33ccc
@@ -302,6 +326,10 @@ periodics:
 - name: periodic-secping
   interval: 24h
   decorate: true
+  annotations:
+    testgrid-dashboards: sig-testing-fejtabot
+    description: files bugs for SECURITY_CONTACTS
+    testgrid-tab-name: periodic-secping
   extra_refs:
   - base_ref: master
     org: jessfraz

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2357,27 +2357,6 @@ dashboards:
     test_group_name: periodic-test-infra-retester
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
-  - name: stale
-    description: Adds lifecycle/stale to issues after 30d of inactivity
-    test_group_name: periodic-test-infra-stale
-  - name: rotten
-    description: Adds lifecycle/rotten to stale issues after 30d of inactivity
-    test_group_name: periodic-test-infra-rotten
-  - name: close
-    description: Closes rotten issues after 30d of inactivity
-    test_group_name: periodic-test-infra-close
-  - name: cla
-    description: Re-checks CLA context when CLA labels are missing
-    test_group_name: periodic-test-infra-cla
-  - name: api-review-help
-    description: Adds API review process description to kind/api-change PRs
-    test_group_name: periodic-api-review-help
-  - name: secping
-    description: files bugs for SECURITY_CONTACTS
-    test_group_name: periodic-secping
-  - name: enhancements-unfreeze
-    description: Prevents issues in `k/enhancements` from being marked as `lifecycle/frozen`
-    test_group_name: periodic-enhancements-unfreeze
   - name: issue-creator
     description: Creates github issues based on data from various 'IssueSource's.
     test_group_name: issue-creator


### PR DESCRIPTION
When I wrote a script to do all these migrations, ruamel.yaml really [didn't want](https://github.com/kubernetes/test-infra/blob/2c53c2d7e3e07a95005d04ca7e36dd53c438582e/experiment/migrate_testgrid_tabs.py#L31) to deserialize this file. So here's an artisinally-crafted solution.

xref #13057 

/cc @fejta-bot
/assign @fejta
