### PR TITLE
Use counter for the number of github requests

### DIFF
--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -48,8 +48,8 @@ var ghTokenUsageGaugeVec = prometheus.NewGaugeVec(
 
 // ghRequestsCounter provides the 'github_requests' counter that keeps track
 // of the number of GitHub requests by API path.
-var ghRequestsCounter = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
+var ghRequestsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
 		Name: "github_requests",
 		Help: "GitHub requests by API path.",
 	},


### PR DESCRIPTION
As the name `ghRequestsCounter` indicates, the type of metric should be `counter` instead of gauge. The number of requests goes up only.