### PR TITLE
Add kind release-blocking jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -1,0 +1,302 @@
+periodics:
+- interval: 20m
+  name: ci-kubernetes-kind-e2e-parallel
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, sig-testing-kind
+    testgrid-tab-name: kind-master-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes master cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-master
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=master"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 20m
+  name: ci-kubernetes-kind-ipv6-e2e-parallel
+  annotations:
+    testgrid-dashboards: sig-release-master-blocking, sig-testing-kind
+    testgrid-tab-name: kind-ipv6-master-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    # run on the ubuntu node pool, which has ipv6 modules
+    tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "ubuntu"
+      effect: "NoSchedule"
+    nodeSelector:
+      dedicated: "ubuntu"
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-master
+      env:
+      # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
+      # tell kind CI script to use ipv6
+      - name: "IP_FAMILY"
+        value: "ipv6"
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=master"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 1h
+  name: ci-kubernetes-kind-e2e-parallel-latest-1-16
+  annotations:
+    testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
+    testgrid-tab-name: kind-1.16-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes release-1.16 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-1.16
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.16"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 1h
+  name: ci-kubernetes-kind-ipv6-e2e-parallel-latest-1-16
+  annotations:
+    testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
+    testgrid-tab-name: kind-ipv6-1.16-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes release-1.16 IPv6 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-1.16
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.16"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 1h
+  name: ci-kubernetes-kind-e2e-parallel-latest-1-15
+  annotations:
+    testgrid-dashboards: sig-release-1.15-blocking, sig-testing-kind
+    testgrid-tab-name: kind-1.15-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes release-1.15 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-managers@kubernetes.io
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-1.15
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.15"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 1h
+  name: ci-kubernetes-kind-e2e-parallel-latest-1-14
+  annotations:
+    testgrid-dashboards: sig-release-1.14-blocking, sig-testing-kind
+    testgrid-tab-name: kind-1.14-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes release-1.14 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-managers@kubernetes.io
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-1.14
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.14"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 1h
+  name: ci-kubernetes-kind-e2e-parallel-latest-1-13
+  annotations:
+    testgrid-dashboards: sig-release-1.13-blocking, sig-testing-kind
+    testgrid-tab-name: kind-1.13-parallel
+    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes release-1.13 cluster created with sigs.k8s.io/kind
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-managers@kubernetes.io
+    testgrid-num-columns-recent: '3'
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-1.13
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.13"
+      - "--repo=sigs.k8s.io/kind=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--scenario=execute"
+      - "--"
+      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m


### PR DESCRIPTION
These are based off of ci-kubernetes-kind-conformance-*

The reason I made separate copies is to allow for the addition of
additional FOCUS regexes as we find e2e tests that can run on kind
beyond just [Conformance] tests. Functionally these jobs are
identical.

When I asked about adding these jobs during the 2019-07-30
sig-release meeting I was given the go-ahead to add directly
to release-blocking

The reason I put these in their own file is in case we feel these
jobs should live elsehwere

Main differences are:
- dash-naming-scheme
- description matches others e2e jobs in release-master-blocking
- annotations moved up underneath name
- dropped the 1.12 job
- added 1.15 and 1.16 jobs
  - only add 1.16 ipv6 job since support was added in 1.16 cycle
- kubernetes-release-team@ added to master, 1.16 alert emails
- release-manager@ added to 1.15 - 1.13 alert emails