### PR TITLE
Update rules_nodejs to 0.36.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -173,8 +173,8 @@ git_repository(
 # https://github.com/bazelbuild/rules_nodejs
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "6d4edbf28ff6720aedf5f97f9b9a7679401bf7fca9d14a0fff80f644a99992b4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.32.2/rules_nodejs-0.32.2.tar.gz"],
+    sha256 = "9abd649b74317c9c135f4810636aaa838d5bea4913bfa93a85c2f52a919fdaf3",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.36.0/rules_nodejs-0.36.0.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/gopherage/cmd/html/static/BUILD.bazel
+++ b/gopherage/cmd/html/static/BUILD.bazel
@@ -48,6 +48,7 @@ ts_library(
 
 rollup_bundle(
     name = "browser_bundle",
+    enable_code_splitting = False,
     entry_point = ":browser.ts",
     deps = [
         ":browser",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "devDependencies": {
     "@bazel/bazel": "0.27.0",
-    "@bazel/jasmine": "0.32.2",
-    "@bazel/typescript": "0.32.2",
+    "@bazel/jasmine": "0.36.0",
+    "@bazel/typescript": "0.36.0",
     "@types/color": "^3.0.0",
     "@types/google.visualization": "^0.0.43",
     "@types/gtag.js": "^0.0.0",

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -62,6 +62,7 @@ jasmine_node_test(
 
 rollup_bundle(
     name = "prow_bundle",
+    enable_code_splitting = False,
     entry_point = ":prow/prow.ts",
     deps = [
         ":prow",
@@ -80,6 +81,7 @@ ts_library(
 
 rollup_bundle(
     name = "plugin_help_bundle",
+    enable_code_splitting = False,
     entry_point = ":plugin-help/plugin-help.ts",
     deps = [
         ":plugin_help",
@@ -98,6 +100,7 @@ ts_library(
 
 rollup_bundle(
     name = "pr_bundle",
+    enable_code_splitting = False,
     entry_point = "pr/pr.ts",
     deps = [
         ":pr",
@@ -117,6 +120,7 @@ ts_library(
 
 rollup_bundle(
     name = "tide_bundle",
+    enable_code_splitting = False,
     entry_point = ":tide/tide.ts",
     deps = [
         ":tide",
@@ -136,6 +140,7 @@ ts_library(
 
 rollup_bundle(
     name = "tide_history_bundle",
+    enable_code_splitting = False,
     entry_point = ":tide-history/tide-history.ts",
     deps = [
         ":tide_history",
@@ -154,6 +159,7 @@ ts_library(
 
 rollup_bundle(
     name = "command_help_bundle",
+    enable_code_splitting = False,
     entry_point = ":command-help/command-help.ts",
     deps = [
         ":command_help",
@@ -185,6 +191,7 @@ ts_library(
 
 rollup_bundle(
     name = "spyglass_bundle",
+    enable_code_splitting = False,
     entry_point = ":spyglass/spyglass.ts",
     deps = [
         ":spyglass",
@@ -194,6 +201,7 @@ rollup_bundle(
 
 rollup_bundle(
     name = "spyglass_lens_bundle",
+    enable_code_splitting = False,
     entry_point = ":spyglass/lens.ts",
     deps = [
         ":spyglass_common",

--- a/prow/spyglass/lenses/buildlog/BUILD.bazel
+++ b/prow/spyglass/lenses/buildlog/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
 
 rollup_bundle(
     name = "script_bundle",
+    enable_code_splitting = False,
     entry_point = ":buildlog.ts",
     deps = [
         ":script",

--- a/prow/spyglass/lenses/coverage/BUILD.bazel
+++ b/prow/spyglass/lenses/coverage/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
 
 rollup_bundle(
     name = "script_bundle",
+    enable_code_splitting = False,
     entry_point = ":coverage.ts",
     deps = [
         ":script",

--- a/prow/spyglass/lenses/junit/BUILD.bazel
+++ b/prow/spyglass/lenses/junit/BUILD.bazel
@@ -24,6 +24,7 @@ ts_library(
 
 rollup_bundle(
     name = "script_bundle",
+    enable_code_splitting = False,
     entry_point = ":lens.ts",
     deps = [
         ":script",

--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -26,6 +26,7 @@ ts_library(
 
 rollup_bundle(
     name = "script_bundle",
+    enable_code_splitting = False,
     entry_point = ":metadata.ts",
     deps = [
         ":script",

--- a/prow/spyglass/write-a-lens.md
+++ b/prow/spyglass/write-a-lens.md
@@ -105,6 +105,7 @@ ts_library(
 
 rollup_bundle(
     name = "script_bundle",
+    enable_code_splitting = False,
     entry_point = ":sample.ts",
     deps = [
         ":script",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,19 +26,19 @@
     "@bazel/bazel-linux_x64" "0.27.0"
     "@bazel/bazel-win32_x64" "0.27.0"
 
-"@bazel/jasmine@0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.32.2.tgz#6375b5b0de3f352c2b2280c54878dd30915fc139"
-  integrity sha512-izF9hBcbTOj1VhJVeo8G479dXo9KlibX0N6Yag15GaIk1fibW4iRyTBC2fy4ihm31CYIId6Zd9AABVShd+1Sgw==
+"@bazel/jasmine@0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.36.0.tgz#26d5b455cdcf09b0000a5a7d50d672ef3a386388"
+  integrity sha512-1UEcHOtn+tqaibNJosGsNrDWvIc5KCrH3OlfYZ8g2Eg8wJ9LPLoKw2BPNz3QIqN2TNUSsjLwVE7HZU/PV3ktNQ==
   dependencies:
-    jasmine "~3.3.1"
-    jasmine-core "~3.3.0"
+    jasmine "~3.4.0"
+    jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.32.2.tgz#c296bb44cb6362a0e3a08ca88752852bc9591ecf"
-  integrity sha512-32zDyvHdYjIa63vtImhl6wy5ErOFVWPkjMT2T035D0UPSKI1tvENW/bRZ3QFlFHqfmJZRBpaI3GiUpO3vUvzmw==
+"@bazel/typescript@0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.36.0.tgz#e080255c4219a5e045fb6ae6aacce966c34e4628"
+  integrity sha512-/Kb/Uxi4nuJrbSAJTre0aE0D9BwIgEpsuwMJ/ThA25rlJ6Xl3UG4EYbgsrf66PZvznKOVdu6Jc8bVvhG3ldSPw==
   dependencies:
     protobufjs "6.8.8"
     semver "5.6.0"
@@ -399,7 +399,7 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
-glob@^7.0.6, glob@^7.1.1:
+glob@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -531,23 +531,10 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-jasmine-core@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.3.0.tgz#dea1cdc634bc93c7e0d4ad27185df30fa971b10e"
-  integrity sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==
-
 jasmine-core@~3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.4.0.tgz#2a74618e966026530c3518f03e9f845d26473ce3"
   integrity sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==
-
-jasmine@~3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.3.1.tgz#d61bb1dd8888859bd11ea83074a78ee13d949905"
-  integrity sha512-/vU3/H7U56XsxIXHwgEuWpCgQ0bRi2iiZeUpx7Nqo8n1TpoDHfZhkPIc7CO8I4pnMzYsi3XaSZEiy8cnTfujng==
-  dependencies:
-    glob "^7.0.6"
-    jasmine-core "~3.3.0"
 
 jasmine@~3.4.0:
   version "3.4.0"


### PR DESCRIPTION
To make this work we have to set `enable_code_splitting = False` on all `rollup_bundle` targets.

I can't figure out how this is actually supposed to work, and all the examples either disable it or use an unfinished internal API. Disabling the new feature works, though.