### PR TITLE
[config/jobs][kubetest] Refactor version marker usage

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -22,7 +22,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=cos_containerd
       - --gcp-zone=us-central1-f
@@ -358,7 +358,7 @@ periodics:
       - --cluster=
       - --deployment=gke
       - --down=false
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=cos_containerd
       - --gcp-project=k8s-jkns-e2e-gci-gke-staging

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -289,7 +289,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=ca
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-e2e-gci-gke-autoscaling
@@ -318,7 +318,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=hpa
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-e2e-gci-gke-autoscaling
@@ -346,7 +346,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-gci-autoscaling-regio

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -69,7 +69,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -99,7 +99,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -547,7 +547,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -579,7 +579,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -609,7 +609,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -640,7 +640,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/sig-gcp-gpu-autoscaling.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/sig-gcp-gpu-autoscaling.yaml
@@ -15,7 +15,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-k80
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -45,7 +45,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-p100
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -75,7 +75,7 @@ periodics:
       - --cluster=ca-gpu
       - --deployment=gke
       - --env=TESTED_GPU_TYPE=nvidia-tesla-v100
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-gke-gpu-boskos-v100

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/sig-gcp-gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/sig-gcp-gpu-gke.yaml
@@ -13,7 +13,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -73,7 +73,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -101,7 +101,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -280,7 +280,7 @@ periodics:
       - --check-leaked-resources
       - --deployment=gke
       - --env=NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
       - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-gke-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-gke-config.yaml
@@ -57,7 +57,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -87,7 +87,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -116,7 +116,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -146,7 +146,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -174,7 +174,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -204,7 +204,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -232,7 +232,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -260,7 +260,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -288,7 +288,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -316,7 +316,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-e2e-regional
@@ -345,7 +345,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-region=us-central1
@@ -372,7 +372,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-region=us-central1
@@ -400,7 +400,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -429,7 +429,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --down=false
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-gke-gci-soak
@@ -465,7 +465,7 @@ periodics:
       - --deployment=gke
       - --env=CLOUDSDK_CONTAINER_USE_V1_API=false
       - --env=TAG=0.8.0
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=istio-project

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-windows.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-windows.yaml
@@ -87,7 +87,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci-cross/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -196,7 +196,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci-cross/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -235,7 +235,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci-cross/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
       - --provider=gce

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/k8s-upgrade-gke.yaml
@@ -15,7 +15,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -24,7 +24,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
 
 # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
@@ -49,7 +49,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -59,7 +59,7 @@ periodics:
       - --skew
       - --timeout=1200m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
 
   annotations:
@@ -81,7 +81,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -92,7 +92,7 @@ periodics:
       - --skew
       - --timeout=1200m
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
 
   annotations:
@@ -114,7 +114,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -124,7 +124,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
 
   annotations:
@@ -146,7 +146,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -155,7 +155,7 @@ periodics:
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
-      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci-cross/latest --upgrade-image=gci
+      - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-master
 
   annotations:
@@ -177,7 +177,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --extract=ci/k8s-stable2
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
@@ -615,7 +615,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c
@@ -647,7 +647,7 @@ periodics:
       - --check-version-skew=false
       - --deployment=gke
       - --extract=ci/k8s-stable1
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-c

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -165,7 +165,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -246,7 +246,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
@@ -300,7 +300,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-e2e-gke-stackdriver

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -403,7 +403,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=ingress-project
@@ -433,7 +433,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --deployment=gke
-      - --extract=ci-cross/latest
+      - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -151,34 +151,4 @@ periodics:
     fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: build-master
-    testgrid-alert-email: "kubernetes-release-team@googlegroups.com"
-
-- interval: 1h
-  name: ci-kubernetes-cross-build
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190817-7b62498
-      args:
-      - --repo=k8s.io/kubernetes
-      - --repo=k8s.io/release
-      - --root=/go/src
-      - --timeout=120
-      - --scenario=kubernetes_build
-      - --
-      - --hyperkube
-      - --registry=gcr.io/kubernetes-ci-images
-      - --suffix=-cross
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7
-          memory: "41Gi"
-  annotations:
-    testgrid-dashboards: sig-release-misc
-    testgrid-tab-name: cross-build
-    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    testgrid-alert-email: release-managers@kubernetes.io,kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -28,7 +28,42 @@ presubmits:
             memory: "41Gi"
     annotations:
       testgrid-create-test-group: 'true'
+
 periodics:
+- interval: 1h
+  name: ci-kubernetes-build
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20190817-7b62498
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=180
+      - --scenario=kubernetes_build
+      - --
+      - --allow-dup
+      - --extra-publish-file=k8s-master
+      - --hyperkube
+      - --registry=gcr.io/kubernetes-ci-images
+        # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-release-master-blocking
+    testgrid-tab-name: build-master
+    testgrid-alert-email: release-managers@kubernetes.io,kubernetes-release-team@googlegroups.com
+
 - interval: 5m
   name: ci-kubernetes-build-fast
   labels:
@@ -118,37 +153,3 @@ periodics:
     testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: build-packages-rpms
-
-- interval: 1h
-  name: ci-kubernetes-build
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190817-7b62498
-      args:
-      - --repo=k8s.io/kubernetes
-      - --repo=k8s.io/release
-      - --root=/go/src
-      - --timeout=180
-      - --scenario=kubernetes_build
-      - --
-      - --allow-dup
-      - --extra-publish-file=k8s-master
-      - --hyperkube
-      - --registry=gcr.io/kubernetes-ci-images
-        # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 4
-          memory: "8Gi"
-  annotations:
-    fork-per-release: "true"
-    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
-    fork-per-release-generic-suffix: "true"
-    testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: build-master
-    testgrid-alert-email: release-managers@kubernetes.io,kubernetes-release-team@googlegroups.com

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -49,7 +49,6 @@ const (
 	gcs                 // gs://bucket/prefix/v1.6.0-alpha.0
 	load                // Load a --save cluster
 	bazel               // A pre/postsubmit bazel build version, prefixed with bazel/
-	ciCross             // ci-cross/latest
 )
 
 type extractStrategy struct {
@@ -82,7 +81,6 @@ func (l *extractStrategies) Set(value string) error {
 		`^(v\d+\.\d+\.\d+[\w.\-+]*)$`: version,
 		`^(gs://.*)$`:                 gcs,
 		`^(bazel/.*)$`:                bazel,
-		`^ci-cross/(.+)$`:             ciCross,
 	}
 
 	if len(*l) == 2 {
@@ -513,9 +511,6 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		return loadState(e.option, extractSrc)
 	case bazel:
 		return getKube("", e.option, extractSrc)
-	case ciCross:
-		prefix := "kubernetes-release-dev/ci-cross"
-		return setReleaseFromHTTP(prefix, e.option, extractSrc)
 	}
 	return fmt.Errorf("Unrecognized extraction: %v(%v)", e.mode, e.value)
 }

--- a/prow/cmd/tot/main_test.go
+++ b/prow/cmd/tot/main_test.go
@@ -202,11 +202,11 @@ func TestGetURL(t *testing.T) {
 		{
 			name: "fallback bucket - periodic",
 
-			jobName: "ci-kubernetes-cross-build",
+			jobName: "ci-kubernetes-build",
 			c:       c,
 			bucket:  "https://storage.googleapis.com/kubernetes-jenkins",
 
-			expected: "https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-cross-build/latest-build.txt",
+			expected: "https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-build/latest-build.txt",
 		},
 		{
 			name: "fallback bucket - unknown",


### PR DESCRIPTION
- Use `ci/k8s-master` marker for Windows node jobs (`--ginkgo.skip=\[LinuxOnly\]`)
- Replace `ci-cross/latest` marker with `ci/latest`
- Remove references to ci-cross GCS bucket (kubernetes-release-dev/ci-cross)
  in kubetest
- Remove extraneous `ci-kubernetes-cross-build`
  (`ci-kubernetes-build` already does a cross-build)
- Add release-managers@kubernetes.io to ci-kubernetes-build alerts
- Rearrange kubernetes-builds.yaml

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

---


This PR came about from [an issue regarding discrepancies in the versions of CI container images available](https://github.com/kubernetes/release/issues/854) and [the chat](https://kubernetes.slack.com/archives/C2C40FMNF/p1566398444348500) @neolit123, @BenTheElder, and I had to try and investigate that.

```shell
$ curl -L https://dl.k8s.io/ci/latest.txt
v1.17.0-alpha.0.433+8dea3310e532fc


$ curl -L https://dl.k8s.io/ci-cross/latest.txt
v1.17.0-alpha.0.431+c008cf95a92c5b
```

`latest.txt` is a version marker file that we use for consuming Kubernetes versions and is described in some detail here: https://github.com/kubernetes/test-infra/blob/de444e721bee5dcb5203a0d915ed66b392def117/docs/kubernetes-versions.md

### So, why are they different?

[`push-build.sh`](https://github.com/kubernetes/release/blob/f7a62b08a652f269927bc3d65fed0b68e63f4a63/push-build.sh#L225-L236) is a script responsible for building [Kubernetes artifacts](https://github.com/kubernetes/sig-release/blob/83de5102f00be6133ff72b39c5fa9f6cd8f77d3e/release-engineering/artifacts.md), including tarballs, container images, and version marker files.

We currently have three jobs that push master branch-targeted jobs that push `latest.txt` version marker files:
- [`ci-kubernetes-build-fast`](https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L32-L60), which runs a `make quick-release`
- [`ci-kubernetes-build`](https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L122-L154), which runs a `make release`
- [`ci-kubernetes-cross-build`](https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L156-L184), which runs a `make release`

That means at any one time https://dl.k8s.io/ci/latest.txt will represent the build version from `ci-kubernetes-build-fast` or `ci-kubernetes-build`, and https://dl.k8s.io/ci-cross/latest.txt will represent the build version from `ci-kubernetes-cross-build`.

Additionally, `ci-kubernetes-build` AND `ci-kubernetes-cross-build` publish container images to the [CI GCR](https://console.cloud.google.com/gcr/images/kubernetes-ci-images/GLOBAL), which leads to the inconsistency that was reported.

### Let's fix that!

Okay. The next piece is figuring out which job(s) we should get rid of.
From the configs above, you can see that `ci-kubernetes-build` and `ci-kubernetes-cross-build` are nearly identical.

A few things stand out in `ci-kubernetes-build` though...
https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L138

The extra publish file means we're writing an additional version marker `k8s-master.txt`.

https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L149

`fork-per-release` allows this job to be forked when we generate new release branches.

https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L150

`fork-per-release-replacements` is rewriting `k8s-master.txt` to `k8s-beta.txt` when we generate a new release branch.

https://github.com/kubernetes/test-infra/blob/7fa9a9c372cfaf3b0e05396a5459326047d4bf46/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L152

This job is on the [`sig-release-master-blocking` dashboard](https://testgrid.k8s.io/sig-release-master-blocking).

Finally, we can see that `ci/latest` is used more frequently than `ci-cross/latest` for test jobs:

- https://cs.k8s.io/?q=ci%2Flatest&i=nope&files=&repos=kubernetes/test-infra
- https://cs.k8s.io/?q=ci-cross%2Flatest&i=nope&files=&repos=kubernetes/test-infra

All of that suggests that we should get rid of `ci-kubernetes-cross-build`. As point of note, both jobs are running `make release`, which is a cross-build.

### What about `ci-kubernetes-build-fast`?

We now know that `ci-kubernetes-build-fast` and `ci-kubernetes-build` will publish a `latest.txt` marker to the same GCS, which means at any one time `ci/latest` could reference a `linux-amd64` build or a cross-build.

This is inconsistent behavior, and if you depend on having artifacts that only exist in cross-builds, then you could be looking at test failures when they don't exist in `ci/latest`.

For jobs that `ci/latest`, we can sort of infer that they can pass using the artifacts from a `linux-amd64` build or a cross-build.

The jobs that use `ci-cross/latest` are the ones we need to worry about breaking.

### Who needs a cross build?

Thinking about it a little, we basically target tests on `linux-amd64` or Windows, so the Windows jobs are the ones we need to worry about.

You can hone on those here: https://cs.k8s.io/?q=LinuxOnly&i=nope&files=&repos=kubernetes/test-infra.

There are a few Windows jobs that use `ci-cross/latest` and `--ginkgo.skip=\[LinuxOnly\]`.

Now how do we differentiate between jobs that need cross-build and those that don't?

Remember the `ci-kubernetes-build` job?

It publishes another marker file, `ci/k8s-master.txt`, which can be used to specify a cross-build, instead of `ci-cross/latest`.

From what I can gather, all of this effectively removes our need to use https://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci-cross/

/hold