### PR TITLE
Add Presubmit config getters

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",


### PR DESCRIPTION
Done prior to move everything over to use the Getters, in order to be
able to have a dynamic job config.

Ref: https://github.com/kubernetes/test-infra/issues/13370

After this is merged, I will create follow-ups to move all components that access the Presubmit config over to use one of the getters and eventually unexport the `config.Presubmit` property. At that point, `GetPresubmits` will get renamed to `Presubmits` to be more idomatic.

When that worked out, `inrepoconfig` itself can be implemented.

/assign @cjwagner @stevekuznetsov 