### PR TITLE
Recognize /graphql as a valid path

### DIFF
--- a/ghproxy/ghmetrics/ghpath.go
+++ b/ghproxy/ghmetrics/ghpath.go
@@ -131,6 +131,8 @@ func GetSimplifiedPath(path string) string {
 		l("hub"),
 		l("rate_limit"),
 		l("teams"),
+		// end point for gh api v4
+		l("graphql"),
 		l("licenses"))
 
 	splitPath := strings.Split(path, "/")

--- a/ghproxy/ghmetrics/ghpath_test.go
+++ b/ghproxy/ghmetrics/ghpath_test.go
@@ -58,6 +58,8 @@ func Test_GetSimplifiedPath(t *testing.T) {
 		{name: "gists starred", args: args{path: "/gists/starred"}, want: "/gists/starred"},
 
 		{name: "notifications", args: args{path: "/notifications"}, want: "/notifications"},
+
+		{name: "graphql", args: args{path: "/graphql"}, want: "/graphql"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This path is used in gh api v4 [1].

[1]. https://developer.github.com/v4/guides/forming-calls/#communicating-with-graphql