### PR TITLE
Skip e2e case: Checks that the node becomes unreachable.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -456,8 +456,9 @@ periodics:
       # 1. regular resource usage tracking, haven't found the cause of the failures.
       # 2. DNS config map nameserver, the coredns configmap config in aks-engine is set to reconcile, making it impossible for the newly generated configmap in test cases to overwrite the original one. https://github.com/Azure/aks-engine/blob/master/parts/k8s/addons/coredns.yaml#L59
       # 3. validates MaxPods limit number of pods that are allowed to run, related to issue kubernetes/kubernetes#80177
+      # 4. Checks that the node becomes unreachable, the externel IP is unavailable since the corresponding configuration in aks-engine is set to false.
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.37.3/aks-engine-v0.37.3-linux-amd64.tar.gz
-      - --test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|should\sunmount|When\skubelet\srestarts|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|DNS\sconfigMap\snameserver --minStartupPods=8
+      - --test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|should\sunmount|When\skubelet\srestarts|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|DNS\sconfigMap\snameserver|Checks\sthat\sthe\snode\sbecomes\sunreachable --minStartupPods=8
       - --timeout=600m
       securityContext:
         privileged: true


### PR DESCRIPTION
This case should be skipped because the externel IP is unavailable since the conrresponding 
configuration in aks-engine is set to false.