### PR TITLE
Minor change: update error message for not run from kubernetes root

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -211,7 +211,7 @@ func validWorkingDirectory() error {
 	}
 	// This also matches "kubernetes_skew" for upgrades.
 	if !strings.Contains(filepath.Base(acwd), "kubernetes") {
-		return fmt.Errorf("must run from kubernetes directory root: %v", acwd)
+		return fmt.Errorf("must run from kubernetes directory root. current: %v", acwd)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Error message misleading when running kubetest out of kubernetes root.

I'm running kubetest from `$GOPATH/bin`, there is an error that misleading me.
> 2019/08/05 15:23:32 main.go:316: Something went wrong: called from invalid working directory: must run from kubernetes directory root: /root/horen/go/bin

According this message, seems it telling I should run from `/root/horen/go/bin`.  Actually, it is the wrong directory. And it is the working directory current using.
