### PR TITLE
Remove configparser lint requirement

### DIFF
--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -302,7 +302,6 @@ py_binary(
     deps = [
         requirement("astroid"),
         requirement("backports.functools_lru_cache"),
-        requirement("configparser"),
         requirement("enum34"),
         requirement("influxdb"),
         requirement("isort"),


### PR DESCRIPTION
/assign @clarketm @michelle192837 

As both `configparser` and `backports.functools_lru_cache` have a `backports` module, importing both in the same binary causes issues.