### PR TITLE
Add a specific base image for boskosctl

### DIFF
--- a/images/boskosctl-base/Dockerfile
+++ b/images/boskosctl-base/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes tools people like to use when using boskosctl
+FROM alpine:latest
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+RUN apk add --no-cache bash jq
+
+ENTRYPOINT ["/bin/bash"]

--- a/images/boskosctl-base/cloudbuild.yaml
+++ b/images/boskosctl-base/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/boskosctl-base:$_GIT_TAG',
+            '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/boskosctl-base:$_GIT_TAG',
+            '.' ]
+    dir: images/boskosctl-base/
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/boskosctl-base:$_GIT_TAG', 'gcr.io/$PROJECT_ID/boskosctl-base:latest']
+substitutions:
+  _GIT_TAG: '12345'
+images:
+  - 'gcr.io/$PROJECT_ID/boskosctl-base:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/boskosctl-base:latest'


### PR DESCRIPTION
Users of boskosctl inside of a container will require `jq` as well as
`bash` in order to process the resource records that `boskosctl` prints
when leases are appropriately made. The `alpine-bash` image may remain
useful as a base image for other derivatives, so no change is made
there, but a new image is specifically made for `boskosctl` so adding
more packages to this image is simpler.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @krzyzacy @Katharine 