### PR TITLE
Enable directly rerunning jobs via Deck

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true
+        - --rerun-creates-job
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/github

--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -18,10 +18,7 @@ rules:
       - get
       - list
       # Required when deck runs with `--rerun-creates-job=true`
-      # **Warning:** Only use this for non-public deck instances, this allows
-      # anyone with access to your Deck instance to create new Prowjobs.
-      # Additionally, there is not yet protection against CSRF. Use with caution
-      # - create
+      - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Enables the rerun feature as described in this [design doc](https://docs.google.com/document/d/1ykgWeEnh4SwX9AuQz28sicFCpqjuEaYclLVTlStNggg/edit?userstoinvite=snxq1995%40gmail.com&ts=5d1dad06&actionButton=1#heading=h.pdiblci9jvof), with the current functionality described under "Enabling".
See also #13321 
Let me know if there's anything else I should do. I will also email kubernetes-sig-testing.

/cc @spiffxp @cblecker @fejta @Katharine @cjwagner 
/hold