### PR TITLE
Fix backward-compatibility ReplaceAll

### DIFF
--- a/prow/config/secret/agent.go
+++ b/prow/config/secret/agent.go
@@ -125,11 +125,11 @@ func (f censoringFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	for sKey := range f.agent.secretsMap {
 		secret := f.agent.GetSecret(sKey)
-		message = strings.ReplaceAll(message, string(secret), censored)
+		message = strings.Replace(message, string(secret), censored, -1)
 
 		for key, value := range data {
 			if valueString, ok := value.(string); ok {
-				data[key] = strings.ReplaceAll(valueString, string(secret), censored)
+				data[key] = strings.Replace(valueString, string(secret), censored, -1)
 			}
 		}
 	}


### PR DESCRIPTION
Hello,
 
I was compiling `mkpj` locally using Go11, it failed only because of this line:
```
agent.go:128:13: undefined: strings.ReplaceAll
```

We can mention that the minimum Go version is 12 and close this.