### PR TITLE
Fix to Branch Protector's Prow Job Dir

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -828,7 +828,7 @@ periodics:
       - /app/prow/cmd/branchprotector/app.binary
       args:
       - --config-path=prow/config.yaml
-      - --job-config-path=config
+      - --job-config-path=config/jobs
       - --github-token-path=/etc/github/oauth
       - --confirm
       - --github-endpoint=http://ghproxy.default.svc.cluster.local


### PR DESCRIPTION
Using /config captures more than the prow jobs in the directory.

It works for now, but if there were a PR that added a different kind of config to the config directory, this could cause a [failure](https://github.com/kubernetes/test-infra/pull/13530)

/cc @cblecker 
/cc @Katharine 