### PR TITLE
verify-owners: improve bot comment message

### DIFF
--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -43,7 +43,9 @@ const (
 	PluginName                    = "verify-owners"
 	ownersFileName                = "OWNERS"
 	ownersAliasesFileName         = "OWNERS_ALIASES"
-	nonCollaboratorResponseFormat = "The following users are mentioned in %s file(s) but are not members of the %s org."
+	nonCollaboratorResponseFormat = `The following users are mentioned in %s file(s) but are not members of the %s org.
+
+Once all users have been added as members of the org, you can trigger verification by writing ` + "`/verify-owners`" + ` in a comment.`
 )
 
 var (

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -426,14 +426,14 @@ func TestHandle(t *testing.T) {
 			},
 		}
 
-		prState := state{
+		prInfo := info{
 			org:          "org",
 			repo:         "repo",
 			repoFullName: "org/repo",
 			number:       pr,
 		}
 
-		if err := handle(fghc, c, makeFakeRepoOwnersClient(), logrus.WithField("plugin", PluginName), &pre.PullRequest, prState, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, false, &fakePruner{}); err != nil {
+		if err := handle(fghc, c, makeFakeRepoOwnersClient(), logrus.WithField("plugin", PluginName), &pre.PullRequest, prInfo, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, false, &fakePruner{}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}
 		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {
@@ -878,14 +878,14 @@ func TestNonCollaborators(t *testing.T) {
 			froc.foc.dirBlacklist = blacklist
 		}
 
-		prState := state{
+		prInfo := info{
 			org:          "org",
 			repo:         "repo",
 			repoFullName: "org/repo",
 			number:       pr,
 		}
 
-		if err := handle(fghc, c, froc, logrus.WithField("plugin", PluginName), &pre.PullRequest, prState, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, test.skipTrustedUserCheck, &fakePruner{}); err != nil {
+		if err := handle(fghc, c, froc, logrus.WithField("plugin", PluginName), &pre.PullRequest, prInfo, []string{labels.Approved, labels.LGTM}, plugins.Trigger{}, test.skipTrustedUserCheck, &fakePruner{}); err != nil {
 			t.Fatalf("Handle PR: %v", err)
 		}
 		if !test.shouldLabel && IssueLabelsAddedContain(fghc.IssueLabelsAdded, labels.InvalidOwners) {


### PR DESCRIPTION
This PR contains the following changes:

- Currently, if a non-member is added as a reviewer and approver to an OWNERS file, the comment is something like (encountered in https://github.com/kubernetes/kube-state-metrics/pull/861, comment is now deleted by the bot though):

```
The following users are mentioned in OWNERS file(s) but are not members of the kubernetes org.

- username
  - OWNERS
  - OWNERS
```
So we should avoid checking for the same user/filename more than once (first commit).

- Add a note about using the `/verify-owners` command in the comment (second commit).

- Address some nits from https://github.com/kubernetes/test-infra/pull/13741. Doesn't address https://github.com/kubernetes/test-infra/pull/13741#discussion_r310746785 because that makes testing very hard. :/ (third commit)

/sig contributor-experience
/cc @spiffxp @cblecker @petr-muller 
/assign @spiffxp 