### PR TITLE
Fix formatting in logexporter/Makefile.

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -23,7 +23,7 @@ cmd/logexporter: cmd/main.go
 build: cmd/logexporter
 
 push-prod:
-  bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch logexporter
+	bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch logexporter
 
 push:
 	bazel run //images/builder -- --allow-dirty logexporter


### PR DESCRIPTION
This is to addres the "make: Nothing to be done for 'push-prod'." error that I run into when trying to push v0.1.6 version that was never pushed.