### PR TITLE
Manually update image for metrics-{bigquery,kettle} jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -70,7 +70,7 @@ periodics:
   interval: 24h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20190821-67acd53
+    - image: gcr.io/k8s-testimages/bigquery:v20190821-92d6d70
       args:
       - --scenario=execute
       - --
@@ -102,7 +102,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20190821-67acd53
+    - image: gcr.io/k8s-testimages/bigquery:v20190821-92d6d70
       args:
       - --scenario=execute
       - --


### PR DESCRIPTION
`metrics-bigquery` and `metrics-kettle` periodic jobs are using a stale image. https://k8s-testgrid.appspot.com/sig-testing-misc#metrics-kettle