### PR TITLE
pull-cip-lint: turn on GitHub reporting

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -53,7 +53,7 @@ presubmits:
   # Run linter.
   - name: pull-cip-lint
     decorate: true
-    skip_report: true
+    skip_report: false
     always_run: true
     branches:
     - ^master$


### PR DESCRIPTION
The linter job passes now (since
https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/108).
So we should turn the reporting on.