### PR TITLE
Fix v4 endpoint parsing

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -189,7 +189,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	apiVersion := "v3"
-	if strings.HasPrefix(req.URL.Path, "search") || strings.HasPrefix(req.URL.Path, "/search") {
+	if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") {
 		apiVersion = "v4"
 	}
 


### PR DESCRIPTION
Somehow the wrong endpoint is checked for v4 API. Based on the documentation:
https://developer.github.com/v4/guides/forming-calls/#the-graphql-endpoint

The v4 endpoint is solely the graphql endpoint.