### PR TITLE
Add gencert tool for creating client cert and key to authenticate to cluster.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -119,6 +119,7 @@ filegroup(
         "//metrics:all-srcs",
         "//pkg/benchmarkjunit:all-srcs",
         "//pkg/flagutil:all-srcs",
+        "//pkg/gencert:all-srcs",
         "//pkg/genyaml:all-srcs",
         "//pkg/ghclient:all-srcs",
         "//pkg/io:all-srcs",

--- a/pkg/gencert/BUILD.bazel
+++ b/pkg/gencert/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gencert.go"],
+    data = ["//prow/plugins:config-src"],
+    importpath = "k8s.io/test-infra/pkg/gencert",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
+        "//vendor/k8s.io/client-go/util/keyutil:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gencert_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/gencert/README.md
+++ b/pkg/gencert/README.md
@@ -1,0 +1,58 @@
+# Gencert
+
+## Description
+
+`gencert` is a simple tool used to generate a client key and certificate (w/ [**cluster-admin**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) permissions) for authenticating to a Kubernetes cluster.
+> **NOTE:** since `gencert` creates a certificate with `cluster-admin` level access, the kube context used **must** also be bound to the `cluster-admin` role.
+
+## Caveats
+1. The use of [x509 client certificate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs) with [super-user](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) privileges for cluster authentication/authorization has several drawbacks:
+    - Certificates **cannot** be revoked ([kubernetes/kubernetes#60917](https://github.com/kubernetes/kubernetes/issues/60917))
+    - Authorization roles are essentially *global* and thus **cannot** be tweaked at the node level.
+    - Unless setup with near expiry and explicit rotation, certificates are *long-lived* and **increase** the risk of exposure.
+
+2. Client certificate authentication will be deprecated in future versions of Prow  ([kubernetes/test-infra#13972](https://github.com/kubernetes/test-infra/issues/13972)).
+
+## Usage
+
+Generate a client key and certificate for a cluster.
+
+```go
+// Import gencert
+import "k8s.io/test-infra/pkg/gencert"
+
+//...
+
+// Create a Kubernetes clientset for interacting with the cluster.
+// In this case we are simply using the `current-context` defined in our local `~/.kube/config`.
+homedir, _ := os.UserHomeDir()
+kubeconfig := filepath.Join(homedir, ".kube", "config")
+config, _ := clientcmd.BuildConfigFromFlags("", kubeconfig)
+clientset, _ := kubernetes.NewForConfig(config)
+
+// Generate a client key and certificate, as well as return the certificate authority that issued the certificate.
+certPEM, keyPEM, caPEM, err := gencert.CreateClusterAuthCredentials(clientset)
+```  
+
+`certPEM` will contain the **client certificate**, `keyPEM` will contain the **client key**, and `caPEM` will contain the **serve certificate authority**.
+
+```go
+import "encoding/base64"
+
+//...
+
+// Base64 encode the `cert`, `key`, and `ca` to use in a kubeconfig.
+cert := base64.StdEncoding.EncodeToString(certPEM)
+key := base64.StdEncoding.EncodeToString(keyPEM)
+ca := base64.StdEncoding.EncodeToString(caPEM)
+
+fmt.Println("cert:", cert)
+fmt.Println("key:", key)
+fmt.Println("ca:", ca)
+```
+
+```text
+cert: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1...
+key: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNL...
+ca: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURER...
+```

--- a/pkg/gencert/gencert.go
+++ b/pkg/gencert/gencert.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gencert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	certificates "k8s.io/api/certificates/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+const (
+	// systemPrivilegedGroup is a superuser by default (i.e. bound to the cluster-admin ClusterRole).
+	systemPrivilegedGroup = "system:masters"
+	// certWaitInterval certificate request poll interval.
+	certWaitInterval = time.Second
+	// certWaitTimeout certificate request poll timeout.
+	certWaitTimeout = 20 * time.Second
+)
+
+// generateCSR generates a certificate signing request (CSR).
+func generateCSR() (*certificates.CertificateSigningRequest, []byte, error) {
+
+	// Generate a new private key.
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %v", err)
+	}
+
+	// Marshal pk -> der.
+	der, err := x509.MarshalECPrivateKey(pk)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key to DER: %v", err)
+	}
+
+	// Generate PEM key.
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: keyutil.ECPrivateKeyBlockType, Bytes: der})
+
+	// Generate a x509 certificate signing request.
+	csrPEM, err := cert.MakeCSR(pk, &pkix.Name{CommonName: "client", Organization: []string{systemPrivilegedGroup}}, nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create CSR from key: %v", err)
+	}
+
+	// Generate a Kubernetes CSR object.
+	csrObj := &certificates.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "",
+			GenerateName: "csr-",
+		},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: csrPEM,
+			Usages: []certificates.KeyUsage{
+				certificates.UsageDigitalSignature,
+				certificates.UsageKeyEncipherment,
+				certificates.UsageClientAuth,
+			},
+		},
+	}
+
+	return csrObj, keyPEM, nil
+}
+
+// requestCSR requests a certificate signing request (CSR).
+func requestCSR(clientset kubernetes.Interface, csrObj *certificates.CertificateSigningRequest) ([]byte, error) {
+	client := clientset.CertificatesV1beta1().CertificateSigningRequests()
+
+	// Create CSR.
+	csrObj, err := client.Create(csrObj)
+	if err != nil {
+		return nil, fmt.Errorf("create CSR: %v", err)
+	}
+
+	csrName := csrObj.Name
+
+	// Approve CSR.
+	err = wait.Poll(certWaitInterval, certWaitTimeout, func() (bool, error) {
+		appendApprovalCondition(csrObj)
+		csrObj, err = client.UpdateApproval(csrObj)
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("approve CSR: %v", err)
+	}
+
+	// Get CSR.
+	err = wait.Poll(certWaitInterval, certWaitTimeout, func() (bool, error) {
+		csrObj, err = client.Get(csrName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get CSR: %v", err)
+	}
+
+	return csrObj.Status.Certificate, nil
+}
+
+// getRootCA fetches the service account root certificate authority (CA).
+func getRootCA(clientset kubernetes.Interface) ([]byte, error) {
+	secrets, err := clientset.CoreV1().Secrets(metav1.NamespaceSystem).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(secrets.Items) <= 0 {
+		return nil, errors.New("locate root CA secret")
+	}
+
+	return secrets.Items[0].Data[v1.ServiceAccountRootCAKey], nil
+}
+
+// appendApprovalCondition appends the approval condition to the certificate signing request (CSR).
+func appendApprovalCondition(csr *certificates.CertificateSigningRequest) {
+	csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+		Type:           certificates.CertificateApproved,
+		Reason:         "GenCertApprove",
+		Message:        "This CSR was approved by gencert.",
+		LastUpdateTime: metav1.Now(),
+	})
+}
+
+// CreateClusterAuthCredentials creates a client certificate and key to authenticate to a cluster API server
+func CreateClusterAuthCredentials(clientset kubernetes.Interface) (certPEM []byte, keyPEM []byte, caPEM []byte, err error) {
+	csrObj, keyPEM, err := generateCSR()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generate CSR: %v", err)
+	}
+
+	certPEM, err = requestCSR(clientset, csrObj)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("request CSR: %v", err)
+	}
+
+	caPEM, err = getRootCA(clientset)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("get root CA: %v", err)
+	}
+
+	return certPEM, keyPEM, caPEM, nil
+}
+
+// TODO(clarketm): implement `Create` method that returns a kube config file as string.
+// CreateKubeConfigCredentials creates a kube config containing a certificate and key to authenticate to a Kubernetes cluster API server
+//func CreateKubeConfigCredentials(clientset kubernetes.Interface) (string, error) {}

--- a/pkg/gencert/gencert_test.go
+++ b/pkg/gencert/gencert_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gencert
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sFake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateClusterAuthCredentials(t *testing.T) {
+	tests := []struct {
+		name         string
+		createClient func() kubernetes.Interface
+		expected     bool
+	}{
+		{
+			name: "create cluster auth credentials success",
+			createClient: func() kubernetes.Interface {
+				return k8sFake.NewSimpleClientset(&v1.Secret{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: metav1.NamespaceSystem,
+					},
+					Data: map[string][]uint8{v1.ServiceAccountRootCAKey: {1, 2, 3}},
+				})
+			},
+			expected: true,
+		},
+		{
+			name: "create cluster auth credentials fail",
+			createClient: func() kubernetes.Interface {
+				return k8sFake.NewSimpleClientset()
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := test.createClient()
+			_, _, _, err := CreateClusterAuthCredentials(client)
+			hasError := err != nil
+
+			if hasError == test.expected {
+				t.Fatalf("Expected %v, but got result %v", test.expected, hasError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `gencert` tool for creating client cert and key to authenticate to cluster.

There are at *least* two intended purposes for this tool.
1. First, and most immediate, is to use this library in `mkbuild-cluster` (#13820) to generate a cert and key in cases where `gcloud` fails; this also makes the cert generation process cloud-provider agnostic (i.e. not tied to `gcloud` command).
2. The output of the `CreateClusterAuthCredentials` method can be *directly* used to construct a **kubeconfig** file for authenticating across multiple clusters. This will make it easier to deprecate the usage of `--build-cluster` in favor or `--kubeconfig` for generating Kubernetes clients in Prow.