### PR TITLE
add daemonset for tuning sysctls (namely inotify watches)

### DIFF
--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -38,6 +38,11 @@ release(
     component("tide", "service", "deployment"),
     component("tls-ing", "ingress"),
     component("tot", "service", "deployment"),
+    component(
+        "tune-sysctls",
+        "daemonset",
+        cluster = BUILD_CLUSTER,
+    ),
 )
 
 component("starter", MULTI_KIND)

--- a/prow/cluster/tune-sysctls_daemonset.yaml
+++ b/prow/cluster/tune-sysctls_daemonset.yaml
@@ -1,0 +1,43 @@
+# a simple daemonset to tune sysctls
+# intended to be used in a prow build cluster
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tune-sysctls
+  namespace: kube-system
+  labels:
+    app: tune-sysctls
+spec:
+  selector:
+    matchLabels:
+      name: tune-sysctls
+  template:
+    metadata:
+      labels:
+        name: tune-sysctls
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      containers:
+      - name: setsysctls 
+        command:
+        - sh
+        - -c
+        - |
+          while true; do
+            sysctl -w fs.inotify.max_user_watches=524288
+            sleep 10
+          done
+        image: alpine:3.6
+        imagePullPolicy: IfNotPresent
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/kind/issues/717

We should consider something like this for our build cluster(s) & for the istio build cluster(s).

Anything using inotify watches in pods could hit the default limits (including integration tests in kubernetes, running kind clusters, etc... most likely clusters...).

The value is arbitrary and adapted from https://github.com/Azure/AKS/issues/772#issuecomment-477760184

If we ever want / need to set other sysctls we should use the same daemonset to avoid unnecessarily more containers.

This is slightly hacky, but a pretty well known option.

https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod

> Sysctls with no namespace are called node-level sysctls. If you need to set them, you must manually configure them on each node’s operating system, or by using a DaemonSet with privileged containers.


