### PR TITLE
Fix GitHub login bug

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1296,8 +1296,8 @@ func handleRerun(prowJobClient prowv1.ProwJobInterface, createProwJob bool, cfg 
 				}
 				login, err := goa.GetLogin(r, ghc)
 				if err != nil {
-					http.Error(w, fmt.Sprintf("Error retrieving GitHub login: %v", err), http.StatusInternalServerError)
 					l.WithError(err).Errorf("Error retrieving GitHub login")
+					http.Error(w, "Error retrieving GitHub login", http.StatusUnauthorized)
 					return
 				}
 				allowed = canTriggerJob(login, authConfig)

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -378,7 +378,7 @@ func TestRerun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error making access token session: %v", err)
 			}
-			session.Values["access-token"] = &oauth2.Token{}
+			session.Values["access-token"] = &oauth2.Token{AccessToken: "validtoken"}
 
 			if err != nil {
 				t.Fatalf("Error making request: %v", err)

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -686,7 +686,11 @@ function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob:
                         method: 'post',
                     });
                     const data = await result.text();
-                    rerunElement.innerHTML = data;
+                    if (result.status === 401) {
+                        window.location.href = window.location.origin + "/github-login?dest=%2F?rerun=gh_redirect";
+                    } else {
+                        rerunElement.innerHTML = data;
+                    }
                 };
             }
             rerunElement.appendChild(runButton);

--- a/prow/githuboauth/githuboauth.go
+++ b/prow/githuboauth/githuboauth.go
@@ -155,14 +155,9 @@ func (ga *Agent) GetLogin(r *http.Request, getter GitHubClientGetter) (string, e
 	if err != nil {
 		return "", err
 	}
-	val := session.Values[tokenKey]
-	if val == nil {
+	token, ok := session.Values[tokenKey].(*oauth2.Token)
+	if !ok || !token.Valid() {
 		return "", fmt.Errorf("Could not find GitHub token")
-	}
-	var token = &oauth2.Token{}
-	token, ok := val.(*oauth2.Token)
-	if !ok {
-		return "", fmt.Errorf("Unexpected GitHub token type")
 	}
 	ghc := getter.GetGitHubClient(token.AccessToken, false)
 	userInfo, err := ghc.GetUser("")

--- a/prow/githuboauth/githuboauth_test.go
+++ b/prow/githuboauth/githuboauth_test.go
@@ -257,7 +257,7 @@ func TestGetLogin(t *testing.T) {
 	mockConfig := getMockConfig(cookie)
 	mockLogger := logrus.WithField("uni-test", "githuboauth")
 	mockAgent := NewAgent(mockConfig, mockLogger)
-	mockToken := &oauth2.Token{}
+	mockToken := &oauth2.Token{AccessToken: "tokentokentoken"}
 	mockRequest := httptest.NewRequest(http.MethodGet, "/someurl", nil)
 	mockSession, err := sessions.GetRegistry(mockRequest).Get(cookie, "access-token-session")
 	if err != nil {


### PR DESCRIPTION
Fixes an issue where `access-token-session` expires before `github_login`, causing the frontend to think the user is logged into GitHub while there is no user access token stored on the backend. Now if there's no user token present, we redirect to github login.

/assign @cjwagner 
/cc @clarketm 