### PR TITLE
Add an alert for webhooks

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
@@ -5,6 +5,7 @@ jsonnet_library(
     srcs = [
         "ci_absent_alerts.libsonnet",
         "configmap_alerts.libsonnet",
+        "hook_alert.libsonnet",
         "prometheus.libsonnet",
         "prow_monitoring_absent_alerts.libsonnet",
     ],

--- a/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -1,0 +1,28 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'abnormal webhook behaviors',
+        rules: [
+          {
+            alert: 'no-webhook-calls',
+            // Monday-Friday 9am-5pm PDT (in UTC)
+            expr: |||
+              (sum(increase(prow_webhook_counter[1m])) == 0 or absent(prow_webhook_counter))
+              and ( ((day_of_week() == 1) and (hour() >= 18)) or
+                    ((day_of_week() > 2) and (day_of_week() < 6) and ((hour() >= 18) or (hour() <= 2))) or
+                    ((day_of_week() == 6) and (hour() <= 2)) )
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'slack',
+            },
+            annotations: {
+              message: 'There have been no webhook calls on working hours for 5 minutes',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -1,3 +1,4 @@
 (import 'ci_absent_alerts.libsonnet') +
 (import 'prow_monitoring_absent_alerts.libsonnet') +
-(import 'configmap_alerts.libsonnet')
+(import 'configmap_alerts.libsonnet') +
+(import 'hook_alert.libsonnet')


### PR DESCRIPTION
The added alerts should be fired when `prow_webhook_counter` does not increase which usually is a reflection of github-having-accidents.