### PR TITLE
Add pull-test-infra-validate-manifests presubmit

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -105,3 +105,20 @@ presubmits:
         - prow/cluster
     annotations:
       testgrid-create-test-group: 'true'
+  - name: pull-test-infra-validate-manifests
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-create-test-group: 'true'
+    spec:
+      # Kubectl needs access the discovery info from the kube api in order
+      # to know the schema used for validation
+      automountServiceAccountToken: true
+      containers:
+      - image: launcher.gcr.io/google/bazel:0.29.1
+        command:
+        - bazel
+        - run
+        - //prow/cluster:production.create
+        - --
+        - --dry-run=true

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -833,6 +833,9 @@ dashboards:
   - name: verify-yaml
     test_group_name: pull-test-infra-yamllint
     base_options: width=10
+  - name: verify-manifests
+    test_group_name: pull-test-infra-validate-manifests
+    base_options: width=10
 
 - name: presubmits-cluster-registry
   dashboard_tab:


### PR DESCRIPTION
This PR adds a presubmit that validates the manifests in `prow/cluster` to prevent merges of yaml that is not a valid kubernetes manifest like it happened in https://github.com/kubernetes/test-infra/pull/13647

I did test this presubmit in our cluster which was a big pita as `mkpj|mkpod` is generally not nice and we happen to use a different GCS bucket and different name for that secret (cant wait for https://github.com/kubernetes/test-infra/issues/13370 to be resolved) but I would still suggest someone tests it on the actual cluster this will run on.

/assign @stevekuznetsov @Katharine 