### PR TITLE
Rename efs testgrid tab from e2e-test-single-az to e2e-test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -55,6 +55,6 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-aws-efs-csi-driver
-      testgrid-tab-name: e2e-test-single-az
+      testgrid-tab-name: e2e-test
       description: aws efs csi driver e2e test
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
unlike ebs, there's no single-az/multi-az. There is only multi-az (test creates mount targets in all zones)