### PR TITLE
Restoration of global testgrid default behavior

### DIFF
--- a/config/testgrids/README.md
+++ b/config/testgrids/README.md
@@ -2,6 +2,7 @@
 
 See [config.md](../../testgrid/config.md) for how to configure testgrid
 
-Please note that default dashboard configurations are necessary for each file
+For these files, do not set your own defaults; they're still global variables and may affect
+other configurations.
 
 TODO(slchase): Further documentation


### PR DESCRIPTION
As part of #13472, changes were made to force each individual file to set its own defaults,
to prevent cross-talk between files.

Because of how prow annotations are handled, this enhancement doesn't
_actually_ do that, and requiring defaults is more likely to result in
conflicting defaults.

As such, I think the best approach for now is to discourage setting defaults in files, and add code to prevent it at a later date.