### PR TITLE
Add support for labels to trigger cherry pick semantics.

### DIFF
--- a/prow/external-plugins/cherrypicker/README.md
+++ b/prow/external-plugins/cherrypicker/README.md
@@ -2,7 +2,7 @@
 
 Cherrypicker is an external prow plugin that can also run as a standalone bot.
 It automates cherry-picking merged PRs into different branches. Cherrypicks are
-triggered from either comments or lebals in GitHub PRs that need to be cherrypicked.
+triggered from either comments or labels in GitHub PRs that need to be cherrypicked.
 
 For comments:
 
@@ -16,7 +16,7 @@ once the PR where the comment was made gets merged or is already merged.
 To use label, you need to apply labels that contain the name of the branch in the form:
 
 ```
-action/cherrypick-to-XXX
+cherrypick/XXX
 ```
 
 where XXX is the name of the branch.

--- a/prow/external-plugins/cherrypicker/README.md
+++ b/prow/external-plugins/cherrypicker/README.md
@@ -2,7 +2,9 @@
 
 Cherrypicker is an external prow plugin that can also run as a standalone bot.
 It automates cherry-picking merged PRs into different branches. Cherrypicks are
-triggered from comments in GitHub PRs that need to be cherrypicked.
+triggered from either comments or lebals in GitHub PRs that need to be cherrypicked.
+
+For comments:
 
 ```
 /cherrypick release-1.10
@@ -10,6 +12,14 @@ triggered from comments in GitHub PRs that need to be cherrypicked.
 
 The above comment will result in opening a new PR against the `release-1.10` branch
 once the PR where the comment was made gets merged or is already merged.
+
+To use label, you need to apply labels that contain the name of the branch in the form:
+
+```
+action/cherrypick-to-XXX
+```
+
+where XXX is the name of the branch.
 
 The bot uses its own fork to push patches that need to be cherry-picked and opens
 PRs out of those patches. The fork is created automatically by the bot so there is

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -51,6 +51,7 @@ type githubClient interface {
 	GetRepo(owner, name string) (github.Repo, error)
 	IsMember(org, user string) (bool, error)
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	ListOrgMembers(org, role string) ([]github.TeamMember, error)
 }
 
@@ -222,7 +223,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		WithField("requestor", ic.Comment.User.Login).
 		WithField("target_branch", targetBranch).
 		Debug("Cherrypick request.")
-	return s.handle(l, ic.Comment.User.Login, ic.Comment, org, repo, targetBranch, title, body, num)
+	return s.handle(l, ic.Comment.User.Login, &ic.Comment, org, repo, targetBranch, title, body, num)
 }
 
 func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent) error {
@@ -269,9 +270,25 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 		}
 		requestorToComments[c.User.Login][targetBranch] = &c
 	}
+
 	if len(requestorToComments) == 0 {
-		return nil
+		// didn't find any magic comments so look for magic labels instead
+
+		labels, err := s.ghc.GetIssueLabels(org, repo, num)
+		if err != nil {
+			return err
+		}
+
+		requestorToComments[pr.User.Login] = make(map[string]*github.IssueComment)
+
+		magicPrefix := "action/cherrypick-to-"
+		for _, label := range labels {
+			if strings.HasPrefix(label.Name, magicPrefix) {
+				requestorToComments[pr.User.Login][label.Name[len(magicPrefix):]] = nil
+			}
+		}
 	}
+
 	// Figure out membership.
 	if !s.allowAll {
 		// TODO: Possibly cache this.
@@ -301,7 +318,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 			if targetBranch == baseBranch {
 				resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
 				s.log.WithFields(l.Data).Info(resp)
-				s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(*ic, resp))
+				s.createComment(org, repo, num, ic, resp)
 				continue
 			}
 			if handledBranches[targetBranch] {
@@ -313,7 +330,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 				WithField("requestor", requestor).
 				WithField("target_branch", targetBranch).
 				Debug("Cherrypick request.")
-			err := s.handle(l, requestor, *ic, org, repo, targetBranch, title, body, num)
+			err := s.handle(l, requestor, ic, org, repo, targetBranch, title, body, num)
 			if err != nil {
 				return err
 			}
@@ -324,7 +341,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 
 var cherryPickBranchFmt = "cherry-pick-%d-to-%s"
 
-func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueComment, org, repo, targetBranch, title, body string, num int) error {
+func (s *Server) handle(l *logrus.Entry, requestor string, comment *github.IssueComment, org, repo, targetBranch, title, body string, num int) error {
 	if err := s.ensureForkExists(org, repo); err != nil {
 		return err
 	}
@@ -343,7 +360,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	if err := r.Checkout(targetBranch); err != nil {
 		resp := fmt.Sprintf("cannot checkout %s: %v", targetBranch, err)
 		s.log.WithFields(l.Data).Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+		return s.createComment(org, repo, num, comment, resp)
 	}
 	s.log.WithFields(l.Data).WithField("duration", time.Since(startClone)).Info("Cloned and checked out target branch.")
 
@@ -374,7 +391,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	if err := r.Am(localPath); err != nil {
 		resp := fmt.Sprintf("#%d failed to apply on top of branch %q:\n```%v\n```", num, targetBranch, err)
 		s.log.WithFields(l.Data).Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+		return s.createComment(org, repo, num, comment, resp)
 	}
 
 	push := r.Push
@@ -385,7 +402,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	if err := push(repo, newBranch); err != nil {
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
 		s.log.WithFields(l.Data).Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+		return s.createComment(org, repo, num, comment, resp)
 	}
 
 	// Open a PR in GitHub.
@@ -403,23 +420,35 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment github.IssueC
 	if err != nil {
 		resp := fmt.Sprintf("new pull request could not be created: %v", err)
 		s.log.WithFields(l.Data).Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+		return s.createComment(org, repo, num, comment, resp)
 	}
 	resp := fmt.Sprintf("new pull request created: #%d", createdNum)
 	s.log.WithFields(l.Data).Info(resp)
-	if err := s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp)); err != nil {
+	if err := s.createComment(org, repo, num, comment, resp); err != nil {
 		return err
 	}
 	if !s.prowAssignments {
-		if err := s.ghc.AssignIssue(org, repo, createdNum, []string{comment.User.Login}); err != nil {
+		login := requestor
+		if comment != nil {
+			login = comment.User.Login
+		}
+
+		if err := s.ghc.AssignIssue(org, repo, createdNum, []string{login}); err != nil {
 			s.log.WithFields(l.Data).Warningf("Cannot assign to new PR: %v", err)
 			// Ignore returning errors on failure to assign as this is most likely
-			// due to users not being members of the org so that they can be assigned
+			// due to users not being members of the org so that they can't be assigned
 			// in PRs.
 			return nil
 		}
 	}
 	return nil
+}
+
+func (s *Server) createComment(org, repo string, num int, comment *github.IssueComment, resp string) error {
+	if comment != nil {
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(*comment, resp))
+	}
+	return s.ghc.CreateComment(org, repo, num, resp)
 }
 
 // ensureForkExists ensures a fork of org/repo exists for the bot.

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -386,7 +386,7 @@ func TestCherryPickPR(t *testing.T) {
 	}
 }
 
-func TestCherryPickPRWithLebals(t *testing.T) {
+func TestCherryPickPRWithLabels(t *testing.T) {
 	lg, c, err := localgit.New()
 	if err != nil {
 		t.Fatalf("Making localgit: %v", err)
@@ -434,13 +434,13 @@ func TestCherryPickPRWithLebals(t *testing.T) {
 		},
 		prLabels: []github.Label{
 			{
-				Name: "action/cherrypick-to-release-1.5",
+				Name: "cherrypick/release-1.5",
 			},
 			{
-				Name: "action/cherrypick-to-release-1.6",
+				Name: "cherrypick/release-1.6",
 			},
 			{
-				Name: "action/cherrypick-to-release-1.7",
+				Name: "cherrypick/release-1.7",
 			},
 		},
 		isMember:   true,


### PR DESCRIPTION
- For use in Istio, this makes it possible to trigger auto-cherry-pick semantics based on
labels applied to a PR. The specific labels have the form action/charrypick-to-XXX where
XXX is the name of a branch.