### PR TITLE
Use space instead of tab in OWNERS

### DIFF
--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -8,7 +8,7 @@ filters:
       - fejta
       - stevekuznetsov
     emeritus_approvers:
-      - spxtr	# 2018-09-17
+      - spxtr # 2018-09-17
     reviewers:
       - matthyx
       - alvaroaleman


### PR DESCRIPTION
The tab messes up `ruamel.yaml` when attempting to parse

Yes I could probably just make my code handle this but this is the only file
in the entire kubernetes project that has this issue, this seemed a quicker
fix