### PR TITLE
rules_nodejs 0.36.0 builds bad bundles.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -173,8 +173,8 @@ git_repository(
 # https://github.com/bazelbuild/rules_nodejs
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "9abd649b74317c9c135f4810636aaa838d5bea4913bfa93a85c2f52a919fdaf3",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.36.0/rules_nodejs-0.36.0.tar.gz"],
+    sha256 = "6d4edbf28ff6720aedf5f97f9b9a7679401bf7fca9d14a0fff80f644a99992b4",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.32.2/rules_nodejs-0.32.2.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")


### PR DESCRIPTION
Roll this upgrade back until we figure out how this changed yet again.

/cc @fejta 