### PR TITLE
change to temp directory to avoid polluting current directory

### DIFF
--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -45,7 +45,9 @@ install_kind() {
     TMP_DIR=$(mktemp -d)
     # ensure bin dir
     mkdir -p "${TMP_DIR}/bin"
+    pushd "${TMP_DIR}"
     env "GOPATH=${TMP_DIR}" GO111MODULE="on" go get -u "sigs.k8s.io/kind@${STABLE_KIND_VERSION}"
+    popd
     PATH="${TMP_DIR}/bin:${PATH}"
     export PATH
 }


### PR DESCRIPTION
When we run this in k/k directory, the go.sum/go.mod files get update. Let's avoid that.