### PR TITLE
Add openshift release informing jobs to testgrid

### DIFF
--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -619,6 +619,26 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
 - name: release-openshift-ocp-installer-e2e-aws-serial-4.2
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-aws-fips-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-fips-4.2
+- name: canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-azure-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-4.2
+- name: canary-openshift-ocp-installer-e2e-azure-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-azure-fips-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-fips-4.2
+- name: canary-openshift-ocp-installer-e2e-azure-fips-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-fips-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-gcp-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-gcp-4.2
+- name: canary-openshift-ocp-installer-e2e-gcp-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-gcp-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-gcp-fips-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-gcp-fips-4.2
+- name: canary-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
 
 # OpenShift Dedicated integration
 - name: osd-int-4.1
@@ -2519,6 +2539,49 @@ dashboards:
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
     base_options: width=10
 
+- name: redhat-openshift-release-informing
+  dashboard_tab:
+    - name: redhat-canary-openshift-ocp-installer-e2e-aws-fips-4.2
+      description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on AWS with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-aws-fips-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+      description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on AWS with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-azure-4.2
+      description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on Azure.
+      test_group_name: canary-openshift-ocp-installer-e2e-azure-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-azure-serial-4.2
+      description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on Azure.
+      test_group_name: canary-openshift-ocp-installer-e2e-azure-serial-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-azure-fips-4.2
+      description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on Azure with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-azure-fips-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-azure-fips-serial-4.2
+      description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on Azure with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-azure-fips-serial-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-gcp-4.2
+      description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on GCP.
+      test_group_name: canary-openshift-ocp-installer-e2e-gcp-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-gcp-serial-4.2
+      description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on GCP.
+      test_group_name: canary-openshift-ocp-installer-e2e-gcp-serial-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-gcp-fips-4.2
+      description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on GCP with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-gcp-fips-4.2
+      base_options: width=10
+    - name: redhat-canary-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
+      description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on GCP with FIPS mode enabled.
+      test_group_name: canary-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
+      base_options: width=10
+
 # OpenShift Dedicated integration dashboard
 - name: redhat-osd-int
   dashboard_tab:
@@ -2815,6 +2878,7 @@ dashboard_groups:
 - name: redhat
   dashboard_names:
   - redhat-openshift-release-blocking
+  - redhat-openshift-release-informing
   - redhat-osd-int
   - redhat-osd-stage
   - redhat-osd-prod


### PR DESCRIPTION
This adds new release informing jobs for Openshift OCP 4.2 to testgrid.

/cc @stevekuznetsov 