### PR TITLE
Configurator "Output YAML" Flag

### DIFF
--- a/testgrid/cmd/configurator/config_test.go
+++ b/testgrid/cmd/configurator/config_test.go
@@ -85,7 +85,8 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Prow config agent error: %v", err)
 		os.Exit(1)
 	}
-	if err := applyProwjobAnnotations(c, pca); err != nil {
+
+	if err := applyProwjobAnnotations(c, pca, true); err != nil {
 		fmt.Printf("Couldn't apply prowjob annotations: %v", err)
 		os.Exit(1)
 	}

--- a/testgrid/default-template.yaml
+++ b/testgrid/default-template.yaml
@@ -1,0 +1,46 @@
+# Default Settings are required for TestGrid YAML Configuration files
+# These defaults apply to all of the test groups and dashboard tabs within the same file
+
+default_test_group:
+  days_of_results: 14 # Number of days of test results to gather and serve.
+  tests_name_policy: 2 # replace the name of the test
+  ignore_pending: false # Show in-progress tests.
+  column_header:
+    - configuration_value: Commit # Shows the commit number on column header
+    - configuration_value: infra-commit
+  num_columns_recent: 10
+  use_kubernetes_client: true # These two fields are deprecated and should always be true
+  is_external: true
+  alert_stale_results_hours: 0 # Don't alert for staleness by default.
+  num_failures_to_alert: 3 # Consider a test failed if it has 3 or more consecutive failures.
+  num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes.
+  code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
+
+default_dashboard_tab:
+  open_test_template: # The URL template to visit after clicking on a cell
+    url: https://prow.k8s.io/view/gcs/<gcs_prefix>/<changelist>
+  file_bug_template: # The URL template to visit when filing a bug
+    url: https://github.com/kubernetes/kubernetes/issues/new
+    options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+  attach_bug_template: # The URL template to visit when attaching a bug
+    url: # empty
+    options: #empty
+  results_text: See these results on Prow # Text to show in the about menu as a link to another view of the results
+  results_url_template: # The URL template to visit after clicking
+    url: https://prow.k8s.io/job-history/<gcs_prefix>
+  code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
+  num_columns_recent: 10
+  code_search_url_template: # The URL template to visit when searching for changelists
+    url: https://github.com/kubernetes/kubernetes/compare/<start-custom-0>...<end-custom-0>
+
+
+# Dashboards need to be specified here
+# A prow annotation will be invalid if it references a dashboard that doesn't exist
+
+dashboards:
+  - name: example-dashboard-one
+  - name: example-dashboard-two


### PR DESCRIPTION
Added to allow conversion from prow annotations to only Testgrid YAML

In this way, other instances of Configurator could chain their outputs into a sharded Testgrid Config folder.
Revision of #13510 for issue #13455 

The prow job annotation functions now take a flag, but the flag is really doing two things:
- Allow generation of dashboards from prow annotations
- Suppress the "reconciliation" of the default variables
Should it be two booleans instead?