### PR TITLE
roll back kubernetes master to bazel 0.23.2

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     CONFIG: master
     GO_VERSION: 1.12.1
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.28.1
+    BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
     GO_VERSION: 1.12.1


### PR DESCRIPTION
we'll need to do a kubekins bump after this, however one does that these days
/cc @cblecker 