### PR TITLE
Fix port name of alertmanager svc in prometheus config

### DIFF
--- a/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/prow/cluster/monitoring/prow_prometheus.yaml
@@ -22,7 +22,7 @@ spec:
     alertmanagers:
       - namespace: prow-monitoring
         name: alertmanager
-        port: web
+        port: http
   enableAdminAPI: false
   ruleSelector:
     matchLabels:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/12854

The name should be same as:

https://github.com/kubernetes/test-infra/blob/a4125ca527f7674afe326517ab2c781bba7a2a27/prow/cluster/monitoring/alertmanager_expose.yaml#L11