### PR TITLE
sig-release: Update Release Managers' email address for job alerts

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -36,7 +36,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-misc
       testgrid-tab-name: release-cluster-up
-      testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+      testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-unit
     always_run: true
@@ -53,7 +53,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-misc
       testgrid-tab-name: release-unit
-      testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+      testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-verify
     always_run: true
@@ -75,14 +75,14 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-misc
       testgrid-tab-name: release-verify
-      testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+      testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
 # package tests
 periodics:
 - name: periodic-release-verify-packages-debs
   interval: 6h
   annotations:
-    testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: verify-packages-debs
   decorate: true
@@ -101,7 +101,7 @@ periodics:
 - name: periodic-release-verify-packages-rpms
   interval: 6h
   annotations:
-    testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: verify-packages-rpms
   decorate: true

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -85,7 +85,7 @@ periodics:
           cpu: 4
           memory: "8Gi"
   annotations:
-    testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: build-packages-debs
 
@@ -115,7 +115,7 @@ periodics:
           cpu: 4
           memory: "8Gi"
   annotations:
-    testgrid-alert-email: kubernetes-release-managers@googlegroups.com
+    testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: build-packages-rpms
 


### PR DESCRIPTION
Dependent on: https://github.com/kubernetes/sig-release/pull/747
ref: https://github.com/kubernetes/sig-release/issues/732

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold
/assign @calebamiles @tpepper 
/cc @kubernetes/release-engineering 