### PR TITLE
Revert "Clean up pods whose ProwJob is in aborted state"

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -49,9 +49,8 @@ type options struct {
 }
 
 const (
-	reasonPodAged           = "aged"
-	reasonPodOrphaned       = "orphaned"
-	reasonPodProwJobAborted = "prowjob-aborted"
+	reasonPodAged     = "aged"
+	reasonPodOrphaned = "orphaned"
 
 	reasonProwJobAged         = "aged"
 	reasonProwJobAgedPeriodic = "aged-periodic"
@@ -249,17 +248,13 @@ func (c *controller) clean() {
 	}
 	metrics.prowJobsCreated = len(prowJobs.Items)
 
-	// Only delete pod if its prowjob is marked as finished or aborted
+	// Only delete pod if its prowjob is marked as finished
 	isExist := sets.NewString()
 	isFinished := sets.NewString()
-	isAborted := sets.NewString()
 
 	maxProwJobAge := c.config().Sinker.MaxProwJobAge.Duration
 	for _, prowJob := range prowJobs.Items {
 		isExist.Insert(prowJob.ObjectMeta.Name)
-		if prowJob.Status.State == prowapi.AbortedState {
-			isAborted.Insert(prowJob.ObjectMeta.Name)
-		}
 		// Handle periodics separately.
 		if prowJob.Spec.Type == prowapi.PeriodicJob {
 			continue
@@ -339,12 +334,6 @@ func (c *controller) clean() {
 				reason = reasonPodOrphaned
 				clean = true
 			}
-			if isAborted.Has(pod.ObjectMeta.Name) {
-				// prowjob is in aborted state, the result of this pod doesn't matter anymore
-				// so free up the resources it occupies
-				reason = reasonPodProwJobAborted
-				clean = true
-			}
 
 			if !clean {
 				continue
@@ -352,7 +341,7 @@ func (c *controller) clean() {
 
 			// Delete old finished or orphan pods. Don't quit if we fail to delete one.
 			if err := client.Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{}); err == nil {
-				c.logger.WithField("pod", pod.ObjectMeta.Name).WithField("reason", reason).Info("Deleted old pod.")
+				c.logger.WithField("pod", pod.ObjectMeta.Name).Info("Deleted old completed pod.")
 				metrics.podsRemoved[reason]++
 			} else {
 				c.logger.WithField("pod", pod.ObjectMeta.Name).WithError(err).Error("Error deleting pod.")

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -207,19 +207,6 @@ func TestClean(t *testing.T) {
 				StartTime: startTime(time.Now().Add(-maxPodAge).Add(-time.Second)),
 			},
 		},
-		&corev1api.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "prowjob-aborted",
-				Namespace: "ns",
-				Labels: map[string]string{
-					kube.CreatedByProw: "true",
-				},
-			},
-			Status: corev1api.PodStatus{
-				Phase:     corev1api.PodRunning,
-				StartTime: startTime(time.Now().Add(-10 * time.Second)),
-			},
-		},
 	}
 	deletedPods := sets.NewString(
 		"new-running-no-pj",
@@ -227,7 +214,6 @@ func TestClean(t *testing.T) {
 		"old-succeeded",
 		"old-pending-abort",
 		"old-running",
-		"prowjob-aborted",
 	)
 	setComplete := func(d time.Duration) *metav1.Time {
 		completed := metav1.NewTime(time.Now().Add(d))
@@ -369,16 +355,6 @@ func TestClean(t *testing.T) {
 			Status: prowv1.ProwJobStatus{
 				StartTime:      metav1.NewTime(time.Now().Add(-maxProwJobAge).Add(-time.Second)),
 				CompletionTime: setComplete(-time.Second),
-			},
-		},
-		&prowv1.ProwJob{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "prowjob-aborted",
-				Namespace: "ns",
-			},
-			Status: prowv1.ProwJobStatus{
-				State:     prowv1.AbortedState,
-				StartTime: metav1.NewTime(time.Now().Add(-time.Second)),
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit 3718d95a58b9099de2e3ee247622bd5602a0dd86.

This is supposed to be configured with Planks `AllowCancellations`
setting.