### PR TITLE
Add migration presubmit to aws-ebs-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -117,3 +117,25 @@ presubmits:
       testgrid-tab-name: e2e-test-multi-az
       description: aws ebs csi driver e2e test on mutiple AZs
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-migration-test-latest
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20190806-012cf5f-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-migration
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-tab-name: migration-test-latest
+      description: aws ebs csi driver migration test on latest kubernetes
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
I've set always_run to false which means the test will only run when requested. I plan to make a PR adding the `make test-e2e-migration` rule and make sure the tests runs as expected, then move this to a periodic job.
/cc @leakingtapan 