### PR TITLE
Sort sig-release testgrid dashboards manually

### DIFF
--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -3,20 +3,20 @@
 dashboard_groups:
 - name: sig-release
   dashboard_names:
-  - sig-release-1.13-all
-  - sig-release-1.13-blocking
-  - sig-release-1.13-informing
-  - sig-release-1.14-all
-  - sig-release-1.14-blocking
-  - sig-release-1.14-informing
-  - sig-release-1.15-all
-  - sig-release-1.15-blocking
-  - sig-release-1.15-informing
-  - sig-release-1.16-all
-  - sig-release-1.16-blocking
-  - sig-release-1.16-informing
   - sig-release-master-blocking
   - sig-release-master-informing
+  - sig-release-1.16-blocking
+  - sig-release-1.16-informing
+  - sig-release-1.16-all
+  - sig-release-1.15-blocking
+  - sig-release-1.15-informing
+  - sig-release-1.15-all
+  - sig-release-1.14-blocking
+  - sig-release-1.14-informing
+  - sig-release-1.14-all
+  - sig-release-1.13-blocking
+  - sig-release-1.13-informing
+  - sig-release-1.13-all
   - sig-release-misc
   - sig-release-orphaned
   - sig-release-publishing-bot


### PR DESCRIPTION
I now realize the old dashboard order is a thing I was used to,
and was surprised to see it changed when navigating testgrid.

Manual order is as follows:
- master-* boards are the most frequently accessed and should
  be first / top-left
- then release-1.y-* boards ordered by strongest signal, then recency
- non release team dashboards alpha-sorted

/priority important-soon