### PR TITLE
Add pull-kubernetes-{dependencies,verify} jobs for 1.16

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3841,6 +3841,53 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
+    - release-1.16
+    cluster: security
+    context: pull-security-kubernetes-dependencies
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-security-prow
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15s
+      timeout: 2h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-dependencies
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-dependencies
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - make
+        - verify
+        command:
+        - runner.sh
+        env:
+        - name: WHAT
+          value: vendor vendor-licenses
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.16
+        name: main
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-dependencies,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
     - release-1.15
     cluster: security
     context: pull-security-kubernetes-dependencies
@@ -4322,6 +4369,63 @@ presubmits:
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-master
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-verify,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-1.16
+    cluster: security
+    context: pull-security-kubernetes-verify
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-security-prow
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15s
+      timeout: 2h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-security-kubernetes-verify
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-verify
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - ./hack/jenkins/verify-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_FORCE_VERIFY_CHECKS
+          value: "n"
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.16
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.16
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -35,6 +35,32 @@ presubmits:
     path_alias: "k8s.io/kubernetes"
     decorate: true
     branches:
+    - release-1.16
+    always_run: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - name: main
+        command:
+        - runner.sh
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.16
+        args:
+        - make
+        - verify
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        # Space separated list of the checks to run
+        - name: WHAT
+          value: "vendor vendor-licenses"
+  - name: pull-kubernetes-dependencies
+    path_alias: "k8s.io/kubernetes"
+    decorate: true
+    branches:
     - release-1.15
     always_run: true
     skip_report: false

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -44,6 +44,40 @@ presubmits:
     always_run: true
     decorate: true
     branches:
+    - release-1.16
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.16
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/verify-dockerized.sh
+        env:
+        - name: KUBE_FORCE_VERIFY_CHECKS
+          value: "n"
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.16
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+  - name: pull-kubernetes-verify
+    always_run: true
+    decorate: true
+    branches:
     - release-1.15
     path_alias: k8s.io/kubernetes
     labels:


### PR DESCRIPTION
Like https://github.com/kubernetes/test-infra/pull/13672, but for 1.16.
related https://github.com/kubernetes/test-infra/pull/13723, https://github.com/kubernetes/test-infra/pull/13882

/cc @Katharine @justaugustus @idealhack @imkin 
/assign @justaugustus @Katharine 
