### PR TITLE
Only test/check go source if they've changed

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -3,12 +3,11 @@ presubmits:
 
   # Runs "gofmt", "go vet", and "golint" on the sources.
   - name: pull-vsphere-csi-driver-check
+    always_run: false
+    run_if_changed: '^(cmd|pkg)'
     decorate: true
-    branches:
-    - ^master$
     path_alias: sigs.k8s.io/vsphere-csi-driver
     skip_submodules: true
-    always_run: true
     skip_report: false
     spec:
       containers:
@@ -60,12 +59,11 @@ presubmits:
 
   # Builds the CSI binary
   - name: pull-vsphere-csi-driver-build
+    always_run: false
+    run_if_changed: '^(cmd|pkg|go.mod)'
     decorate: true
-    branches:
-    - ^master$
     path_alias: sigs.k8s.io/vsphere-csi-driver
     skip_submodules: true
-    always_run: true
     skip_report: false
     spec:
       containers:
@@ -80,12 +78,11 @@ presubmits:
 
   # Executes the unit tests.
   - name: pull-vsphere-csi-driver-unit-test
+    always_run: false
+    run_if_changed: '^(cmd|pkg|go.mod)'
     decorate: true
-    branches:
-    - ^master$
     path_alias: sigs.k8s.io/vsphere-csi-driver
     skip_submodules: true
-    always_run: true
     skip_report: false
     spec:
       containers:


### PR DESCRIPTION
This patch modifies the tests that do go fmt|vet|lint to only run if the
go sources in `pkg` or `cmd` have changed. Additionally, we only need to
see if the build actually builds if the go sources have changed, or
go.mod, which indicates a change in dependencies.

This means that a simple doc change won't re-run all the Go tests.

/assign @dvonthenen 