### PR TITLE
update go in kubernetes images to reflect updates in kubernetes

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,32 +1,32 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.12.7
+    GO_VERSION: 1.12.9
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.12.7
+    GO_VERSION: 1.12.9
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.12.7
+    GO_VERSION: 1.12.9
     K8S_RELEASE: latest-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
-    GO_VERSION: 1.12.7
+    GO_VERSION: 1.12.9
     K8S_RELEASE: stable-1.15
     BAZEL_VERSION: 0.23.2
   '1.14':
     CONFIG: '1.14'
-    GO_VERSION: 1.12.5
+    GO_VERSION: 1.12.9
     K8S_RELEASE: stable-1.14
     BAZEL_VERSION: 0.21.0
   '1.13':
     CONFIG: '1.13'
-    GO_VERSION: 1.11.5
+    GO_VERSION: 1.11.13
     K8S_RELEASE: stable-1.13
     BAZEL_VERSION: 0.18.1

--- a/images/kubekins-test/Dockerfile-1.13
+++ b/images/kubekins-test/Dockerfile-1.13
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.11.5
+FROM golang:1.11.13
 
 # Setup workspace and symlink to gopath
 WORKDIR /workspace

--- a/images/kubekins-test/Dockerfile-1.14
+++ b/images/kubekins-test/Dockerfile-1.14
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM golang:1.12.1
+FROM golang:1.12.9
 
 # Setup workspace and symlink to gopath
 WORKDIR /workspace


### PR DESCRIPTION
Kubernetes >= 1.14 should be on go 1.12.9 now
Kubernetes 1.13 is moving to go 1.11.13