### PR TITLE
bump bazel to 0.28.1

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     CONFIG: master
     GO_VERSION: 1.12.1
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: 0.28.1
   '1.15':
     CONFIG: '1.15'
     GO_VERSION: 1.12.1


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/13668

/cc @Katharine @spiffxp 

once this goes in we should check https://testgrid.k8s.io/sig-testing-canaries#gce

if that's green, there are other places to upgrade this (RBE job specs, RBE in WORKSPACE in Kubernetes ...)

FYI @dims 