### PR TITLE
Fix tackle ingress API incompatibility, #13492

### DIFF
--- a/prow/cmd/tackle/BUILD.bazel
+++ b/prow/cmd/tackle/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "ingress.go",
+        "main.go",
+    ],
     importpath = "k8s.io/test-infra/prow/cmd/tackle",
     visibility = ["//visibility:public"],
     deps = [
@@ -11,13 +14,33 @@ go_library(
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/networking/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ingress_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/networking/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )
 

--- a/prow/cmd/tackle/ingress.go
+++ b/prow/cmd/tackle/ingress.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+var runtimeScheme = runtime.NewScheme()
+
+func init() {
+	extensions.AddToScheme(runtimeScheme)
+	networking.AddToScheme(runtimeScheme)
+}
+
+// hasResource determines if an API resource is available.
+func hasResource(client discovery.DiscoveryInterface, resource schema.GroupVersionResource) bool {
+	resources, err := client.ServerResourcesForGroupVersion(resource.GroupVersion().String())
+	if err != nil {
+		return false
+	}
+
+	for _, serverResource := range resources.APIResources {
+		if serverResource.Name == resource.Resource {
+			return true
+		}
+	}
+
+	return false
+}
+
+// toNewIngress converts a legacy "extensions/v1beta1" IngressList to the newer "networking.k8s.io/v1beta1" IngressList.
+func toNewIngress(oldIng *extensions.IngressList) (*networking.IngressList, error) {
+	var newIng networking.IngressList
+
+	err := runtimeScheme.Convert(oldIng, &newIng, nil)
+
+	return &newIng, err
+}

--- a/prow/cmd/tackle/ingress_test.go
+++ b/prow/cmd/tackle/ingress_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	discoveryFake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	k8sFake "k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"time"
+)
+
+func createExtensionsIngressList() *extensions.IngressList {
+	return &extensions.IngressList{
+		Items: []extensions.Ingress{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-ingress",
+					Namespace:         "demo",
+					CreationTimestamp: metav1.NewTime(time.Now()),
+				},
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.bar",
+							IngressRuleValue: extensions.IngressRuleValue{
+								HTTP: &extensions.HTTPIngressRuleValue{
+									Paths: []extensions.HTTPIngressPath{
+										{
+											Backend: extensions.IngressBackend{
+												ServiceName: "demo",
+												ServicePort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createNetworkingIngressList() *networking.IngressList {
+	return &networking.IngressList{
+		Items: []networking.Ingress{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-ingress",
+					Namespace:         "demo",
+					CreationTimestamp: metav1.NewTime(time.Now()),
+				},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{
+						{
+							Host: "foo.bar",
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{
+										{
+											Backend: networking.IngressBackend{
+												ServiceName: "demo",
+												ServicePort: intstr.FromInt(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestHasResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		createClient func() kubernetes.Interface
+		expected     bool
+	}{
+		{
+			name: "networking ingress is unavailable",
+			createClient: func() kubernetes.Interface {
+				return k8sFake.NewSimpleClientset()
+			},
+			expected: false,
+		},
+		{
+			name: "networking ingress is available",
+			createClient: func() kubernetes.Interface {
+				fakeClient := k8sFake.NewSimpleClientset()
+				fakeDiscovery := fakeClient.Discovery().(*discoveryFake.FakeDiscovery)
+				fakeNetworking := metav1.APIResourceList{
+					GroupVersion: "networking.k8s.io/v1beta1",
+					APIResources: []metav1.APIResource{{Name: "ingresses"}},
+				}
+				fakeDiscovery.Resources = append(fakeDiscovery.Resources, &fakeNetworking)
+				return fakeClient
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := test.createClient()
+			isAvailable := hasResource(client.Discovery(), networking.SchemeGroupVersion.WithResource("ingresses"))
+
+			if isAvailable != test.expected {
+				t.Errorf("Expected %v, but got result %v", test.expected, isAvailable)
+			}
+		})
+	}
+}
+
+func TestToNewIngress(t *testing.T) {
+	oldIng, err := toNewIngress(createExtensionsIngressList())
+	if err != nil {
+		t.Errorf("Unexpected error converting extensions ingress: %v", err)
+	}
+
+	oldBytes, err := oldIng.Marshal()
+	if err != nil {
+		t.Errorf("Unexpected error marshalling extensions ingress: %v", err)
+	}
+
+	newIng := createNetworkingIngressList()
+
+	newBytes, err := newIng.Marshal()
+	if err != nil {
+		t.Errorf("Unexpected error marshalling networking ingress: %v", err)
+	}
+
+	if bytes.Compare(oldBytes, newBytes) != 0 {
+		t.Errorf("Expected marshalling of types should be equal")
+	}
+}


### PR DESCRIPTION
This aims to resolve #13492, the following issues w/ **tackle**:
1. the ingress client returning 404:
> The Kubernetes ingress resource from the current API group `extensions.v1beta1` is moving to `networking.v1beta1` in [v1.16](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#116). This code change detects the server version for the currently selected context and invokes the appropriate ingress `List` resource.   
2. errant cluster overwrite behavior:
> There was a bug in the overwrite prompt where it would error when the response to the prompt was *yes* (i.e. "y", "Y" or "yes") due to overwriting the deployment configuration.
