### PR TITLE
Implement the tiniest oncall updater (but don't use it (yet))

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -73,6 +73,7 @@ filegroup(
         "//experiment/manual-trigger:all-srcs",
         "//experiment/resultstore:all-srcs",
         "//experiment/slack-oncall-updater:all-srcs",
+        "//experiment/tiny-oncall:all-srcs",
         "//experiment/tracer:all-srcs",
     ],
     tags = ["automanaged"],

--- a/experiment/tiny-oncall/BUILD.bazel
+++ b/experiment/tiny-oncall/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "oncall.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/tiny-oncall",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/io:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "tiny-oncall",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/tiny-oncall/README.md
+++ b/experiment/tiny-oncall/README.md
@@ -1,0 +1,23 @@
+# tiny-oncall
+
+Tiny oncall implements sufficient oncall infrastructure for the Kubernetes test-infra oncall
+rotation, and nothing else. In particular, it implements:
+
+* Defining a rotation of n people
+* Two people are selected from it once per week
+* You can have some shadows, who are perma-scheduled as shadows
+* Switching over at a definable time.
+* Uploading the resulting file to a fixed location on GCS
+
+It does not implement:
+
+* Calendar integration (we can't share our calendars anyway)
+* State (this burderns humans but saves substantially on complexity)
+* Vacations (manually swap with someone if you have an upcoming vacation)
+* Shift change notifications (but the slack-oncall-updater will tell you you're oncall if you aren't Katharine)
+* Paging (ping @test-infra-oncall on slack, probably - maybe we update a mailing list in the future)
+
+Limitations:
+
+* Adding or removing oncallers will change who is currently oncall. Please ensure you rotate the
+  list to avoid surprsing disruptions.

--- a/experiment/tiny-oncall/main.go
+++ b/experiment/tiny-oncall/main.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+
+	"k8s.io/test-infra/pkg/io"
+)
+
+type options struct {
+	configPath string
+	output     string
+	creds      string
+}
+
+func gatherOptions() (options, error) {
+	o := options{}
+	flag.StringVar(&o.configPath, "config", "", "Path to the oncall config")
+	flag.StringVar(&o.creds, "gcp-service-account", "", "Optionally, path to the GCP service account credentials")
+	flag.StringVar(&o.output, "output", "-", "Path to the output. stdout if not specified")
+	flag.Parse()
+	if o.configPath == "" {
+		return o, errors.New("--config is mandatory")
+	}
+	return o, nil
+}
+
+func run(o options) error {
+	c, err := parseConfig(o.configPath)
+	if err != nil {
+		return fmt.Errorf("couldn't parse config: %v", err)
+	}
+	oncall, err := pickOncallers(c)
+	if err != nil {
+		return fmt.Errorf("couldn't pick oncallers: %v", err)
+	}
+
+	output, err := generateOncall(oncall)
+	if err != nil {
+		return fmt.Errorf("couldn't generate oncall file: %v", err)
+	}
+
+	if o.output == "-" || o.output == "" {
+		fmt.Println(string(output))
+		return nil
+	}
+
+	opener, err := io.NewOpener(context.Background(), o.creds)
+	if err != nil {
+		return fmt.Errorf("couldn't create opener: %v", err)
+	}
+	writer, err := opener.Writer(context.Background(), o.output)
+	if err != nil {
+		return fmt.Errorf("couldn't create writer: %v", err)
+	}
+	if _, err := writer.Write(output); err != nil {
+		return fmt.Errorf("couldn't write output file: %v", err)
+	}
+	writer.Close()
+	return nil
+}
+
+func main() {
+	o, err := gatherOptions()
+	if err != nil {
+		log.Fatalf("Bad flags: %v.\n", err)
+	}
+	if err := run(o); err != nil {
+		log.Fatalf("tiny-oncall: %v.\n", err)
+	}
+}

--- a/experiment/tiny-oncall/oncall.go
+++ b/experiment/tiny-oncall/oncall.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+type config struct {
+	Oncallers           []string `json:"oncallers"`
+	Shadows             []string `json:"shadows"`
+	ChangeDay           int      `json:"change_day"`
+	ChangeHour          int      `json:"change_hour"`
+	GenerateSecondaries bool     `json:"generate_secondaries"`
+}
+
+type legacyOncall struct {
+	TestInfra string `json:"testinfra"`
+}
+
+type oncall struct {
+	Primary   string   `json:"primary"`
+	Secondary string   `json:"secondary,omitempty"`
+	Shadows   []string `json:"shadows"`
+	Next      *oncall  `json:"next,omitempty"`
+}
+
+type currentOncall struct {
+	// legacy version
+	LegacyOncall legacyOncall `json:"Oncall"`
+	Oncall       oncall       `json:"oncall"`
+}
+
+func pickOncallers(c config) (oncall, error) {
+	if len(c.Oncallers) == 0 {
+		return oncall{}, errors.New("at least one oncaller is required")
+	}
+	t := time.Now().UTC().AddDate(0, 0, -(c.ChangeDay - 1)).Add(time.Duration(-c.ChangeHour) * time.Hour)
+	_, week := t.ISOWeek()
+	l := len(c.Oncallers)
+	if c.Shadows == nil {
+		c.Shadows = []string{}
+	}
+	o := oncall{
+		Primary:   c.Oncallers[week%l],
+		Secondary: c.Oncallers[(week+1)%l],
+		Shadows:   c.Shadows,
+		Next: &oncall{
+			Primary:   c.Oncallers[(week+1)%l],
+			Secondary: c.Oncallers[(week+2)%l],
+			Shadows:   c.Shadows,
+		},
+	}
+	if !c.GenerateSecondaries || o.Primary == o.Secondary {
+		o.Secondary = ""
+	}
+	if !c.GenerateSecondaries || o.Next.Primary == o.Next.Secondary {
+		o.Next.Secondary = ""
+	}
+	return o, nil
+}
+
+func generateOncall(o oncall) ([]byte, error) {
+	c := currentOncall{
+		Oncall: o,
+		LegacyOncall: legacyOncall{
+			TestInfra: o.Primary,
+		},
+	}
+	return json.Marshal(c)
+}
+
+func parseConfig(path string) (config, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return config{}, err
+	}
+	c := config{}
+	if err := yaml.UnmarshalStrict(b, &c); err != nil {
+		return config{}, err
+	}
+	return c, nil
+}

--- a/experiment/tiny-oncall/oncallers.yaml
+++ b/experiment/tiny-oncall/oncallers.yaml
@@ -1,0 +1,18 @@
+# WARNING: when adding or removing oncallers, the current oncall will be shuffled.
+# This is undesirable. To mitigate this effect, when adding or removing entries, rotate the list
+# such that the current ISO week number mod the number of oncallers remains unchanged.
+# Check https://www.epochconverter.com/weeknumbersfor the current week number.
+oncallers:
+  - michelle192837
+  - cjwagner
+  - fejta
+  - Katharine
+  - krzyzacy
+  - stevekuznetsov
+generate_secondaries: true
+# Shadows are considered permanently scheduled as long as they are listed here.
+shadows:
+# The day of the week on which to switch over.
+change_day: 3  # wednesday
+# The hour of the day on which to switch over (in UTC).
+change_hour: 19


### PR DESCRIPTION
This implements a very simple oncall updater:

- It has a list of people who can be oncall
- It rotates through them based on the current date
- It can do handoffs at any hour of any day of the week.
- It can have a secondary (who is always the next primary)
- It can have shadows (who are always scheduled as shadows - this is just here so other tools can read it)
- It can upload a file to GCS

The support for secondaries and shadows is based on recent conversations about what oncall should be and how to onboard it.

Things it does not do:

- Read calendars (we presumably can't share our calendars anyway)
- Maintain any state (it just uses the clock)
- Support shift lengths that are not exactly a week
- Vacations (manually swap your position in the rotation with someone else if a vacation is coming up)
  - This would be nice to have; maybe later.
- Shift change notifications (but the slack bot will tell you when you're oncall)
- Paging or mail forwarding (people can ping @test-infra-oncall, maybe we can manipulate a mailing list or something in the future)
- Run continuously - toss it in a periodic prowjob

Because of its simplicity, changing the number of oncallers will immediately change who is currently oncall. This can be mitigated by rotating the list to maintain the current oncaller when doing this. It's probably fairly rare, so I'm not overly concerned about it.

/cc @spiffxp 