### PR TITLE
sig-release: Use kubekins for debs/rpms build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -72,7 +72,7 @@ periodics:
     path_alias: "k8s.io/release"
   spec:
     containers:
-    - image: quay.io/k8s/release-tools:latest
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-master
       imagePullPolicy: Always
       command:
       - make
@@ -102,7 +102,7 @@ periodics:
     path_alias: "k8s.io/release"
   spec:
     containers:
-    - image: quay.io/k8s/release-tools:latest
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-master
       imagePullPolicy: Always
       command:
       - make


### PR DESCRIPTION
Switch to using the `master` image for kubekins-e2e (currently `gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-master`).

Fixes: https://github.com/kubernetes/kubernetes/issues/80715

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

cc: @alejandrox1 @kubernetes/release-engineering 
/area release-eng
/priority important-soon
/kind bug
/milestone v1.16