### PR TITLE
deck config snippet implementation, #9079

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/bazelbuild/buildtools v0.0.0-20190404153937-93253d6efaa9
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bwmarrin/snowflake v0.0.0
+	github.com/clarketm/json v1.13.0
 	github.com/client9/misspell v0.3.4
 	github.com/denisenkom/go-mssqldb v0.0.0-20190111225525-2fea367d496d // indirect
 	github.com/djherbis/atime v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bwmarrin/snowflake v0.0.0 h1:dRbqXFjM10uA3wdrVZ8Kh19uhciRMOroUYJ7qAqDLhY=
 github.com/bwmarrin/snowflake v0.0.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
+github.com/clarketm/json v1.13.0 h1:gvWCzx4JHbBeVPpSV9LVr+PXfRInRnDy80D9nnTLULs=
+github.com/clarketm/json v1.13.0/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "code-prettify": "^0.1.0",
     "color": "^3.1.2",
     "dialog-polyfill": "^0.5.0",
     "moment": "^2.22.2",

--- a/pkg/genyaml/BUILD.bazel
+++ b/pkg/genyaml/BUILD.bazel
@@ -6,7 +6,10 @@ go_library(
     data = ["//prow/plugins:config-src"],
     importpath = "k8s.io/test-infra/pkg/genyaml",
     visibility = ["//visibility:public"],
-    deps = ["@in_gopkg_yaml_v3//:go_default_library"],
+    deps = [
+        "@com_github_clarketm_json//:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/genyaml/OWNERS
+++ b/pkg/genyaml/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- clarketm

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -61,18 +61,19 @@ package genyaml
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/parser"
 	"go/token"
-	yaml3 "gopkg.in/yaml.v3"
 	"reflect"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/clarketm/json"
+	yaml3 "gopkg.in/yaml.v3"
 )
 
 const (

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -85,6 +85,7 @@ rollup_bundle(
     entry_point = ":plugin-help/plugin-help.ts",
     deps = [
         ":plugin_help",
+        "@npm//code-prettify",
         "@npm//dialog-polyfill",
     ],
 )

--- a/prow/cmd/deck/static/api/help.ts
+++ b/prow/cmd/deck/static/api/help.ts
@@ -11,6 +11,7 @@ export interface PluginHelp {
   Config: {[key: string]: string};
   Events: string[];
   Commands: Command[];
+  Snippet?: string;
 }
 
 export interface Help {

--- a/prow/cmd/deck/static/plugin-help/plugin-help.ts
+++ b/prow/cmd/deck/static/plugin-help/plugin-help.ts
@@ -1,8 +1,11 @@
+import "code-prettify";
 import dialogPolyfill from "dialog-polyfill";
 import {Command, Help, PluginHelp} from "../api/help";
 import {getParameterByName} from '../common/urls';
+import {Language, Prettify} from "./prettify";
 
 declare const allHelp: Help;
+declare const PR: Prettify;
 
 function redrawOptions(): void {
     const rs = allHelp.AllRepos.sort();
@@ -64,6 +67,15 @@ function addDialogSection(title: string, body: string | HTMLElement[]): HTMLElem
     container.appendChild(sectionBody);
 
     return container;
+}
+
+function genCodeSnippetSummary(snippet: string, language: Language = "yaml"): string {
+    return `
+        <details>
+            <summary>Example <b>plugins.yaml</b> configuration:</summary>
+            <pre class="prettyprint"><code class="language-${language}">${snippet}</code></pre>
+        </details>
+    `;
 }
 
 /**
@@ -141,6 +153,10 @@ function createPlugin(repo: string, name: string, pluginObj: {isExternal: boolea
         if (plugin.Commands) {
             const sectionContent = getLinkableCommands(plugin.Commands);
             contentElement.appendChild(addDialogSection("Commands", sectionContent));
+        }
+        if (plugin.Snippet) {
+            contentElement.appendChild(addDialogSection("Snippet", genCodeSnippetSummary(plugin.Snippet)));
+            PR.prettyPrint();
         }
         dialogElement.showModal();
     });

--- a/prow/cmd/deck/static/plugin-help/prettify.css
+++ b/prow/cmd/deck/static/plugin-help/prettify.css
@@ -1,0 +1,37 @@
+/* google/code-prettify (https://github.com/google/code-prettify) */
+
+/* desert scheme ported from vim to google prettify */
+pre.prettyprint { display: block; background-color: #333; overflow-x: scroll; font-size: 12px; max-height: 300px; padding: 10px; }
+pre.prettyprint code { background-color: transparent; padding: 0 6px; }
+pre .nocode { background-color: none; color: #000 }
+pre .str { color: #ffa0a0 } /* string  - pink */
+pre .kwd { color: #f0e68c; font-weight: bold }
+pre .com { color: #87ceeb } /* comment - skyblue */
+pre .typ { color: #98fb98 } /* type    - lightgreen */
+pre .lit { color: #cd5c5c } /* literal - darkred */
+pre .pun { color: #fff }    /* punctuation */
+pre .pln { color: #fff }    /* plaintext */
+pre .tag { color: #f0e68c; font-weight: bold } /* html/xml tag    - lightyellow */
+pre .atn { color: #bdb76b; font-weight: bold } /* attribute name  - khaki */
+pre .atv { color: #ffa0a0 } /* attribute value - pink */
+pre .dec { color: #98fb98 } /* decimal         - lightgreen */
+
+/* Specify class=linenums on a pre to get line numbering */
+ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE } /* IE indents via margin-left */
+li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8 { list-style-type: none }
+/* Alternate shading for lines */
+li.L1,li.L3,li.L5,li.L7,li.L9 { }
+
+@media print {
+  pre.prettyprint { background-color: none }
+  pre .str, code .str { color: #060 }
+  pre .kwd, code .kwd { color: #006; font-weight: bold }
+  pre .com, code .com { color: #600; font-style: italic }
+  pre .typ, code .typ { color: #404; font-weight: bold }
+  pre .lit, code .lit { color: #044 }
+  pre .pun, code .pun { color: #440 }
+  pre .pln, code .pln { color: #000 }
+  pre .tag, code .tag { color: #006; font-weight: bold }
+  pre .atn, code .atn { color: #404 }
+  pre .atv, code .atv { color: #060 }
+}

--- a/prow/cmd/deck/static/plugin-help/prettify.ts
+++ b/prow/cmd/deck/static/plugin-help/prettify.ts
@@ -1,0 +1,39 @@
+export type Language =
+    "apollo" |
+    "basic" |
+    "clj" |
+    "css" |
+    "dart" |
+    "erlang" |
+    "ex" |
+    "go" |
+    "hs" |
+    "kotlin" |
+    "lasso" |
+    "lisp" |
+    "llvm" |
+    "logtalk" |
+    "lua" |
+    "matlab" |
+    "ml" |
+    "mumps" |
+    "n" |
+    "pascal" |
+    "proto" |
+    "r" |
+    "rd" |
+    "rust" |
+    "scala" |
+    "sql" |
+    "swift" |
+    "tcl" |
+    "tex" |
+    "vb" |
+    "vhdl" |
+    "wiki" |
+    "xq" |
+    "yaml";
+
+export interface Prettify {
+    prettyPrint(): void;
+}

--- a/prow/cmd/deck/template/plugins.html
+++ b/prow/cmd/deck/template/plugins.html
@@ -2,6 +2,7 @@
 
 {{define "scripts"}}
 <link rel="stylesheet" href="/static/dialog-polyfill.css">
+<link rel="stylesheet" href="static/plugin-help/prettify.css">
 <script type="text/javascript" src="/static/plugin_help_bundle.min.js"></script>
 <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
 {{end}}

--- a/prow/pluginhelp/pluginhelp.go
+++ b/prow/pluginhelp/pluginhelp.go
@@ -45,6 +45,8 @@ type PluginHelp struct {
 	// The key "" should map to a string describing configuration that applies to all repos if any.
 	// This configuration strings may include HTML.
 	Config map[string]string
+	// Snippet is a snippet of yaml for delineating configuration for the plugin.
+	Snippet string `json:",omitempty"`
 	// Events is a slice containing the events that are handled by the plugin.
 	// NOTE: Plugins do not need to populate this. Hook populates it on their behalf.
 	Events []string

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/plugins",
     deps = [
+        "//pkg/genyaml:go_default_library",
         "//prow/bugzilla:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/commentpruner:go_default_library",

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -134,9 +134,9 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 					"ORGANIZATION/REPOSITORY",
 				},
 				DeprecatedImplicitSelfApprove: new(bool),
-				RequireSelfApproval: new(bool),
-				DeprecatedReviewActsAsApprove:   new(bool),
-				IgnoreReviewState:   new(bool),
+				RequireSelfApproval:           new(bool),
+				DeprecatedReviewActsAsApprove: new(bool),
+				IgnoreReviewState:             new(bool),
 			},
 		},
 	})

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -125,12 +125,32 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.HasSelfApproval()), willNot(opts.LgtmActsAsApprove), willNot(opts.ConsiderReviewState()))
 	}
+
+	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
+		Approve: []plugins.Approve{
+			{
+				Repos: []string{
+					"ORGANIZATION",
+					"ORGANIZATION/REPOSITORY",
+				},
+				DeprecatedImplicitSelfApprove: new(bool),
+				RequireSelfApproval: new(bool),
+				DeprecatedReviewActsAsApprove:   new(bool),
+				IgnoreReviewState:   new(bool),
+			},
+		},
+	})
+	if err != nil {
+		logrus.WithError(err).Warn("cannot generate comments for approve plugin")
+	}
+
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
 <br>
 <br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
 <br>For more information see <a href="https://git.k8s.io/test-infra/prow/plugins/approve/approvers/README.md">here</a>.`,
-		Config: approveConfig,
+		Config:  approveConfig,
+		Snippet: yamlSnippet,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/approve [no-issue|cancel]",

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -54,19 +54,20 @@ type Configuration struct {
 	Owners Owners `json:"owners,omitempty"`
 
 	// Built-in plugins specific configuration.
+
 	Approve                    []Approve                    `json:"approve,omitempty"`
 	UseDeprecatedSelfApprove   bool                         `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`
 	UseDeprecatedReviewApprove bool                         `json:"use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019,omitempty"`
 	Blockades                  []Blockade                   `json:"blockades,omitempty"`
 	Blunderbuss                Blunderbuss                  `json:"blunderbuss,omitempty"`
-	Bugzilla                   Bugzilla                     `json:"bugzilla"`
+	Bugzilla                   Bugzilla                     `json:"bugzilla,omitempty"`
 	Cat                        Cat                          `json:"cat,omitempty"`
 	CherryPickUnapproved       CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
 	ConfigUpdater              ConfigUpdater                `json:"config_updater,omitempty"`
 	Dco                        map[string]*Dco              `json:"dco,omitempty"`
-	Golint                     Golint                       `json:"golint"`
+	Golint                     Golint                       `json:"golint,omitempty"`
 	Heart                      Heart                        `json:"heart,omitempty"`
-	Label                      Label                        `json:"label"`
+	Label                      Label                        `json:"label,omitempty"`
 	Lgtm                       []Lgtm                       `json:"lgtm,omitempty"`
 	MilestoneApplier           map[string]BranchToMilestone `json:"milestone_applier,omitempty"`
 	RepoMilestone              map[string]Milestone         `json:"repo_milestone,omitempty"`
@@ -76,7 +77,7 @@ type Configuration struct {
 	Retitle                    Retitle                      `json:"retitle,omitempty"`
 	Slack                      Slack                        `json:"slack,omitempty"`
 	SigMention                 SigMention                   `json:"sigmention,omitempty"`
-	Size                       Size                         `json:"size"`
+	Size                       Size                         `json:"size,omitempty"`
 	Triggers                   []Trigger                    `json:"triggers,omitempty"`
 	Welcome                    []Welcome                    `json:"welcome,omitempty"`
 }

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
+	"k8s.io/test-infra/pkg/genyaml"
 	"sync"
 	"time"
 
@@ -49,6 +50,7 @@ var (
 	reviewEventHandlers        = map[string]ReviewEventHandler{}
 	reviewCommentEventHandlers = map[string]ReviewCommentEventHandler{}
 	statusEventHandlers        = map[string]StatusEventHandler{}
+	CommentMap                 = genyaml.NewCommentMap("prow/plugins/config.go")
 )
 
 // HelpProvider defines the function type that construct a pluginhelp.PluginHelp for enabled

--- a/repos.bzl
+++ b/repos.bzl
@@ -1904,6 +1904,14 @@ def go_repositories():
         version = "v0.0.0-20180111231733-ee0de3bc6815",
     )
     go_repository(
+        name = "com_github_clarketm_json",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/clarketm/json",
+        sum = "h1:gvWCzx4JHbBeVPpSV9LVr+PXfRInRnDy80D9nnTLULs=",
+        version = "v1.13.0",
+    )
+    go_repository(
         name = "com_github_golang_lint",
         build_file_generation = "on",
         build_file_proto_mode = "disable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,6 +242,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+code-prettify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/code-prettify/-/code-prettify-0.1.0.tgz#46870cc8c1a50d09bad539b33a983dbd4aa34b1e"
+  integrity sha1-RocMyMGlDQm61TmzOpg9vUqjSx4=
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"


### PR DESCRIPTION
This is the implementation of snippet (i.e. `plugins.yaml`) serving for prow plugins in `deck`. This includes an *example* using the [approve](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/approve) plugin, but once implementation is approved I will PR the config snippets for other plugins.  

![image](https://user-images.githubusercontent.com/9957358/61488875-2a1bdd80-a95e-11e9-9090-c78d4f9501f6.png)

