### PR TITLE
Censor secrets provided by SecretAgent from the logs

### DIFF
--- a/prow/config/secret/BUILD.bazel
+++ b/prow/config/secret/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -25,4 +25,11 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["agent_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
 )

--- a/prow/config/secret/agent_test.go
+++ b/prow/config/secret/agent_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCensoringFormatter(t *testing.T) {
+	var err error
+	secret1, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("failed to set up a temporary file: %v", err)
+	}
+	if _, err := secret1.WriteString("SECRET"); err != nil {
+		t.Fatalf("failed to write a fake secret to a file: %v", err)
+	}
+	defer secret1.Close()
+	defer os.Remove(secret1.Name())
+	secret2, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("failed to set up a temporary file: %v", err)
+	}
+	if _, err := secret2.WriteString("MYSTERY"); err != nil {
+		t.Fatalf("failed to write a fake secret to a file: %v", err)
+	}
+	defer secret2.Close()
+	defer os.Remove(secret2.Name())
+
+	agent := Agent{}
+	if err = agent.Start([]string{secret1.Name(), secret2.Name()}); err != nil {
+		t.Fatalf("failed to start a secret agent: %v", err)
+	}
+
+	testCases := []struct {
+		description string
+		entry       *logrus.Entry
+		expected    string
+	}{
+		{
+			description: "all occurrences of a single secret in a message are censored",
+			entry:       &logrus.Entry{Message: "A SECRET is a SECRET if it is secret"},
+			expected:    "level=panic msg=\"A CENSORED is a CENSORED if it is secret\"\n",
+		},
+		{
+			description: "occurrences of a multiple secrets in a message are censored",
+			entry:       &logrus.Entry{Message: "A SECRET is a MYSTERY"},
+			expected:    "level=panic msg=\"A CENSORED is a CENSORED\"\n",
+		},
+		{
+			description: "occurrences of a multiple secrets in a field",
+			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": "A SECRET is a MYSTERY"}},
+			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+		},
+	}
+
+	baseFormatter := &logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: true,
+	}
+	formatter := agent.GetCensoringFormatter(baseFormatter)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			censored, err := formatter.Format(tc.entry)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if string(censored) != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, string(censored))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #11640

SecretAgent can now produce a logrus formatter that wraps another formatter and censors all secret values from fields and messages of a log entry. Because all components rely on the standard logger set up by the code in `logrusutils`, I added a method there that wraps the standard logger formatter with the censoring one. This method is then called by all components that use a SecretAgent.

I was considering to make `SecretAgent.Start()` set up the censoring logger, which would remove the need to modify all the users and would also be less prone to people forgetting to set up the censoring formatter in the future. I very lightly prefer the explicit setup and not surprising users with messing up with loggers in `SecretAgent.Start()`, but I'm totally open to reconsidering.

/cc @stevekuznetsov 