### PR TITLE
Automatically bump robots/issue-creator image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -111,7 +111,7 @@ postsubmits:
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(prow|ghproxy|label_sync|robots/commenter)/'
+    run_if_changed: '^(prow|ghproxy|label_sync|robots/commenter|robots/issue-creator)/'
     decorate: true
     spec:
       containers:

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -45,6 +45,7 @@ prow_push(
             "ghproxy": "//ghproxy:image",
             "label_sync": "//label_sync:image",
             "commenter": "//robots/commenter:image",
+            "issue-creator": "//robots/issue-creator:image",
         },
     ),
 )

--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -135,7 +135,7 @@ else
 fi
 
 # Determine what deployment images we need to update.
-imagedirs="//prow/... + //label_sync/... + //ghproxy/... + //robots/commenter/..."
+imagedirs="//prow/... + //label_sync/... + //ghproxy/... + //robots/commenter/... + //robots/issue-creator/..."
 images=("$@")
 if [[ "${#images[@]}" == 0 ]]; then
   echo -e "querying bazel for $(color-target :image) targets under $(color-target ${imagedirs}) ..." >&2

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -7,7 +7,10 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-prow_image(name = "image")
+prow_image(
+    name = "image",
+    visibility = ["//visibility:public"],
+)
 
 prow_push(
     name = "push",


### PR DESCRIPTION
This is currently used by @fejta-bot (and to be used by @k8s-triage-robot, ref: https://github.com/kubernetes/test-infra/pull/13683):

https://github.com/kubernetes/test-infra/blob/3d363168392cd6727e15ccf0b11d3c990347d0f7/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml#L271

Since this wasn't part of the autobump, the image wasn't bumped even though there have since been changes to issue-creator: https://github.com/kubernetes/test-infra/commits/master/robots/issue-creator

/cc @spiffxp @fejta 
/assign @fejta 