### PR TITLE
Add shell linting for CAPV

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -129,6 +129,22 @@ presubmits:
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Verifies the markdown has been linted
 
+  - name: pull-cluster-api-provider-vsphere-verify-shell
+    always_run: false
+    run_if_changed: '.*\.\w*sh$'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.6.0
+        command:
+        - /bin/shellcheck.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-verify-shell
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Verifies the shell scripts have been linted
+
   - name: pull-cluster-api-provider-vsphere-verify-crds
     always_run: false
     run_if_changed: '^((config|pkg|vendor)/)|hack/verify-crds\.sh'


### PR DESCRIPTION
This patch adds a pre-submit for CAPV to lint the project's shell scripts with shellcheck.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/441, but is not blocked by it as the images are already pushed.