### PR TITLE
Fix prometheus snapshot names.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -187,6 +187,7 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
       - --test-cmd-args=--nodes=5000
       - --test-cmd-args=--provider=kubemark
       - --test-cmd-args=--report-dir=/workspace/_artifacts

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -78,7 +78,7 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
-      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name="${JOB_NAME}-${BUILD_ID}"
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
       - --test-cmd-args=--nodes=5000
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts
@@ -137,7 +137,7 @@ periodics:
       - --test-cmd-args=cluster-loader2
       # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Turn off when the investigation is over or assess if it can stay
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
-      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name="${JOB_NAME}-${BUILD_ID}"
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
       - --test-cmd-args=--nodes=100
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts


### PR DESCRIPTION
Looks like kubetest escapes quotes, so clusterloader is currently trying to create snapshot with name containing " and it fails:

```
Snapshotting PD 'e2e-big-dynamic-pvc-46e494a8-52a6-43ca-a3ed-034c13a2a528' into snapshot '"ci-kubernetes-e2e-gci-gce-scalability-1153522462407790593"' in zone 'us-east1-b'
W0723 05:22:39.007] I0723 05:22:39.007279   12421 experimental.go:85] Creating disk snapshot finished with: "ERROR: (gcloud.compute.disks.snapshot) HTTPError 400: Invalid value for field 'snapshot.name': '\"ci-kubernetes-e2e-gci-gce-scalability-1153522462407790593\"'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'\n"
```