### PR TITLE
add OWNERS to unsharded testgrid configs

### DIFF
--- a/config/testgrids/OWNERS
+++ b/config/testgrids/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- michelle192837
+- spiffxp
+- wojtek-t
+- shyamjvs
+labels:
+- area/testgrid


### PR DESCRIPTION
Until we've sharded them we should use the same OWNERS as testgrid/

/cc @chases2 @michelle192837