### PR TITLE
Test containerd 1.1 against Kubernetes 1.12.

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -116,7 +116,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: release-1.11
+      base_ref: release-1.12
       path_alias: k8s.io/kubernetes
     - org: kubernetes
       repo: test-infra

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -144,7 +144,7 @@ periodics:
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.11
+      - --extract=ci/latest-1.12
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
@@ -152,7 +152,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190513-95c7cbe-1.11
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-1.12
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.1
@@ -253,10 +253,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190513-95c7cbe-1.11
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-1.12
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.11
+      - --repo=k8s.io/kubernetes=release-1.12
       - --repo=github.com/containerd/cri=release/1.0
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -343,10 +343,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190513-95c7cbe-1.11
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190801-9ec6db7-1.12
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.11
+      - --repo=k8s.io/kubernetes=release-1.12
       - --repo=github.com/containerd/cri=release/1.0
       - --timeout=90
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Test containerd 1.1 against Kubernetes 1.12, because Kubernetes 1.11 is not built any more.

Signed-off-by: Lantao Liu <lantaol@google.com>