### PR TITLE
Split the xbuild job for the Service Catalog images

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -24,13 +24,7 @@ presubmits:
         - name: NO_DOCKER
           value: "1"
   - name: pull-service-catalog-integration
-    decorate: true
-    decoration_config:
-      timeout: 45m
-    always_run: true
-    skip_report: false
-    labels:
-      preset-dind-enabled: "true"
+    <<: *build_image_cfg
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
@@ -43,7 +37,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-service-catalog-build-image-all-arch
+  - name: pull-build-all-images-for-amd64
     <<: *build_image_cfg
     spec:
       containers:
@@ -53,11 +47,11 @@ presubmits:
         - runner.sh
         args:
         - make
-        - service-catalog-image-all-arch
+        - arch-image-amd64
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-brokers-build-image-all-arch
+  - name: pull-build-all-images-for-arm
     <<: *build_image_cfg
     spec:
       containers:
@@ -67,12 +61,11 @@ presubmits:
             - runner.sh
           args:
             - make
-            - user-broker-image-all-arch
-            - test-broker-image-all-arch
+            - arch-image-arm
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
-  - name: pull-healthcheck-build-image-all-arch
+  - name: pull-build-all-images-for-arm64
     <<: *build_image_cfg
     spec:
       containers:
@@ -82,11 +75,39 @@ presubmits:
             - runner.sh
           args:
             - make
-            - healthcheck-image-all-arch
+            - arch-image-arm64
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
-  - name: pull-svcat-build-image-all-arch
+  - name: pull-build-all-images-for-ppc64le
+    <<: *build_image_cfg
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - arch-image-ppc64le
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-build-all-images-for-s390x
+    <<: *build_image_cfg
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - arch-image-ppc64le
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-build-all-images-for-svcat
     <<: *build_image_cfg
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -1,3 +1,12 @@
+build_image_cfg: &build_image_cfg
+  decorate: true
+  decoration_config:
+    timeout: 45m
+  always_run: true
+  skip_report: false
+  labels:
+    preset-dind-enabled: "true"
+
 presubmits:
   kubernetes-sigs/service-catalog:
   - name: pull-service-catalog-unit
@@ -34,14 +43,8 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-service-catalog-xbuild
-    decorate: true
-    decoration_config:
-      timeout: 90m
-    always_run: true
-    skip_report: false
-    labels:
-      preset-dind-enabled: "true"
+  - name: pull-service-catalog-build-image-all-arch
+    <<: *build_image_cfg
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
@@ -50,8 +53,50 @@ presubmits:
         - runner.sh
         args:
         - make
-        - images-all
-        - svcat-all
+        - service-catalog-image-all-arch
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+  - name: pull-brokers-build-image-all-arch
+    <<: *build_image_cfg
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - user-broker-image-all-arch
+            - test-broker-image-all-arch
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-healthcheck-build-image-all-arch
+    <<: *build_image_cfg
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - healthcheck-image-all-arch
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-svcat-build-image-all-arch
+    <<: *build_image_cfg
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190612-bf4a71f-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - svcat-all
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true


### PR DESCRIPTION
### Description

Split the `pull-service-catalog-xbuild` job. 

Instead of having one pipeline for building all images we split that into:
- pull-build-all-images-for-amd64
- pull-build-all-images-for-arm
- pull-build-all-images-for-arm64
- pull-build-all-images-for-ppc64le
- pull-build-all-images-for-s390x
- pull-build-all-images-for-svcat (cli for darwin, linux, windows)

**pros:**
- reduce pipeline time from 1h to around 7min
- based on investigation https://github.com/kubernetes-sigs/service-catalog/issues/2663#issuecomment-509289729, the most common random failures are connected with architecture so splitting by that type will help for restarting only failed builds

**cons:**
- have 5 additional pipelines

Based on the pros IMO is worth to have those additional 5 pipelines. What's more, they are split by arch so it's a fixed number of pipeline regardless of the number of domains (brokers, apiservers, healtchecks etc.)

I've tested that solution by executing those build on our prow cluster, results:
- [pull-build-all-images-for-svcat](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-svcat/1161022417468919808) **duration:** 4m31s
- [pull-build-all-images-for-amd64](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-amd64/1161017508644261888) **duration:** 4m24s
- [pull-build-all-images-for-arm](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-arm/1161019018442706944) **duration:** 7m2s
- [pull-build-all-images-for-arm64](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-arm64/1160963275727310848) **duration:** 5m27s
- [pull-build-all-images-for-ppc64le](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-ppc64le/1160966170300387328) **duration:**  6m49s
- [pull-build-all-images-for-s390x](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-test-sc-build-s390x/1160968561213050880) **duration:** 5m36s

_Sum duration: 43m55s_

<details><summary><b>### Click here</b> to see outdated solution</summary>
<p>

#### Outdated

The first approach was to split build into:
- brokers-build-image-all-arch (user-broker & test-broker)
- service-catalog-build-image-all-arch
- healthcheck-build-image-all-arch
- svcat-build-image-all-arch

pros:
- reduce time to merge from 1h to 25min
- have only 3 additional pipelines

cons:
- based on investigation https://github.com/kubernetes-sigs/service-catalog/issues/2663#issuecomment-509289729, the most common failures are connected with architecture so splitting by domain does not help too much 
- requires changes in makefile: https://github.com/mszostok/service-catalog/compare/master...mszostok:change-mf

</p>
</details>


**Related issue:**

- https://github.com/kubernetes-sigs/service-catalog/issues/2663