### PR TITLE
Fix hours defined in webhook alerts

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -6,12 +6,10 @@
         rules: [
           {
             alert: 'no-webhook-calls',
-            // Monday-Friday 9am-5pm PDT (in UTC)
+            // Monday-Friday 9:00-17:00 PDT = (7 hours different) 16:00-24:00  (in UTC)
             expr: |||
               (sum(increase(prow_webhook_counter[1m])) == 0 or absent(prow_webhook_counter))
-              and ( ((day_of_week() == 1) and (hour() >= 18)) or
-                    ((day_of_week() > 2) and (day_of_week() < 6) and ((hour() >= 18) or (hour() <= 2))) or
-                    ((day_of_week() == 6) and (hour() <= 2)) )
+              and ((day_of_week() > 0) and (day_of_week() < 6) and (hour() >= 16))
             |||,
             'for': '5m',
             labels: {


### PR DESCRIPTION
Before the current commit, it was 9 hour time difference and it should be 7 instead.