### PR TITLE
Fixed upgrade/downgrade jobs to go from stable to latest and vice versa

### DIFF
--- a/config/jobs/kubernetes/sig-gcp/k8s-upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-gcp/k8s-upgrade-gce.yaml
@@ -338,7 +338,7 @@ periodics:
       - --env=TEST_ETCD_VERSION=3.0.17
       # In 1.11 influxdb is no longer deployed by default.
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -374,7 +374,7 @@ periodics:
       - --env=TEST_ETCD_VERSION=3.0.17
       # In 1.11 influxdb is no longer deployed by default.
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel
@@ -473,7 +473,7 @@ periodics:
       # In 1.11 influxdb is no longer deployed by default.
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -504,7 +504,7 @@ periodics:
       - --check-version-skew=false
       - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -534,7 +534,7 @@ periodics:
       - --check-version-skew=false
       - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel
@@ -572,7 +572,7 @@ periodics:
       # In 1.11 influxdb is no longer deployed by default.
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel
       - --provider=gce
@@ -602,7 +602,7 @@ periodics:
       - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -632,7 +632,7 @@ periodics:
       - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
       - --env=KUBE_ENABLE_CLUSTER_MONITORING=standalone
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel


### PR DESCRIPTION
All these upgrade/downgrade jobs were incorrectly beuing
upgraded/downgraded by 2 minor versions, i.e., 1.14 -> 1.16.

Want to keep this jobs working for a bit more to properly continue work on https://github.com/kubernetes/kubernetes/issues/78995 which aims to completely deprecate the cluster directory.
It will also allow us to verify whether https://github.com/kubernetes/kubernetes/issues/79740 and https://github.com/kubernetes/kubernetes/issues/79533 are due to a test misconfguration or whether there is some other underlying problem.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>