### PR TITLE
swap periodic bazel jobs for postsubmits in sig-release boards

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -117,15 +117,15 @@ periodics:
           cpu: "4"
       securityContext:
         privileged: true
-- annotations:
-    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
-    testgrid-tab-name: periodic-bazel-build-1.13
+- name: periodic-kubernetes-bazel-build-1-13
+  annotations:
+    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
+    testgrid-tab-name: bazel-build-1.13
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-build-1-13
   spec:
     containers:
     - args:
@@ -148,15 +148,15 @@ periodics:
       resources:
         requests:
           memory: 6Gi
-- annotations:
-    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all
-    testgrid-tab-name: periodic-bazel-test-1.13
+- name: periodic-kubernetes-bazel-test-1-13
+  annotations:
+    testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
+    testgrid-tab-name: bazel-test-1.13
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-test-1-13
   spec:
     containers:
     - args:
@@ -288,16 +288,15 @@ periodics:
   - 'perfDashJobType: performance'
 postsubmits:
   kubernetes/kubernetes:
-  - annotations:
-      testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
-      testgrid-tab-name: bazel-build-1.13
+  - name: ci-kubernetes-bazel-build-1-13
+    annotations:
+      testgrid-dashboards: sig-release-1.13-all
     branches:
     - release-1.13
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-build-1-13
     spec:
       containers:
       - args:
@@ -318,16 +317,15 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
-  - annotations:
-      testgrid-dashboards: sig-release-1.13-blocking, sig-release-1.13-all, google-unit
-      testgrid-tab-name: bazel-test-1.13
+  - name: ci-kubernetes-bazel-test-1-13
+    annotations:
+      testgrid-dashboards: sig-release-1.13-all
     branches:
     - release-1.13
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-test-1-13
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -161,15 +161,15 @@ periodics:
           cpu: "4"
       securityContext:
         privileged: true
-- annotations:
-    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all
-    testgrid-tab-name: periodic-bazel-build-1.14
+- name: periodic-kubernetes-bazel-build-1-14
+  annotations:
+    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
+    testgrid-tab-name: bazel-build-1.14
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-build-1-14
   spec:
     containers:
     - args:
@@ -192,15 +192,15 @@ periodics:
       resources:
         requests:
           memory: 6Gi
-- annotations:
-    testgrid-dashboards: sig-release-1.14-all
-    testgrid-tab-name: periodic-bazel-test-1.14
+- name: periodic-kubernetes-bazel-test-1-14
+  annotations:
+    testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
+    testgrid-tab-name: bazel-test-1.14
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-test-1-14
   spec:
     containers:
     - args:
@@ -331,16 +331,15 @@ periodics:
   - 'perfDashJobType: performance'
 postsubmits:
   kubernetes/kubernetes:
-  - annotations:
-      testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
-      testgrid-tab-name: bazel-build-1.14
+  - name: ci-kubernetes-bazel-build-1-14
+    annotations:
+      testgrid-dashboards: sig-release-1.14-all
     branches:
     - release-1.14
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-build-1-14
     spec:
       containers:
       - args:
@@ -361,16 +360,15 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
-  - annotations:
-      testgrid-dashboards: sig-release-1.14-blocking, sig-release-1.14-all, google-unit
-      testgrid-tab-name: bazel-test-1.14
+  - name: ci-kubernetes-bazel-test-1-14
+    annotations:
+      testgrid-dashboards: sig-release-1.14-all
     branches:
     - release-1.14
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-test-1-14
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -32,7 +32,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.15-blocking
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.15
   cron: 0 3-23/6 * * *
@@ -63,7 +63,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-node-kubelet
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.15
   interval: 2h
   labels:
@@ -127,7 +127,7 @@ periodics:
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, google-unit
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, google-unit
     testgrid-tab-name: build-1.15
   interval: 1h
   labels:
@@ -159,7 +159,7 @@ periodics:
     fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.15-blocking, sig-scalability-gce, google-gce
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, sig-scalability-gce, google-gce
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: gce-cos-1.15-scalability-100
   cron: 0 0/12 * * *
@@ -205,8 +205,11 @@ periodics:
   - 'perfDashPrefix: gce-100Nodes'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
-- annotations:
-    testgrid-dashboards: sig-release-1.15-all
+- name: periodic-kubernetes-bazel-build-1-15
+  annotations:
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, google-unit
+    testgrid-tab-name: bazel-build-1.15
   decorate: true
   extra_refs:
   - base_ref: release-1.15
@@ -219,7 +222,6 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-build-1-15
   spec:
     containers:
     - args:
@@ -239,8 +241,11 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190813-5765933-1.15
       name: ""
       resources: {}
-- annotations:
-    testgrid-dashboards: sig-release-1.15-all
+- name: periodic-kubernetes-bazel-test-1-15
+  annotations:
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, google-unit
+    testgrid-tab-name: bazel-test-1.15
   decorate: true
   extra_refs:
   - base_ref: release-1.15
@@ -253,7 +258,6 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-test-1-15
   spec:
     containers:
     - args:
@@ -275,7 +279,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.15-blocking, google-unit
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, google-unit
     testgrid-tab-name: integration-1.15
   interval: 2h
   labels:
@@ -303,7 +307,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.15-blocking, google-unit
+    testgrid-dashboards: sig-release-1.15-blocking, sig-release-1.15-all, google-unit
     testgrid-tab-name: verify-1.15
   decorate: true
   extra_refs:
@@ -341,17 +345,15 @@ periodics:
         privileged: true
 postsubmits:
   kubernetes/kubernetes:
-  - annotations:
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-dashboards: sig-release-1.15-blocking, google-unit
-      testgrid-tab-name: bazel-build-1.15
+  - name: ci-kubernetes-bazel-build-1-15
+    annotations:
+      testgrid-dashboards: sig-release-1.15-all
     branches:
     - release-1.15
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-build-1-15
     spec:
       containers:
       - args:
@@ -372,7 +374,8 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
-  - annotations:
+  - name: post-kubernetes-bazel-test-1-15
+    annotations:
       testgrid-dashboards: sig-release-1.15-all
     branches:
     - release-1.15
@@ -384,7 +387,6 @@ postsubmits:
     labels:
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: post-kubernetes-bazel-test-1-15
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -211,9 +211,11 @@ periodics:
   - 'perfDashPrefix: gce-100Nodes'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
-- annotations:
-    testgrid-dashboards: google-unit, sig-release-1.16-all
-    testgrid-tab-name: periodic-bazel-build-1.16
+- name: periodic-kubernetes-bazel-build-1-16
+  annotations:
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-1.16-blocking, sig-release-1.16-all, google-unit
+    testgrid-tab-name: bazel-build-1.16
   decorate: true
   extra_refs:
   - base_ref: release-1.16
@@ -226,7 +228,6 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-build-1-16
   spec:
     containers:
     - args:
@@ -246,9 +247,11 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190813-5765933-1.16
       name: ""
       resources: {}
-- annotations:
-    testgrid-dashboards: google-unit, sig-release-1.16-all
-    testgrid-tab-name: periodic-bazel-test-1.16
+- name: periodic-kubernetes-bazel-test-1-16
+  annotations:
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-1.16-blocking, sig-release-1.16-all, google-unit
+    testgrid-tab-name: bazel-test-1.16
   decorate: true
   extra_refs:
   - base_ref: release-1.16
@@ -261,7 +264,6 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-test-1-16
   spec:
     containers:
     - args:
@@ -349,17 +351,15 @@ periodics:
         privileged: true
 postsubmits:
   kubernetes/kubernetes:
-  - annotations:
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-dashboards: sig-release-1.16-blocking, google-unit
-      testgrid-tab-name: bazel-build-1.16
+  - name: ci-kubernetes-bazel-build-1-16
+    annotations:
+      testgrid-dashboards: sig-release-1.16-all
     branches:
     - release-1.16
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-build-1-16
     spec:
       containers:
       - args:
@@ -380,9 +380,9 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
-  - annotations:
-      testgrid-dashboards: sig-release-1.16-informing
-      testgrid-tab-name: bazel-test-1.16
+  - name: post-kubernetes-bazel-test-1-16
+    annotations:
+      testgrid-dashboards: sig-release-1.16-all
     branches:
     - release-1.16
     decorate: true
@@ -393,7 +393,6 @@ postsubmits:
     labels:
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: post-kubernetes-bazel-test-1-16
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -59,9 +59,7 @@ postsubmits:
     annotations:
       fork-per-release: "true"
       fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
-      testgrid-dashboards: sig-release-master-blocking, google-unit
-      testgrid-tab-name: bazel-build-master
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-dashboards: google-unit
       description: "Builds kubernetes using bazel"
     labels:
       preset-service-account: "true"
@@ -125,10 +123,8 @@ postsubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
     annotations:
-      testgrid-dashboards: sig-release-master-blocking, google-unit
-      testgrid-tab-name: bazel-test-master
-      testgrid-alert-email: kubernetes-sig-testing-alert@googlegroups.com
-      description: "OWNER: sig-testing. Tests kubernetes using bazel."
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-dashboards: google-unit
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -158,9 +154,9 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: sig-release-master-informing
-      testgrid-tab-name: bazel-test-master
-      description: 'OWNER: sig-testing; Runs kubernetes unit tests using bazel'
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-dashboards: sig-release-master-informing, google-unit
+      description: 'OWNER: sig-testing; Runs kubernetes unit tests at each commit using bazel'
     extra_refs:
     - base_ref: master
       org: kubernetes
@@ -186,17 +182,19 @@ postsubmits:
 periodics:
 # periodic bazel build jobs
 - name: periodic-kubernetes-bazel-build-master
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
+    fork-per-release-periodic-interval: 6h
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-tab-name: bazel-build-master
+    description: run bazel build //... -//vendor/...
   interval: 5m
   decorate: true
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
-    fork-per-release-periodic-interval: 6h
-    testgrid-dashboards: google-unit
-    testgrid-tab-name: periodic-bazel-build-master
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -223,6 +221,10 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
 
 - name: periodic-kubernetes-bazel-build-canary
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: bazel-build
+    description: run kubernetes-bazel-build with latest image
   interval: 1h
   decorate: true
   labels:
@@ -256,21 +258,19 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt
 
 # periodic bazel test jobs
+- name: periodic-kubernetes-bazel-test-master
   annotations:
-    testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: bazel-build
-    description: run kubernetes-bazel-build with latest image
-- interval: 5m
-  name: periodic-kubernetes-bazel-test-master
+    fork-per-release: "true"
+    fork-per-release-periodic-interval: 6h
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-tab-name: bazel-test-master
+    description: "runs bazel test //... //hack:verify-all -//build/... -//vendor/..."
+  interval: 5m
   decorate: true
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-periodic-interval: 6h
-    testgrid-dashboards: google-unit
-    testgrid-tab-name: periodic-bazel-test-master
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -293,8 +293,12 @@ periodics:
       - --
       - -//build/...
       - -//vendor/...
-- interval: 1h
-  name: periodic-kubernetes-bazel-test-canary
+- name: periodic-kubernetes-bazel-test-canary
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: bazel-test
+    description: run kubernetes-bazel-test with latest image
+  interval: 1h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -321,7 +325,3 @@ periodics:
       - --
       - -//build/...
       - -//vendor/...
-  annotations:
-    testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: bazel-test
-    description: run kubernetes-bazel-test with latest image


### PR DESCRIPTION
There are postsubmit and periodic variants of bazel test and build
jobs on sig-release dashboards. The postsubmits are currently in the
-blocking and -all boards, and the periodics in -all.

Jobs on release-blocking boards are expected to run at least every
3 hours. The postsubmits fail to meet this expectation since they
tend to go quiet on the weekend when no commits are coming in.

Reconcile to the following state for all but master
- postsubmit bazel-foo goes to sig-release-1.y-all
- periodic bazel-foo goes to sig-release-1.y-blocking, -all, google-unit

For master:
- postsubmit bazel-foo goes to google-unit
- periodic bazel-foo goes to sig-release-master-blocking, -all,
google-unit
- bazel-foo-canary untouched, just field reordering

I also adjusted the ordering of `name:` and `annotation:` fields for
human readability