### PR TITLE
Send SIGINT instead of SIGABRT on timeout to ginkgo

### DIFF
--- a/kubetest/process/process.go
+++ b/kubetest/process/process.go
@@ -196,11 +196,11 @@ func (c *Control) FinishRunning(cmd *exec.Cmd) error {
 			c.intLock.Lock()
 			c.interrupted = true
 			c.intLock.Unlock()
-			log.Printf("Abort after %s timeout during %s. Will terminate in another 15m", c.Timeout, stepName)
+			log.Printf("Interrupt after %s timeout during %s. Will terminate in another 15m", c.Timeout, stepName)
 			c.Terminate.Reset(15 * time.Minute)
 			pgid := getGroupPid(cmd.Process.Pid)
-			if err := syscall.Kill(-pgid, syscall.SIGABRT); err != nil {
-				log.Printf("Failed to abort %s. Will terminate immediately: %v", stepName, err)
+			if err := syscall.Kill(-pgid, syscall.SIGINT); err != nil {
+				log.Printf("Failed to interrupt %s. Will terminate immediately: %v", stepName, err)
 				syscall.Kill(-pgid, syscall.SIGTERM)
 				cmd.Process.Kill()
 			}


### PR DESCRIPTION
SIGABRT results in killing the test immediately without dumping buffered logs.
SIGINT is handled nicely by ginkgo, buffered logs for the pending tests and suites are emitted to stdout and wrote to junit.xml summary files.

This addresses the problem we have with timing-out correctness tests, if they timeout it's impossible to efficiently pinpoint the test that is causing troubles, see https://github.com/kubernetes/kubernetes/issues/80242#issuecomment-512257575