### PR TITLE
Update boskos stateful set to use RollingUpdate (default @v1)

### DIFF
--- a/boskos/deployment.yaml
+++ b/boskos/deployment.yaml
@@ -15,27 +15,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-pods
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    app: boskos
-  name: boskos-storage
-  namespace: test-pods
-spec:
-  claimRef:
-    name: boskos-volume-boskos-0
-    namespace: test-pods
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  hostPath:
-    path: "/tmp/dir"
-    type: "DirectoryOrCreate"
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -67,15 +46,16 @@ roleRef:
   name: boskos
   apiGroup: rbac.authorization.k8s.io
 ---
-# Start of StatefulSet
-apiVersion: apps/v1beta1
-kind: StatefulSet
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: boskos
   namespace: test-pods
 spec:
-  serviceName: "boskos"
   replicas: 1  # one canonical source of resources
+  selector:
+    matchLabels:
+      app: boskos
   template:
     metadata:
       labels:
@@ -88,15 +68,12 @@ spec:
       - name: boskos
         image: gcr.io/k8s-prow/boskos/boskos:v20190723-99235c860
         args:
-        - --storage=/store/boskos.json
         - --config=/etc/config/config
         - --namespace=test-pods
         ports:
           - containerPort: 8080
             protocol: TCP
         volumeMounts:
-        - name: boskos-volume
-          mountPath: /store
         - name: boskos-config
           mountPath: /etc/config
           readOnly: true
@@ -104,12 +81,3 @@ spec:
         - name: boskos-config
           configMap:
             name: resources
-  volumeClaimTemplates:
-  - metadata:
-      name: boskos-volume
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: boskos
-      resources:
-        requests:
-          storage: 1Gi


### PR DESCRIPTION
Remove all the persistent volumes things, since we have using CRDs for more than a year now.

Fixes #https://github.com/kubernetes/test-infra/issues/11956