### PR TITLE
Make rerun not redirect to GH login unnecessarily

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -314,7 +314,11 @@ func main() {
 		indexHandler := handleSimpleTemplate(o, cfg, "index.html", struct {
 			SpyglassEnabled bool
 			ReRunCreatesJob bool
-		}{o.spyglass, o.rerunCreatesJob})
+			AllowAnyone     bool
+		}{
+			SpyglassEnabled: o.spyglass,
+			ReRunCreatesJob: o.rerunCreatesJob,
+			AllowAnyone:     cfg().Deck.RerunAuthConfig.AllowAnyone})
 		indexHandler(w, r)
 	})
 

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -9,6 +9,7 @@ declare const allBuilds: Job[];
 declare const spyglass: boolean;
 declare const rerunCreatesJob: boolean;
 declare const csrfToken: string;
+declare const allowAnyone: boolean;
 
 function shortenBuildRefs(buildRef: string): string {
     return buildRef && buildRef.replace(/:[0-9a-f]*/g, '');
@@ -670,7 +671,7 @@ function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob:
         if (rerunCreatesJob) {
             const runButton = document.createElement('a');
             runButton.innerHTML = "<button class='mdl-button mdl-js-button'>Rerun</button>";
-            if (login === "") {
+            if (login === "" && !allowAnyone) {
                 runButton.href = `/github-login?dest=%2F?rerun=gh_redirect`;
             } else {
                 runButton.onclick = async () => {

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -6,6 +6,7 @@
 <script type="text/javascript">
   var spyglass = {{.SpyglassEnabled}};
   var rerunCreatesJob = {{.ReRunCreatesJob}};
+  var allowAnyone = {{.AllowAnyone}};
 </script>
 {{end}}
 


### PR DESCRIPTION
If we allow anyone to rerun jobs, we don't need to make users login to github. 

/assign @cjwagner 
/cc @fejta 