### PR TITLE
Branchprotector and Tide: Use GetPresubmits

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -360,7 +360,7 @@ func validateRestrictions(org, repo string, bp *github.BranchProtectionRequest, 
 
 // UpdateBranch updates the branch with the specified configuration
 func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch config.Branch, protected bool, authorizedCollaborators, authorizedTeams []string) error {
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic())
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic()[orgName+"/"+repo])
 	if err != nil {
 		return fmt.Errorf("get policy: %v", err)
 	}

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -190,7 +190,10 @@ func (p *protector) protect() {
 	}
 
 	// Some repos with presubmits might not be listed in the branch-protection
-	for repo := range p.cfg.Presubmits {
+	// Using PresubmitsStatic here is safe because this is only about getting to
+	// know which repos exist. Repos that use in-repo config will appear here,
+	// because we generate a verification job for them
+	for repo := range p.cfg.PresubmitsStatic() {
 		if p.completedRepos[repo] == true {
 			continue
 		}
@@ -357,7 +360,7 @@ func validateRestrictions(org, repo string, bp *github.BranchProtectionRequest, 
 
 // UpdateBranch updates the branch with the specified configuration
 func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch config.Branch, protected bool, authorizedCollaborators, authorizedTeams []string) error {
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch)
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic())
 	if err != nil {
 		return fmt.Errorf("get policy: %v", err)
 	}

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config/secret:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -232,7 +232,7 @@ type Branch struct {
 // GetBranchProtection returns the policy for a given branch.
 //
 // Handles merging any policies defined at repo/org/global levels into the branch policy.
-func (c *Config) GetBranchProtection(org, repo, branch string) (*Policy, error) {
+func (c *Config) GetBranchProtection(org, repo, branch string, presubmits map[string][]Presubmit) (*Policy, error) {
 	if _, present := c.BranchProtection.Orgs[org]; !present {
 		return nil, nil // only consider branches in configured orgs
 	}
@@ -241,15 +241,15 @@ func (c *Config) GetBranchProtection(org, repo, branch string) (*Policy, error) 
 		return nil, err
 	}
 
-	return c.GetPolicy(org, repo, branch, *b)
+	return c.GetPolicy(org, repo, branch, *b, presubmits)
 }
 
 // GetPolicy returns the protection policy for the branch, after merging in presubmits.
-func (c *Config) GetPolicy(org, repo, branch string, b Branch) (*Policy, error) {
+func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits map[string][]Presubmit) (*Policy, error) {
 	policy := b.Policy
 
 	// Automatically require contexts from prow which must always be present
-	if prowContexts, _, _ := BranchRequirements(org, repo, branch, c.Presubmits); len(prowContexts) > 0 {
+	if prowContexts, _, _ := BranchRequirements(org, repo, branch, presubmits); len(prowContexts) > 0 {
 		// Error if protection is disabled
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies {

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -811,7 +811,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := tc.config.GetBranchProtection("org", "repo", "branch")
+			actual, err := tc.config.GetBranchProtection("org", "repo", "branch", tc.config.Presubmits)
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -371,7 +371,7 @@ func TestBranchRequirements(t *testing.T) {
 		presubmits := map[string][]Presubmit{
 			"o/r": tc.config,
 		}
-		masterActual, masterActualIfPresent, masterOptional := BranchRequirements("o", "r", "master", presubmits)
+		masterActual, masterActualIfPresent, masterOptional := BranchRequirements("master", presubmits["o/r"])
 		if !reflect.DeepEqual(masterActual, tc.masterExpected) {
 			t.Errorf("%s: identified incorrect required contexts on branch master: %s", tc.name, diff.ObjectReflectDiff(masterActual, tc.masterExpected))
 		}
@@ -381,7 +381,7 @@ func TestBranchRequirements(t *testing.T) {
 		if !reflect.DeepEqual(masterActualIfPresent, tc.masterIfPresent) {
 			t.Errorf("%s: identified incorrect if-present contexts on branch master: %s", tc.name, diff.ObjectReflectDiff(masterActualIfPresent, tc.masterIfPresent))
 		}
-		otherActual, otherActualIfPresent, otherOptional := BranchRequirements("o", "r", "other", presubmits)
+		otherActual, otherActualIfPresent, otherOptional := BranchRequirements("other", presubmits["o/r"])
 		if !reflect.DeepEqual(masterActual, tc.masterExpected) {
 			t.Errorf("%s: identified incorrect required contexts on branch other: : %s", tc.name, diff.ObjectReflectDiff(otherActual, tc.otherExpected))
 		}
@@ -811,7 +811,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := tc.config.GetBranchProtection("org", "repo", "branch", tc.config.Presubmits)
+			actual, err := tc.config.GetBranchProtection("org", "repo", "branch", tc.config.Presubmits["org/repo"])
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -81,6 +81,9 @@ type JobConfig struct {
 	// AllRepos contains all Repos that have one or more jobs configured or
 	// for which a tide query is configured.
 	AllRepos sets.String `json:"-"`
+
+	// FakeInRepoConfig is used for tests. Its key is the headSHA.
+	FakeInRepoConfig map[string][]Presubmit `json:"-"`
 }
 
 // ProwConfig is config for all prow controllers
@@ -145,8 +148,8 @@ type ProwConfig struct {
 // a no-op that always returns false, as the underlying feature is not implemented
 // yet. See https://github.com/kubernetes/test-infra/issues/13370 for a current
 // status.
-func (pc *ProwConfig) InRepoConfigEnabled(identifier string) bool {
-	return FakeInRepoConfig != nil
+func (jc *JobConfig) InRepoConfigEnabled(identifier string) bool {
+	return jc.FakeInRepoConfig != nil
 }
 
 // RefGetter is used to retrieve a Git Reference. Its purpose is
@@ -244,9 +247,6 @@ func (rg *RefGetterForGitHubPullRequest) BaseSHA() (string, error) {
 	return rg.baseSHA, nil
 }
 
-// FakeInRepoConfig can be used in tests. Its key is the headSHA.
-var FakeInRepoConfig map[string][]Presubmit
-
 // GetPresubmits will return all presumits for the given identifier.
 // Once https://github.com/kubernetes/test-infra/issues/13370 is resolved, it will
 // also return Presubmits that are versioned inside the tested repo, if that feature
@@ -277,8 +277,8 @@ func (c *Config) GetPresubmits(gc *git.Client, identifier string, baseSHAGetter 
 	// Pending implementation of https://github.com/kubernetes/test-infra/issues/13370
 	// Currently, only a fake implementation exists for tests.
 	_ = baseSHA
-	if FakeInRepoConfig != nil {
-		return append(c.Presubmits[identifier], FakeInRepoConfig[strings.Join(headSHAs, "")]...), nil
+	if c.FakeInRepoConfig != nil {
+		return append(c.Presubmits[identifier], c.FakeInRepoConfig[strings.Join(headSHAs, "")]...), nil
 	}
 	return nil, errors.New("inrepoconfig is not yet implemented :/")
 }

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
 )
 
@@ -572,7 +571,10 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 				FakeInRepoConfig = nil
 			}()
 
-			p, err := tc.config.GetTideContextPolicy(&fakegithub.FakeClient{}, &git.Client{}, org, repo, branch, "some-sha")
+			baseSHAGetter := func() (string, error) {
+				return "baseSHA", nil
+			}
+			p, err := tc.config.GetTideContextPolicy(&git.Client{}, org, repo, branch, baseSHAGetter, "some-sha")
 			if !reflect.DeepEqual(p, &tc.expected) {
 				t.Errorf("%s - did not get expected policy: %s", tc.name, diff.ObjectReflectDiff(&tc.expected, p))
 			}

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "//prow/tide/blockers:go_default_library",

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -35,6 +35,7 @@ import (
 
 	"k8s.io/test-infra/pkg/io"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/tide/blockers"
 )
@@ -59,6 +60,7 @@ type statusController struct {
 	logger *logrus.Entry
 	config config.Getter
 	ghc    githubClient
+	gc     *git.Client
 
 	// newPoolPending is a size 1 chan that signals that the main Tide loop has
 	// updated the 'poolPRs' field with a freshly updated pool.
@@ -289,9 +291,12 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 			return
 		}
 		cr, err := sc.config().GetTideContextPolicy(
+			sc.ghc,
+			sc.gc,
 			string(pr.Repository.Owner.Login),
 			string(pr.Repository.Name),
-			string(pr.BaseRef.Name))
+			string(pr.BaseRef.Name),
+			string(pr.HeadRefOID))
 		if err != nil {
 			log.WithError(err).Error("setting up context register")
 			return

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 )
 
@@ -379,7 +380,9 @@ func TestSetStatuses(t *testing.T) {
 		if tc.inPool {
 			pool[prKey(&pr)] = pr
 		}
-		fc := &fgc{}
+		fc := &fgc{
+			refs: map[string]string{"/ heads/": "SHA"},
+		}
 		ca := &config.Agent{}
 		ca.Set(&config.Config{})
 		// setStatuses logs instead of returning errors.
@@ -390,7 +393,7 @@ func TestSetStatuses(t *testing.T) {
 			t.Fatalf("Failed to get log output before testing: %v", err)
 		}
 
-		sc := &statusController{ghc: fc, config: ca.Config, logger: log}
+		sc := &statusController{ghc: fc, gc: &git.Client{}, config: ca.Config, logger: log}
 		sc.setStatuses([]PullRequest{pr}, pool, blockers.Blockers{})
 		if str, err := log.String(); err != nil {
 			t.Fatalf("For case %s: failed to get log output: %v", tc.name, err)

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -449,7 +449,7 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 	}
 	sp.cc = make(map[int]contextChecker, len(sp.prs))
 	for _, pr := range sp.prs {
-		sp.cc[int(pr.Number)], err = c.config().GetTideContextPolicy(c.ghc, c.gc, sp.org, sp.repo, sp.branch, string(pr.HeadRefOID))
+		sp.cc[int(pr.Number)], err = c.config().GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), string(pr.HeadRefOID))
 		if err != nil {
 			return fmt.Errorf("error setting up context checker for pr %d: %v", int(pr.Number), err)
 		}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1191,12 +1191,12 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 	}
 
 	for _, pr := range sp.prs {
-		presubmits, err := c.config().GetPresubmits(c.gc, sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(string(pr.HeadRefOID)))
+		presubmitsForPull, err := c.config().GetPresubmits(c.gc, sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(string(pr.HeadRefOID)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get presubmits for PR %d: %v", int(pr.Number), err)
 		}
 
-		for _, ps := range presubmits {
+		for _, ps := range presubmitsForPull {
 			if !ps.ContextRequired() {
 				continue
 			}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1152,17 +1152,17 @@ func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvid
 
 func (c *changedFilesAgent) batchChanges(prs []PullRequest) config.ChangedFilesProvider {
 	return func() ([]string, error) {
-		var result []string
+		result := sets.String{}
 		for _, pr := range prs {
 			changes, err := c.prChanges(&pr)()
 			if err != nil {
 				return nil, err
 			}
 
-			result = append(result, changes...)
+			result.Insert(changes...)
 		}
 
-		return result, nil
+		return result.List(), nil
 	}
 }
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -210,6 +210,7 @@ func NewController(ghcSync, ghcStatus github.Client, prowJobClient prowv1.ProwJo
 	sc := &statusController{
 		logger:         logger.WithField("controller", "status-update"),
 		ghc:            ghcStatus,
+		gc:             gc,
 		config:         cfg,
 		newPoolPending: make(chan bool, 1),
 		shutDown:       make(chan bool),
@@ -446,9 +447,12 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 	if err != nil {
 		return fmt.Errorf("error determining required presubmit prowjobs: %v", err)
 	}
-	sp.cc, err = c.config().GetTideContextPolicy(sp.org, sp.repo, sp.branch)
-	if err != nil {
-		return fmt.Errorf("error setting up context checker: %v", err)
+	sp.cc = make(map[int]contextChecker, len(sp.prs))
+	for _, pr := range sp.prs {
+		sp.cc[int(pr.Number)], err = c.config().GetTideContextPolicy(c.ghc, c.gc, sp.org, sp.repo, sp.branch, string(pr.HeadRefOID))
+		if err != nil {
+			return fmt.Errorf("error setting up context checker for pr %d: %v", int(pr.Number), err)
+		}
 	}
 	return nil
 }
@@ -502,7 +506,7 @@ func filterPR(ghc githubClient, sp *subpool, pr *PullRequest) bool {
 		}
 		return false
 	}
-	for _, ctx := range unsuccessfulContexts(contexts, sp.cc, log) {
+	for _, ctx := range unsuccessfulContexts(contexts, sp.cc[int(pr.Number)], log) {
 		if ctx.State != githubql.StatusStatePending {
 			log.WithField("context", ctx.Context).Debug("filtering out PR as unsuccessful context is not pending")
 			return true
@@ -584,7 +588,7 @@ func unsuccessfulContexts(contexts []Context, cc contextChecker, log *logrus.Ent
 	return failed
 }
 
-func pickSmallestPassingNumber(log *logrus.Entry, ghc githubClient, prs []PullRequest, cc contextChecker) (bool, PullRequest) {
+func pickSmallestPassingNumber(log *logrus.Entry, ghc githubClient, prs []PullRequest, cc map[int]contextChecker) (bool, PullRequest) {
 	smallestNumber := -1
 	var smallestPR PullRequest
 	for _, pr := range prs {
@@ -594,7 +598,7 @@ func pickSmallestPassingNumber(log *logrus.Entry, ghc githubClient, prs []PullRe
 		if len(pr.Commits.Nodes) < 1 {
 			continue
 		}
-		if !isPassingTests(log, ghc, pr, cc) {
+		if !isPassingTests(log, ghc, pr, cc[int(pr.Number)]) {
 			continue
 		}
 		smallestNumber = int(pr.Number)
@@ -603,17 +607,13 @@ func pickSmallestPassingNumber(log *logrus.Entry, ghc githubClient, prs []PullRe
 	return smallestNumber > -1, smallestPR
 }
 
-// accumulateBatch returns a list of PRs that can be merged after passing batch
-// testing, if any exist. It also returns a list of PRs currently being batch
-// tested.
-func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []prowapi.ProwJob, log *logrus.Entry) ([]PullRequest, []PullRequest) {
-	log.Debug("accumulating PRs for batch testing")
-	if len(presubmits) == 0 {
-		log.Debug("no presubmits configured, no batch can be triggered")
-		return nil, nil
-	}
+// accumulateBatch looks at existing batch ProwJobs and, if applicable, returns:
+// * A list of PRs that are part of a batch test that finished successfully
+// * A list of PRs that are part of a batch test that hasn't finished yet but didn't have any failures so far
+func (c *Controller) accumulateBatch(sp subpool) (successBatch []PullRequest, pendingBatch []PullRequest) {
+	sp.log.Debug("accumulating PRs for batch testing")
 	prNums := make(map[int]PullRequest)
-	for _, pr := range prs {
+	for _, pr := range sp.prs {
 		prNums[int(pr.Number)] = pr
 	}
 	type accState struct {
@@ -624,7 +624,7 @@ func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, p
 		validPulls bool
 	}
 	states := make(map[string]*accState)
-	for _, pj := range pjs {
+	for _, pj := range sp.pjs {
 		if pj.Spec.Type != prowapi.BatchJob {
 			continue
 		}
@@ -640,11 +640,11 @@ func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, p
 					state.prs = append(state.prs, pr)
 				} else if !ok {
 					state.validPulls = false
-					log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR left pool")
+					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR left pool")
 					break
 				} else {
 					state.validPulls = false
-					log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR HEAD changed")
+					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR HEAD changed")
 					break
 				}
 			}
@@ -663,22 +663,22 @@ func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, p
 			states[ref].jobStates[context] = jobState
 		}
 	}
-	var pendingBatch, successBatch []PullRequest
 	for ref, state := range states {
 		if !state.validPulls {
 			continue
 		}
-		requiredPresubmits := sets.NewString()
-		for _, pr := range state.prs {
-			for _, job := range presubmits[int(pr.Number)] {
-				requiredPresubmits.Insert(job.Context)
-			}
+
+		requiredPresubmits, err := c.presubmitsForBatch(state.prs, sp.org, sp.repo, sp.sha, sp.branch)
+		if err != nil {
+			sp.log.WithError(err).Error("Error getting presubmits for batch")
+			continue
 		}
+
 		overallState := successState
-		for _, p := range requiredPresubmits.List() {
-			if s, ok := state.jobStates[p]; !ok || s == failureState {
+		for _, p := range requiredPresubmits {
+			if s, ok := state.jobStates[p.Context]; !ok || s == failureState {
 				overallState = failureState
-				log.WithField("batch", ref).Debugf("batch invalid, required presubmit %s is not passing", p)
+				sp.log.WithField("batch", ref).Debugf("batch invalid, required presubmit %s is not passing", p.Context)
 				break
 			} else if s == pendingState && overallState == successState {
 				overallState = pendingState
@@ -765,44 +765,45 @@ func prNumbers(prs []PullRequest) []int {
 	return nums
 }
 
-func (c *Controller) pickBatch(sp subpool, cc contextChecker) ([]PullRequest, error) {
+func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker) ([]PullRequest, []config.Presubmit, error) {
 	batchLimit := c.config().Tide.BatchSizeLimit(sp.org, sp.repo)
 	if batchLimit < 0 {
 		sp.log.Debug("Batch merges disabled by configuration in this repo.")
-		return nil, nil
+		return nil, nil, nil
 	}
+
 	// we must choose the oldest PRs for the batch
 	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
 
 	var candidates []PullRequest
 	for _, pr := range sp.prs {
-		if isPassingTests(sp.log, c.ghc, pr, cc) {
+		if isPassingTests(sp.log, c.ghc, pr, cc[int(pr.Number)]) {
 			candidates = append(candidates, pr)
 		}
 	}
 
 	if len(candidates) == 0 {
 		sp.log.Debugf("of %d possible PRs, none were passing tests, no batch will be created", len(sp.prs))
-		return nil, nil
+		return nil, nil, nil
 	}
 	sp.log.Debugf("of %d possible PRs, %d are passing tests", len(sp.prs), len(candidates))
 
 	r, err := c.gc.Clone(sp.org + "/" + sp.repo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer r.Clean()
 	if err := r.Config("user.name", "prow"); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := r.Config("user.email", "prow@localhost"); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := r.Config("commit.gpgsign", "false"); err != nil {
 		sp.log.Warningf("Cannot set gpgsign=false in gitconfig: %v", err)
 	}
 	if err := r.Checkout(sp.sha); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var res []PullRequest
@@ -810,7 +811,7 @@ func (c *Controller) pickBatch(sp subpool, cc contextChecker) ([]PullRequest, er
 		if ok, err := r.Merge(string(pr.HeadRefOID)); err != nil {
 			// we failed to abort the merge and our git client is
 			// in a bad state; it must be cleaned before we try again
-			return nil, err
+			return nil, nil, err
 		} else if ok {
 			res = append(res, pr)
 			// TODO: Make this configurable per subpool.
@@ -819,7 +820,13 @@ func (c *Controller) pickBatch(sp subpool, cc contextChecker) ([]PullRequest, er
 			}
 		}
 	}
-	return res, nil
+
+	presubmits, err := c.presubmitsForBatch(res, sp.org, sp.repo, sp.sha, sp.branch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return res, presubmits, nil
 }
 
 func checkMergeLabels(pr PullRequest, squash, rebase, merge string, method github.PullRequestMergeType) (github.PullRequestMergeType, error) {
@@ -1000,7 +1007,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 	return true, err
 }
 
-func (c *Controller) trigger(sp subpool, presubmits map[int][]config.Presubmit, prs []PullRequest) error {
+func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []PullRequest) error {
 	refs := prowapi.Refs{
 		Org:     sp.org,
 		Repo:    sp.repo,
@@ -1022,26 +1029,24 @@ func (c *Controller) trigger(sp subpool, presubmits map[int][]config.Presubmit, 
 	// If multiple required jobs have the same context, we assume the
 	// same shard will be run to provide those contexts
 	triggeredContexts := sets.NewString()
-	for _, pr := range prs {
-		for _, ps := range presubmits[int(pr.Number)] {
-			if triggeredContexts.Has(string(ps.Context)) {
-				continue
-			}
-			triggeredContexts.Insert(string(ps.Context))
-			var spec prowapi.ProwJobSpec
-			if len(prs) == 1 {
-				spec = pjutil.PresubmitSpec(ps, refs)
-			} else {
-				spec = pjutil.BatchSpec(ps, refs)
-			}
-			pj := pjutil.NewProwJob(spec, ps.Labels, ps.Annotations)
-			start := time.Now()
-			if _, err := c.prowJobClient.Create(&pj); err != nil {
-				c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
-				return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
-			}
-			c.logger.WithField("duration", time.Since(start).String()).Debug("Created ProwJob on the cluster.")
+	for _, ps := range presubmits {
+		if triggeredContexts.Has(string(ps.Context)) {
+			continue
 		}
+		triggeredContexts.Insert(string(ps.Context))
+		var spec prowapi.ProwJobSpec
+		if len(prs) == 1 {
+			spec = pjutil.PresubmitSpec(ps, refs)
+		} else {
+			spec = pjutil.BatchSpec(ps, refs)
+		}
+		pj := pjutil.NewProwJob(spec, ps.Labels, ps.Annotations)
+		start := time.Now()
+		if _, err := c.prowJobClient.Create(&pj); err != nil {
+			c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
+			return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
+		}
+		c.logger.WithField("duration", time.Since(start).String()).Debug("Created ProwJob on the cluster.")
 	}
 	return nil
 }
@@ -1064,18 +1069,18 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, m
 	}
 	// If we have no batch, trigger one.
 	if len(sp.prs) > 1 && len(batchPending) == 0 {
-		batch, err := c.pickBatch(sp, sp.cc)
+		batch, presubmits, err := c.pickBatch(sp, sp.cc)
 		if err != nil {
 			return Wait, nil, err
 		}
 		if len(batch) > 1 {
-			return TriggerBatch, batch, c.trigger(sp, sp.presubmits, batch)
+			return TriggerBatch, batch, c.trigger(sp, presubmits, batch)
 		}
 	}
 	// If we have no serial jobs pending or successful, trigger one.
 	if len(missings) > 0 && len(pendings) == 0 && len(successes) == 0 {
 		if ok, pr := pickSmallestPassingNumber(sp.log, c.ghc, missings, sp.cc); ok {
-			return Trigger, []PullRequest{pr}, c.trigger(sp, missingSerialTests, []PullRequest{pr})
+			return Trigger, []PullRequest{pr}, c.trigger(sp, missingSerialTests[int(pr.Number)], []PullRequest{pr})
 		}
 	}
 	return Wait, nil, nil
@@ -1145,12 +1150,34 @@ func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvid
 	}
 }
 
+func (c *changedFilesAgent) batchChanges(prs []PullRequest) config.ChangedFilesProvider {
+	return func() ([]string, error) {
+		var result []string
+		for _, pr := range prs {
+			changes, err := c.prChanges(&pr)()
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, changes...)
+		}
+
+		return result, nil
+	}
+}
+
 // prune removes any cached file changes that were not used since the last prune.
 func (c *changedFilesAgent) prune() {
 	c.Lock()
 	defer c.Unlock()
 	c.changeCache = c.nextChangeCache
 	c.nextChangeCache = make(map[changeCacheKey][]string)
+}
+
+func refGetterFactory(ref string) config.RefGetter {
+	return func() (string, error) {
+		return ref, nil
+	}
 }
 
 func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, error) {
@@ -1163,12 +1190,17 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 		}
 	}
 
-	for _, ps := range c.config().Presubmits[sp.org+"/"+sp.repo] {
-		if !ps.ContextRequired() {
-			continue
+	for _, pr := range sp.prs {
+		presubmits, err := c.config().GetPresubmits(c.gc, sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(string(pr.HeadRefOID)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get presubmits for PR %d: %v", int(pr.Number), err)
 		}
 
-		for _, pr := range sp.prs {
+		for _, ps := range presubmits {
+			if !ps.ContextRequired() {
+				continue
+			}
+
 			if shouldRun, err := ps.ShouldRun(sp.branch, c.changedFiles.prChanges(&pr), false, false); err != nil {
 				return nil, err
 			} else if shouldRun {
@@ -1179,10 +1211,41 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 	return presubmits, nil
 }
 
+func (c *Controller) presubmitsForBatch(prs []PullRequest, org, repo, baseSHA, baseBranch string) ([]config.Presubmit, error) {
+	var headRefGetters []config.RefGetter
+	for _, pr := range prs {
+		headRefGetters = append(headRefGetters, refGetterFactory(string(pr.HeadRefOID)))
+	}
+
+	presubmits, err := c.config().GetPresubmits(c.gc, org+"/"+repo, refGetterFactory(baseSHA), headRefGetters...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get presubmits for batch: %v", err)
+	}
+
+	var result []config.Presubmit
+	for _, ps := range presubmits {
+		if !ps.ContextRequired() {
+			continue
+		}
+
+		shouldRun, err := ps.ShouldRun(baseSHA, c.changedFiles.batchChanges(prs), false, false)
+		if err != nil {
+			return nil, err
+		}
+		if !shouldRun {
+			continue
+		}
+
+		result = append(result, ps)
+	}
+
+	return result, nil
+}
+
 func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, error) {
 	sp.log.Infof("Syncing subpool: %d PRs, %d PJs.", len(sp.prs), len(sp.pjs))
 	successes, pendings, missings, missingSerialTests := accumulate(sp.presubmits, sp.prs, sp.pjs, sp.log)
-	batchMerge, batchPending := accumulateBatch(sp.presubmits, sp.prs, sp.pjs, sp.log)
+	batchMerge, batchPending := c.accumulateBatch(sp)
 	sp.log.WithFields(logrus.Fields{
 		"prs-passing":   prNumbers(successes),
 		"prs-pending":   prNumbers(pendings),
@@ -1286,7 +1349,7 @@ type subpool struct {
 	pjs []prowapi.ProwJob
 	prs []PullRequest
 
-	cc contextChecker
+	cc map[int]contextChecker
 	// presubmit contains all required presubmits for each PR
 	// in this subpool
 	presubmits map[int][]config.Presubmit

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3008,7 +3008,7 @@ func TestChangedFilesAgentBatchChanges(t *testing.T) {
 			expected: []string{"foo"},
 		},
 		{
-			name: "Multiple PRs",
+			name: "Multiple PRs, changes are de-duplicated",
 			prs: []PullRequest{
 				getPR("org", "repo", 1),
 				getPR("org", "repo", 2),
@@ -3019,7 +3019,7 @@ func TestChangedFilesAgentBatchChanges(t *testing.T) {
 					{org: "org", repo: "repo", number: 2}: {"foo", "bar"},
 				},
 			},
-			expected: []string{"foo", "foo", "bar"},
+			expected: []string{"bar", "foo"},
 		},
 	}
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -229,10 +229,6 @@ func TestAccumulateBatch(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			config.FakeInRepoConfig = test.fakeInRepoConfig
-			defer func() {
-				config.FakeInRepoConfig = nil
-			}()
 
 			var pulls []PullRequest
 			for _, p := range test.pulls {
@@ -271,6 +267,7 @@ func TestAccumulateBatch(t *testing.T) {
 							Presubmits: map[string][]config.Presubmit{
 								"org/repo": test.presubmits,
 							},
+							FakeInRepoConfig: test.fakeInRepoConfig,
 						},
 					}
 				},
@@ -2164,10 +2161,6 @@ func TestIsPassing(t *testing.T) {
 }
 
 func TestPresubmitsByPull(t *testing.T) {
-	defer func() {
-		config.FakeInRepoConfig = nil
-	}()
-
 	samplePR := PullRequest{
 		Number:     githubql.Int(100),
 		HeadRefOID: githubql.String("sha"),
@@ -2409,12 +2402,12 @@ func TestPresubmitsByPull(t *testing.T) {
 			tc.expectedChangeCache = map[changeCacheKey][]string{}
 		}
 
-		config.FakeInRepoConfig = tc.fakeInRepoConfig
 		cfg := &config.Config{}
 		cfg.SetPresubmits(map[string][]config.Presubmit{
 			"/":       tc.presubmits,
 			"foo/bar": {{Reporter: config.Reporter{Context: "wrong-repo"}, AlwaysRun: true}},
 		})
+		cfg.FakeInRepoConfig = tc.fakeInRepoConfig
 		cfgAgent := &config.Agent{}
 		cfgAgent.Set(cfg)
 		sp := &subpool{
@@ -2939,10 +2932,6 @@ func TestPresubmitsForBatch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config.FakeInRepoConfig = tc.inrepoconfig
-			defer func() {
-				config.FakeInRepoConfig = nil
-			}()
 
 			if tc.changedFiles == nil {
 				tc.changedFiles = &changedFilesAgent{
@@ -2970,6 +2959,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 							Presubmits: map[string][]config.Presubmit{
 								"org/repo": tc.jobs,
 							},
+							FakeInRepoConfig: tc.inrepoconfig,
 						},
 					}
 				},

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -39,6 +39,7 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/tide/history"
@@ -85,10 +86,11 @@ func TestAccumulateBatch(t *testing.T) {
 		state prowapi.ProwJobState
 	}
 	tests := []struct {
-		name       string
-		presubmits map[int][]config.Presubmit
-		pulls      []pull
-		prowJobs   []prowjob
+		name             string
+		presubmits       []config.Presubmit
+		pulls            []pull
+		prowJobs         []prowjob
+		fakeInRepoConfig map[string][]config.Presubmit
 
 		merges  []int
 		pending bool
@@ -98,9 +100,8 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name: "batch pending",
-			presubmits: map[int][]config.Presubmit{
-				1: {{Reporter: config.Reporter{Context: "foo"}}},
-				2: {{Reporter: config.Reporter{Context: "foo"}}},
+			presubmits: []config.Presubmit{
+				{Reporter: config.Reporter{Context: "foo"}},
 			},
 			pulls:    []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}}},
@@ -108,13 +109,13 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "pending batch missing presubmits is ignored",
-			presubmits: map[int][]config.Presubmit{1: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs:   []prowjob{{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}}},
 		},
 		{
 			name:       "batch pending, successful previous run",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}},
@@ -129,7 +130,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "successful run",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{2, "b"}}},
@@ -140,7 +141,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "successful run, multiple PRs",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -151,7 +152,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "successful run, failures in past",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -165,7 +166,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "failures",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.FailureState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -176,17 +177,24 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "missing job required by one PR",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 			},
+			// We need to use the concatenated headSHAs of all PRs here, as GetPresubmits is called
+			// for the whole batch and not for individual PRs, because inrepoconfig allows one Pr to
+			// change the required PRs for all batch members
+			fakeInRepoConfig: map[string][]config.Presubmit{"ab": {{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "boo"},
+			}}},
 		},
 		{
 			name:       "successful run with PR that requires additional job",
-			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
+			presubmits: jobSet,
 			pulls:      []pull{{1, "a"}, {2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -194,6 +202,10 @@ func TestAccumulateBatch(t *testing.T) {
 				{job: "baz", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "boo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 			},
+			fakeInRepoConfig: map[string][]config.Presubmit{"b": {{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "boo"},
+			}}},
 			merges: []int{1, 2},
 		},
 		{
@@ -203,7 +215,7 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 		{
 			name:       "pending batch with PR that left pool, successful previous run",
-			presubmits: map[int][]config.Presubmit{2: jobSet},
+			presubmits: jobSet,
 			pulls:      []pull{{2, "b"}},
 			prowJobs: []prowjob{
 				{job: "foo", state: prowapi.PendingState, prs: []pull{{1, "a"}}},
@@ -216,38 +228,60 @@ func TestAccumulateBatch(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		var pulls []PullRequest
-		for _, p := range test.pulls {
-			pr := PullRequest{
-				Number:     githubql.Int(p.number),
-				HeadRefOID: githubql.String(p.sha),
+		t.Run(test.name, func(t *testing.T) {
+			config.FakeInRepoConfig = test.fakeInRepoConfig
+			defer func() {
+				config.FakeInRepoConfig = nil
+			}()
+
+			var pulls []PullRequest
+			for _, p := range test.pulls {
+				pr := PullRequest{
+					Number:     githubql.Int(p.number),
+					HeadRefOID: githubql.String(p.sha),
+				}
+				pulls = append(pulls, pr)
 			}
-			pulls = append(pulls, pr)
-		}
-		var pjs []prowapi.ProwJob
-		for _, pj := range test.prowJobs {
-			npj := prowapi.ProwJob{
-				Spec: prowapi.ProwJobSpec{
-					Job:     pj.job,
-					Context: pj.job,
-					Type:    prowapi.BatchJob,
-					Refs:    new(prowapi.Refs),
+			var pjs []prowapi.ProwJob
+			for _, pj := range test.prowJobs {
+				npj := prowapi.ProwJob{
+					Spec: prowapi.ProwJobSpec{
+						Job:     pj.job,
+						Context: pj.job,
+						Type:    prowapi.BatchJob,
+						Refs:    new(prowapi.Refs),
+					},
+					Status: prowapi.ProwJobStatus{State: pj.state},
+				}
+				for _, pr := range pj.prs {
+					npj.Spec.Refs.Pulls = append(npj.Spec.Refs.Pulls, prowapi.Pull{
+						Number: pr.number,
+						SHA:    pr.sha,
+					})
+				}
+				pjs = append(pjs, npj)
+			}
+			for idx := range test.presubmits {
+				test.presubmits[idx].AlwaysRun = true
+			}
+			c := &Controller{
+				config: func() *config.Config {
+					return &config.Config{
+						JobConfig: config.JobConfig{
+							Presubmits: map[string][]config.Presubmit{
+								"org/repo": test.presubmits,
+							},
+						},
+					}
 				},
-				Status: prowapi.ProwJobStatus{State: pj.state},
+				changedFiles: &changedFilesAgent{},
 			}
-			for _, pr := range pj.prs {
-				npj.Spec.Refs.Pulls = append(npj.Spec.Refs.Pulls, prowapi.Pull{
-					Number: pr.number,
-					SHA:    pr.sha,
-				})
+			merges, pending := c.accumulateBatch(subpool{org: "org", repo: "repo", prs: pulls, pjs: pjs, log: logrus.WithField("test", test.name)})
+			if (len(pending) > 0) != test.pending {
+				t.Errorf("For case \"%s\", got wrong pending.", test.name)
 			}
-			pjs = append(pjs, npj)
-		}
-		merges, pending := accumulateBatch(test.presubmits, pulls, pjs, logrus.NewEntry(logrus.New()))
-		if (len(pending) > 0) != test.pending {
-			t.Errorf("For case \"%s\", got wrong pending.", test.name)
-		}
-		testPullsMatchList(t, test.name, merges, test.merges)
+			testPullsMatchList(t, test.name, merges, test.merges)
+		})
 	}
 }
 
@@ -636,10 +670,15 @@ func TestDividePool(t *testing.T) {
 		},
 	}
 	fc := &fgc{
-		refs: map[string]string{"k/t-i heads/master": "123"},
+		refs: map[string]string{
+			"k/t-i heads/master":    "123",
+			"k/k heads/master":      "456",
+			"k/k heads/release-1.6": "789",
+		},
 	}
 	c := &Controller{
 		ghc:    fc,
+		gc:     &git.Client{},
 		logger: logrus.WithField("component", "tide"),
 	}
 	pulls := make(map[string]PullRequest)
@@ -676,7 +715,7 @@ func TestDividePool(t *testing.T) {
 		name := fmt.Sprintf("%s/%s %s", sp.org, sp.repo, sp.branch)
 		sha := fc.refs[sp.org+"/"+sp.repo+" heads/"+sp.branch]
 		if sp.sha != sha {
-			t.Errorf("For subpool %s, got sha %s, expected %s.", name, sp.sha, sha)
+			t.Errorf("For subpool %s, got sha %q, expected %q.", name, sp.sha, sha)
 		}
 		if len(sp.prs) == 0 {
 			t.Errorf("Subpool %s has no PRs.", name)
@@ -736,21 +775,9 @@ func TestPickBatch(t *testing.T) {
 			included: false,
 		},
 		{
-			files:    map[string][]byte{"qux": []byte("ok")},
-			success:  false,
-			number:   6,
-			included: false,
-		},
-		{
-			files:    map[string][]byte{"bazel": []byte("ok")},
+			files:    map[string][]byte{"something": []byte("ok")},
 			success:  true,
-			number:   7,
-			included: false, // batch of 5 smallest excludes this
-		},
-		{
-			files:    map[string][]byte{"other": []byte("ok")},
-			success:  true,
-			number:   5,
+			number:   3,
 			included: true,
 		},
 		{
@@ -760,10 +787,28 @@ func TestPickBatch(t *testing.T) {
 			included: true,
 		},
 		{
-			files:    map[string][]byte{"something": []byte("ok")},
+			files:    map[string][]byte{"other": []byte("ok")},
 			success:  true,
-			number:   3,
+			number:   5,
+			included: false, // excluded by context policy
+		},
+		{
+			files:    map[string][]byte{"qux": []byte("ok")},
+			success:  false,
+			number:   6,
+			included: false,
+		},
+		{
+			files:    map[string][]byte{"bazel": []byte("ok")},
+			success:  true,
+			number:   7,
 			included: true,
+		},
+		{
+			files:    map[string][]byte{"bazel": []byte("ok")},
+			success:  true,
+			number:   8,
+			included: false, // batch of 5 smallest excludes this
 		},
 	}
 	sp := subpool{
@@ -803,15 +848,39 @@ func TestPickBatch(t *testing.T) {
 				BatchSizeLimitMap: map[string]int{"*": 5},
 			},
 		},
+		JobConfig: config.JobConfig{
+			Presubmits: map[string][]config.Presubmit{
+				"o/r": {{
+					AlwaysRun: true,
+					JobBase: config.JobBase{
+						Name: "my-presubmit",
+					},
+				}},
+			},
+		},
 	})
 	c := &Controller{
 		logger: logrus.WithField("component", "tide"),
 		gc:     gc,
 		config: ca.Config,
 	}
-	prs, err := c.pickBatch(sp, &config.TideContextPolicy{})
+	prs, presubmits, err := c.pickBatch(sp, map[int]contextChecker{
+		0: &config.TideContextPolicy{},
+		1: &config.TideContextPolicy{},
+		2: &config.TideContextPolicy{},
+		3: &config.TideContextPolicy{},
+		4: &config.TideContextPolicy{},
+		// Test if scoping of ContextPolicy works correctly
+		5: &config.TideContextPolicy{RequiredContexts: []string{"context-from-context-checker"}},
+		6: &config.TideContextPolicy{},
+		7: &config.TideContextPolicy{},
+		8: &config.TideContextPolicy{},
+	})
 	if err != nil {
 		t.Fatalf("Error from pickBatch: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(presubmits, ca.Config().PresubmitsStatic()["o/r"]) {
+		t.Errorf("resolving presubmits failed, diff:\n%v\n", diff.ObjectReflectDiff(presubmits, ca.Config().PresubmitsStatic()["o/r"]))
 	}
 	for _, testpr := range testprs {
 		var found bool
@@ -1248,11 +1317,22 @@ func TestTakeAction(t *testing.T) {
 		sp := subpool{
 			log:        logrus.WithField("component", "tide"),
 			presubmits: tc.presubmits,
-			cc:         &config.TideContextPolicy{},
-			org:        "o",
-			repo:       "r",
-			branch:     "master",
-			sha:        "master",
+			cc: map[int]contextChecker{
+				0:   &config.TideContextPolicy{},
+				1:   &config.TideContextPolicy{},
+				2:   &config.TideContextPolicy{},
+				3:   &config.TideContextPolicy{},
+				4:   &config.TideContextPolicy{},
+				5:   &config.TideContextPolicy{},
+				6:   &config.TideContextPolicy{},
+				7:   &config.TideContextPolicy{},
+				8:   &config.TideContextPolicy{},
+				100: &config.TideContextPolicy{},
+			},
+			org:    "o",
+			repo:   "r",
+			branch: "master",
+			sha:    "master",
 		}
 		genPulls := func(nums []int) []PullRequest {
 			var prs []PullRequest
@@ -1286,6 +1366,10 @@ func TestTakeAction(t *testing.T) {
 			config:        ca.Config,
 			ghc:           &fgc,
 			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			changedFiles: &changedFilesAgent{
+				ghc:             &fgc,
+				nextChangeCache: make(map[changeCacheKey][]string),
+			},
 		}
 		var batchPending []PullRequest
 		if tc.batchPending {
@@ -1555,7 +1639,15 @@ func TestSync(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Logf("Starting case %q...", tc.name)
-		fgc := &fgc{prs: tc.prs}
+		fgc := &fgc{
+			prs: tc.prs,
+			refs: map[string]string{
+				"org/repo heads/A": "SHA",
+				"org/repo A":       "SHA",
+				"org/repo heads/B": "SHA",
+				"org/repo B":       "SHA",
+			},
+		}
 		fakeProwJobClient := fake.NewSimpleClientset()
 		ca := &config.Agent{}
 		ca.Set(&config.Config{
@@ -1574,6 +1666,7 @@ func TestSync(t *testing.T) {
 		sc := &statusController{
 			logger:         logrus.WithField("controller", "status-update"),
 			ghc:            fgc,
+			gc:             &git.Client{},
 			config:         ca.Config,
 			newPoolPending: make(chan bool, 1),
 			shutDown:       make(chan bool),
@@ -1583,6 +1676,7 @@ func TestSync(t *testing.T) {
 		c := &Controller{
 			config:        ca.Config,
 			ghc:           fgc,
+			gc:            &git.Client{},
 			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
 			logger:        logrus.WithField("controller", "sync"),
 			sc:            sc,
@@ -1624,10 +1718,17 @@ func TestFilterSubpool(t *testing.T) {
 	}
 
 	trueVar := true
-	cc := &config.TideContextPolicy{
-		RequiredContexts:    []string{"pj-a", "pj-b", "other-a"},
-		OptionalContexts:    []string{"tide", "pj-c"},
-		SkipUnknownContexts: &trueVar,
+	cc := map[int]contextChecker{
+		1: &config.TideContextPolicy{
+			RequiredContexts:    []string{"pj-a", "pj-b", "other-a"},
+			OptionalContexts:    []string{"tide", "pj-c"},
+			SkipUnknownContexts: &trueVar,
+		},
+		2: &config.TideContextPolicy{
+			RequiredContexts:    []string{"pj-a", "pj-b", "other-a"},
+			OptionalContexts:    []string{"tide", "pj-c"},
+			SkipUnknownContexts: &trueVar,
+		},
 	}
 
 	type pr struct {
@@ -2063,6 +2164,10 @@ func TestIsPassing(t *testing.T) {
 }
 
 func TestPresubmitsByPull(t *testing.T) {
+	defer func() {
+		config.FakeInRepoConfig = nil
+	}()
+
 	samplePR := PullRequest{
 		Number:     githubql.Int(100),
 		HeadRefOID: githubql.String("sha"),
@@ -2072,6 +2177,8 @@ func TestPresubmitsByPull(t *testing.T) {
 
 		initialChangeCache map[changeCacheKey][]string
 		presubmits         []config.Presubmit
+		prs                []PullRequest
+		fakeInRepoConfig   map[string][]config.Presubmit
 
 		expectedPresubmits  map[int][]config.Presubmit
 		expectedChangeCache map[changeCacheKey][]string
@@ -2267,6 +2374,29 @@ func TestPresubmitsByPull(t *testing.T) {
 			}}},
 			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"FILE"}},
 		},
+		{
+			name: "inrepoconfig presubmits get only added to the corresponding pull",
+			presubmits: []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "always"},
+			}},
+			fakeInRepoConfig: map[string][]config.Presubmit{"1": {{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "inrepoconfig"},
+			}}},
+			prs: []PullRequest{
+				{Number: githubql.Int(1), HeadRefOID: githubql.String("1")},
+			},
+			expectedPresubmits: map[int][]config.Presubmit{
+				1: {
+					{AlwaysRun: true, Reporter: config.Reporter{Context: "always"}},
+					{AlwaysRun: true, Reporter: config.Reporter{Context: "inrepoconfig"}},
+				},
+				100: {
+					{AlwaysRun: true, Reporter: config.Reporter{Context: "always"}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -2279,6 +2409,7 @@ func TestPresubmitsByPull(t *testing.T) {
 			tc.expectedChangeCache = map[changeCacheKey][]string{}
 		}
 
+		config.FakeInRepoConfig = tc.fakeInRepoConfig
 		cfg := &config.Config{}
 		cfg.SetPresubmits(map[string][]config.Presubmit{
 			"/":       tc.presubmits,
@@ -2288,11 +2419,13 @@ func TestPresubmitsByPull(t *testing.T) {
 		cfgAgent.Set(cfg)
 		sp := &subpool{
 			branch: "master",
-			prs:    []PullRequest{samplePR},
+			sha:    "master-sha",
+			prs:    append(tc.prs, samplePR),
 		}
 		c := &Controller{
 			config: cfgAgent.Config,
 			ghc:    &fgc{},
+			gc:     &git.Client{},
 			changedFiles: &changedFilesAgent{
 				ghc:             &fgc{},
 				changeCache:     tc.initialChangeCache,
@@ -2676,4 +2809,243 @@ func TestAccumulateReturnsCorrectMissingTests(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPresubmitsForBatch(t *testing.T) {
+	testCases := []struct {
+		name         string
+		prs          []PullRequest
+		changedFiles *changedFilesAgent
+		jobs         []config.Presubmit
+		inrepoconfig map[string][]config.Presubmit
+		expected     []config.Presubmit
+	}{
+		{
+			name: "All jobs get picked",
+			prs:  []PullRequest{getPR("org", "repo", 1)},
+			jobs: []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "foo"},
+			}},
+			expected: []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "foo"},
+			}},
+		},
+		{
+			name: "Optional jobs are excluded",
+			prs:  []PullRequest{getPR("org", "repo", 1)},
+			jobs: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "foo"},
+				},
+				{
+					Reporter: config.Reporter{Context: "bar"},
+				},
+			},
+			expected: []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "foo"},
+			}},
+		},
+		{
+			name: "Jobs that are required by any of the PRs get included",
+			prs: []PullRequest{
+				getPR("org", "repo", 2),
+				getPR("org", "repo", 1, func(pr *PullRequest) {
+					pr.HeadRefOID = githubql.String("sha")
+				}),
+			},
+			jobs: []config.Presubmit{{
+				RegexpChangeMatcher: config.RegexpChangeMatcher{
+					RunIfChanged: "/very-important",
+				},
+				Reporter: config.Reporter{Context: "foo"},
+			}},
+			changedFiles: &changedFilesAgent{
+				changeCache: map[changeCacheKey][]string{
+					{org: "org", repo: "repo", number: 1, sha: "sha"}: {"/very-important"},
+					{org: "org", repo: "repo", number: 2}:             {},
+				},
+				nextChangeCache: map[changeCacheKey][]string{},
+			},
+			expected: []config.Presubmit{{
+				RegexpChangeMatcher: config.RegexpChangeMatcher{
+					RunIfChanged: "/very-important",
+				},
+				Reporter: config.Reporter{Context: "foo"},
+			}},
+		},
+		{
+			name: "Inrepoconfig jobs get included if headref matches",
+			prs: []PullRequest{
+				getPR("org", "repo", 2),
+				getPR("org", "repo", 1, func(pr *PullRequest) {
+					pr.HeadRefOID = githubql.String("sha")
+				}),
+			},
+			jobs: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "foo"},
+				},
+			},
+			inrepoconfig: map[string][]config.Presubmit{
+				"sha": {{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "bar"},
+				}},
+			},
+			expected: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "foo"},
+				},
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "bar"},
+				},
+			},
+		},
+		{
+			name: "Inrepoconfig jobs do not get included if headref doesnt match",
+			prs: []PullRequest{
+				getPR("org", "repo", 2),
+				getPR("org", "repo", 1, func(pr *PullRequest) {
+					pr.HeadRefOID = githubql.String("sha")
+				}),
+			},
+			jobs: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "foo"},
+				},
+			},
+			inrepoconfig: map[string][]config.Presubmit{
+				"other-sha": {{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "bar"},
+				}},
+			},
+			expected: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "foo"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config.FakeInRepoConfig = tc.inrepoconfig
+			defer func() {
+				config.FakeInRepoConfig = nil
+			}()
+
+			if tc.changedFiles == nil {
+				tc.changedFiles = &changedFilesAgent{
+					changeCache: map[changeCacheKey][]string{},
+				}
+				for _, pr := range tc.prs {
+					key := changeCacheKey{
+						org:    string(pr.Repository.Owner.Login),
+						repo:   string(pr.Repository.Name),
+						number: int(pr.Number),
+						sha:    string(pr.HeadRefOID),
+					}
+					tc.changedFiles.changeCache[key] = []string{}
+				}
+			}
+
+			if err := config.SetPresubmitRegexes(tc.jobs); err != nil {
+				t.Fatalf("failed to set presubmit regexes: %v", err)
+			}
+			c := &Controller{
+				changedFiles: tc.changedFiles,
+				config: func() *config.Config {
+					return &config.Config{
+						JobConfig: config.JobConfig{
+							Presubmits: map[string][]config.Presubmit{
+								"org/repo": tc.jobs,
+							},
+						},
+					}
+				},
+			}
+
+			presubmits, err := c.presubmitsForBatch(tc.prs, "org", "repo", "baseSHA", "master")
+			if err != nil {
+				t.Fatalf("failed to get presubmits for batch: %v", err)
+			}
+			// Clear regexes, otherwise DeepEqual comparison wont work
+			config.ClearCompiledRegexes(presubmits)
+			if !equality.Semantic.DeepEqual(tc.expected, presubmits) {
+				t.Errorf("returned presubmits do not match expected, diff: %v\n", diff.ObjectReflectDiff(tc.expected, presubmits))
+			}
+		})
+	}
+}
+
+func TestChangedFilesAgentBatchChanges(t *testing.T) {
+	testCases := []struct {
+		name         string
+		prs          []PullRequest
+		changedFiles *changedFilesAgent
+		expected     []string
+	}{
+		{
+			name: "Single PR",
+			prs: []PullRequest{
+				getPR("org", "repo", 1),
+			},
+			changedFiles: &changedFilesAgent{
+				changeCache: map[changeCacheKey][]string{
+					{org: "org", repo: "repo", number: 1}: {"foo"},
+				},
+			},
+			expected: []string{"foo"},
+		},
+		{
+			name: "Multiple PRs",
+			prs: []PullRequest{
+				getPR("org", "repo", 1),
+				getPR("org", "repo", 2),
+			},
+			changedFiles: &changedFilesAgent{
+				changeCache: map[changeCacheKey][]string{
+					{org: "org", repo: "repo", number: 1}: {"foo"},
+					{org: "org", repo: "repo", number: 2}: {"foo", "bar"},
+				},
+			},
+			expected: []string{"foo", "foo", "bar"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.changedFiles.nextChangeCache = map[changeCacheKey][]string{}
+
+			result, err := tc.changedFiles.batchChanges(tc.prs)()
+			if err != nil {
+				t.Fatalf("fauked to get changed files: %v", err)
+			}
+			if !equality.Semantic.DeepEqual(result, tc.expected) {
+				t.Errorf("returned changes do not match expected; diff: %v\n", diff.ObjectReflectDiff(tc.expected, result))
+			}
+		})
+	}
+}
+
+func getPR(org, name string, number int, opts ...func(*PullRequest)) PullRequest {
+	pr := PullRequest{}
+	pr.Repository.Owner.Login = githubql.String(org)
+	pr.Repository.NameWithOwner = githubql.String(org + "/" + name)
+	pr.Repository.Name = githubql.String(name)
+	pr.Number = githubql.Int(number)
+	for _, opt := range opts {
+		opt(&pr)
+	}
+	return pr
 }


### PR DESCRIPTION
Another step towards fixing #13370, this PR changes the branchprotector and Tide to use `GetPresubmits` instead of directly accessing the `Presubmits` property