### PR TITLE
[release] Run a make target for pull-release-unit

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,10 +46,9 @@ presubmits:
       containers:
       - image: golang:1.12
         command:
-        - go
+        - make
         args:
         - test
-        - ./...
     annotations:
       testgrid-dashboards: sig-release-misc
       testgrid-tab-name: release-unit


### PR DESCRIPTION
We do have a makefile in place now where we can control which tests to
run. Currently it is set up to not only run go tests but also some shell
tests.

/area release-eng
/sig release
/kind cleanup
/assign @tpepper @calebamiles @justaugustus 
/cc @kubernetes/release-engineering