### PR TITLE
Be stricter about how we create logs and post to GitHub with regards to secrets

### DIFF
--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -309,7 +309,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to start secrets agent")
 	}
 
-	gc := github.NewClient(sa.GetTokenGenerator(o.githubToken), github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+	gc := github.NewClient(sa.GetTokenGenerator(o.githubToken), sa.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 
 	if err := cdToRootDir(); err != nil {
 		logrus.WithError(err).Fatal("Failed to change to root dir")

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -153,7 +153,7 @@ func main() {
 		log.Fatalf("cannot setup Jenkins client: %v", err)
 	}
 
-	gc := github.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.graphqlEndpoint, o.githubEndpoint)
+	gc := github.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), secretAgent.Censor, o.graphqlEndpoint, o.githubEndpoint)
 
 	pr, err := gc.GetPullRequest(o.org, o.repo, o.num)
 	if err != nil {

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -654,9 +654,9 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEnd
 	}
 
 	if dryRun {
-		return github.NewDryRunClient(secretAgent.GetTokenGenerator(tokenPath), graphqlEndpoint, hosts...), nil
+		return github.NewDryRunClient(secretAgent.GetTokenGenerator(tokenPath), secretAgent.Censor, graphqlEndpoint, hosts...), nil
 	}
-	c := github.NewClient(secretAgent.GetTokenGenerator(tokenPath), graphqlEndpoint, hosts...)
+	c := github.NewClient(secretAgent.GetTokenGenerator(tokenPath), secretAgent.Censor, graphqlEndpoint, hosts...)
 	if tokens > 0 && tokenBurst >= tokens {
 		return nil, fmt.Errorf("--tokens=%d must exceed --token-burst=%d", tokens, tokenBurst)
 	}

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -564,10 +564,11 @@ func githubClient(tokenPath string, dry bool) (github.Client, error) {
 	}
 
 	gen := secretAgent.GetTokenGenerator(tokenPath)
+	censor := secretAgent.Censor
 	if dry {
-		return github.NewDryRunClient(gen, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
+		return github.NewDryRunClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
 	}
-	return github.NewClient(gen, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
+	return github.NewClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
 }
 
 func applySecret(ctx, ns, name, key, path string) error {

--- a/prow/config/secret/agent.go
+++ b/prow/config/secret/agent.go
@@ -20,7 +20,6 @@ package secret
 import (
 	"bytes"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -122,27 +121,18 @@ func (f censoringFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		return raw, err
 	}
 
-	return f.agent.CensorBytes(raw), nil
+	return f.agent.Censor(raw), nil
 }
 
 const censored = "CENSORED"
 
 var censoredBytes = []byte(censored)
 
-// CensorBytes replaces sensitive parts of the content with a placeholder.
-func (a *Agent) CensorBytes(content []byte) []byte {
+// Censor replaces sensitive parts of the content with a placeholder.
+func (a *Agent) Censor(content []byte) []byte {
 	for sKey := range a.secretsMap {
 		secret := a.GetSecret(sKey)
 		content = bytes.ReplaceAll(content, secret, censoredBytes)
-	}
-	return content
-}
-
-// Censor replaces sensitive parts of the content with a placeholder.
-func (a *Agent) Censor(content string) string {
-	for sKey := range a.secretsMap {
-		secret := a.GetSecret(sKey)
-		content = strings.ReplaceAll(content, string(secret), censored)
 	}
 	return content
 }

--- a/prow/config/secret/agent_test.go
+++ b/prow/config/secret/agent_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package secret
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestCensoringFormatter(t *testing.T) {
@@ -65,8 +67,13 @@ func TestCensoringFormatter(t *testing.T) {
 			expected:    "level=panic msg=\"A CENSORED is a CENSORED\"\n",
 		},
 		{
-			description: "occurrences of a multiple secrets in a field",
+			description: "occurrences of multiple secrets in a field",
 			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": "A SECRET is a MYSTERY"}},
+			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+		},
+		{
+			description: "occurrences of a secret in a non-string field",
+			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": fmt.Errorf("A SECRET is a MYSTERY")}},
 			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
 		},
 	}

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -102,9 +102,9 @@ func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dry
 	}
 
 	if dryRun {
-		return github.NewDryRunClientWithFields(fields, *generator, o.graphqlEndpoint, o.endpoint.Strings()...), nil
+		return github.NewDryRunClientWithFields(fields, *generator, secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...), nil
 	}
-	return github.NewClientWithFields(fields, *generator, o.graphqlEndpoint, o.endpoint.Strings()...), nil
+	return github.NewClientWithFields(fields, *generator, secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...), nil
 }
 
 // GitHubClient returns a GitHub client.

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -193,6 +193,9 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 		}
 
+		noopCensor := func(content []byte) []byte {
+			return content
+		}
 		// If access token exists, get user login using the access token. This is a
 		// chance to validate whether the access token is consumable or not. If
 		// not, we invalidate the sessions and continue as if not logged in.
@@ -200,7 +203,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 		var user *github.User
 		var botName string
 		if ok && token.Valid() {
-			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+			githubClient := github.NewClient(func() []byte { return []byte(token.AccessToken) }, noopCensor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 			var err error
 			botName, err = githubClient.BotName()
 			user = &github.User{Login: botName}
@@ -237,7 +240,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 
 			// Construct query
-			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+			ghc := github.NewClient(func() []byte { return []byte(token.AccessToken) }, noopCensor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -174,9 +174,9 @@ func main() {
 
 	var c client
 	if o.confirm {
-		c = github.NewClient(secretAgent.GetTokenGenerator(o.token), o.graphqlEndpoint, o.endpoint.Strings()...)
+		c = github.NewClient(secretAgent.GetTokenGenerator(o.token), secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.token), o.graphqlEndpoint, o.endpoint.Strings()...)
+		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.token), secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	}
 
 	query, err := makeQuery(o.query, o.includeArchived, o.includeClosed, o.updated)

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -102,9 +102,9 @@ func main() {
 
 	var c client
 	if o.confirm {
-		c = github.NewClient(secretAgent.GetTokenGenerator(o.tokenPath), o.graphqlEndpoint, o.endpoint.Strings()...)
+		c = github.NewClient(secretAgent.GetTokenGenerator(o.tokenPath), secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.tokenPath), o.graphqlEndpoint, o.endpoint.Strings()...)
+		c = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.tokenPath), secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	}
 
 	// get all open PRs


### PR DESCRIPTION
Factor out censoring helper from the secret agent for reuse

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Censor during post-processing for logging

It is not simple to determine which of the possible types embedded in a
logger will be string-ified into something containing sensitive
information, so it is better to post-process the delegate's formatted
output for a log and be certain we catch all types of leaked
credentials.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Censor outgoing content to GitHub

We should disallow content in our secret agent to be posted to GitHub.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

