### PR TITLE
Enable GOPROXY in default preset

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3737,10 +3737,6 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        - name: GOPROXY
-          value: https://proxy.golang.org
-        - name: GOSUMDB
-          value: sum.golang.org
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190726-d319b3f-master
         name: main
         resources: {}

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -56,10 +56,6 @@ presubmits:
         # Space separated list of the checks to run
         - name: WHAT
           value: "vendor vendor-licenses"
-        - name: GOPROXY
-          value: https://proxy.golang.org
-        - name: GOSUMDB
-          value: sum.golang.org
     annotations:
       testgrid-create-test-group: 'true'
   - name: pull-kubernetes-godeps

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -635,3 +635,7 @@ presets:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
+# enable GOPROXY by default
+- env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"


### PR DESCRIPTION
fixes #13645.

Create a preset that adds the `GOPROXY=https://proxy.golang.org` env var to all jobs on prow.k8s.io.

Summary of benefits:
- proxy.golang.org is a Google-run service on Borg. Should be highly reliable.
- As both prow and proxy.golang.org are on the Google network, it should be faster to download.
- As the cached modules don't require a full version control checkout, the download size should be smaller (read: faster)
- For any jobs that don't use go modules, this is a noop.