### PR TITLE
Update create to allow for cert auth for cluster

### DIFF
--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -318,7 +318,7 @@ func createCluster(proj, choice string) (*cluster, error) {
 		return nil, fmt.Errorf("select current zone for cluster: %v", err)
 	}
 
-	cmd := exec.Command("gcloud", "container", "clusters", "create", choice, "--zone="+zone)
+	cmd := exec.Command("gcloud", "container", "clusters", "create", choice, "--zone="+zone, "--enable-legacy-authorization", "--issue-client-certificate")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This is the immediate fix to handle backwards incompatible changes to GKE *defaults* (i.e. legacy auth and client cert generation) that are affecting the Prow setup process using `tackle` and `mkbuild-cluster` (#13820).
