### PR TITLE
Revert "turn off storage pv tests"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -197,46 +197,46 @@ periodics:
       - --timeout=40m
       - --use-logexporter
 
-#- name: ci-kubernetes-storage-scalability-max-persistent-vol-per-pod
-#  tags:
-#    - "perfDashPrefix: storage-max-persistent-vol-per-pod"
-#    - "perfDashJobType: storage"
-#  interval: 1h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#    preset-e2e-scalability-node: "true"
-#  annotations:
-#    testgrid-dashboards: sig-scalability-experiments
-#    testgrid-tab-name: max-persistent-vol-per-pod
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --repo=k8s.io/perf-tests=master
-#          - --root=/go/src
-#          - --timeout=60
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --check-leaked-resources
-#          - --cluster=
-#          - --extract=ci/latest
-#          - --gcp-node-image=gci
-#          - --gcp-nodes=1
-#          - --provider=gce
-#          - --test=false
-#          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-#          - --test-cmd-args=cluster-loader2
-#          - --test-cmd-args=--nodes=1
-#          - --test-cmd-args=--provider=gce
-#          - --test-cmd-args=--report-dir=/workspace/_artifacts
-#          - --test-cmd-args=--testconfig=testing/experimental/storage/pod-startup/config.yaml
-#          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/volume-types/persistentvolume/override.yaml
-#          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
-#          - --test-cmd-name=ClusterLoaderV2
-#          - --timeout=40m
-#          - --use-logexporter
+- name: ci-kubernetes-storage-scalability-max-persistent-vol-per-pod
+  tags:
+    - "perfDashPrefix: storage-max-persistent-vol-per-pod"
+    - "perfDashJobType: storage"
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-node: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-experiments
+    testgrid-tab-name: max-persistent-vol-per-pod
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --repo=k8s.io/perf-tests=master
+          - --root=/go/src
+          - --timeout=60
+          - --scenario=kubernetes_e2e
+          - --
+          - --check-leaked-resources
+          - --cluster=
+          - --extract=ci/latest
+          - --gcp-node-image=gci
+          - --gcp-nodes=1
+          - --provider=gce
+          - --test=false
+          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+          - --test-cmd-args=cluster-loader2
+          - --test-cmd-args=--nodes=1
+          - --test-cmd-args=--provider=gce
+          - --test-cmd-args=--report-dir=/workspace/_artifacts
+          - --test-cmd-args=--testconfig=testing/experimental/storage/pod-startup/config.yaml
+          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/volume-types/persistentvolume/override.yaml
+          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
+          - --test-cmd-name=ClusterLoaderV2
+          - --timeout=40m
+          - --use-logexporter
 
 # max volumes per node test cases
 - name: ci-kubernetes-storage-scalability-max-emptydir-vol-per-node
@@ -403,43 +403,43 @@ periodics:
       - --timeout=40m
       - --use-logexporter
 
-#- name: ci-kubernetes-storage-scalability-max-persistent-vol-per-node
-#  tags:
-#    - "perfDashPrefix: storage-max-persistent-vol-per-node"
-#    - "perfDashJobType: storage"
-#  interval: 1h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#    preset-e2e-scalability-node: "true"
-#  annotations:
-#    testgrid-dashboards: sig-scalability-experiments
-#    testgrid-tab-name: max-persistent-vol-per-node
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --repo=k8s.io/perf-tests=master
-#          - --root=/go/src
-#          - --timeout=60
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --check-leaked-resources
-#          - --cluster=
-#          - --extract=ci/latest
-#          - --gcp-node-image=gci
-#          - --gcp-nodes=1
-#          - --provider=gce
-#          - --test=false
-#          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-#          - --test-cmd-args=cluster-loader2
-#          - --test-cmd-args=--nodes=1
-#          - --test-cmd-args=--provider=gce
-#          - --test-cmd-args=--report-dir=/workspace/_artifacts
-#          - --test-cmd-args=--testconfig=testing/experimental/storage/pod-startup/config.yaml
-#          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/volume-types/persistentvolume/override.yaml
-#          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
-#          - --test-cmd-name=ClusterLoaderV2
-#          - --timeout=40m
-#          - --use-logexporter
+- name: ci-kubernetes-storage-scalability-max-persistent-vol-per-node
+  tags:
+    - "perfDashPrefix: storage-max-persistent-vol-per-node"
+    - "perfDashJobType: storage"
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-node: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-experiments
+    testgrid-tab-name: max-persistent-vol-per-node
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190730-f00516f-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --repo=k8s.io/perf-tests=master
+          - --root=/go/src
+          - --timeout=60
+          - --scenario=kubernetes_e2e
+          - --
+          - --check-leaked-resources
+          - --cluster=
+          - --extract=ci/latest
+          - --gcp-node-image=gci
+          - --gcp-nodes=1
+          - --provider=gce
+          - --test=false
+          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+          - --test-cmd-args=cluster-loader2
+          - --test-cmd-args=--nodes=1
+          - --test-cmd-args=--provider=gce
+          - --test-cmd-args=--report-dir=/workspace/_artifacts
+          - --test-cmd-args=--testconfig=testing/experimental/storage/pod-startup/config.yaml
+          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/volume-types/persistentvolume/override.yaml
+          - --test-cmd-args=--testoverrides=./testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
+          - --test-cmd-name=ClusterLoaderV2
+          - --timeout=40m
+          - --use-logexporter


### PR DESCRIPTION
Reverts kubernetes/test-infra#13721 after https://github.com/kubernetes/perf-tests/issues/722 is resolved following the merge of https://github.com/kubernetes/perf-tests/pull/723 and https://github.com/kubernetes/perf-tests/pull/724.

@msau42 @davidz627 @jingxu97 @verult

/assign @wojtek-t
/hold
