### PR TITLE
add gke storage perf tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -197,6 +197,51 @@ periodics:
       - --timeout=40m
       - --use-logexporter
 
+  # single node GKE storage experiments
+- name: ci-kubernetes-storage-scalability-storage-single-node-gke
+  tags:
+    - "perfDashPrefix: storage-single-node-gke"
+    - "perfDashJobType: storage"
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-node: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-experiments
+    testgrid-tab-name: storage-single-node-gke
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --repo=k8s.io/perf-tests=master
+          - --repo=k8s.io/test-infra=master
+          - --root=/go/src
+          - --timeout=80
+          - --scenario=kubernetes_e2e
+          - --
+          - --check-leaked-resources
+          - --cluster=
+          - --extract=ci/latest
+          - --deployment=gke
+          - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
+          - --gcp-node-image=gci
+          - --gke-environment=staging
+          - --gke-create-command=container clusters create --quiet --cluster-version latest
+          - --gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}
+          - --provider=gke
+          - --test=false
+          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+          - --test-cmd-args=cluster-loader2
+          - --test-cmd-args=--nodes=1
+          - --test-cmd-args=--provider=gke
+          - --test-cmd-args=--report-dir=/workspace/_artifacts
+          - --test-cmd-args=--testsuite=$GOPATH/src/k8s.io/test-infra/config/jobs/kubernetes/sig-scalability/testsuites/single-node-storage.yaml
+          - --test-cmd-name=ClusterLoaderV2
+          - --timeout=60m
+          - --use-logexporter
+
 #- name: ci-kubernetes-storage-scalability-max-persistent-vol-per-pod
 #  tags:
 #    - "perfDashPrefix: storage-max-persistent-vol-per-pod"


### PR DESCRIPTION
Dependent on #13747 for the test suite.

/assign @wojtek-t
/cc @davidz627 @jingxu97
cc @msau42 @verult

@krzyzacy, is this how I can boot a 1 node GKE cluster of machine size n1-standard-2 with the latest available staging version? And I want to make it consistent with the default for GCE, which is n1-standard-2 right?