### PR TITLE
WIP fix ignored omitempty in RerunAuthConfig

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -164,7 +164,7 @@ type ProwJobSpec struct {
 	ReporterConfig *ReporterConfig `json:"reporter_config,omitempty"`
 
 	// RerunAuthConfig holds information about which users can rerun the job
-	RerunAuthConfig RerunAuthConfig `json:"rerun_auth_config,omitempty"`
+	RerunAuthConfig *RerunAuthConfig `json:"rerun_auth_config,omitempty"`
 }
 
 type GitHubTeamSlug struct {

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -255,7 +255,11 @@ func (in *ProwJobSpec) DeepCopyInto(out *ProwJobSpec) {
 		*out = new(ReporterConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	in.RerunAuthConfig.DeepCopyInto(&out.RerunAuthConfig)
+	if in.RerunAuthConfig != nil {
+		in, out := &in.RerunAuthConfig, &out.RerunAuthConfig
+		*out = new(RerunAuthConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -23,12 +23,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/gorilla/sessions"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
-	"k8s.io/test-infra/prow/githuboauth"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -36,6 +32,11 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/gorilla/sessions"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"k8s.io/test-infra/prow/githuboauth"
 
 	"github.com/google/go-github/github"
 
@@ -391,7 +392,7 @@ func TestRerun(t *testing.T) {
 							{Number: 1},
 						},
 					},
-					RerunAuthConfig: prowapi.RerunAuthConfig{
+					RerunAuthConfig: &prowapi.RerunAuthConfig{
 						AllowAnyone:   false,
 						GitHubUsers:   []string{"authorized", "alsoauthorized"},
 						GitHubTeamIDs: []int{1},

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -156,9 +156,9 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 	if jb.Namespace != nil {
 		namespace = *jb.Namespace
 	}
-	var rerunAuthConfig prowapi.RerunAuthConfig
+	var rerunAuthConfig *prowapi.RerunAuthConfig
 	if jb.RerunAuthConfig != nil {
-		rerunAuthConfig = *jb.RerunAuthConfig
+		rerunAuthConfig = jb.RerunAuthConfig
 	}
 	return prowapi.ProwJobSpec{
 		Job:             jb.Name,

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -50,7 +50,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-defaulted-decoration
   type: presubmit
 status:

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -50,7 +50,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-explicit-decoration
   type: presubmit
 status:

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -36,7 +36,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-no-decoration
   type: presubmit
 status:


### PR DESCRIPTION
after #13564 merged, `omitempty` is ignored in `RerunAuthConfig`. That is causes a job to be generated with empty `rerun_auth_config: {}`.