### PR TITLE
Make tide history page load much faster

### DIFF
--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -224,7 +224,7 @@ function redraw(): void {
     }
   }
   // Sort by descending time.
-  filteredRecs = filteredRecs.sort((a, b) => moment(b.time).unix() - moment(a.time).unix());
+  filteredRecs = filteredRecs.sort((a, b) => a.time > b.time ? -1 : (a.time < b.time ? 1 : 0));
   redrawRecords(filteredRecs);
 }
 


### PR DESCRIPTION
The tide history page currently takes several seconds to load. As it turns out, 90% of that time is spent parsing date strings for sorting purposes. This takes approximately forever.

Also, the string representation used sorts lexicographically anyway, so the parsing is entirely unnecessary in the first place.

Change the sort to just use the strings directly, reducing sort time on my workstation from 6 seconds to negligible.

/cc @stevekuznetsov @michelle192837 @cjwagner 