### PR TITLE
mkbuild-cluster create cert and key (if needed)

### DIFF
--- a/prow/cmd/mkbuild-cluster/BUILD.bazel
+++ b/prow/cmd/mkbuild-cluster/BUILD.bazel
@@ -6,9 +6,13 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/mkbuild-cluster",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/gencert:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )


### PR DESCRIPTION
This is to patch current cert retrieval logic in `mkbuild-cluster` (#13820).
> **NOTE:** future improvements will be towards alternative, provider-agnostic auth strategies (#13972)

/assign @fejta 