### PR TITLE
Roll back the bigquery image version used for metrics-kettle

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -102,7 +102,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20190816-95e572a
+    - image: gcr.io/k8s-testimages/bigquery:v20180330-f723e8d3f
       args:
       - --scenario=execute
       - --


### PR DESCRIPTION
Currently it's busted.

/cc @cjwagner @spiffxp 