### PR TITLE
Use git client in tide to get the list of files changed by each PR

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -141,6 +141,11 @@ func (c *Client) unlockRepo(repo string) {
 	c.repoLocks[repo].Unlock()
 }
 
+// Directory returns the directory used for caching all cloned repositories.
+func (c *Client) Directory() string {
+	return c.dir
+}
+
 // Clone clones a repository. Pass the full repository name, such as
 // "kubernetes/test-infra" as the repo.
 // This function may take a long time if it is the first time cloning the repo.

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -54,6 +54,10 @@ func (a *clientFactoryAdapter) ClientFor(org, repo string) (RepoClient, error) {
 	return &repoClientAdapter{Repo: r}, err
 }
 
+func (a *clientFactoryAdapter) Directory() string {
+	return a.Client.Directory()
+}
+
 type repoClientAdapter struct {
 	*git.Repo
 }

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -35,6 +35,9 @@ type ClientFactory interface {
 	// ClientFor creates a client that operates on a new clone of the repo.
 	ClientFor(org, repo string) (RepoClient, error)
 
+	// Directory returns the central repo directory
+	Directory() string
+
 	// Clean removes the caches used to generate clients
 	Clean() error
 }
@@ -281,6 +284,11 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 	}
 
 	return repoClient, nil
+}
+
+// Directory returns the cache directory
+func (c *clientFactory) Directory() string {
+	return c.cacheDir
 }
 
 // Clean removes the caches used to generate clients


### PR DESCRIPTION
As described [here](https://github.com/kubernetes/test-infra/pull/12751#discussion_r299261536), tide calls the `GetPullRequestChanges` from the github API to get the list of files changes by each PR. However, as tide needs to clone the repository anyway, it is faster to use the git client directly for this purpose.