### PR TITLE
Fix CPO e2e conformance tests gate failure

### DIFF
--- a/hack/verify-pylint.sh
+++ b/hack/verify-pylint.sh
@@ -38,4 +38,4 @@ shopt -s extglob globstar
 
 # TODO(clarketm) there is no version of `pylint` that supports "both" PY2 and PY3
 # I am disabling pylint checks for python3 files until migration complete
-"$DIR/pylint_bin" !(metrics|triage|velodrome|hack|gubernator|external|vendor|bazel-*)/**/*.py
+"$DIR/pylint_bin" !(metrics|triage|velodrome|hack|gubernator|external|vendor|testgrid|bazel-*)/**/*.py

--- a/testgrid/conformance/upload_e2e.py
+++ b/testgrid/conformance/upload_e2e.py
@@ -171,7 +171,7 @@ def upload_string(gcs_path, text, dry):
     print('Run:', cmd, 'stdin=%s' % text, file=sys.stderr)
     if dry:
         return
-    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, encoding='utf8')
     proc.communicate(input=text)
     if proc.returncode != 0:
         raise RuntimeError(


### PR DESCRIPTION
Cloud-provider-openstack e2e tests are failing after upgrade to python 3.7
Ref: https://logs.openlabtesting.org/logs/periodic-4/16/github.com/kubernetes/cloud-provider-openstack/release-1.15/cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.15/d80905a/job-output.txt.gz

Traceback (most recent call last):
2019-08-16 05:48:30.546650 | ubuntu-xenial-citynetwork |   File "upload_e2e.py", line 328, in <module>
2019-08-16 05:48:30.546692 | ubuntu-xenial-citynetwork |     main(sys.argv[1:])
2019-08-16 05:48:30.546745 | ubuntu-xenial-citynetwork |   File "upload_e2e.py", line 318, in main
2019-08-16 05:48:30.546818 | ubuntu-xenial-citynetwork |     upload_string(gcs_dir+'/started.json', started_json, args.dry_run)
2019-08-16 05:48:30.546876 | ubuntu-xenial-citynetwork |   File "upload_e2e.py", line 175, in upload_string
2019-08-16 05:48:30.546920 | ubuntu-xenial-citynetwork |     proc.communicate(input=text)
2019-08-16 05:48:30.546990 | ubuntu-xenial-citynetwork |   File "/usr/lib/python3.7/subprocess.py", line 924, in communicate
2019-08-16 05:48:30.547032 | ubuntu-xenial-citynetwork |     self._stdin_write(input)
2019-08-16 05:48:30.547102 | ubuntu-xenial-citynetwork |   File "/usr/lib/python3.7/subprocess.py", line 873, in _stdin_write
2019-08-16 05:48:30.547142 | ubuntu-xenial-citynetwork |     self.stdin.write(input)
2019-08-16 05:48:30.547202 | ubuntu-xenial-citynetwork | TypeError: a bytes-like object is required, not 'str'
This commit is to fix the same.