### PR TITLE
Fix bazel rules

### DIFF
--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -91,6 +91,8 @@ filegroup(
         ":package-srcs",
         "//prow/cluster/monitoring/mixins/dashboards_out:all-srcs",
         "//prow/cluster/monitoring/mixins/grafana_dashboards:all-srcs",
+        "//prow/cluster/monitoring/mixins/prometheus:all-srcs",
+        "//prow/cluster/monitoring/mixins/prometheus_out:all-srcs",
         "//prow/cluster/monitoring/mixins/vendor/grafonnet:all-srcs",
     ],
     tags = ["automanaged"],

--- a/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
@@ -3,10 +3,10 @@ load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet
 jsonnet_library(
     name = "prom_lib",
     srcs = [
-        "prometheus.libsonnet",
         "ci_absent_alerts.libsonnet",
-        "prow_monitoring_absent_alerts.libsonnet",
         "configmap_alerts.libsonnet",
+        "prometheus.libsonnet",
+        "prow_monitoring_absent_alerts.libsonnet",
     ],
 )
 
@@ -14,10 +14,10 @@ jsonnet_to_json(
     name = "prow_prometheusrule",
     src = "prow_prometheusrule.jsonnet",
     outs = ["prow_prometheusrule.yaml"],
-    deps = [":prom_lib"],
     #uncomment the following line when https://github.com/bazelbuild/rules_jsonnet/issues/114 has a fix.
     #yaml_stream = True,
     visibility = ["//visibility:public"],
+    deps = [":prom_lib"],
 )
 
 filegroup(


### PR DESCRIPTION
/assign @cjwagner @chases2 @hongkailiu @stevekuznetsov 

We really need to add a presubmit to ensure that all BUILD.bazel files include an :all-srcs kazel rule

fixes https://github.com/kubernetes/test-infra/issues/13566