### PR TITLE
[release] change image for k/release unit tests

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -44,7 +44,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: golang:1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190813-5765933-master
         command:
         - make
         args:


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/13887 we switched to running `make test`. This runs not only go tests but also shell tests. Therefore we have a dependency on more tools (e.g. `jq` and others). Currently that means that our test will never succeed with the vanilla `golang:1.12` image.

Remarks:
- I don't have much of an idea about prow, its decorators and all that jazz. Therefore I am not sure if I need to setup `env`/`GOPATH`
- I am not sure if we want to use the kube-cross image, but at least it brings all the dependencies we currently have
- I am not sure how we will upgrade this config when a new kube-cross image is published

/area release-eng
/sig release
/kind cleanup
/assign @tpepper @calebamiles @justaugustus
/cc @kubernetes/release-engineering