### PR TITLE
document default prowjob preset behavior

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -63,6 +63,8 @@ files here. eg:
   kubernetes e2e tests less susceptible to flakes
 - [`preset-aws-credentials: "true"`] ensures the prowjob has AWS credentials
   for kops tests in a well known location, with an env var pointint to it
+- [the default preset with no labels] is used to set the `GOPROXY` env var
+  for all jobs by default
 
 ## Job Examples
 
@@ -227,3 +229,4 @@ bazel run //experiment/config-forker -- \
 [`preset-service-account: "true"`]: https://github.com/kubernetes/test-infra/blob/f4e6553b27d9ee8b35b2f2e588ea2e18c3fa818b/prow/config.yaml#L467-L483
 [`preset-pull-kubernetes-e2e: "true"`]: https://github.com/kubernetes/test-infra/blob/f4e6553b27d9ee8b35b2f2e588ea2e18c3fa818b/config/jobs/kubernetes/sig-gcp/sig-gcp-gce-config.yaml#L2-L8
 [`preset-aws-credentials: "true"`]: https://github.com/kubernetes/test-infra/blob/f4e6553b27d9ee8b35b2f2e588ea2e18c3fa818b/config/jobs/kubernetes/sig-aws/sig-aws-credentials.yaml#L3-L15
+[the default preset with no labels]: https://github.com/kubernetes/test-infra/blob/551edb4702e262989fe5d162a2c642c3201bf68e/prow/config.yaml#L630

--- a/prow/jobs.md
+++ b/prow/jobs.md
@@ -99,6 +99,13 @@ presets:
   - name: bar
     mountPath: /etc/bar
     readOnly: true
+- env:                     # a preset with no labels is applied to all jobs
+  - name: BAZ
+    value: qux
+  volumes:
+    # etc...
+  volumeMounts:
+    # etc...
 ```
 
 ## Standard Triggering and Execution Behavior for Jobs


### PR DESCRIPTION
Specifically

- added an example to the prowjob docs
- linked to the way we use it for GOPROXY in k8s-specific job docs
- added unit tests for presets
- since we use it for env vars, added a unit test to confirm env vars
  will conflict

Fixes https://github.com/kubernetes/test-infra/issues/13665