### PR TITLE
Add --stamp in build rules to generate x_defs.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,3 +56,6 @@ build:ci-instance --remote_instance_name=projects/k8s-prow-builds/instances/defa
 
 # Config we want to use in ci
 build:ci --config=remote --config=ci-instance
+
+# https://github.com/bazelbuild/rules_go/pull/2110#issuecomment-508713878
+build --stamp=true


### PR DESCRIPTION
https://prow.k8s.io -> hamburger -> bottom left isn't getting the {STABLE_BUILD_GIT_COMMIT} from workspace.

https://github.com/bazelbuild/rules_go/pull/2110#issuecomment-508713878

/cc @fejta @Katharine 