### PR TITLE
Add test for implicit ref functionality in pipeline controller

### DIFF
--- a/prow/cmd/pipeline/BUILD.bazel
+++ b/prow/cmd/pipeline/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",


### PR DESCRIPTION
I was looking at how the implicit ref works and realised there wasn't really a test for getting the implicit resource created, so I've added one

/CC @cjwagner 