### PR TITLE
Handle a nil response from Bugzilla

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -163,7 +163,9 @@ func (c *client) request(req *http.Request, logger *logrus.Entry) ([]byte, error
 		req.URL.RawQuery = values.Encode()
 	}
 	resp, err := c.client.Do(req)
-	logger.WithField("response", resp.StatusCode).Debug("Got response from Bugzilla.")
+	if resp != nil {
+		logger.WithField("response", resp.StatusCode).Debug("Got response from Bugzilla.")
+	}
 	if err != nil {
 		code := -1
 		if resp != nil {


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x721f80]

goroutine 164178 [running]:
k8s.io/test-infra/prow/bugzilla.(*client).request(0xc00212c3c0, 0xc0004e6100, 0xc0069ce690, 0x0, 0x0, 0x0, 0x0, 0x0)
	prow/bugzilla/client.go:166 +0xc0
k8s.io/test-infra/prow/bugzilla.(*client).GetBug(0xc00212c3c0, 0x1a8de8, 0x7fd0163d0460, 0x0, 0xc000871620)
	prow/bugzilla/client.go:70 +0x2bc
k8s.io/test-infra/prow/plugins/bugzilla.getBug(0x19fb8a0, 0xc00212c3c0, 0x1a8de8, 0xc0069ce5b0, 0xc003ec0040, 0x0, 0x0, 0x0)
	prow/plugins/bugzilla/bugzilla.go:565 +0x59
k8s.io/test-infra/prow/plugins/bugzilla.handle(0xc0007fe206, 0x9, 0xc0007fe200, 0x6, 0xc0007fe1f0, 0xb, 0x5c27, 0x1a8de8, 0x0, 0xc007e82400, ...)
	prow/plugins/bugzilla/bugzilla.go:337 +0x1052
k8s.io/test-infra/prow/plugins/bugzilla.handlePullRequest(0x1a493c0, 0xc000630080, 0x1a16ea0, 0xc0030b74e0, 0x1a3b540, 0xc00164cf00, 0xc002c67480, 0xc0030b7520, 0x19fb8a0, 0xc00212c3c0, ...)
	prow/plugins/bugzilla/bugzilla.go:179 +0x251
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1(0xc0025c5c70, 0xc001af6000, 0xc0023bf000, 0xc00200d620, 0x8, 0x17ffef0)
	prow/hook/events.go:177 +0x2b4
created by k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent
	prow/hook/events.go:169 +0x5f6
```

/assign @droslean @cblecker 