### PR TITLE
Don't pass --namespace to sinker

### DIFF
--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        - --namespace=$(MY_POD_NAMESPACE)
+        #- --namespace=$(MY_POD_NAMESPACE)
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Since we haven't actually deployed a sinker that supports this, it's now crash looping forever. 

Configuration cannot be changed in backwards-incompatible ways before new binaries are deployed.

/assign @alvaroaleman 