### PR TITLE
Deck: Use presubmit config getter

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -303,12 +303,16 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8080
         volumeMounts:
         - name: config
           mountPath: /etc/config
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
           readOnly: true
         livenessProbe:
           httpGet:
@@ -327,6 +331,9 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: oauth
+        secret:
+          secretName: oauth-token
 ---
 apiVersion: v1
 kind: Service

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
 
 container_image(
     name = "asset-base",
-    base = "@alpine-base//image",
+    base = "@git-base//image",
     # With paths relative to the current directory.
     data_path = ".",
     # Add files under into the root directory.
@@ -66,6 +66,8 @@ go_test(
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/git:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/githuboauth:go_default_library",
         "//prow/pluginhelp:go_default_library",
@@ -112,6 +114,7 @@ go_library(
         "//prow/errorutil:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/gcsupload:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/githuboauth:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/deck/jobs"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/git"
 	prowgithub "k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/githuboauth"
 	"k8s.io/test-infra/prow/kube"
@@ -398,7 +399,7 @@ func localOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.Serve
 	mux.Handle("/github-login", gziphandler.GzipHandler(handleSimpleTemplate(o, cfg, "github-login.html", nil)))
 
 	if o.spyglass {
-		initSpyglass(cfg, o, mux, nil)
+		initSpyglass(cfg, o, mux, nil, nil, nil)
 	}
 
 	return mux
@@ -487,8 +488,28 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 
 	mux.Handle("/prowjob", gziphandler.GzipHandler(handleProwJob(prowJobClient)))
 
+	// We use the GH client to resolve GH teams when determining who is permitted to rerun a job.
+	// When inrepoconfig is enabled, both the GitHubClient and the gitClient are used to resolve
+	// presubmits dynamically which we need for the PR history page.
+	var githubClient deckGitHubClient
+	var gitClient *git.Client
+	secretAgent := &secret.Agent{}
+	if o.github.TokenPath != "" {
+		if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
+		githubClient, err = o.github.GitHubClient(secretAgent, o.dryRun)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting GitHub client.")
+		}
+		gitClient, err = o.github.GitClient(secretAgent, o.dryRun)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error getting Git client.")
+		}
+	}
+
 	if o.spyglass {
-		initSpyglass(cfg, o, mux, ja)
+		initSpyglass(cfg, o, mux, ja, githubClient, gitClient)
 	}
 
 	if o.hookURL != "" {
@@ -512,8 +533,6 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 		mux.Handle("/tide-history.js", gziphandler.GzipHandler(handleTideHistory(ta)))
 	}
 
-	// We use the GH client to resolve GH teams when determining who is permitted to rerun a job.
-	var githubClient prowgithub.RerunClient
 	// Enable Git OAuth feature if oauthURL is provided.
 	var goa *githuboauth.Agent
 	if o.oauthURL != "" {
@@ -554,17 +573,6 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 			Endpoint:     github.Endpoint,
 		},
 		)
-
-		secretAgent := &secret.Agent{}
-		if o.github.TokenPath != "" {
-			if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
-				logrus.WithError(err).Fatal("Error starting secrets agent.")
-			}
-			githubClient, err = o.github.GitHubClient(secretAgent, o.dryRun)
-			if err != nil {
-				logrus.WithError(err).Fatal("Error getting GitHub client.")
-			}
-		}
 
 		repos := cfg().AllRepos.List()
 
@@ -611,7 +619,7 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 	return mux
 }
 
-func initSpyglass(cfg config.Getter, o options, mux *http.ServeMux, ja *jobs.JobAgent) {
+func initSpyglass(cfg config.Getter, o options, mux *http.ServeMux, ja *jobs.JobAgent, gitHubClient deckGitHubClient, gitClient *git.Client) {
 	var c *storage.Client
 	var err error
 	if o.gcsCredentialsFile == "" {
@@ -629,7 +637,7 @@ func initSpyglass(cfg config.Getter, o options, mux *http.ServeMux, ja *jobs.Job
 	mux.Handle("/spyglass/lens/", gziphandler.GzipHandler(http.StripPrefix("/spyglass/lens/", handleArtifactView(o, sg, cfg))))
 	mux.Handle("/view/", gziphandler.GzipHandler(handleRequestJobViews(sg, cfg, o)))
 	mux.Handle("/job-history/", gziphandler.GzipHandler(handleJobHistory(o, cfg, c)))
-	mux.Handle("/pr-history/", gziphandler.GzipHandler(handlePRHistory(o, cfg, c)))
+	mux.Handle("/pr-history/", gziphandler.GzipHandler(handlePRHistory(o, cfg, c, gitHubClient, gitClient)))
 }
 
 func loadToken(file string) ([]byte, error) {
@@ -784,10 +792,10 @@ func handleJobHistory(o options, cfg config.Getter, gcsClient *storage.Client) h
 // The url must look like this:
 //
 // /pr-history?org=<org>&repo=<repo>&pr=<pr number>
-func handlePRHistory(o options, cfg config.Getter, gcsClient *storage.Client) http.HandlerFunc {
+func handlePRHistory(o options, cfg config.Getter, gcsClient *storage.Client, gitHubClient deckGitHubClient, gitClient *git.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setHeadersNoCaching(w)
-		tmpl, err := getPRHistory(r.URL, cfg(), gcsClient)
+		tmpl, err := getPRHistory(r.URL, cfg(), gcsClient, gitHubClient, gitClient)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get PR history: %v", err)
 			logrus.WithField("url", r.URL).Info(msg)
@@ -1416,4 +1424,10 @@ func handleFavicon(staticFilesLocation string, cfg config.Getter) http.HandlerFu
 func isValidatedGitOAuthConfig(githubOAuthConfig *config.GitHubOAuthConfig) bool {
 	return githubOAuthConfig.ClientID != "" && githubOAuthConfig.ClientSecret != "" &&
 		githubOAuthConfig.RedirectURL != ""
+}
+
+type deckGitHubClient interface {
+	prowgithub.RerunClient
+	GetPullRequest(org, repo string, number int) (*prowgithub.PullRequest, error)
+	GetRef(org, repo, ref string) (string, error)
 }

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -566,21 +566,7 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 			}
 		}
 
-		repoSet := make(map[string]bool)
-		for r := range cfg().Presubmits {
-			repoSet[r] = true
-		}
-		for _, q := range cfg().Tide.Queries {
-			for _, v := range q.Repos {
-				repoSet[v] = true
-			}
-		}
-		var repos []string
-		for k, v := range repoSet {
-			if v {
-				repos = append(repos, k)
-			}
-		}
+		repos := cfg().AllRepos.List()
 
 		prStatusAgent := prstatus.NewDashboardAgent(
 			repos,

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -973,7 +973,7 @@ func Test_gatherOptions(t *testing.T) {
 			case tc.err:
 				t.Errorf("failed to receive expected error")
 			case !reflect.DeepEqual(*expected, actual):
-				t.Errorf("%#v != expected %#v", actual, *expected)
+				t.Errorf("\n%#v\n!= expected\n%#v", actual, *expected)
 			}
 		})
 	}

--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -32,6 +32,7 @@ import (
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
@@ -201,11 +202,16 @@ func parsePullURL(u *url.URL) (org, repo string, pr int, err error) {
 }
 
 // getGCSDirsForPR returns a map from bucket names -> set of "directories" containing presubmit data
-func getGCSDirsForPR(config *config.Config, org, repo string, pr int) (map[string]sets.String, error) {
+func getGCSDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitClient *git.Client, org, repo string, prNumber int) (map[string]sets.String, error) {
 	toSearch := make(map[string]sets.String)
 	fullRepo := org + "/" + repo
-	presubmits, ok := config.Presubmits[fullRepo]
-	if !ok {
+
+	prRefGetter := config.NewRefGetterForGitHubPullRequest(gitHubClient, org, repo, prNumber)
+	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, prRefGetter.BaseSHA, prRefGetter.HeadSHA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Presubmits for pull request %s/%s#%d: %v", org, repo, prNumber, err)
+	}
+	if len(presubmits) == 0 {
 		return toSearch, fmt.Errorf("couldn't find presubmits for %q in config", fullRepo)
 	}
 
@@ -215,7 +221,7 @@ func getGCSDirsForPR(config *config.Config, org, repo string, pr int) (map[strin
 			gcsConfig = presubmit.DecorationConfig.GCSConfiguration
 		} else {
 			// for undecorated jobs assume the default
-			gcsConfig = config.Plank.DefaultDecorationConfig.GCSConfiguration
+			gcsConfig = c.Plank.DefaultDecorationConfig.GCSConfiguration
 		}
 
 		gcsPath, _, _ := gcsupload.PathsForJob(gcsConfig, &downwardapi.JobSpec{
@@ -225,7 +231,7 @@ func getGCSDirsForPR(config *config.Config, org, repo string, pr int) (map[strin
 				Repo: repo,
 				Org:  org,
 				Pulls: []v1.Pull{
-					{Number: pr},
+					{Number: prNumber},
 				},
 			},
 		}, "")
@@ -238,7 +244,7 @@ func getGCSDirsForPR(config *config.Config, org, repo string, pr int) (map[strin
 	return toSearch, nil
 }
 
-func getPRHistory(url *url.URL, config *config.Config, gcsClient *storage.Client) (prHistoryTemplate, error) {
+func getPRHistory(url *url.URL, config *config.Config, gcsClient *storage.Client, gitHubClient deckGitHubClient, gitClient *git.Client) (prHistoryTemplate, error) {
 	start := time.Now()
 	template := prHistoryTemplate{}
 
@@ -249,7 +255,7 @@ func getPRHistory(url *url.URL, config *config.Config, gcsClient *storage.Client
 	template.Name = fmt.Sprintf("%s/%s #%d", org, repo, pr)
 	template.Link = githubPRLink(org, repo, pr) // TODO(ibzib) support Gerrit :/
 
-	toSearch, err := getGCSDirsForPR(config, org, repo, pr)
+	toSearch, err := getGCSDirsForPR(config, gitHubClient, gitClient, org, repo, pr)
 	if err != nil {
 		return template, fmt.Errorf("failed to list GCS directories for PR %s: %v", template.Name, err)
 	}

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -28,6 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 )
 
 type fakeBucket struct {
@@ -402,7 +405,12 @@ func TestGetGCSDirsForPR(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		toSearch, err := getGCSDirsForPR(tc.config, tc.org, tc.repo, tc.pr)
+		gitHubClient := &fakegithub.FakeClient{
+			PullRequests: map[int]*github.PullRequest{
+				123: {Number: 123},
+			},
+		}
+		toSearch, err := getGCSDirsForPR(tc.config, gitHubClient, &git.Client{}, tc.org, tc.repo, tc.pr)
 		if (err != nil) != tc.expErr {
 			t.Errorf("%s: unexpected error %v", tc.name, err)
 		}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -252,9 +252,6 @@ func (rg *RefGetterForGitHubPullRequest) BaseSHA() (string, error) {
 // also need the result of that GitHub call just keep a pointer to its result, bust must
 // nilcheck that pointer before accessing it.
 func (c *Config) GetPresubmits(gc *git.Client, identifier string, baseSHAGetter RefGetter, headSHAGetters ...RefGetter) ([]Presubmit, error) {
-	if gc == nil {
-		return nil, errors.New("gitClient is nil")
-	}
 	if identifier == "" {
 		return nil, errors.New("no identifier for repo given")
 	}
@@ -262,6 +259,9 @@ func (c *Config) GetPresubmits(gc *git.Client, identifier string, baseSHAGetter 
 		return c.Presubmits[identifier], nil
 	}
 
+	if gc == nil {
+		return nil, errors.New("gitClient is nil")
+	}
 	baseSHA, err := baseSHAGetter()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get baseSHA: %v", err)


### PR DESCRIPTION
This PR changes deck to use the `GetPresubmits` function instead of directly accessing the presubmits config. This is done in order to fix https://github.com/kubernetes/test-infra/issues/13370