### PR TITLE
Point the testgrid config upload job at the testgrid config

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -63,7 +63,7 @@ postsubmits:
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
-    run_if_changed: '^(testgrid/.*|config/jobs/.*)$'
+    run_if_changed: '^config/(jobs|testgrids)/.*$'
     decorate: true
     spec:
       containers:

--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -23,7 +23,7 @@ TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
 for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
   dir="$(dirname "${BASH_SOURCE}")"
   bazel run //testgrid/cmd/configurator -- \
-    --yaml="$(realpath "${dir}/config.yaml"),$(realpath "${dir}/generated-test-config.yaml")" \
+    --yaml="${TESTINFRA_ROOT}/config/testgrids" \
     --prow-config="${TESTINFRA_ROOT}/prow/config.yaml" \
     --prow-job-config="${TESTINFRA_ROOT}/config/jobs/" \
     --output="${output}" \


### PR DESCRIPTION
Currently it doesn't run when the testgrid config changes, and fails when the testgrid configurator changes.

/cc @chases2 @fejta 