### PR TITLE
boskosctl: add support for a heartbeat

### DIFF
--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -258,7 +258,7 @@ func (c *Client) UpdateAll(state string) error {
 	}
 	var allErrors error
 	for _, r := range resources {
-		if err := c.update(r.GetName(), state, nil); err != nil {
+		if err := c.Update(r.GetName(), state, nil); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 			continue
 		}
@@ -289,7 +289,7 @@ func (c *Client) SyncAll() error {
 			allErrors = multierror.Append(allErrors, err)
 			continue
 		}
-		if err := c.update(r.Name, r.State, nil); err != nil {
+		if err := c.Update(r.Name, r.State, nil); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 			continue
 		}
@@ -309,7 +309,7 @@ func (c *Client) UpdateOne(name, state string, userData *common.UserData) error 
 	if err != nil {
 		return fmt.Errorf("no resource name %v", name)
 	}
-	if err := c.update(r.GetName(), state, userData); err != nil {
+	if err := c.Update(r.GetName(), state, userData); err != nil {
 		return err
 	}
 	return c.updateLocalResource(r, state, userData)
@@ -416,6 +416,7 @@ func (c *Client) acquireByState(state, dest string, names []string) ([]common.Re
 	return nil, fmt.Errorf("status %s, status code %v", resp.Status, resp.StatusCode)
 }
 
+// Release a lease for a resource and set its state to the destination state
 func (c *Client) Release(name, dest string) error {
 	values := url.Values{}
 	values.Set("name", name)
@@ -433,7 +434,8 @@ func (c *Client) Release(name, dest string) error {
 	return nil
 }
 
-func (c *Client) update(name, state string, userData *common.UserData) error {
+// Update a resource on the server, setting the state and user data
+func (c *Client) Update(name, state string, userData *common.UserData) error {
 	var body io.Reader
 	if userData != nil {
 		b := new(bytes.Buffer)

--- a/boskos/cmd/cli/cli.go
+++ b/boskos/cmd/cli/cli.go
@@ -36,9 +36,10 @@ type options struct {
 
 	c *client.Client
 
-	acquire acquireOptions
-	release releaseOptions
-	metrics metricsOptions
+	acquire   acquireOptions
+	release   releaseOptions
+	metrics   metricsOptions
+	heartbeat heartbeatOptions
 }
 
 func (o *options) initializeClient() {
@@ -60,6 +61,12 @@ type releaseOptions struct {
 
 type metricsOptions struct {
 	requestedType string
+}
+
+type heartbeatOptions struct {
+	resourceJSON string
+	period       time.Duration
+	timeout      time.Duration
 }
 
 // for test mocking
@@ -239,6 +246,87 @@ Examples:
 		}
 	}
 	root.AddCommand(metrics)
+
+	heartbeat := &cobra.Command{
+		Use:   "heartbeat",
+		Short: "Send a heartbeat for a resource reservation",
+		Long: `Send a heartbeat for a resource reservation
+
+When the Boskos reaper is deployed, resource lessees must send a
+heartbeat for every lease they hold or the leases will be revoked.
+This command will send a heartbeat at the provided period and is
+blocking.
+
+Examples:
+
+  # Acquire one clean "my-thing" and mark it dirty when leasing
+  $ resource="$( boskosctl acquire --type my-thing --state clean --target-state dirty )"
+  # Send periodic heartbeat for the lease in the background
+  $ boskosctl heartbeat --resource "${resource}" --period 30s &
+
+  # Send periodic heartbeat for the lease with custom period and timeout
+  $ boskosctl heartbeat --resource "${resource}" --period 3s --timeout 1h`,
+		Run: func(cmd *cobra.Command, args []string) {
+			options.initializeClient()
+			var resource common.Resource
+			if err := json.Unmarshal([]byte(options.heartbeat.resourceJSON), &resource); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to parse resource: %v\n", err)
+				exit(1)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), options.heartbeat.timeout)
+			defer func() {
+				// the context wants to be cancelled but since we want to differentiate
+				// between a timeout and a SIGINT we don't have a good reason to cancel
+				// it in normal operation
+				cancel()
+			}()
+			sig := make(chan os.Signal, 1)
+			signal.Notify(sig, os.Interrupt)
+			go func() {
+				<-sig
+			}()
+
+			tick := time.Tick(options.heartbeat.period)
+			work := func() bool {
+				select {
+				case <-tick:
+					if err := options.c.Update(resource.Name, resource.State, resource.UserData); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "failed to send heartbeat for resource %q: %v\n", resource.Name, err)
+						exit(1)
+						return true
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "heartbeat sent for resource %q\n", resource.Name)
+				case <-sig:
+					fmt.Fprintf(cmd.OutOrStdout(), "received interrupt, stopping heartbeats for resource %q\n", resource.Name)
+					return true
+				case <-ctx.Done():
+					fmt.Fprintf(cmd.OutOrStdout(), "reached timeout, stopping heartbeats for resource %q\n", resource.Name)
+					return true
+				}
+				return false
+			}
+
+			for {
+				done := work()
+				if done {
+					break
+				}
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+	heartbeat.Flags().StringVar(&options.heartbeat.resourceJSON, "resource", "", "JSON resource lease object to send heartbeat for")
+	for _, flag := range []string{"resource"} {
+		if err := heartbeat.MarkFlagRequired(flag); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	heartbeat.Flags().DurationVar(&options.heartbeat.period, "period", 30*time.Second, "Period to send heartbeats on")
+	heartbeat.Flags().DurationVar(&options.heartbeat.timeout, "timeout", 5*time.Hour, "How long to send heartbeats for")
+	root.AddCommand(heartbeat)
 
 	return root
 }


### PR DESCRIPTION
In order to use boskosctl with a cluster that has the reaper deployed,
it is necessary to send heartbeats for resources you want to hold on to.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @krzyzacy @sebastienvas 