### PR TITLE
Tag releases as 'latest'

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -286,6 +286,7 @@ postsubmits:
         - runner.sh
         args:
         - ./hack/release.sh
+        - -l
         - -p
         - -k
         - /root/.capv/keyfile.json


### PR DESCRIPTION
Later on, we'll want to control which ones get tagged as latest by
branch, but right now any tagged commit is the 'latest' version.

/assign @akutz