### PR TITLE
Git push: Return and log output in case of error

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -292,8 +292,12 @@ func (r *Repo) Push(repo, branch string) error {
 	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, repo, branch)
 	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, github, r.user, repo)
 	co := r.gitCommand("push", remote, branch)
-	_, err := co.CombinedOutput()
-	return err
+	out, err := co.CombinedOutput()
+	if err != nil {
+		r.logger.Errorf("Pushing failed with error: %v and output: %q", err, string(out))
+		return fmt.Errorf("pushing failed, output: %q, error: %v", string(out), err)
+	}
+	return nil
 }
 
 // CheckoutPullRequest does exactly that.


### PR DESCRIPTION
We currently have a bunch of cherrypicks fail, because:

> @user: failed to push cherry-picked changes in GitHub: exit status 1

Which is not exactly helpful. This PR makes the git package return the command output if there was an error instead of discarding it.

/assign @cblecker @stevekuznetsov 