### PR TITLE
Ensure ghproxy not to use cache for github v4 api

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -192,6 +192,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	apiVersion := "v3"
 	if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") {
+		resp.Header.Set("Cache-Control", "no-store")
 		apiVersion = "v4"
 	}
 


### PR DESCRIPTION
github api v4 [1] has different limit from v3 and the mechanism used
in our caching for v3 does not apply any more.

More specifically, headers like `If-None-Match`, or `If-Modified-Since` [2]
are not mentioned in the v4 doc [1].

[1]. https://developer.github.com/v4/guides/resource-limitations/#rate-limit
[2]. https://developer.github.com/v3/#conditional-requests