### PR TITLE
service catalog: bump service catalog units golang version to 1.12

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: golang:1.10
+      - image: golang:1.12
         command:
         - make
         args:


### PR DESCRIPTION
[we just bumped this on our end](https://github.com/kubernetes-sigs/service-catalog/pull/2682), looks like we actually forgot to update this last time