### PR TITLE
Partially remove the default for --cookie-secret-file.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,10 @@
 # Announcements
 
 New features added to each component:
+ - *July 19, 2019* deck will soon remove its default value for `--cookie-secret-file`.
+   If you set `--oauth-url` but not `--cookie-secret-file`, add
+   `--cookie-secret-file=/etc/cookie-secret` to your deck instance. The default value
+   will be removed at the end of October 2019.
  - *July 2, 2019* prow defaults to report status for both presubmit and postsubmit
    jobs on GitHub now.
  - *June 17, 2019* It is now possible to configure the channel for the Slack reporter

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -877,7 +877,7 @@ func Test_gatherOptions(t *testing.T) {
 			expected := &options{
 				configPath:            "yo",
 				githubOAuthConfigFile: "/etc/github/secret",
-				cookieSecretFile:      "/etc/cookie/secret",
+				cookieSecretFile:      "",
 				staticFilesLocation:   "/static",
 				templateFilesLocation: "/template",
 				spyglassFilesLocation: "/lenses",


### PR DESCRIPTION
Code added to deck in #13323 assumes that `--cookie-secret-file` is either set to a file that exists or not set at all. This is not the case - the default is `/etc/cookie/secret`, but unless you set a _different_ flag nothing ever checked that it existed until now. The result is deck crashing on startup trying to read a file that doesn't exist.

This PR removes the default. However, for backwards compatibility, if it is not set, and the flag depending on it is set, and a file exists at the old default location, we use the default, emit an error message, and continue silently.

/cc @stevekuznetsov @fejta 