### PR TITLE
boskos: use a base image with bash for boskosctl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,6 +105,14 @@ container_pull(
 )
 
 container_pull(
+    name = "fedora-base",
+    digest = "sha256:b74e6841a4f44f9fd2a40ce7f533ef4996624666bf536f9a78dbc8ab30fd91b9",  # 2019/07/29
+    registry = "index.docker.io",
+    repository = "library/fedora",
+    tag = "30",
+)
+
+container_pull(
     name = "gcloud-base",
     digest = "sha256:8e51eea50a45c6be2a735be97139f85a04c623ca448801a317a737c1d9917d00",  # 2019/07/10
     registry = "gcr.io",

--- a/boskos/cmd/cli/BUILD.bazel
+++ b/boskos/cmd/cli/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
 
 prow_image(
     name = "image",
-    base = "@alpine-base//image",
+    base = "@fedora-base//image",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Downstream users of the CLI for boskos will want a full featured shell
in the container image we publish as restricting to POSIX shell as
available in alpine will be too restrictive.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @Katharine @fejta @krzyzacy 