### PR TITLE
Extend node e2e serial timeout for containerd.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1044,7 +1044,7 @@ periodics:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
       - --repo=github.com/containerd/cri=master
-      - --timeout=265
+      - --timeout=320
       - --scenario=kubernetes_e2e
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/cri-master/image-config.yaml
@@ -1055,7 +1055,7 @@ periodics:
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeAlphaFeature:.+\]"
-      - --timeout=245m
+      - --timeout=300m
       env:
       - name: GOPATH
         value: /go


### PR DESCRIPTION
The test is timeout today. https://k8s-testgrid.appspot.com/sig-node-containerd#node-e2e-serial

This PR changes containerd node e2e serial test timeout to match the regular node e2e serial.

Signed-off-by: Lantao Liu <lantaol@google.com>