### PR TITLE
Remove testgrid annotations from forked presubmits.

### DIFF
--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -273,11 +273,19 @@ func fixTestgridAnnotations(annotations map[string]string, version string, isPre
 	didDashboards := false
 annotations:
 	for k, v := range annotations {
+		if isPresubmit {
+			// Forked presubmits do not get renamed, and so their annotations will be applied to master.
+			// In some cases, they will do things that are so explicitly contradictory the run will fail.
+			// Therefore, if we're forking a presubmit, just drop all testgrid config and defer to master.
+			if strings.HasPrefix(k, "testgrid-") {
+				continue
+			}
+		}
 		switch k {
 		case testgridDashboardsAnnotation:
 			fmt.Println(v)
 			v = r.Replace(v)
-			if !isPresubmit && !inOtherSigReleaseDashboard(v, version) {
+			if !inOtherSigReleaseDashboard(v, version) {
 				v += ", " + "sig-release-" + version + "-all"
 			}
 			didDashboards = true

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -346,15 +346,9 @@ func TestFixTestgridAnnotations(t *testing.T) {
 		isPresubmit bool
 	}{
 		{
-			name:        "update master-blocking to point at 1.15-blocking",
-			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking"},
-			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking"},
-			isPresubmit: true,
-		},
-		{
-			name:        "update master-informing to point at 1.15-informing",
-			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-informing"},
-			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-informing"},
+			name:        "remove presubmit additions to dashboards",
+			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking, google-unit"},
+			expected:    map[string]string{},
 			isPresubmit: true,
 		},
 		{
@@ -362,12 +356,6 @@ func TestFixTestgridAnnotations(t *testing.T) {
 			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking"},
 			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking"},
 			isPresubmit: false,
-		},
-		{
-			name:        "update master-blocking to point at 1.15-blocking and leave other entries alone",
-			annotations: map[string]string{testgridDashboardsAnnotation: "sig-release-master-blocking, google-unit"},
-			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-blocking, google-unit"},
-			isPresubmit: true,
 		},
 		{
 			name:        "drop 'description'",
@@ -378,8 +366,8 @@ func TestFixTestgridAnnotations(t *testing.T) {
 		{
 			name:        "update tab names",
 			annotations: map[string]string{testgridTabNameAnnotation: "foo master"},
-			expected:    map[string]string{testgridTabNameAnnotation: "foo 1.15"},
-			isPresubmit: true,
+			expected:    map[string]string{testgridDashboardsAnnotation: "sig-release-1.15-all", testgridTabNameAnnotation: "foo 1.15"},
+			isPresubmit: false,
 		},
 	}
 
@@ -449,9 +437,10 @@ func TestGeneratePresubmits(t *testing.T) {
 				JobBase: config.JobBase{
 					Name: "pull-replace-some-things",
 					Annotations: map[string]string{
-						forkAnnotation:        "true",
-						replacementAnnotation: "foo -> {{.Version}}",
-						"some-annotation":     "yup",
+						forkAnnotation:                 "true",
+						replacementAnnotation:          "foo -> {{.Version}}",
+						"testgrid-generate-test-group": "true",
+						"some-annotation":              "yup",
 					},
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{


### PR DESCRIPTION
Presubmits do not get renamed, which results in their forks being duplicates. In some cases this is a detectable error, but in other cases the configurations of each version will be merged (with properties
being overwritten with arbitrary precedence).

To avoid the problem, just drop the testgrid annotations from the duplicate jobs.

Fixes (I think?) #13886 - the jobs are already correctly set up for forking, but they run into problems that this change mitigates.