### PR TITLE
Re-enable prometheus snapshots in gce-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -134,6 +134,8 @@ periodics:
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
+      # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Turn off when the investigation is over or assess if it can stay
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
       - --test-cmd-args=--nodes=100
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts


### PR DESCRIPTION
There is not enough data from the Friday's runs where we enabled the snapshots. Let's keep them on for a few more days.

Ref. https://github.com/kubernetes/kubernetes/issues/80212