### PR TITLE
Needs rebase: Handle issue comment events

### DIFF
--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -163,8 +163,18 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 			return err
 		}
 		go func() {
-			if err := plugin.HandleEvent(l, s.ghc, &pre); err != nil {
-				l.Info("Error handling event.")
+			if err := plugin.HandlePullRequestEvent(l, s.ghc, &pre); err != nil {
+				l.WithField("event-type", eventType).WithError(err).Info("Error handling event.")
+			}
+		}()
+	case "issue_comment":
+		var ice github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ice); err != nil {
+			return err
+		}
+		go func() {
+			if err := plugin.HandleIssueCommentEvent(l, s.ghc, &ice); err != nil {
+				l.WithField("event-type", eventType).WithError(err).Info("Error handling event.")
 			}
 		}()
 	default:

--- a/prow/plugins/README.md
+++ b/prow/plugins/README.md
@@ -41,6 +41,9 @@ external_plugins:
     # No endpoint specified implies "http://{{name}}".
     events:
     - pull_request
+    # Dispatching issue_comment events to the needs-rebase plugin is optional. If enabled, this may cost up to two token per comment on a PR. If `ghproxy`
+    # is in use, these two tokens are only needed if the PR or its mergeability changed.
+    - issue_comment
   - name: cherrypick
     # No events specified implies all event types.
 ```


### PR DESCRIPTION
This PR adds functionality to the needs-rebase plugin to handle issue
comment events. This is implicitly optional by the fact that the
needs-rebase plugin is an external plugin and one needs to explicitly
configure hook to dispatch issue_comment events to it.

Enabling this can cost up to one token per comment on a pull request.

The reason for wanting this is that we have a bot that comments with a
`/retest` on PRs that are ready to merge. If such a PR has merge
conflicts, the retest will fail and the bot will comment forever until
there is a `needs-rebase` label.