### PR TITLE
[boskos] re-enable aws sweeping on the aws janitor

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -95,5 +95,3 @@ spec:
         image: gcr.io/k8s-testimages/janitor-aws:v20190326-5dd3da15c
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        # Turn off sweeping until https://github.com/kubernetes/test-infra/issues/12527 is resolved
-        - --sweep-count=0


### PR DESCRIPTION
Re-enable aws sweeping for the aws janitor in Boskos now that https://github.com/kubernetes/test-infra/issues/12527 has been resolved

/assign @justinsb @spiffxp 
/cc @ncdc