### PR TITLE
Yamllint prow/cluster

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -96,5 +96,6 @@ presubmits:
         - -c
         - config/jobs/.yamllint.conf
         - config/jobs
+        - prow/cluster
     annotations:
       testgrid-create-test-group: 'true'

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name:  grandmatriarch
+  name: grandmatriarch
   namespace: test-pods
 ---
 kind: Role

--- a/prow/cluster/monitoring/alertmanager_expose.yaml
+++ b/prow/cluster/monitoring/alertmanager_expose.yaml
@@ -15,4 +15,3 @@ spec:
   selector:
     alertmanager: prow
     app: alertmanager
-

--- a/prow/cluster/monitoring/alertmanager_rbac.yaml
+++ b/prow/cluster/monitoring/alertmanager_rbac.yaml
@@ -4,4 +4,3 @@ kind: ServiceAccount
 metadata:
   name: alertmanager
   namespace: prow-monitoring
-

--- a/prow/cluster/pipeline_deployment.yaml
+++ b/prow/cluster/pipeline_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate 
+    type: Recreate
   selector:
     matchLabels:
       app: prow-pipeline

--- a/prow/cluster/tune-sysctls_daemonset.yaml
+++ b/prow/cluster/tune-sysctls_daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
       containers:
-      - name: setsysctls 
+      - name: setsysctls
         command:
         - sh
         - -c


### PR DESCRIPTION
This pr changes the yamllint presubmit to also include the prow/cluster folder and fixes the errors found there. This is done in order to prevent merges of broken yaml as it happend in #13647 

/assign @Katharine @stevekuznetsov 