### PR TITLE
Only run E2E on release-0.4 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -202,6 +202,8 @@ presubmits:
       preset-service-account: "true"
       preset-cluster-api-provider-vsphere-e2e-creds: "true"
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    branches:
+    - ^release-0.4$
     always_run: false
     run_if_changed: '^((cmd|config|pkg|(scripts/e2e)|vendor)/)|Dockerfile'
     decorate: true
@@ -283,6 +285,7 @@ postsubmits:
         args:
         - ./hack/release.sh
         - -p
+        - -l
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
/assign @akutz 

This will make it so the E2E tests only run on the `release-0.4` branch. We can keep this until `master` is in a good shape for v1alpha2 and tests are passing.

The postsubmit that releases a "CI" build after every merge to master is unchanged. Do we want to keep that as-is, or have it only push images from the release branch as well?

The postsubmit that releases a "release" build adds the `-l` flag to automatically tag images as `latest` when it is triggered. This job only runs when tags are pushed, and right now we should only be tagging commits on the release branch. If that changes, we will need to revisit this.