### PR TITLE
 Simplify handling root element for path parsing

### DIFF
--- a/ghproxy/ghmetrics/ghpath.go
+++ b/ghproxy/ghmetrics/ghpath.go
@@ -17,11 +17,12 @@ limitations under the License.
 package ghmetrics
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+const unmatchedPath = "unmatched"
 
 // GetSimplifiedPath returns a variable-free path that can be used as label for prometheus metrics
 func GetSimplifiedPath(path string) string {
@@ -136,7 +137,7 @@ func GetSimplifiedPath(path string) string {
 	resolvedPath, matches := resolve(tree, splitPath)
 	if !matches {
 		logrus.WithField("path", path).Warning("Path not handled. This is a bug in GHProxy, please open an issue against the kubernetes/test-infra repository with this error message.")
-		return path
+		return unmatchedPath
 	}
 	return resolvedPath
 }

--- a/ghproxy/ghmetrics/ghpath_test.go
+++ b/ghproxy/ghmetrics/ghpath_test.go
@@ -27,9 +27,9 @@ func Test_GetSimplifiedPath(t *testing.T) {
 		args args
 		want string
 	}{
-		{name: "path not in tree", args: args{path: "/this/path/is/not/in/the/tree"}, want: "/this/path/is/not/in/the/tree"},
-		{name: "path not in tree #2", args: args{path: "/repos/hello/world/its/a/party"}, want: "/repos/hello/world/its/a/party"},
-		{name: "path not in tree #3", args: args{path: "/path-not-handled"}, want: "/path-not-handled"},
+		{name: "path not in tree", args: args{path: "/this/path/is/not/in/the/tree"}, want: "unmatched"},
+		{name: "path not in tree #2", args: args{path: "/repos/hello/world/its/a/party"}, want: "unmatched"},
+		{name: "path not in tree #3", args: args{path: "/path-not-handled"}, want: "unmatched"},
 
 		{name: "repo branches protection (restrictions for users) by name ", args: args{path: "/repos/testOwner/testRepo/branches/testBranch/protection/restrictions/users"}, want: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"},
 		{name: "repositories", args: args{path: "/repositories"}, want: "/repositories"},
@@ -78,7 +78,7 @@ func Test_GetSimplifiedPathRepos(t *testing.T) {
 		want string
 	}{
 		{name: "access repos/ path should not fail, is not explicitly handled", args: args{path: "/repos"}, want: "/repos"},
-		{name: "access repos/ path should not fail, is not explicitly handled", args: args{path: "/repos/testOwner/testRepo/"}, want: "/repos/:owner/:repo"},
+		{name: "access repos/ path should not fail, is not explicitly handled", args: args{path: "/repos/testOwner/testRepo/"}, want: "unmatched"},
 
 		{name: "repo issues", args: args{path: "/repos/testOwner/testRepo/issues"}, want: "/repos/:owner/:repo/issues"},
 		{name: "repo issue by number", args: args{path: "/repos/testOwner/testRepo/issues/21342"}, want: "/repos/:owner/:repo/issues/:issueId"},


### PR DESCRIPTION
Use a simple unmatched label for paths we do not know

When we add labels to a Prometheus metric, we do not want the set of
possible labels to be unbounded, as this will eat up memory very quickly
and lead to crashes. Use a simple label for GitHub paths we do not
match, as the value of these will be in the logs for debugging.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Simplify handling root element for path parsing

There is no need to special-case the empty string or root element if we
handle it appropraitely with the parsing logic.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

