### PR TITLE
Specify default backend for ingress, #13688

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -439,10 +439,13 @@ metadata:
   namespace: default
   name: ing
 spec:
+  backend: # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
+    serviceName: deck
+    servicePort: 80
   rules:
   - http:
       paths:
-      - path: /* # Correct for GKE, need / on many other distros
+      - path: /
         backend:
           serviceName: deck
           servicePort: 80


### PR DESCRIPTION
This configuration change will resolve #13688 . As specified in the [documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend), the default GKE ingress controller (i.e. [ingress-gce](https://github.com/kubernetes/ingress-gce)) supports a *unique* set of wildcards and conventions for indicating a *catch-all* route. While in NGINX this would simply be `/`, GCE requires the specification of a **default backend** (i.e. `spec`-level `backend` in the `Ingress` resource definition).

This Ingress configuration will work for both [ingress-gce](https://github.com/kubernetes/ingress-gce) and [ingress-nginx](https://github.com/kubernetes/ingress-nginx) simultaneously and without modification.