### PR TITLE
Add a prototype boskos command-line client

### DIFF
--- a/boskos/BUILD.bazel
+++ b/boskos/BUILD.bazel
@@ -83,6 +83,7 @@ filegroup(
         ":package-srcs",
         "//boskos/cleaner:all-srcs",
         "//boskos/client:all-srcs",
+        "//boskos/cmd/cli:all-srcs",
         "//boskos/common:all-srcs",
         "//boskos/crds:all-srcs",
         "//boskos/janitor:all-srcs",

--- a/boskos/cmd/cli/BUILD.bazel
+++ b/boskos/cmd/cli/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cli.go"],
+    importpath = "k8s.io/test-infra/boskos/cmd/cli",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//boskos/client:go_default_library",
+        "//boskos/common:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+prow_image(
+    name = "image",
+    base = "@alpine-base//image",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "boskosctl",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cli_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library"],
+)

--- a/boskos/cmd/cli/cli.go
+++ b/boskos/cmd/cli/cli.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/test-infra/boskos/client"
+	"k8s.io/test-infra/boskos/common"
+)
+
+type options struct {
+	// common, used to create the client
+	serverURL string
+	ownerName string
+
+	c *client.Client
+
+	acquire acquireOptions
+}
+
+type acquireOptions struct {
+	requestedType  string
+	requestedState string
+	targetState    string
+	timeout        time.Duration
+}
+
+// for test mocking
+var exit func(int)
+
+func command() *cobra.Command {
+	options := options{}
+
+	root := &cobra.Command{
+		Use:   "boskosctl",
+		Short: "Boskos command-line client for resource leasing",
+		Long: `Boskos provides a flexible resource leasing server.
+
+The boskosctl is a command-line client for this server,
+allowing for a user to acquire and release leases from
+scripts with a simple interface.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// the root command does nothing, so just print help
+			return cmd.Help()
+		},
+		Args: cobra.NoArgs,
+	}
+	root.PersistentFlags().StringVar(&options.serverURL, "server-url", "", "URL of the Boskos server")
+	root.PersistentFlags().StringVar(&options.ownerName, "owner-name", "", "Name identifying the user of this client")
+	for _, flag := range []string{"server-url", "owner-name"} {
+		if err := root.MarkPersistentFlagRequired(flag); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	acquire := &cobra.Command{
+		Use:   "acquire",
+		Short: "Acquire resource leases",
+		Long: `Acquire a resource lease, either best-effort or blocking.
+
+Resources can be leased by identifying which type of resource is needed
+and what state the resource should be in when leased. Resources will also
+transition to a new state upon being leased.
+
+On a successful lease acquisition, the leased resource will be printed in
+JSON format for downstream consumption.
+
+Examples:
+
+  # Acquire one clean "my-thing" and mark it dirty when leasing
+  $ boskosctl acquire --type my-thing --state clean --target-state dirty
+
+  # Acquire one new "my-thing" and mark it old when leasing, block until successfully leased
+  $ boskosctl acquire --type my-thing --state new --target-state old --timeout 30s`,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.c = client.NewClient(options.ownerName, options.serverURL)
+			acquireFunc := options.c.Acquire
+			if options.acquire.timeout != 0*time.Second {
+				acquireFunc = func(rtype, state, dest string) (resource *common.Resource, e error) {
+					ctx := context.Background()
+					ctx, cancel := context.WithTimeout(ctx, options.acquire.timeout)
+
+					sig := make(chan os.Signal, 1)
+					signal.Notify(sig, os.Interrupt)
+					go func() {
+						<-sig
+						cancel()
+					}()
+
+					return options.c.AcquireWait(ctx, rtype, state, dest)
+				}
+			}
+			resource, err := acquireFunc(options.acquire.requestedType, options.acquire.requestedState, options.acquire.targetState)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to acquire a resource: %v\n", err)
+				exit(1)
+				return
+			}
+			raw, err := json.Marshal(resource)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to marshal acquired resource: %v\n", err)
+				exit(1)
+				return
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+		},
+		Args: cobra.NoArgs,
+	}
+	acquire.Flags().StringVar(&options.acquire.requestedType, "type", "", "Type of resource to acquire")
+	acquire.Flags().StringVar(&options.acquire.requestedState, "state", "", "State to acquire the resource in")
+	acquire.Flags().StringVar(&options.acquire.targetState, "target-state", "", "Move resource to this state after acquiring")
+	for _, flag := range []string{"type", "state", "target-state"} {
+		if err := acquire.MarkFlagRequired(flag); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	acquire.Flags().DurationVar(&options.acquire.timeout, "timeout", 0*time.Second, "If set, retry this long until the resource has been acquired")
+	root.AddCommand(acquire)
+
+	return root
+}
+
+func main() {
+	exit = os.Exit
+	if err := command().Execute(); err != nil {
+		fmt.Println(err)
+		exit(1)
+	}
+}

--- a/boskos/cmd/cli/cli_test.go
+++ b/boskos/cmd/cli/cli_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type request struct {
+	method string
+	header http.Header
+	url    url.URL
+	body   []byte
+}
+
+type response struct {
+	code int
+	data []byte
+}
+
+func TestAcquire(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		args           []string
+		responses      map[string]response
+		expectedCalls  []request
+		expectedErr    bool // this means cobra error, print usage
+		expectedCode   int  // this is the real exit code
+		expectedOutput string
+	}{
+		{
+			name:        "no flags fails",
+			args:        []string{"acquire"},
+			expectedErr: true,
+			expectedOutput: `Error: required flag(s) "state", "target-state", "type" not set
+Usage:
+  boskosctl acquire [flags]
+
+Flags:
+  -h, --help                  help for acquire
+      --state string          State to acquire the resource in
+      --target-state string   Move resource to this state after acquiring
+      --timeout duration      If set, retry this long until the resource has been acquired
+      --type string           Type of resource to acquire
+
+Global Flags:
+      --owner-name string   Name identifying the user of this client
+      --server-url string   URL of the Boskos server
+
+`,
+		},
+		{
+			name: "normal acquire sends a request and succeeds",
+			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old"},
+			responses: map[string]response{
+				"/acquire": {
+					code: http.StatusOK,
+					data: []byte(`{"type":"thing","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"old","owner":"test","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}`),
+				},
+			},
+			expectedCalls: []request{{
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}},
+			expectedOutput: `{"type":"thing","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"old","owner":"test","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}
+`,
+		},
+		{
+			name: "normal acquire sends a request and fails on bad response",
+			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old"},
+			responses: map[string]response{
+				"/acquire": {
+					code: http.StatusOK,
+					data: []byte(`nonsense`),
+				},
+			},
+			expectedCalls: []request{{
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}},
+			expectedOutput: `failed to acquire a resource: invalid character 'o' in literal null (expecting 'u')
+`,
+			expectedCode: 1,
+		},
+		{
+			name:      "normal acquire sends a request and fails on 404",
+			args:      []string{"acquire", "--state=new", "--type=thing", "--target-state=old"},
+			responses: map[string]response{},
+			expectedCalls: []request{{
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}},
+			expectedCode: 1,
+			expectedOutput: `failed to acquire a resource: resources not found
+`,
+		},
+		{
+			name: "retry acquire sends requests and times out",
+			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old", "--timeout=5s"},
+			responses: map[string]response{
+				"/acquire": {
+					code: http.StatusUnauthorized,
+				},
+			},
+			expectedCalls: []request{{
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}, {
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}},
+			expectedOutput: `failed to acquire a resource: resources already used by another user
+`,
+			expectedCode: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var recordedCalls []request
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("failed to read request body in test server: %v", err)
+			}
+			recordedCalls = append(recordedCalls, request{
+				method: r.Method,
+				header: r.Header,
+				url:    *r.URL,
+				body:   body,
+			})
+			for path, response := range testCase.responses {
+				if r.URL.Path == path {
+					w.WriteHeader(response.code)
+					if _, err := w.Write(response.data); err != nil {
+						t.Fatalf("failed to write response in test server: %v", err)
+					}
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}))
+
+		var exitCode int
+		exit = func(i int) {
+			exitCode = i
+		}
+
+		cmd := command()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs(append(testCase.args, fmt.Sprintf("--server-url=%s", server.URL), "--owner-name=test"))
+		err := cmd.Execute()
+		if testCase.expectedErr && err == nil {
+			t.Errorf("%s: expected an error but got none", testCase.name)
+		}
+		if !testCase.expectedErr && err != nil {
+			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+		}
+
+		if expected, actual := testCase.expectedOutput, buf.String(); expected != actual {
+			t.Errorf("%s: got incorrect output: %s", testCase.name, diff.StringDiff(expected, actual))
+		}
+
+		if expected, actual := len(testCase.expectedCalls), len(recordedCalls); expected != actual {
+			t.Errorf("%s: expected %d calls to boskos but saw %d", testCase.name, expected, actual)
+		}
+
+		if expected, actual := testCase.expectedCode, exitCode; expected != actual {
+			t.Errorf("%s: expected to exit with %d, but saw %d", testCase.name, expected, actual)
+		}
+
+		for i, request := range recordedCalls {
+			if expected, actual := testCase.expectedCalls[i].method, request.method; expected != actual {
+				t.Errorf("%s: request %d: incorrect method, expected %s, saw %s", testCase.name, i, expected, actual)
+			}
+
+			if expected, actual := testCase.expectedCalls[i].url.Path, request.url.Path; expected != actual {
+				t.Errorf("%s: request %d: incorrect path, expected %s, saw %s", testCase.name, i, expected, actual)
+			}
+
+			if expected, actual := testCase.expectedCalls[i].url.Query(), request.url.Query(); !reflect.DeepEqual(expected, actual) {
+				t.Errorf("%s: request %d: incorrect query: %s", testCase.name, i, diff.ObjectReflectDiff(expected, actual))
+			}
+
+			if expected, actual := testCase.expectedCalls[i].header.Get("Content-Type"), request.header.Get("Content-Type"); expected != actual {
+				t.Errorf("%s: request %d: incorrect content-type header, expected %s, saw %s", testCase.name, i, expected, actual)
+			}
+
+			if expected, actual := testCase.expectedCalls[i].body, request.body; !reflect.DeepEqual(expected, actual) {
+				t.Errorf("%s: request %d: incorrect body: %s", testCase.name, i, diff.StringDiff(string(expected), string(actual)))
+			}
+		}
+	}
+}


### PR DESCRIPTION
For projects that do not want to vendor the Boskos Go library and use
the client internally, we can publish a CLI that will expose the API.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Usage:

```
$ boskosctl acquire --help
Acquire a resource lease, either best-effort or blocking.

Resources can be leased by identifying which type of resource is needed
and what state the resource should be in when leased. Resources will also
transition to a new state upon being leased.

On a successful lease acquisition, the leased resource will be printed in
JSON format for downstream consumption.

Examples:

  # Acquire one clean "my-thing" and mark it dirty when leasing
  $ boskosctl acquire --type my-thing --state clean --target-state dirty

  # Acquire one new "my-thing" and mark it old when leasing, block until successfully leased
  $ boskosctl acquire --type my-thing --state new --target-state old --wait

Usage:
  boskosctl acquire [flags]

Flags:
  -h, --help                  help for acquire
      --state string          State to acquire the resource in
      --target-state string   Move resource to this state after acquiring
      --type string           Type of resource to acquire
      --wait                  Block until the resource has been acquired

Global Flags:
      --owner-name string   Name identifying the user of this client
      --server-url string   URL of the Boskos server
```

Example:

```
$ boskosctl acquire --owner-name steve --server-url http://127.0.0.1:41679 --state dirty --type aws-quota-slice --target-state dirty
{"type":"aws-quota-slice","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"dirty","owner":"steve","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}
```

/assign @krzyzacy 