### PR TITLE
Adds request priority support to Boskos

### DIFF
--- a/boskos/README.md
+++ b/boskos/README.md
@@ -76,6 +76,13 @@ Use `/acquire` when you want to get hold of some resource.
 | `dest`  | `string` | destination state of the requested resource |
 | `owner` | `string` | requester of the resource                   |
 
+#### Optional Parameters
+
+| Name         | Type     | Description                                   |
+| ------------ | -------- | --------------------------------------------- |
+| `request_id` | `string` | request id to use to keep your priority rank  |
+
+
 Example: `/acquire?type=gce-project&state=free&dest=busy&owner=user`.
 
 On a successful request, `/acquire` will return HTTP 200 and a valid Resource JSON object.

--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -43,7 +43,7 @@ var (
 	configPath        = flag.String("config", "config.yaml", "Path to init resource file")
 	storagePath       = flag.String("storage", "", "Path to persistent volume to load the state")
 	syncPeriod        = flag.Duration("sync-period", defaultSyncPeriod, "Period at which to sync config")
-	requestTTL        = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before being removed from Priority queue")
+	requestTTL        = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before losing priority in the queue")
 	kubeClientOptions crds.KubernetesClientOptions
 )
 

--- a/boskos/boskos_test.go
+++ b/boskos/boskos_test.go
@@ -30,7 +30,10 @@ import (
 	"k8s.io/test-infra/boskos/ranch"
 )
 
-var fakeNow = now()
+var (
+	fakeNow = now()
+	testTTL = time.Millisecond
+)
 
 func MakeTestRanch(resources []common.Resource) *ranch.Ranch {
 	resourceClient := crds.NewTestResourceClient()
@@ -39,7 +42,7 @@ func MakeTestRanch(resources []common.Resource) *ranch.Ranch {
 	for _, r := range resources {
 		s.AddResource(r)
 	}
-	r, _ := ranch.NewRanch("", s)
+	r, _ := ranch.NewRanch("", s, testTTL)
 	return r
 }
 

--- a/boskos/cleaner/cleaner_test.go
+++ b/boskos/cleaner/cleaner_test.go
@@ -29,6 +29,7 @@ import (
 const (
 	testOwner      = "cleaner"
 	testWaitPeriod = time.Millisecond
+	testTTL        = time.Millisecond
 )
 
 type releasedResource struct {
@@ -43,7 +44,7 @@ type fakeBoskos struct {
 func createFakeBoskos(resources []common.Resource, dlrcs []common.DynamicResourceLifeCycle) (*ranch.Storage, boskosClient, chan releasedResource) {
 	names := make(chan releasedResource, 100)
 	s, _ := ranch.NewStorage(storage.NewMemoryStorage(), storage.NewMemoryStorage(), "")
-	r, _ := ranch.NewRanch("", s)
+	r, _ := ranch.NewRanch("", s, testTTL)
 
 	for _, lc := range dlrcs {
 		s.AddDynamicResourceLifeCycle(lc)
@@ -55,7 +56,7 @@ func createFakeBoskos(resources []common.Resource, dlrcs []common.DynamicResourc
 }
 
 func (fb *fakeBoskos) Acquire(rtype, state, dest string) (*common.Resource, error) {
-	return fb.ranch.Acquire(rtype, state, dest, testOwner)
+	return fb.ranch.Acquire(rtype, state, dest, testOwner, "")
 }
 
 func (fb *fakeBoskos) AcquireByState(state, dest string, names []string) ([]common.Resource, error) {

--- a/boskos/client/BUILD.bazel
+++ b/boskos/client/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/storage:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/hashicorp/go-multierror:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -41,6 +41,10 @@ import (
 	"k8s.io/test-infra/boskos/storage"
 )
 
+const (
+	acquireWait = 3 * time.Second
+)
+
 var (
 	// ErrNotFound is returned by Acquire() when no resources are available.
 	ErrNotFound = errors.New("resources not found")
@@ -149,7 +153,7 @@ func (c *Client) AcquireWait(ctx context.Context, rtype, state, dest string) (*c
 				select {
 				case <-ctx.Done():
 					return nil, err
-				case <-time.After(3 * time.Second):
+				case <-time.After(acquireWait):
 					continue
 				}
 			}
@@ -190,7 +194,7 @@ func (c *Client) AcquireByStateWait(ctx context.Context, state, dest string, nam
 				select {
 				case <-ctx.Done():
 					return nil, err
-				case <-time.After(3 * time.Second):
+				case <-time.After(acquireWait):
 					continue
 				}
 			}
@@ -348,6 +352,7 @@ func (c *Client) acquire(rtype, state, dest, requestID string) (*common.Resource
 	values.Set("type", rtype)
 	values.Set("state", state)
 	values.Set("owner", c.owner)
+	values.Set("dest", dest)
 	values.Set("request_id", requestID)
 	resp, err := c.httpPost("/acquire", values, "", nil)
 	if err != nil {

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	acquireWait = 3 * time.Second
+	acquireWait = 15 * time.Second
 )
 
 var (

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -33,6 +34,8 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/storage"
@@ -109,7 +112,14 @@ func NewClient(owner string, url string) *Client {
 // Acquire asks boskos for a resource of certain type in certain state, and set the resource to dest state.
 // Returns the resource on success.
 func (c *Client) Acquire(rtype, state, dest string) (*common.Resource, error) {
-	r, err := c.acquire(rtype, state, dest)
+	return c.AcquireWithPriority(rtype, state, dest, "")
+}
+
+// AcquireWithPriority asks boskos for a resource of certain type in certain state, and set the resource to dest state.
+// Returns the resource on success.
+// Bosokos Priority are FIFO.
+func (c *Client) AcquireWithPriority(rtype, state, dest, requestID string) (*common.Resource, error) {
+	r, err := c.acquire(rtype, state, dest, requestID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,10 +138,12 @@ func (c *Client) AcquireWait(ctx context.Context, rtype, state, dest string) (*c
 	if ctx == nil {
 		return nil, ErrContextRequired
 	}
+	// request with FIFO priority
+	requestID := uuid.New().String()
 	// Try to acquire the resource until available or the context is
 	// cancelled or its deadline exceeded.
 	for {
-		r, err := c.Acquire(rtype, state, dest)
+		r, err := c.AcquireWithPriority(rtype, state, dest, requestID)
 		if err != nil {
 			if err == ErrAlreadyInUse || err == ErrNotFound {
 				select {
@@ -331,9 +343,13 @@ func (c *Client) updateLocalResource(i common.Item, state string, data *common.U
 	return err
 }
 
-func (c *Client) acquire(rtype, state, dest string) (*common.Resource, error) {
-	resp, err := c.httpPost(fmt.Sprintf("%v/acquire?type=%v&state=%v&dest=%v&owner=%v",
-		c.url, rtype, state, dest, c.owner), "", nil)
+func (c *Client) acquire(rtype, state, dest, requestID string) (*common.Resource, error) {
+	values := url.Values{}
+	values.Set("type", rtype)
+	values.Set("state", state)
+	values.Set("owner", c.owner)
+	values.Set("request_id", requestID)
+	resp, err := c.httpPost("/acquire", values, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +380,12 @@ func (c *Client) acquire(rtype, state, dest string) (*common.Resource, error) {
 }
 
 func (c *Client) acquireByState(state, dest string, names []string) ([]common.Resource, error) {
-	resp, err := c.httpPost(fmt.Sprintf("%v/acquirebystate?state=%v&dest=%v&owner=%v&names=%v",
-		c.url, state, dest, c.owner, strings.Join(names, ",")), "", nil)
+	values := url.Values{}
+	values.Set("state", state)
+	values.Set("dest", dest)
+	values.Set("names", strings.Join(names, ","))
+	values.Set("owner", c.owner)
+	resp, err := c.httpPost("/acquirebystate", values, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -387,8 +407,11 @@ func (c *Client) acquireByState(state, dest string, names []string) ([]common.Re
 }
 
 func (c *Client) Release(name, dest string) error {
-	resp, err := c.httpPost(fmt.Sprintf("%v/release?name=%v&dest=%v&owner=%v",
-		c.url, name, dest, c.owner), "", nil)
+	values := url.Values{}
+	values.Set("name", name)
+	values.Set("dest", dest)
+	values.Set("owner", c.owner)
+	resp, err := c.httpPost("/release", values, "", nil)
 	if err != nil {
 		return err
 	}
@@ -410,8 +433,11 @@ func (c *Client) update(name, state string, userData *common.UserData) error {
 		}
 		body = b
 	}
-	resp, err := c.httpPost(fmt.Sprintf("%v/update?name=%v&owner=%v&state=%v",
-		c.url, name, c.owner, state), "application/json", body)
+	values := url.Values{}
+	values.Set("name", name)
+	values.Set("owner", c.owner)
+	values.Set("state", state)
+	resp, err := c.httpPost("/update", values, "application/json", body)
 	if err != nil {
 		return err
 	}
@@ -425,8 +451,12 @@ func (c *Client) update(name, state string, userData *common.UserData) error {
 
 func (c *Client) reset(rtype, state string, expire time.Duration, dest string) (map[string]string, error) {
 	rmap := make(map[string]string)
-	resp, err := c.httpPost(fmt.Sprintf("%v/reset?type=%v&state=%v&expire=%v&dest=%v",
-		c.url, rtype, state, expire.String(), dest), "", nil)
+	values := url.Values{}
+	values.Set("type", rtype)
+	values.Set("state", state)
+	values.Set("expire", expire.String())
+	values.Set("dest", dest)
+	resp, err := c.httpPost("/reset", values, "", nil)
 	if err != nil {
 		return rmap, err
 	}
@@ -447,7 +477,9 @@ func (c *Client) reset(rtype, state string, expire time.Duration, dest string) (
 
 func (c *Client) metric(rtype string) (common.Metric, error) {
 	var metric common.Metric
-	resp, err := c.httpGet(fmt.Sprintf("%v/metric?type=%v", c.url, rtype))
+	values := url.Values{}
+	values.Set("type", rtype)
+	resp, err := c.httpGet("/metric", values)
 	if err != nil {
 		return metric, err
 	}
@@ -466,16 +498,22 @@ func (c *Client) metric(rtype string) (common.Metric, error) {
 	return metric, err
 }
 
-func (c *Client) httpGet(url string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func (c *Client) httpGet(action string, values url.Values) (*http.Response, error) {
+	u, _ := url.ParseRequestURI(c.url)
+	u.Path = action
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 	return c.http.Do(req)
 }
 
-func (c *Client) httpPost(url, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodPost, url, body)
+func (c *Client) httpPost(action string, values url.Values, contentType string, body io.Reader) (*http.Response, error) {
+	u, _ := url.ParseRequestURI(c.url)
+	u.Path = action
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequest(http.MethodPost, u.String(), body)
 	if err != nil {
 		return nil, err
 	}

--- a/boskos/cmd/cli/cli_test.go
+++ b/boskos/cmd/cli/cli_test.go
@@ -61,6 +61,7 @@ Usage:
 
 Flags:
   -h, --help                  help for acquire
+      --request-id string     request id to acquire the resource in
       --state string          State to acquire the resource in
       --target-state string   Move resource to this state after acquiring
       --timeout duration      If set, retry this long until the resource has been acquired
@@ -122,7 +123,7 @@ Global Flags:
 		},
 		{
 			name: "retry acquire sends requests and times out",
-			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old", "--timeout=5s"},
+			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old", "--timeout=5s", "--request-id=testingRequest"},
 			responses: map[string]response{
 				"/acquire": {
 					code: http.StatusUnauthorized,
@@ -130,11 +131,11 @@ Global Flags:
 			},
 			expectedCalls: []request{{
 				method: http.MethodPost,
-				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing&request_id=testingRequest`},
 				body:   []byte{},
 			}, {
 				method: http.MethodPost,
-				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing&request_id=testingRequest`},
 				body:   []byte{},
 			}},
 			expectedOutput: `failed to acquire a resource: resources already used by another user

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	errConstruct = fmt.Errorf("failed to construct")
+	testTTL      = time.Millisecond
 )
 
 const (
@@ -98,7 +99,7 @@ func createFakeBoskos(tc testConfig) (*ranch.Storage, *Client, chan releasedReso
 	names := make(chan releasedResource, 100)
 	configNames := map[string]bool{}
 	s, _ := ranch.NewStorage(storage.NewMemoryStorage(), storage.NewMemoryStorage(), "")
-	r, _ := ranch.NewRanch("", s)
+	r, _ := ranch.NewRanch("", s, testTTL)
 
 	for rtype, c := range tc {
 		for i := 0; i < c.count; i++ {
@@ -129,7 +130,7 @@ func createFakeBoskos(tc testConfig) (*ranch.Storage, *Client, chan releasedReso
 }
 
 func (fb *fakeBoskos) Acquire(rtype, state, dest string) (*common.Resource, error) {
-	return fb.ranch.Acquire(rtype, state, dest, owner)
+	return fb.ranch.Acquire(rtype, state, dest, owner, "")
 }
 
 func (fb *fakeBoskos) AcquireByState(state, dest string, names []string) ([]common.Resource, error) {

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -8,7 +8,10 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["ranch_test.go"],
+    srcs = [
+        "priority_test.go",
+        "ranch_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//boskos/common:go_default_library",
@@ -19,6 +22,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "priority.go",
         "ranch.go",
         "storage.go",
     ],

--- a/boskos/ranch/priority.go
+++ b/boskos/ranch/priority.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ranch
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// request stores request information with expiration
+type request struct {
+	id         string
+	expiration time.Time
+}
+
+func newRequestQueue() *requestQueue {
+	return &requestQueue{
+		requestMap: map[string]request{},
+	}
+}
+
+// requestQueue is a simple FIFO queue for requests.
+type requestQueue struct {
+	lock        sync.RWMutex
+	requestList []string
+	requestMap  map[string]request
+}
+
+// update updates expiration time is updated if already present,
+// add a new requestID at the end otherwise (FIFO)
+func (rq *requestQueue) update(requestID string, newExpiration time.Time) {
+	if requestID == "" {
+		// Nothing to do
+		return
+	}
+	rq.lock.Lock()
+	defer rq.lock.Unlock()
+	if rq.requestMap == nil {
+		rq.requestMap = map[string]request{}
+	}
+	req, exists := rq.requestMap[requestID]
+	if !exists {
+		req = request{id: requestID}
+		rq.requestList = append(rq.requestList, requestID)
+		logrus.Infof("request id %s added", requestID)
+	}
+	// Update timestamp
+	req.expiration = newExpiration
+	rq.requestMap[requestID] = req
+	logrus.Infof("request id %s set to expire at %v", requestID, newExpiration)
+}
+
+// delete an element
+func (rq *requestQueue) delete(requestID string) {
+	rq.lock.Lock()
+	defer rq.lock.Unlock()
+	delete(rq.requestMap, requestID)
+	index := -1
+	for i, id := range rq.requestList {
+		if id == requestID {
+			index = i
+			break
+		}
+	}
+	if index >= 0 {
+		rq.requestList = append(rq.requestList[0:index], rq.requestList[index+1:len(rq.requestList)]...)
+		logrus.Infof("request id %s deleted", requestID)
+	}
+}
+
+// cleanup checks for all expired  or marked for deletion items and delete them.
+func (rq *requestQueue) cleanup(now time.Time) {
+	rq.lock.Lock()
+	defer rq.lock.Unlock()
+	var newRequestList []string
+	newRequestMap := map[string]request{}
+	for _, requestID := range rq.requestList {
+		req := rq.requestMap[requestID]
+		// Checking expiration
+		if now.After(req.expiration) {
+			logrus.Infof("request id %s expired", req.id)
+			continue
+		}
+		// Keeping
+		newRequestList = append(newRequestList, requestID)
+		newRequestMap[requestID] = req
+	}
+	rq.requestMap = newRequestMap
+	rq.requestList = newRequestList
+}
+
+// getRank provides the rank of a given requestID following the order it was added (FIFO).
+// If requestID is an empty string, getRank assumes it is added last (lowest rank + 1).
+func (rq *requestQueue) getRank(requestID string, ttl time.Duration, now time.Time) int {
+	rq.update(requestID, now.Add(ttl))
+	rank := 1
+	rq.lock.RLock()
+	defer rq.lock.RUnlock()
+	for _, existingID := range rq.requestList {
+		req := rq.requestMap[existingID]
+		if now.After(req.expiration) {
+			logrus.Infof("request id %s expired", req.id)
+			continue
+		}
+		if requestID == existingID {
+			return rank
+		}
+		rank++
+	}
+	return rank
+}
+
+func (rq *requestQueue) isEmpty() bool {
+	rq.lock.Lock()
+	defer rq.lock.Unlock()
+	return len(rq.requestList) == 0
+}
+
+// RequestManager facilitates management of RequestQueues for a set of (resource type, resource state) tuple.
+type RequestManager struct {
+	lock     sync.Mutex
+	requests map[interface{}]*requestQueue
+	ttl      time.Duration
+	stopGC   context.CancelFunc
+	wg       sync.WaitGroup
+	// For testing only
+	now func() time.Time
+}
+
+// NewRequestManager creates a new RequestManager
+func NewRequestManager(ttl time.Duration) *RequestManager {
+	return &RequestManager{
+		requests: map[interface{}]*requestQueue{},
+		ttl:      ttl,
+		now:      time.Now,
+	}
+}
+
+func (rp *RequestManager) cleanup(now time.Time) {
+	rp.lock.Lock()
+	defer rp.lock.Unlock()
+	for key, rq := range rp.requests {
+		logrus.Infof("cleaning up %v request queue", key)
+		rq.cleanup(now)
+		if rq.isEmpty() {
+			delete(rp.requests, key)
+		}
+	}
+}
+
+// StartGC starts a goroutine that will call cleanup every gcInterval
+func (rp *RequestManager) StartGC(gcPeriod time.Duration) {
+	ctx, stop := context.WithCancel(context.Background())
+	rp.stopGC = stop
+	tick := time.Tick(gcPeriod)
+	go func() {
+		logrus.Info("starting cleanup go routine")
+		defer logrus.Info("exiting cleanup go routine")
+		rp.wg.Add(1)
+		defer rp.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick:
+				rp.cleanup(rp.now())
+			}
+		}
+
+	}()
+}
+
+// StopGC is a blocking call that will stop the GC goroutine.
+func (rp *RequestManager) StopGC() {
+	if rp.stopGC != nil {
+		rp.stopGC()
+		rp.wg.Wait()
+	}
+}
+
+// GetRank provides the rank of a given request
+func (rp *RequestManager) GetRank(key interface{}, id string) int {
+	rp.lock.Lock()
+	defer rp.lock.Unlock()
+	rq := rp.requests[key]
+	if rq == nil {
+		rq = newRequestQueue()
+		rp.requests[key] = rq
+	}
+	return rq.getRank(id, rp.ttl, rp.now())
+}
+
+// Delete deletes a specific request such that it is not accounted in the next GetRank call.
+// This is usually called when the request has been fulfilled.
+func (rp *RequestManager) Delete(key interface{}, requestID string) {
+	rp.lock.Lock()
+	defer rp.lock.Unlock()
+	rq := rp.requests[key]
+	if rq != nil {
+		rq.delete(requestID)
+	}
+}

--- a/boskos/ranch/priority_test.go
+++ b/boskos/ranch/priority_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ranch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+const (
+	testTTL      = time.Millisecond
+	testGCPeriod = 20 * time.Millisecond
+)
+
+func TestRequestQueue(t *testing.T) {
+	now := time.Now()
+	rq := newRequestQueue()
+	count := 10
+	for i := 0; i < count; i++ {
+		rank := rq.getRank(fmt.Sprintf("request_%d", i), testTTL, now)
+		if rank != i+1 {
+			t.Errorf("expected %d got %d", i+1, rank)
+		}
+	}
+	if rank := rq.getRank("", testTTL, now); rank != count+1 {
+		t.Errorf("expected %d got %d", count+1, rank)
+	}
+	for i := 0; i < count; i++ {
+		rq.delete(fmt.Sprintf("request_%d", i))
+		for j := i + 1; j < count; j++ {
+			rank := rq.getRank(fmt.Sprintf("request_%d", j), testTTL, now)
+			if rank != j-i {
+				t.Errorf("expected %d got %d", j-i, rank)
+			}
+		}
+		if rank := rq.getRank("", testTTL, now); rank != count-i {
+			t.Errorf("expected %d got %d", count-i, rank)
+		}
+		rq.cleanup(now)
+		// cleanup should not impact result
+		for j := i + 1; j < count; j++ {
+			rank := rq.getRank(fmt.Sprintf("request_%d", j), testTTL, now)
+			if rank != j-i {
+				t.Errorf("expected %d got %d", j-i, rank)
+			}
+		}
+		if rank := rq.getRank("", testTTL, now); rank != count-i {
+			t.Errorf("expected %d got %d", count-i, rank)
+		}
+	}
+	if !rq.isEmpty() {
+		t.Errorf("RQ should be empty")
+	}
+
+}
+
+func TestRequestManager(t *testing.T) {
+	key := "key"
+	id := "request1234"
+	expectedRank := 1
+	expectedRankEmpty := 2
+	expectedRankAfterDelete := 1
+	now := time.Now()
+	expiredFuture := now.Add(2 * testTTL)
+	mgr := NewRequestManager(testTTL)
+	mgr.now = func() time.Time { return now }
+
+	// Getting Rank
+	rank := mgr.GetRank(key, id)
+	emptyRank := mgr.GetRank(key, "")
+	if rank != expectedRank {
+		t.Errorf("expected rank %d got %d", expectedRank, rank)
+	}
+	if emptyRank != expectedRankEmpty {
+		t.Errorf("expected empty rank %d got %d", expectedRankEmpty, emptyRank)
+	}
+
+	// Deleting
+	mgr.Delete(key, id)
+	afterDeleteRank := mgr.GetRank(key, "")
+	if afterDeleteRank != expectedRankAfterDelete {
+		t.Errorf("expected empty rank %d got %d", expectedRankAfterDelete, afterDeleteRank)
+	}
+
+	// Re-adding request
+	mgr.GetRank(key, id)
+
+	// Starting cleanup
+	mgr.cleanup(expiredFuture)
+	afterDeleteRank = mgr.GetRank(key, "")
+	if afterDeleteRank != expectedRankAfterDelete {
+		t.Errorf("expected empty rank %d got %d", expectedRankAfterDelete, afterDeleteRank)
+	}
+}
+
+func TestRequestManager_GC(t *testing.T) {
+	key := "key"
+	id := "request1234"
+	mgr := NewRequestManager(testTTL)
+
+	// Starting GC
+	mgr.StartGC(testGCPeriod)
+
+	// Getting Rank
+	rank := mgr.GetRank(key, id)
+	if rank != 1 {
+		t.Errorf("expected rank %d got %d", 1, rank)
+	}
+
+	// Waiting for GC to happen
+	time.Sleep(2 * testGCPeriod)
+
+	// Checking
+	rank = mgr.GetRank(key, "")
+	if rank != 1 {
+		t.Errorf("expected empty rank %d got %d", 1, rank)
+	}
+
+	done := make(chan bool)
+	go func() {
+		mgr.StopGC()
+		done <- true
+	}()
+	select {
+	case <-done:
+	// OK
+	case <-time.After(2 * testGCPeriod):
+		t.Errorf("could not STOP GC")
+	}
+}

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -32,6 +32,7 @@ import (
 type Ranch struct {
 	Storage       *Storage
 	resourcesLock sync.RWMutex
+	requestMgr    *RequestManager
 	//
 	now func() time.Time
 }
@@ -84,10 +85,11 @@ func (s StateNotMatch) Error() string {
 // In: config - path to resource file
 //     storage - path to where to save/restore the state data
 // Out: A Ranch object, loaded from config/storage, or error
-func NewRanch(config string, s *Storage) (*Ranch, error) {
+func NewRanch(config string, s *Storage, ttl time.Duration) (*Ranch, error) {
 	newRanch := &Ranch{
-		Storage: s,
-		now:     time.Now,
+		Storage:    s,
+		requestMgr: NewRequestManager(ttl),
+		now:        time.Now,
 	}
 	if config != "" {
 		if err := newRanch.SyncConfig(config); err != nil {
@@ -98,6 +100,11 @@ func NewRanch(config string, s *Storage) (*Ranch, error) {
 	return newRanch, nil
 }
 
+// typeState is used as keu
+type typeState struct {
+	rType, state string
+}
+
 // Acquire checks out a type of resource in certain state without an owner,
 // and move the checked out resource to the end of the resource list.
 // In: rtype - name of the target resource
@@ -106,9 +113,13 @@ func NewRanch(config string, s *Storage) (*Ranch, error) {
 //     owner - requester of the resource
 // Out: A valid Resource object on success, or
 //      ResourceNotFound error if target type resource does not exist in target state.
-func (r *Ranch) Acquire(rType, state, dest, owner string) (*common.Resource, error) {
+func (r *Ranch) Acquire(rType, state, dest, owner, requestID string) (*common.Resource, error) {
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
+
+	// Finding Request Priority
+	ts := typeState{rType: rType, state: state}
+	rank := r.requestMgr.GetRank(ts, requestID)
 
 	resources, err := r.Storage.GetResources()
 	if err != nil {
@@ -117,22 +128,30 @@ func (r *Ranch) Acquire(rType, state, dest, owner string) (*common.Resource, err
 	}
 
 	foundType := false
+	// For request priority we need to go over all the list until a matching rank
+	matchingResoucesCount := 0
 	for idx := range resources {
 		res := resources[idx]
 		if rType == res.Type {
 			foundType = true
 			if state == res.State && res.Owner == "" {
-				res.Owner = owner
-				res.State = dest
-				updatedRes, err := r.Storage.UpdateResource(res)
-				if err != nil {
-					logrus.WithError(err).Errorf("could not update resource %s", res.Name)
-					return nil, err
+				matchingResoucesCount++
+				if matchingResoucesCount >= rank {
+					res.Owner = owner
+					res.State = dest
+					updatedRes, err := r.Storage.UpdateResource(res)
+					if err != nil {
+						logrus.WithError(err).Errorf("could not update resource %s", res.Name)
+						return nil, err
+					}
+					// Deleting this request since it has been fulfilled
+					r.requestMgr.Delete(ts, requestID)
+					return &updatedRes, nil
 				}
-				return &updatedRes, nil
 			}
 		}
 	}
+
 	if foundType {
 		return nil, &ResourceNotFound{rType}
 	}
@@ -338,6 +357,11 @@ func (r *Ranch) SyncConfig(configPath string) error {
 		return err
 	}
 	return nil
+}
+
+// StartRequestGC starts the GC of expired requests
+func (r *Ranch) StartRequestGC(gcPeriod time.Duration) {
+	r.requestMgr.StartGC(gcPeriod)
 }
 
 // Metric returns a metric object with metrics filled in

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -100,8 +100,8 @@ func NewRanch(config string, s *Storage, ttl time.Duration) (*Ranch, error) {
 	return newRanch, nil
 }
 
-// typeState is used as keu
-type typeState struct {
+// acquireRequestPriorityKey is used as key for request priority cache.
+type acquireRequestPriorityKey struct {
 	rType, state string
 }
 
@@ -111,6 +111,7 @@ type typeState struct {
 //     state - current state of the requested resource
 //     dest - destination state of the requested resource
 //     owner - requester of the resource
+//     requestID - request ID to get a priority in the queue
 // Out: A valid Resource object on success, or
 //      ResourceNotFound error if target type resource does not exist in target state.
 func (r *Ranch) Acquire(rType, state, dest, owner, requestID string) (*common.Resource, error) {
@@ -118,7 +119,7 @@ func (r *Ranch) Acquire(rType, state, dest, owner, requestID string) (*common.Re
 	defer r.resourcesLock.Unlock()
 
 	// Finding Request Priority
-	ts := typeState{rType: rType, state: state}
+	ts := acquireRequestPriorityKey{rType: rType, state: state}
 	rank := r.requestMgr.GetRank(ts, requestID)
 
 	resources, err := r.Storage.GetResources()

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -146,7 +146,9 @@ func (r *Ranch) Acquire(rType, state, dest, owner, requestID string) (*common.Re
 						return nil, err
 					}
 					// Deleting this request since it has been fulfilled
-					r.requestMgr.Delete(ts, requestID)
+					if requestID != "" {
+						r.requestMgr.Delete(ts, requestID)
+					}
 					return &updatedRes, nil
 				}
 			}

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -67,7 +67,7 @@ func MakeTestRanch(resources []common.Resource, dResources []common.DynamicResou
 	for _, res := range dResources {
 		s.AddDynamicResourceLifeCycle(res)
 	}
-	r, _ := NewRanch("", s)
+	r, _ := NewRanch("", s, testTTL)
 	r.now = func() time.Time {
 		return fakeNow
 	}
@@ -184,7 +184,7 @@ func TestAcquire(t *testing.T) {
 
 	for _, tc := range testcases {
 		c := MakeTestRanch(tc.resources, nil)
-		res, err := c.Acquire(tc.rtype, tc.state, tc.dest, tc.owner)
+		res, err := c.Acquire(tc.rtype, tc.state, tc.dest, tc.owner, "")
 		if !AreErrorsEqual(err, tc.expectErr) {
 			t.Errorf("%s - Got error %v, expected error %v", tc.name, err, tc.expectErr)
 			continue
@@ -215,6 +215,45 @@ func TestAcquire(t *testing.T) {
 	}
 }
 
+func TestAcquirePriority(t *testing.T) {
+	now := time.Now()
+	expiredFuture := now.Add(2 * testTTL)
+	owner := "tester"
+	res := common.NewResource("res", "type", common.Free, "", now)
+	r := MakeTestRanch(nil, nil)
+	r.requestMgr.now = func() time.Time { return now }
+
+	// Setting Priority, this request will fail
+	r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1")
+	r.Storage.AddResource(res)
+	// Attempting to acquire this resource without priority
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err == nil {
+		t.Errorf("this should fail")
+	}
+	// Attempting to acquire this resource without priority
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_2"); err == nil {
+		t.Errorf("this should fail")
+	}
+	// Attempting with the first request
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1"); err != nil {
+		t.Errorf("this should succeed. got %v", err)
+	}
+	r.Release(res.Name, common.Free, "tester")
+	// Attempting with the first request
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1"); err == nil {
+		t.Errorf("this should not succeed since this request has already been fulfilled")
+	}
+	// Attempting to acquire this resource without priority
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err == nil {
+		t.Errorf("this should fail")
+	}
+	r.requestMgr.cleanup(expiredFuture)
+	// Attempting to acquire this resource without priority
+	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err != nil {
+		t.Errorf("request 2 expired, this should work now, got %v", err)
+	}
+}
+
 func TestAcquireRoundRobin(t *testing.T) {
 	var resources []common.Resource
 	for i := 1; i < 5; i++ {
@@ -225,7 +264,7 @@ func TestAcquireRoundRobin(t *testing.T) {
 
 	c := MakeTestRanch(resources, nil)
 	for i := 0; i < 4; i++ {
-		res, err := c.Acquire("t", "s", "d", "foo")
+		res, err := c.Acquire("t", "s", "d", "foo", "")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/boskos/server_client_test.go
+++ b/boskos/server_client_test.go
@@ -218,8 +218,11 @@ func TestClientServerUpdate(t *testing.T) {
 		r := MakeTestRanch([]common.Resource{tc.resource})
 		boskos := makeTestBoskos(r)
 		client := client.NewClient(owner, boskos.URL)
-		client.Acquire(rType, initialState, finalState)
-		err := client.UpdateOne(resourceName, finalState, common.UserDataFromMap(tc.ud))
+		_, err := client.Acquire(rType, initialState, finalState)
+		if err != nil {
+			t.Errorf("failed to acquire resource")
+		}
+		err = client.UpdateOne(resourceName, finalState, common.UserDataFromMap(tc.ud))
 		boskos.Close()
 		if !reflect.DeepEqual(err, tc.err) {
 			t.Errorf("tc: %s - errors don't match, expected %v, received\n %v", tc.name, tc.err, err)


### PR DESCRIPTION
This adds priority support to the Boskos Acquire API.

Priority is FIFO, with ttl. In order to keep a request priority, user needs to keep sending Acquire requests within 30 seconds (default value which is modifiable on the Server side). Acquire requests that don't specify request_id will have the lowest priority.