### PR TITLE
move sig-testing-org dashboard to sig-contribex-org

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -643,6 +643,11 @@ postsubmits:
 periodics:
 - interval: 24h
   name: ci-org-peribolos
+  annotations:
+    testgrid-dashboards: sig-contribex-org
+    testgrid-tab-name: ci-peribolos
+    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
   cluster: test-infra-trusted
   decorate: true
   max_concurrency: 1
@@ -672,11 +677,6 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
-  annotations:
-    testgrid-dashboards: sig-testing-org
-    testgrid-tab-name: ci-peribolos
-    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: '1'
 - cron: "05 15 1-7 * 1"  # Run at 7:05 PST (15:05 UTC) on first monthly monday.
   name: ci-test-infra-autoupdate-minor
   cluster: test-infra-trusted

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -1580,8 +1580,6 @@ dashboards:
 
 - name: sig-cluster-lifecycle-upgrade-skew
 
-- name: sig-contribex-community
-
 - name: wg-resource-management
   dashboard_tab:
   - name: gce-device-plugin-gpu
@@ -3748,8 +3746,6 @@ dashboards:
     test_group_name: pull-release-notes-test
     base_options: width=10
 
-- name: sig-contribex-slack-infra
-
 - name: google-cel
   dashboard_tab:
   - name: cel-go
@@ -3864,11 +3860,6 @@ dashboard_groups:
   - sig-cluster-lifecycle-cluster-api-provider-docker
   - sig-cluster-lifecycle-kops
   - sig-cluster-lifecycle-etcdadm
-
-- name: sig-contribex
-  dashboard_names:
-  - sig-contribex-community
-  - sig-contribex-slack-infra
 
 - name: sig-multicluster
   dashboard_names:

--- a/config/testgrids/kubernetes/sig-contribex.yaml
+++ b/config/testgrids/kubernetes/sig-contribex.yaml
@@ -1,0 +1,30 @@
+# Dashboard Group
+
+dashboard_groups:
+- name: sig-contribex
+  dashboard_names:
+  - sig-contribex-community
+  - sig-contribex-slack-infra
+  - sig-contribex-org
+
+# Dashboards
+
+dashboards:
+- name: sig-contribex-community
+- name: sig-contribex-slack-infra
+- name: sig-contribex-org
+  dashboard_tab:
+    - name: post-peribolos
+      test_group_name: post-org-peribolos
+      alert_options:
+        alert_mail_to_addresses: kubernetes-github-managment-alerts@googlegroups.com
+      code_search_url_template:
+        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
+    - name: test-all
+      test_group_name: pull-org-test-all
+      code_search_url_template:
+        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
+    - name: verify-all
+      test_group_name: pull-org-verify-all
+      code_search_url_template:
+        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/kubernetes/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing.yaml
@@ -8,7 +8,6 @@ dashboard_groups:
     - sig-testing-fejtabot
     - sig-testing-kind
     - sig-testing-maintenance
-    - sig-testing-org
     - sig-testing-prow
     - sig-testing-images
 
@@ -162,23 +161,6 @@ dashboards:
         url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-
-- name: sig-testing-org
-  dashboard_tab:
-    - name: post-peribolos
-      test_group_name: post-org-peribolos
-      alert_options:
-        alert_mail_to_addresses: kubernetes-github-managment-alerts@googlegroups.com
-      code_search_url_template:
-        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
-    - name: test-all
-      test_group_name: pull-org-test-all
-      code_search_url_template:
-        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
-    - name: verify-all
-      test_group_name: pull-org-verify-all
-      code_search_url_template:
-        url: https://github.com/kubernetes/org/compare/<start-custom-0>...<end-custom-0>
 
 - name: sig-testing-prow
   dashboard_tab:


### PR DESCRIPTION
the org repo is owned by github-management, a sig-contribex subproject,
so it makes more sense to put the testgrid jobs over there

while I was here I extracted sig-contribex testgrids into their own
config file

/sig contributor-experience