### PR TITLE
Move anonymous GH client warning

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -572,6 +572,7 @@ func prodOnlyMain(cfg config.Getter, o options, mux *http.ServeMux) *http.ServeM
 	}
 
 	// We use the GH client to resolve GH teams when determining who is permitted to rerun a job.
+	// If no token path is provided, we do not create a client.
 	var githubClient prowgithub.Client
 	secretAgent := &secret.Agent{}
 	if o.github.TokenPath != "" {

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -81,10 +81,6 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 		logrus.Error("-github-token-file is deprecated and may be removed anytime after 2019-01-01.  Use -github-token-path instead.")
 	}
 
-	if o.TokenPath == "" {
-		logrus.Warn("empty -github-token-path, will use anonymous github client")
-	}
-
 	return nil
 }
 
@@ -92,6 +88,7 @@ func (o *GitHubOptions) Validate(dryRun bool) error {
 func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dryRun bool, fields logrus.Fields) (client github.Client, err error) {
 	var generator *func() []byte
 	if o.TokenPath == "" {
+		logrus.Warn("empty -github-token-path, will use anonymous github client")
 		generatorFunc := func() []byte {
 			return []byte{}
 		}


### PR DESCRIPTION
Right now it logs the warning when it validates options, which is misleading if the client is never actually created. We should move it to when the client is created. 
/assign @cjwagner 