### PR TITLE
boskos: stop logging entire system state

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -81,12 +81,9 @@ func main() {
 	}
 
 	go func() {
-		logTick := time.NewTicker(time.Minute).C
 		configTick := time.NewTicker(*syncPeriod).C
 		for {
 			select {
-			case <-logTick:
-				r.LogStatus()
 			case <-configTick:
 				r.SyncConfig(*configPath)
 			}

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ranch
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -96,7 +95,6 @@ func NewRanch(config string, s *Storage, ttl time.Duration) (*Ranch, error) {
 			return nil, err
 		}
 	}
-	newRanch.LogStatus()
 	return newRanch, nil
 }
 
@@ -346,21 +344,6 @@ func (r *Ranch) Reset(rtype, state string, expire time.Duration, dest string) (m
 		}
 	}
 	return ret, nil
-}
-
-// LogStatus outputs current status of all resources
-func (r *Ranch) LogStatus() {
-	resources, err := r.Storage.GetResources()
-
-	if err != nil {
-		return
-	}
-
-	resJSON, err := json.Marshal(resources)
-	if err != nil {
-		logrus.WithError(err).Errorf("Fail to marshal Resources. %v", resources)
-	}
-	logrus.Infof("Current Resources : %v", string(resJSON))
 }
 
 // SyncConfig updates resource list from a file


### PR DESCRIPTION
Logging the state of every resource possible is very costly. State
transitions are published already and it is possible to choose which
items are of interest and ask for their metrics specifically.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @krzyzacy @sebastienvas 

On our cluster, we saw `boskos` using ~1GB of logging per day. About 80% of that was due to this log line.