### PR TITLE
Moving config_test.go to config/tests

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -33,6 +33,11 @@ filegroup(
 )
 
 filegroup(
+    name = "testgrid_default",
+    srcs = ["testgrids/default.yaml"],
+)
+
+filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
@@ -45,6 +50,7 @@ filegroup(
         ":package-srcs",
         "//config/jobs/kubernetes-security:all-srcs",
         "//config/tests/jobs:all-srcs",
+        "//config/tests/testgrids:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/config/tests/testgrids/BUILD.bazel
+++ b/config/tests/testgrids/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    args = [
+        "--config=$(location testconf.pb)",
+        "--prow-config=$(location //prow:config.yaml)",
+        "--job-config=config/jobs",
+    ],
+    data = [
+        ":testconf.pb",
+        "//config:prowjobs",
+        "//prow:config.yaml",
+    ],
+    rundir = ".",
+    deps = [
+        "//prow/config:go_default_library",
+        "//testgrid/config:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+genrule(
+    name = "testgrid_config",
+    srcs = [
+        "//config:testgrids",
+        "//config:prowjobs",
+        "//config:testgrid_default",
+        "//prow:config.yaml",
+    ],
+    outs = [":testconf.pb"],
+    cmd = "./$(location //testgrid/cmd/configurator) \
+           --yaml=config/testgrids \
+           --prow-config=$(location //prow:config.yaml) \
+           --prow-job-config=config/jobs \
+           --default=$(location //config:testgrid_default) \
+           --output=$@ \
+           --oneshot",
+    tools = [
+        "//testgrid/cmd/configurator",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/testgrid/cmd/configurator/BUILD.bazel
+++ b/testgrid/cmd/configurator/BUILD.bazel
@@ -14,7 +14,6 @@ prow_image(name = "image")
 go_test(
     name = "go_default_test",
     srcs = [
-        "config_test.go",
         "main_test.go",
         "prow_test.go",
         "yaml2proto_test.go",
@@ -29,7 +28,6 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//testgrid/config:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -327,11 +327,8 @@ func main() {
 	// Setup GCS client
 	var client *storage.Client
 	if opt.output != "" {
-		var err error
-		client, err = gcs.ClientWithCreds(ctx, opt.creds)
-		if err != nil {
-			log.Fatalf("Failed to create storage client: %v", err)
-		}
+		// Error returned if outputting to file; ignore for now
+		client, _ = gcs.ClientWithCreds(ctx, opt.creds)
 	}
 
 	// Oneshot mode, write config and exit


### PR DESCRIPTION
xref #13690

config_test.go now uses configurator as an executable to generate a proto locally.
Then, tests are run on the output of that local file to determine if configuration is correct for our repository.
Also includes a bugfix for configurator for reading to file

/cc @fejta 
/cc @michelle192837