### PR TITLE
correct conformance image test job image and fork for 1.15

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -88,7 +88,48 @@ periodics:
     description: Runs conformance tests using image against latest kubernetes master with a kubernetes-in-docker cluster
     testgrid-alert-email: davanum@gmail.com
     testgrid-num-columns-recent: '3'
-- interval: 1h
+- interval: 3h
+  name: ci-kubernetes-conformance-image-1-15-test
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-1.15
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/test-infra=master"
+      - "--repo=k8s.io/kubernetes=release-1.15"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+            # the script must run from kubernetes, but we're checking out kind
+      - "bash"
+      - "--"
+      - "-c"
+      - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+          memory: "9000Mi"
+              # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    testgrid-tab-name: conformance-image, 1.15 (dev)
+    description: Runs conformance tests using image against kubernetes 1.15 branch with a kubernetes-in-docker cluster
+    testgrid-alert-email: davanum@gmail.com
+    testgrid-num-columns-recent: '3'
+- interval: 3h
   name: ci-kubernetes-conformance-image-1-14-test
   labels:
     preset-service-account: "true"
@@ -98,7 +139,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"


### PR DESCRIPTION
I noticed this job failing because this job uses the `-master` image even for v1.14 and picked up the upgraded bazel version... this fixes that and adds a 1.15 jobs

I don't know how to use the config forker for this properly yet and don't have much time to devote to these at the moment so I'd appreciate a follow up setting that up here.

cc @dims @johnSchnake 