### PR TITLE
Allow configuring individual jobs as hidden

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/githuboauth:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/spyglass/lenses/buildlog:go_default_library",
         "//prow/spyglass/lenses/junit:go_default_library",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -417,6 +417,18 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 
 	var filtered []prowapi.ProwJob
 	for _, item := range prowJobList.Items {
+		if h, ok := item.Labels[kube.ProwHiddenJob]; ok {
+			hidden, err := strconv.ParseBool(h)
+			if err != nil {
+				logrus.WithError(err).Warningf("Invalid value for label: %s, job: %s.", kube.ProwHiddenJob, item.Name)
+			}
+
+			if err != nil || hidden {
+				if !c.showHidden && !c.hiddenOnly {
+					continue
+				}
+			}
+		}
 		if item.Spec.Refs == nil && len(item.Spec.ExtraRefs) == 0 {
 			// periodic jobs with no refs cannot be filtered
 			filtered = append(filtered, item)

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -47,4 +47,8 @@ const (
 	// PullLabel is added in resources created by prow and
 	// carries the PR number associated with the job, eg 321.
 	PullLabel = "prow.k8s.io/refs.pull"
+	// ProwHiddenJob is used to mark a prow job as hidden.
+	// Such jobs are not displayed by deck instances
+	// not configured to show hidden jobs.
+	ProwHiddenJob = "prow.k8s.io/hidden"
 )


### PR DESCRIPTION
The label 'prow.k8s.io/hidden' can now be added to individual jobs,
regardless of the org/repos referenced by their refs.
Deck instances not configured to show hidden jobs will not display
Prow jobs with the mentioned label.
Fixes #12936