### PR TITLE
Revert "Turn on prometheus snapshots in gce-100-perf"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -134,8 +134,6 @@ periodics:
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
-      # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Turn off when the investigation is over or assess if it can stay
-      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
       - --test-cmd-args=--nodes=100
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts


### PR DESCRIPTION
This reverts commit 4ae9b9d3ecab7e2dadb144fee593dd14d96094a7.

It's safer to disable it for the weekend, we can consider re-enabling on Monday.

Ref. https://github.com/kubernetes/kubernetes/issues/80212