### PR TITLE
Remove prometheus counter github_requests

### DIFF
--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -46,16 +46,6 @@ var ghTokenUsageGaugeVec = prometheus.NewGaugeVec(
 	[]string{"token_hash", "api_version"},
 )
 
-// ghRequestsCounter provides the 'github_requests' counter that keeps track
-// of the number of GitHub requests by API path.
-var ghRequestsCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "github_requests",
-		Help: "GitHub requests by API path.",
-	},
-	[]string{"token_hash", "path", "status"},
-)
-
 // ghRequestDurationHistVec provides the 'github_request_duration' histogram that keeps track
 // of the duration of GitHub requests by API path.
 var ghRequestDurationHistVec = prometheus.NewHistogramVec(
@@ -73,7 +63,6 @@ var lastGitHubResponse time.Time
 func init() {
 	prometheus.MustRegister(ghTokenUntilResetGaugeVec)
 	prometheus.MustRegister(ghTokenUsageGaugeVec)
-	prometheus.MustRegister(ghRequestsCounter)
 	prometheus.MustRegister(ghRequestDurationHistVec)
 }
 
@@ -106,7 +95,6 @@ func CollectGitHubTokenMetrics(tokenHash, apiVersion string, headers http.Header
 // CollectGitHubRequestMetrics publishes the number of requests by API path to
 // `github_requests` on prometheus.
 func CollectGitHubRequestMetrics(tokenHash, path, statusCode string, roundTripTime float64) {
-	ghRequestsCounter.With(prometheus.Labels{"token_hash": tokenHash, "path": GetSimplifiedPath(path), "status": statusCode}).Inc()
 	ghRequestDurationHistVec.With(prometheus.Labels{"token_hash": tokenHash, "path": GetSimplifiedPath(path), "status": statusCode}).Observe(roundTripTime)
 }
 


### PR DESCRIPTION
With the histogram `github_request_duration` which comes with a
counter already, the counter `github_requests` is no longer needed.