### PR TITLE
verify-owners: do not fail on removed OWNERS files

### DIFF
--- a/prow/git/localgit/localgit.go
+++ b/prow/git/localgit/localgit.go
@@ -135,6 +135,17 @@ func (lg *LocalGit) AddCommit(org, repo string, files map[string][]byte) error {
 	return runCmd(lg.Git, rdir, "commit", "-m", "wow")
 }
 
+// RmCommit adds a commit that removes some files from the repo
+func (lg *LocalGit) RmCommit(org, repo string, files []string) error {
+	rdir := filepath.Join(lg.Dir, org, repo)
+	for _, f := range files {
+		if err := runCmd(lg.Git, rdir, "rm", f); err != nil {
+			return err
+		}
+	}
+	return runCmd(lg.Git, rdir, "commit", "-m", "remove some files")
+}
+
 // CheckoutNewBranch does git checkout -b.
 func (lg *LocalGit) CheckoutNewBranch(org, repo, branch string) error {
 	rdir := filepath.Join(lg.Dir, org, repo)

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -129,7 +129,7 @@ func handle(ghc githubClient, gc *git.Client, roc repoownersClient, log *logrus.
 	// List modified OWNERS files.
 	var modifiedOwnersFiles []github.PullRequestChange
 	for _, change := range changes {
-		if filepath.Base(change.Filename) == ownersFileName {
+		if filepath.Base(change.Filename) == ownersFileName && change.Status != github.PullRequestFileRemoved {
 			modifiedOwnersFiles = append(modifiedOwnersFiles, change)
 		}
 	}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -358,6 +358,10 @@ func TestHandle(t *testing.T) {
 			filesRemoved: []string{"pkg/OWNERS"},
 			ownersFile:   "valid",
 			shouldLabel:  false,
+		}, {
+			name:         "OWNERS_ALIASES file was removed",
+			filesRemoved: []string{"OWNERS_ALIASES"},
+			shouldLabel:  false,
 		},
 	}
 	lg, c, err := localgit.New()


### PR DESCRIPTION
Hit a bug in https://github.com/openshift/origin/pull/23415#pullrequestreview-264686376 and isolated it in https://github.com/openshift/release/pull/4461#discussion_r305750541

Previously, the plugin would label PRs that remove OWNERS file as having
an invalid OWNERS files, because it would attempt to parse a now
non-existent file in the PR. Make it ignore PR changes deleting files.
Add a test for this case (needed to extend some test helpers to allow removing files).

/cc @stevekuznetsov 