### PR TITLE
Revert "Enable violations from APIResponsivesPrometheus in gce-cos-master-scalability-100"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -148,7 +148,6 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/prometheus/scrape-etcd.yaml
       - --test-cmd-args=--testoverrides=./testing/prometheus/scrape-kube-proxy.yaml
       - --test-cmd-args=--testoverrides=./testing/prometheus/scrape-node-exporter.yaml
-      - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/probes.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m


### PR DESCRIPTION
This reverts commit cd5c41956d8ad90fc931b4fbd3d089323c28cb94.

It makes the gce-cos-master-scalability-100 flaky due to reason that is not fully understood.
Sometimes the Prometheus measurement fails badly (a lot of calls, really bad latency), but the old measurement passes with not a single violation broken. Given that this test takes less than 5h this is quite unexpected. There shouldn't be such big differences. 
Example runs
  * https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/1151325283630977024
  * https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/1151151583426252806

Ref. https://github.com/kubernetes/kubernetes/issues/80242
Ref. https://github.com/kubernetes/perf-tests/issues/498