### PR TITLE
Add release/1.3 branch test for CRI plugin.

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -23,12 +23,57 @@ presubmits:
     - v0.1
     - release/1.0
     - release/1.2
+    - release/1.3
     decoration_config:
       timeout: 100m
     extra_refs:
     - org: kubernetes
       repo: kubernetes
       base_ref: master
+      path_alias: k8s.io/kubernetes
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - name: pull-cri-containerd-node-e2e
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190819-0b0980f-master
+        command:
+        - sh
+        - -c
+        - >
+          runner.sh
+          ./test/build.sh
+          &&
+          cd ${GOPATH}/src/k8s.io/kubernetes
+          &&
+          /workspace/scenarios/kubernetes_e2e.py
+          --deployment=node
+          --gcp-project=cri-c8d-pr-node-e2e
+          --gcp-zone=us-central1-f
+          '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          --node-tests=true
+          --provider=gce
+          '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
+          --timeout=65m
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+
+  - name: pull-cri-containerd-node-e2e
+    always_run: true
+    max_concurrency: 8
+    decorate: true
+    branches:
+    - release/1.3
+    decoration_config:
+      timeout: 100m
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.15
       path_alias: k8s.io/kubernetes
     - org: kubernetes
       repo: test-infra


### PR DESCRIPTION
The release/1.3 branch is cut in the CRI repo. https://github.com/containerd/cri/tree/release/1.3

Add presubmit test for it.

/cc @yujuhong @mikebrow @krzyzacy 

Signed-off-by: Lantao Liu <lantaol@google.com>