### PR TITLE
experiment/graphql_issue_example - upgrade py2 -> py3

### DIFF
--- a/experiment/graphql_issue_example.py
+++ b/experiment/graphql_issue_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # USAGE: find_issues.py <github_token>
+
+# Required for pylint: 1.9.4 to tokenize the python3 print function.
 from __future__ import print_function
 
 import sys


### PR DESCRIPTION
Additional conversions for python2 -> python3 ( #13164 ) migration and targets `experiment/graphql_issue_example`.