### PR TITLE
Fix KUBE_VERIFY_GIT_BRANCH for 1.14 and 1.15

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -4240,7 +4240,7 @@ presubmits:
         - name: EXCLUDE_GODEP
           value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
-          value: master
+          value: release-1.15
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-1.15
@@ -4297,7 +4297,7 @@ presubmits:
         - name: EXCLUDE_GODEP
           value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
-          value: master
+          value: release-1.14
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-1.14

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: EXCLUDE_GODEP
           value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
-          value: master
+          value: release-1.15
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         # docker-in-docker needs privileged mode
@@ -99,7 +99,7 @@ presubmits:
         - name: EXCLUDE_GODEP
           value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
-          value: master
+          value: release-1.14
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
           # docker-in-docker needs privileged mode


### PR DESCRIPTION
Currently, the jobs try to merge against master and this leads to :fire: 

Example - https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/80849/pull-kubernetes-verify/1156814797979783168 for https://github.com/kubernetes/kubernetes/pull/80850

/assign @wojtek-t 
cc @sttts @cblecker 
/cc @kubernetes/patch-release-team 