### PR TITLE
Request a full CPU for jobs that compile

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -212,6 +212,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190725-8880a53-master
+        resources:
+          requests:
+            cpu: "1000m"
         command:
         - runner.sh
         args:
@@ -243,6 +246,9 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190725-8880a53-master
+        resources:
+          requests:
+            cpu: "1000m"
         command:
         - runner.sh
         args:
@@ -273,6 +279,9 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190725-8880a53-master
+        resources:
+          requests:
+            cpu: "1000m"
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The E2E and post-submit jobs all use Docker-in-Docker and do 1 or more
full compiles. They could use at least the guarantee of a full core.

/assign @akutz