### PR TITLE
Use newer ubuntu for containerd test.

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
+    image: ubuntu-gke-1604-xenial-v20180317-1
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
+    image: ubuntu-gke-1604-xenial-v20180317-1
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
+    image: ubuntu-gke-1604-xenial-v20180317-1
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
+    image: ubuntu-gke-1604-xenial-v20180317-1
     project: ubuntu-os-gke-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
+    image: ubuntu-gke-1604-xenial-v20180317-1
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:


### PR DESCRIPTION
We need newer libseccomp (2.3.0+) for containerd test now. See https://github.com/containerd/containerd/pull/3371#issuecomment-515634600

Signed-off-by: Lantao Liu <lantaol@google.com>