### PR TITLE
Remove kubemark-gce-big preset

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -1381,7 +1381,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -1796,7 +1795,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -2211,7 +2209,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -2683,7 +2680,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -3088,7 +3084,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.12.yaml
@@ -620,7 +620,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -649,7 +649,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -666,7 +666,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -738,7 +738,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
     max_concurrency: 12

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -102,7 +102,6 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
-    preset-e2e-kubemark-gce-big: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-500

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -50,15 +50,6 @@ presets:
     value: 1000
   - name: LOGROTATE_MAX_SIZE
     value: "5G"
-### kubemark-gce-big
-- labels:
-    preset-e2e-kubemark-gce-big: "true"
-  env:
-  # kubernetes env
-  ### e2e-env
-  # Increase throughput in Load test.
-  - name: LOAD_TEST_THROUGHPUT
-    value: "50"
 ### kubemark-gce-scale
 - labels:
     preset-e2e-kubemark-gce-scale: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -161,7 +161,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
     annotations:
       fork-per-release: "true"
     spec:
@@ -333,7 +332,6 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
-      preset-e2e-kubemark-gce-big: "true"
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:


### PR DESCRIPTION
IIUC this is no longer needed after we migrated to CL2 and are using override files.

/assign @krzysied @mm4tt 

