### PR TITLE
Add CAPV post-submits to push images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -57,6 +57,20 @@ presets:
       items:
       - key: bootstrapper-key
         path: bootstrapper-key
+- labels:
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+  volumes:
+  - name: cluster-api-provider-vsphere-gcs-creds
+    secret:
+      secretName: cluster-api-provider-vsphere-gcs-prow
+      items:
+      - key: keyfile.json
+        path: keyfile.json
+        mode: 288
+  volumeMounts:
+  - name: cluster-api-provider-vsphere-gcs-creds
+    mountPath: /root/.capv
+    readOnly: true
 
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
@@ -209,3 +223,67 @@ presubmits:
       testgrid-tab-name: pr-e2e
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Runs e2e tests
+
+postsubmits:
+  kubernetes-sigs/cluster-api-provider-vsphere:
+
+  # Deploys images and binaries after all merges to master
+  - name: post-cluster-api-provider-vsphere-deploy
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    branches:
+    - ^master$
+    always_run: false
+    run_if_changed: '^(cmd|config|pkg|vendor)/|Dockerfile'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190719-7cdf877-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/release.sh
+        - -l
+        - -p
+        - -k
+        - /root/.capv/keyfile.json
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: post-deploy
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Pushes new images and binaries from master
+
+  # Deploys images and binaries for tagged releases
+  - name: post-cluster-api-provider-vsphere-release
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    branches:
+    - ^v(\d)+\.(\d)+\.(\d)+(-(alpha|beta|rc)\.(\d)+)?$
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190719-7cdf877-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/release.sh
+        - -p
+        - -k
+        - /root/.capv/keyfile.json
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: release
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: releases new tagged images and binaries


### PR DESCRIPTION
This patch adds two post-submit jobs for CAPV. One builds and pushes new
images/binaries after merges to master, and the other does the same for
tagged releases.

/assign @akutz 