### PR TITLE
Turn off prometheus snapshots in gce-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -137,9 +137,6 @@ periodics:
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
-      # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Turn off when the investigation is over or assess if it can stay
-      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
-      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
       - --test-cmd-args=--nodes=100
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts


### PR DESCRIPTION
We don't need those snapshots anymore, as https://github.com/kubernetes/kubernetes/issues/80212 was closed.

Leaving them on can (and will) eventually create some problems when we hit num snapshots per project limits, so it's safer to turn them off.