### PR TITLE
experiment/flakedetector - upgrade py2 -> py3

### DIFF
--- a/experiment/BUILD.bazel
+++ b/experiment/BUILD.bazel
@@ -3,6 +3,7 @@ load("@py_deps//:requirements.bzl", "requirement")
 py_binary(
     name = "flakedetector",
     srcs = ["flakedetector.py"],
+    python_version = "PY3",
     deps = [requirement("requests")],
 )
 

--- a/experiment/flakedetector.py
+++ b/experiment/flakedetector.py
@@ -28,8 +28,6 @@ ignored.
 
 """
 
-from __future__ import print_function
-
 import operator
 
 import requests


### PR DESCRIPTION
Additional conversions for python2 -> python3 ( #13164 ) migration and targets `experiment/flakedetector`.