### PR TITLE
kettle - upgrade py2 -> py3

### DIFF
--- a/hack/verify-pylint.sh
+++ b/hack/verify-pylint.sh
@@ -38,4 +38,4 @@ shopt -s extglob globstar
 
 # TODO(clarketm) there is no version of `pylint` that supports "both" PY2 and PY3
 # I am disabling pylint checks for python3 files until migration complete
-"$DIR/pylint_bin" !(metrics|triage|velodrome|hack|gubernator|external|vendor|testgrid|bazel-*)/**/*.py
+"$DIR/pylint_bin" !(kettle|metrics|triage|velodrome|hack|gubernator|external|vendor|testgrid|bazel-*)/**/*.py

--- a/kettle/BUILD.bazel
+++ b/kettle/BUILD.bazel
@@ -11,12 +11,12 @@ py_test(
     # https://github.com/bazelbuild/bazel/issues/1973
     # https://github.com/bazelbuild/bazel/issues/2056
     local = True,
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         requirement("certifi"),
         requirement("chardet"),
         requirement("idna"),
-        requirement("PyYAML"),
+        requirement("ruamel.yaml"),
         requirement("requests"),
         requirement("urllib3"),
     ],
@@ -28,7 +28,7 @@ py_binary(
         "make_db.py",
         "model.py",
     ],
-    python_version = "PY2",
+    python_version = "PY3",
 )
 
 # TODO(rmmh): re-enable when Bazel is fixed.
@@ -51,7 +51,7 @@ py_test(
         "model_test.py",
         ":package-srcs",
     ],
-    python_version = "PY2",
+    python_version = "PY3",
 )
 
 py_test(
@@ -65,12 +65,12 @@ py_test(
         "buckets.yaml",
         "schema.json",
     ],
-    python_version = "PY2",
+    python_version = "PY3",
     deps = [
         requirement("certifi"),
         requirement("chardet"),
         requirement("idna"),
-        requirement("PyYAML"),
+        requirement("ruamel.yaml"),
         requirement("requests"),
         requirement("urllib3"),
     ],
@@ -87,8 +87,8 @@ py_test(
     data = [":buckets.yaml"],
     # idem
     local = True,
-    python_version = "PY2",
-    deps = [requirement("PyYAML")],
+    python_version = "PY3",
+    deps = [requirement("ruamel.yaml")],
 )
 
 filegroup(

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu
+FROM ubuntu:18.04
+
+ENV KETTLE_DB=/data/build.db
+ENV TZ=America/Los_Angeles
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get install -y \
     tzdata \
@@ -20,21 +26,23 @@ RUN apt-get update && apt-get install -y \
     pv \
     time \
     sqlite3 \
-    python-pip \
+    python \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2 | tar xj -C opt
-RUN ln -s /opt/pypy*/bin/pypy /usr/bin
+RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.24.0 influxdb ruamel.yaml==0.16
 
-ADD requirements.txt /kettle/
-RUN pip install -r /kettle/requirements.txt
+RUN curl -fsSL https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 | tar xj -C opt  && \
+    ln -s /opt/pypy*/bin/pypy /usr/bin
 
-RUN curl -o installer https://sdk.cloud.google.com && bash installer --disable-prompts --install-dir=/ && rm installer && ln -s /google-cloud-sdk/bin/* /bin/
-
-ENV KETTLE_DB=/data/build.db
-ENV TZ=America/Los_Angeles
+RUN curl -o installer https://sdk.cloud.google.com && \
+    bash installer --disable-prompts --install-dir=/ && \
+    rm installer && \
+    ln -s /google-cloud-sdk/bin/* /bin/
 
 ADD *.py schema.json runner.sh buckets.yaml /kettle/
 
-CMD ["/kettle/runner.sh"]
 VOLUME ["/data"]
+
+CMD ["/kettle/runner.sh"]

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -14,13 +14,12 @@
 
 FROM ubuntu:18.04
 
-ENV KETTLE_DB=/data/build.db
-ENV TZ=America/Los_Angeles
+ENV KETTLE_DB=/data/build.db TZ=America/Los_Angeles
 
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    echo $TZ > /etc/timezone
-
-RUN apt-get update && apt-get install -y \
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone \
+    && apt-get update \
+    && apt-get install -y \
     tzdata \
     curl \
     pv \

--- a/kettle/make_db_test.py
+++ b/kettle/make_db_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -81,15 +81,15 @@ def parse_junit(xml):
 
 
 def buckets_yaml():
-    import yaml  # does not support pypy
+    import ruamel.yaml as yaml  # does not support pypy
     with open(os.path.dirname(os.path.abspath(__file__))+'/buckets.yaml') as fp:
-        return yaml.load(fp)
+        return yaml.safe_load(fp)
 
 # pypy compatibility hack
-def python_buckets_yaml(python='python2'):
+def python_buckets_yaml(python='python3'):
     return json.loads(subprocess.check_output(
-        [python, '-c', 'import json,yaml; print json.dumps(yaml.load(open("buckets.yaml")))'],
-        cwd=os.path.dirname(os.path.abspath(__file__))))
+        [python, '-c', 'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'],
+        cwd=os.path.dirname(os.path.abspath(__file__)), encoding='utf-8'))
 
 for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
     try:
@@ -105,7 +105,7 @@ else:
 
 def path_to_job_and_number(path):
     assert not path.endswith('/')
-    for bucket, meta in BUCKETS.iteritems():
+    for bucket, meta in BUCKETS.items():
         if path.startswith(bucket):
             prefix = meta['prefix']
             break
@@ -171,7 +171,7 @@ def row_for_build(path, started, finished, results):
             if metadata.get('version') == build_version:
                 metadata.pop('version')
             for key, value in metadata.items():
-                if not isinstance(value, basestring):
+                if not isinstance(value, str):
                     # the schema specifies a string value. force it!
                     metadata[key] = json.dumps(value)
         if not metadata:
@@ -247,9 +247,9 @@ def main(db, opts, outfile):
 
     if rows_emitted:
         gen = db.insert_emitted(rows_emitted, incremental_table=incremental_table)
-        print >>sys.stderr, 'incremental progress gen #%d' % gen
+        print('incremental progress gen #%d' % gen, file=sys.stderr)
     else:
-        print >>sys.stderr, 'no rows emitted'
+        print('no rows emitted', file=sys.stderr)
     return 0
 
 

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -89,7 +89,7 @@ def buckets_yaml():
 def python_buckets_yaml(python='python3'):
     return json.loads(subprocess.check_output(
         [python, '-c', 'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'],
-        cwd=os.path.dirname(os.path.abspath(__file__)), encoding='utf-8'))
+        cwd=os.path.dirname(os.path.abspath(__file__))).decode("utf-8"))
 
 for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
     try:

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cStringIO as StringIO
+import io as StringIO
 import json
 import time
 import unittest
@@ -26,7 +26,7 @@ import model
 class ValidateBuckets(unittest.TestCase):
     def test_buckets(self):
         prefixes = set()
-        for name, options in sorted(make_json.BUCKETS.iteritems()):
+        for name, options in sorted(make_json.BUCKETS.items()):
             if name == 'gs://kubernetes-jenkins/logs/':
                 continue  # only bucket without a prefix
             prefix = options.get('prefix', '')

--- a/kettle/model.py
+++ b/kettle/model.py
@@ -20,7 +20,7 @@ import time
 import zlib
 
 
-class Database(object):
+class Database:
     """
     Store build and test result information, and support incremental updates to results.
     """
@@ -103,9 +103,9 @@ class Database(object):
         """
         Insert a junit dictionary {gcs_path: contents} for a given build's rowid.
         """
-        for path, data in junits.iteritems():
+        for path, data in junits.items():
             self.db.execute('replace into file values(?,?)',
-                            (path, buffer(zlib.compress(data, 9))))
+                            (path, memoryview(zlib.compress(data.encode('utf-8'), 9))))
         self.db.execute('delete from build_junit_missing where build_id=?', (build_id,))
 
     ### make_json
@@ -156,7 +156,7 @@ class Database(object):
         for dataz, in self.db.execute(
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
-            data = zlib.decompress(dataz)
+            data = zlib.decompress(dataz).decode('utf-8')
             if data:
                 results.append(data)
         return results

--- a/kettle/model_test.py
+++ b/kettle/model_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 
 """Receive push events for new builds and upload rows to BigQuery."""
 
-from __future__ import print_function
+
 
 import argparse
 import json
@@ -69,15 +69,15 @@ def get_started_finished(gcs_client, db, todo):
     pool = multiprocessing.pool.ThreadPool(16)
     try:
         for ack_id, (build_dir, started, finished) in pool.imap_unordered(
-                lambda (ack_id, job, build): (ack_id, gcs_client.get_started_finished(job, build)),
+                lambda ack_id_job_build: (ack_id_job_build[0], gcs_client.get_started_finished(ack_id_job_build[1], ack_id_job_build[2])),
                 todo):
             if finished:
                 if not db.insert_build(build_dir, started, finished):
                     print('already present??')
                 start = time.localtime(started.get('timestamp', 0) if started else 0)
-                print(build_dir, bool(started), bool(finished),
+                print((build_dir, bool(started), bool(finished),
                       time.strftime('%F %T %Z', start),
-                      finished and finished.get('result'))
+                      finished and finished.get('result')))
                 build_dirs.append(build_dir)
                 acks.append(ack_id)
             else:
@@ -99,7 +99,7 @@ def row_to_mapping(row, schema):
 def retry(func, *args, **kwargs):
     """Run a function with arguments, retrying on server errors. """
     # pylint: disable=no-member
-    for attempt in xrange(20):
+    for attempt in range(20):
         try:
             return func(*args, **kwargs)
         except (socket.error, google.cloud.exceptions.ServerError):
@@ -184,7 +184,7 @@ def main(db, sub, tables, client_class=make_db.GCSClient, stop=None):
 
         if acks:
             print('ACK irrelevant', len(acks))
-            for n in xrange(0, len(acks), 1000):
+            for n in range(0, len(acks), 1000):
                 retry(sub.acknowledge, acks[n: n + 1000])
 
         if todo:
@@ -204,7 +204,7 @@ def main(db, sub, tables, client_class=make_db.GCSClient, stop=None):
 
         # stream new rows to tables
         if build_dirs and tables:
-            for table, incremental_table in tables.itervalues():
+            for table, incremental_table in tables.values():
                 builds = db.get_builds_from_paths(build_dirs, incremental_table)
                 emitted = insert_data(table, make_json.make_rows(db, builds))
                 db.insert_emitted(emitted, incremental_table)
@@ -256,7 +256,7 @@ def load_tables(dataset, tablespecs):
     return tables
 
 
-class StopWhen(object):
+class StopWhen:
     """A simple object that returns True once when the given hour begins."""
     def __init__(self, target, clock=lambda: time.localtime().tm_hour):
         self.clock = clock

--- a/kettle/stream_test.py
+++ b/kettle/stream_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -23,7 +23,7 @@ import make_db_test
 import model
 
 
-class FakeSub(object):
+class FakeSub:
     def __init__(self, pulls):
         self.pulls = pulls
         self.trace = []
@@ -39,7 +39,7 @@ class FakeSub(object):
         self.trace.append(['modify-ack', acks, time])
 
 
-class FakeTable(object):
+class FakeTable:
     def __init__(self, name, schema, trace=None):
         self.name = name
         self.schema = schema
@@ -50,12 +50,12 @@ class FakeTable(object):
         return []
 
 
-class Attrs(object):
+class Attrs:
     def __init__(self, attributes):
         self.attributes = attributes
 
 
-class FakeSchemaField(object):
+class FakeSchemaField:
     def __init__(self, **kwargs):
         self.__dict__ = kwargs
 
@@ -115,10 +115,10 @@ class StreamTest(unittest.TestCase):
                  now - 5,
                  now,
                  True,
-                 u'SUCCESS',
+                 'SUCCESS',
                  None,
-                 u'gs://kubernetes-jenkins/logs/fake/123',
-                 u'fake',
+                 'gs://kubernetes-jenkins/logs/fake/123',
+                 'fake',
                  123,
                  [],
                  [{'name': 'Foo', 'time': 3.0},

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Kubernetes Authors.
 #
@@ -19,14 +19,14 @@ import os
 
 
 def call(cmd):
-    print '+', cmd
+    print('+', cmd)
     status = os.system(cmd)
     if status:
         raise OSError('invocation failed')
 
 
 def main():
-    call('time python make_db.py --buckets buckets.yaml --junit --threads 32')
+    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32')
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
     mj_cmd = 'pypy make_json.py'
@@ -49,7 +49,7 @@ def main():
     call(mj_cmd + ' | pv | gzip > build_all.json.gz')
     call(bq_cmd + ' k8s-gubernator:build.all build_all.json.gz schema.json')
 
-    call('python stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
+    call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
          ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')
 
 


### PR DESCRIPTION
Additional effort towards #13164. The delta is rather large (yet necessary) for this update; the image was outdated and has not been pushed on over a year (03/18), so I took extra *caution* in the update. I verified all test **pass** and local execution of `runner.sh` without *obvious* runtime errors. 

Once this goes through the image will need to be rebuilt if this is not done automatically.

> **NOTE:** `launcher.gcr.io/google/bazel:0.28.1` runs python 3.5.2 so this was written to be compat with that particular version as well.