### PR TITLE
Prow: enable to configure `skip ci` commit content

### DIFF
--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -219,6 +219,9 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 			org, repo, number, branch := pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pr.Number, pr.Base.Ref
 			changes := config.NewGitHubDeferredChangedFilesProvider(c.githubClient, org, repo, number)
 			logger := logrus.WithFields(logrus.Fields{"org": org, "repo": repo, "number": number, "branch": branch})
+			commitMessages := config.NewGitHubCommitMessagesProvider(c.githubClient, org, repo, number)
+
+			// TODO: add comit messages here
 			toTrigger, toSkip, err := pjutil.FilterPresubmits(filter, changes, branch, presubmits, logger)
 			if err != nil {
 				return err


### PR DESCRIPTION
This change is currently Work In Progress.

The goal is to enable prow to be configured with `ignoreCommitMsg: skip ci` and a commit with this content won't trigger a Prow job of any kind to run.