### PR TITLE
Allow the oncall rotation to rerun all jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,6 +43,18 @@ deck:
   hidden_repos:
   - kubernetes-security
   google_analytics: UA-82843984-5
+  rerun_auth_config:
+    github_users:
+    - mirandachrist
+    - cjwagner
+    - amwat
+    - fejta
+    - ixdy
+    - Katharine
+    - krzyzacy
+    - michelle192837
+    - spiffxp
+    - stevekuznetsov
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
This redeploys rerun as it was before. Now that we have logic to user GitHub teams, I will switch over to that in a separate PR, but it requires a bit of setup to use the GitHub bot token. In the meantime, I'd like to get it redeployed as quickly as possible to collect metrics for my presentation, and a list of usernames works.

/assign @cjwagner  