### PR TITLE
Record GitHub request durations in a histogram

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -195,7 +195,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	ghmetrics.CollectGitHubTokenMetrics(authHeaderHash, apiVersion, resp.Header, reqStartTime, responseTime)
-	ghmetrics.CollectGitHubRequestMetrics(authHeaderHash, req.URL.Path, string(resp.StatusCode), roundTripTime.String())
+	ghmetrics.CollectGitHubRequestMetrics(authHeaderHash, req.URL.Path, string(resp.StatusCode), roundTripTime.Seconds())
 
 	return resp, nil
 }


### PR DESCRIPTION
When adding labels to a Prometheus metric, the set of label values
should be bounded in order to bound the memory and CPU footprint that
the metric has on the process exposing it as well as the Prometheus
server scraping it and serving requests for it. Durations of requests
are better exposed as a histogram with the same set of identifying
labels as the counters, instead of as a label.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @tehcyx @droslean 