### PR TITLE
Create Dynamic resources on demand on Acquire

### DIFF
--- a/boskos/README.md
+++ b/boskos/README.md
@@ -4,30 +4,30 @@
 ## Background
 [βοσκός](https://en.wiktionary.org/wiki/%CE%B2%CE%BF%CF%83%CE%BA%CF%8C%CF%82) - shepherd in greek!
 
-boskos is a resource manager service, that handles and manages different kind of resources and transition between different states.
+boskos is a resource manager service, that handles and manages different kind of resources and transition between
+different states.
 
 ## Introduction
 
-Boskos is inited with a config of resources, a list of resources by names. It's passed in by `-config`, usually as a config map.
+Boskos is inited with a config of resources, a list of resources by names. It's passed in by `-config`, usually as a
+config map.
 
-A resource yaml looks looks like:
+Boskos supports 2 types of resources, static and dynamic resources. Static resources are the one that depends on actual
+physical resources, meaning someone needs to physically create it, and add it to the list. Dynamic resources
+may depend on static resources. In the example bellow , aws-account is static resource, and aws-cluster is a dynamic
+resource that depends on having an aws-account. Once a cluster is created, AWS are in used, so admin might want to
+always have a minimum cluster available for testing, and might allow for more cluster to be created for spike usage.
 
 ```yaml
 ---
 resources:
+  # Static
   - type: "aws-account"
     state: free
     names:
     - "account1"
     - "account2"
-```
-
-For dynamic resources, ie resources that are created from static resources (See Mason), a specific config can be used:
-
-```yaml
----
-resources:
-  (...)
+  # Dynamic
   - type: "aws-cluster"
     state: dirty
     min-count: 1
@@ -38,16 +38,8 @@ resources:
     config:
       type: AWSClusterCreator
       content: "..."
+
 ```
-
-Boskos will take care of creating and naming the resources (if the current
-count is below min-count) and deleting the resources if they are expired or
-over max-count.
-
-All resource being deleted (due to config update or expiration) will be marked
-as `ToBeDeleted`. The cleaner component will mark them as `Tombstone` such that
-they can be safely deleted by Boskos. The cleaner will ensure that dynamic
-resources release other leased resources associated with it to prevent leaks.
 
 Type can be GCPProject, cluster, or even a dota2 server, anything that you
 want to be a group of resources. Name is a unique identifier of the resource.
@@ -60,6 +52,24 @@ final resource UserData. It is up to the implementation to parse the string into
 right struct. UserData can be updated using the update API call. All resource
 user data is returned as part of acquisition (calling acquire or acquirebystate)
 
+
+## Dynamic Resources
+
+As explain in the introduction, dynamic resources were introduced to reduce cost.
+
+If all resources are currently being used, and the count of resources is bellow Max,
+boskos will create new resources on Acquire. In order to take advantage of this,
+users need to specify a request ID in Acquire and keep using the same requestID
+until the resource is available.
+
+Boskos will take care of naming and creating resources (if the current
+count is below min-count) and deleting the resources if they are expired (lifetime
+option) or over max-count.
+
+All resource being deleted (due to config update or expiration) will be marked
+as `ToBeDeleted`. The cleaner component will mark them as `Tombstone` such that
+they can be safely deleted by Boskos. The cleaner will ensure that dynamic
+resources release other leased resources associated with it to prevent leaks.
 
 ## API
 

--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -82,6 +82,12 @@ func NewDynamicResourceLifeCycleFromConfig(e ResourceEntry) DynamicResourceLifeC
 	}
 }
 
+// NewResourceFromNewDynamicResourceLifeCycle creates a resource from DynamicResourceLifeCycle given a name and a time.
+// Using this method helps make sure all the resources are created the same way.
+func NewResourceFromNewDynamicResourceLifeCycle(name string, dlrc *DynamicResourceLifeCycle, now time.Time) Resource {
+	return NewResource(name, dlrc.Type, dlrc.InitialState, "", now)
+}
+
 // Copy returns a copy of the TypeToResources
 func (t TypeToResources) Copy() TypeToResources {
 	n := TypeToResources{}

--- a/boskos/ranch/storage.go
+++ b/boskos/ranch/storage.go
@@ -301,7 +301,7 @@ func (s *Storage) updateDynamicResources(lifecycle common.DynamicResourceLifeCyc
 	}
 
 	for i := count; i < lifecycle.MinCount; i++ {
-		res := common.NewResource(s.generateName(), lifecycle.Type, lifecycle.InitialState, "", s.now())
+		res := common.NewResourceFromNewDynamicResourceLifeCycle(s.generateName(), &lifecycle, s.now())
 		toAdd = append(toAdd, res)
 		count++
 	}


### PR DESCRIPTION
If the acquire fails to find a free resource and there is a possibility to add more dynamic resources (actual count < MaxCount), a resource will be created on the first Acquire for a given request id such that successive Acquire calls can be successful. This works well when using AcquireWait() with a timeout, where the first call would fail, but the successive one would work.

Note that this functionality is not available for Acquire calls with empty request id, as this would end up creating resources up to Max.