### PR TITLE
kubekins-e2e: create 1.16 and remove 1.12 images

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -2,7 +2,7 @@ variants:
   experimental:
     CONFIG: experimental
     GO_VERSION: 1.12.7
-    K8S_RELEASE: stable
+    K8S_RELEASE: latest
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
@@ -13,17 +13,17 @@ variants:
   '1.16':
     CONFIG: '1.16'
     GO_VERSION: 1.12.7
-    K8S_RELEASE: stable
+    K8S_RELEASE: latest-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
     GO_VERSION: 1.12.7
-    K8S_RELEASE: stable
+    K8S_RELEASE: stable-1.15
     BAZEL_VERSION: 0.23.2
   '1.14':
     CONFIG: '1.14'
     GO_VERSION: 1.12.5
-    K8S_RELEASE: latest
+    K8S_RELEASE: stable-1.14
     BAZEL_VERSION: 0.21.0
   '1.13':
     CONFIG: '1.13'

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -10,6 +10,11 @@ variants:
     GO_VERSION: 1.12.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
+  '1.16':
+    CONFIG: '1.16'
+    GO_VERSION: 1.12.1
+    K8S_RELEASE: stable
+    BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
     GO_VERSION: 1.12.1
@@ -24,9 +29,4 @@ variants:
     CONFIG: '1.13'
     GO_VERSION: 1.11.5
     K8S_RELEASE: stable-1.13
-    BAZEL_VERSION: 0.18.1
-  '1.12':
-    CONFIG: '1.12'
-    GO_VERSION: 1.10.8
-    K8S_RELEASE: stable-1.12
     BAZEL_VERSION: 0.18.1

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,28 +1,28 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.12.1
+    GO_VERSION: 1.12.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.12.1
+    GO_VERSION: 1.12.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.12.1
+    GO_VERSION: 1.12.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
-    GO_VERSION: 1.12.1
+    GO_VERSION: 1.12.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.14':
     CONFIG: '1.14'
-    GO_VERSION: 1.12.1
+    GO_VERSION: 1.12.5
     K8S_RELEASE: latest
     BAZEL_VERSION: 0.21.0
   '1.13':


### PR DESCRIPTION
In preparation for the 1.16 branch cut as per the [handbook](https://github.com/kubernetes/sig-release/blob/623a390b899996b025203b5477b511352ff528ca/release-engineering/role-handbooks/branch-manager.md#create-cipresubmit-jobs).
xref https://github.com/kubernetes/sig-release/issues/756

This PR also:

- updates the `GO_VERSION` for each branch to reflect k/k.
- fixes the `K8S_RELEASE` for each branch in accordance to https://gcsweb.k8s.io/gcs/kubernetes-release/release/.


/hold
/sig release
/area release-eng

/cc @justaugustus @imkin @idealhack @Katharine 
/assign @justaugustus @imkin 

/cc @BenTheElder @cblecker 
on go version changes