### PR TITLE
Migrate kind arm64 testgrid config

### DIFF
--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -303,8 +303,6 @@ test_groups:
 - name: test_pull_request_crio_e2e_rhel
   gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel
 
-- name: ci-kubernetes-kind-conformance-latest-1-14-arm64
-  gcs_prefix: k8s-conformance-kind-arm64-openlab/periodic-logs/ci-kind-integration-test-arm64
 # cloud-provider-openstack e2e conformance tests
 # name format: PR trigger ci-presubmit-${zuul-job-name}
 #              periodic strigger ci-periodic-${zuul-job-name}
@@ -702,9 +700,6 @@ dashboards:
 - name: conformance-all
   # entries are named $PROVIDER, $KUBERNETES_RELEASE
   dashboard_tab:
-  - name: kind, v1.14 (dev, ARM64)
-    description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster on ARM64 platform
-    test_group_name: ci-kubernetes-kind-conformance-latest-1-14-arm64
   - name: OpenStack, master (dev)
     description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance

--- a/config/testgrids/kubernetes/sig-testing/config.yaml
+++ b/config/testgrids/kubernetes/sig-testing/config.yaml
@@ -1,3 +1,8 @@
+# Test Groups
+test_groups:
+- name: ci-kubernetes-kind-conformance-latest-1-14-arm64
+  gcs_prefix: k8s-conformance-kind-arm64-openlab/periodic-logs/ci-kind-integration-test-arm64
+
 # Dashboard Group
 
 dashboard_groups:
@@ -131,6 +136,10 @@ dashboards:
         url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 
 - name: sig-testing-kind
+  dashboard_tab:
+    - name: kind, v1.14 (dev, ARM64)
+      description: Runs conformance tests using kubetest against latest kubernetes release-1.14 with a kubernetes-in-docker cluster on ARM64 platform
+      test_group_name: ci-kubernetes-kind-conformance-latest-1-14-arm64
 
 - name: sig-testing-maintenance
   dashboard_tab:


### PR DESCRIPTION
Migrating the kind arm64 kind job to the new testgrid config structure

xref https://github.com/kubernetes-sigs/kind/issues/188

