### PR TITLE
Use latest 1.15 Kubernetes binaries for GCE Windows POC test job.

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-windows.yaml
@@ -58,7 +58,7 @@ periodics:
       - --timeout=120m
       env:
       - name: OVERRIDE_NODE_BINARY_TAR_URL
-        value: "https://storage.googleapis.com/kubernetes-release/release/v1.14.1/kubernetes-node-windows-amd64.tar.gz"
+        value: "https://storage.googleapis.com/kubernetes-release/release/v1.15.3/kubernetes-node-windows-amd64.tar.gz"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
       resources:
         requests:


### PR DESCRIPTION
This test job is used for prototype changes to Kubernetes on Windows on GCP. We should have switched it to 1.15 a while ago...