### PR TITLE
checkconfig: add optional check to verify OWNERS presence

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -10,9 +10,11 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/config/secret:go_default_library",
         "//prow/errorutil:go_default_library",
         "//prow/external-plugins/needs-rebase/plugin:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/logrusutil:go_default_library",
@@ -72,6 +74,7 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -210,7 +210,9 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting GitHub client.")
 		}
-		githubClient.Throttle(300, 100) // 300 hourly tokens, bursts of 100
+		githubClient.Throttle(3000, 100) // 300 hourly tokens, bursts of 100
+		// 404s are expected to happen, no point in retrying
+		githubClient.SetMax404Retries(0)
 
 		if err := verifyOwnersPresence(pcfg, githubClient); err != nil {
 			errs = append(errs, err)

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -404,7 +404,7 @@ func getSubCfg(key string, cfg reflect.Value) reflect.Value {
 					return subStruct
 				}
 			} else {
-				field := getJSONTagName(structField, i)
+				field := getJSONTagName(structField)
 				if field == key {
 					return cfgElem.Field(i)
 				}
@@ -414,7 +414,7 @@ func getSubCfg(key string, cfg reflect.Value) reflect.Value {
 	return reflect.Value{}
 }
 
-func getJSONTagName(field reflect.StructField, i int) string {
+func getJSONTagName(field reflect.StructField) string {
 	jsonTag := field.Tag.Get("json")
 	if jsonTag != "" && jsonTag != "-" {
 		if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -24,10 +24,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
-	"sigs.k8s.io/yaml"
 )
 
 func TestEnsureValidConfiguration(t *testing.T) {
@@ -915,5 +917,105 @@ func TestWarningEnabled(t *testing.T) {
 		if actual, expected := opt.warningEnabled(testCase.candidate), testCase.expected; actual != expected {
 			t.Errorf("%s: expected warning %s enablement to be %v but got %v", testCase.name, testCase.candidate, expected, actual)
 		}
+	}
+}
+
+type fakeGHContent map[string]map[string]map[string]bool // org[repo][path] -> exist/does not exist
+
+func (f fakeGHContent) GetFile(org, repo, filepath, _ string) ([]byte, error) {
+	if _, hasOrg := f[org]; !hasOrg {
+		return nil, &github.FileNotFound{}
+	}
+	if _, hasRepo := f[org][repo]; !hasRepo {
+		return nil, &github.FileNotFound{}
+	}
+	if _, hasPath := f[org][repo][filepath]; !hasPath {
+		return nil, &github.FileNotFound{}
+	}
+
+	return []byte("CONTENT"), nil
+}
+
+func (f fakeGHContent) GetRepos(org string, isUser bool) ([]github.Repo, error) {
+	if _, hasOrg := f[org]; !hasOrg {
+		return nil, fmt.Errorf("no such org")
+	}
+	var repos []github.Repo
+	for repo := range f[org] {
+		repos = append(
+			repos,
+			github.Repo{
+				Owner:    github.User{Login: org},
+				Name:     repo,
+				FullName: fmt.Sprintf("%s/%s", org, repo),
+			})
+	}
+	return repos, nil
+}
+
+func TestVerifyOwnersPresence(t *testing.T) {
+	testCases := []struct {
+		description string
+		cfg         *plugins.Configuration
+		gh          fakeGHContent
+
+		expected string
+	}{
+		{
+			description: "org with blunderbuss enabled contains a repo without OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org": {"blunderbuss"}}},
+			gh:          fakeGHContent{"org": {"repo": {"NOOWNERS": true}}},
+			expected: "the following orgs or repos enable at least one" +
+				" plugin that uses OWNERS files (approve, blunderbuss, owners-label), but" +
+				" its master branch does not contain a root level OWNERS file: [org/repo]",
+		}, {
+			description: "org with approve enable contains a repo without OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org": {"approve"}}},
+			gh:          fakeGHContent{"org": {"repo": {"NOOWNERS": true}}},
+			expected: "the following orgs or repos enable at least one" +
+				" plugin that uses OWNERS files (approve, blunderbuss, owners-label), but" +
+				" its master branch does not contain a root level OWNERS file: [org/repo]",
+		}, {
+			description: "org with owners-label enabled contains a repo without OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org": {"owners-label"}}},
+			gh:          fakeGHContent{"org": {"repo": {"NOOWNERS": true}}},
+			expected: "the following orgs or repos enable at least one" +
+				" plugin that uses OWNERS files (approve, blunderbuss, owners-label), but" +
+				" its master branch does not contain a root level OWNERS file: [org/repo]",
+		}, {
+			description: "repo with owners-label enabled does not contain OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org/repo": {"owners-label"}}},
+			gh:          fakeGHContent{"org": {"repo": {"NOOWNERS": true}}},
+			expected: "the following orgs or repos enable at least one" +
+				" plugin that uses OWNERS files (approve, blunderbuss, owners-label), but" +
+				" its master branch does not contain a root level OWNERS file: [org/repo]",
+		}, {
+			description: "org with owners-label enabled contains only repos with OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org": {"owners-label"}}},
+			gh:          fakeGHContent{"org": {"repo": {"OWNERS": true}}},
+			expected:    "",
+		}, {
+			description: "repo with owners-label enabled contains OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org/repo": {"owners-label"}}},
+			gh:          fakeGHContent{"org": {"repo": {"OWNERS": true}}},
+			expected:    "",
+		}, {
+			description: "repo with unrelated plugin enabled does not contain OWNERS",
+			cfg:         &plugins.Configuration{Plugins: map[string][]string{"org/repo": {"cat"}}},
+			gh:          fakeGHContent{"org": {"repo": {"NOOWNERS": true}}},
+			expected:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			var errMessage string
+			if err := verifyOwnersPresence(tc.cfg, tc.gh); err != nil {
+				errMessage = err.Error()
+			}
+			if errMessage != tc.expected {
+				t.Errorf("result differs:\n%s", diff.StringDiff(tc.expected, errMessage))
+			}
+		})
 	}
 }


### PR DESCRIPTION
When a repo enables an `approve` plugin but does not contain OWNERS
file, it does not make sense and the situation pollutes the logs.

The file presence is checked using `RepositoryClient.GetFile()` method
which transfers the content that we do not actually use, but given
OWNERS files are generally very small, I think it is not worth
implementing something like a `HasFile` with a HEAD request.

Because this check is not local and cheap, I did not make it run by
default and introduced a new option to enable "expensive" checks.