### PR TITLE
kubeadm: add 1.16 jobs for kind/kinder

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -757,6 +757,87 @@ presubmits:
     trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
   - agent: kubernetes
     always_run: false
+    branches:
+    - release-1.16
+    cluster: security
+    context: pull-security-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: kubernetes-security-prow
+        default_org: kubernetes
+        default_repo: kubernetes
+        path_strategy: legacy
+      gcs_credentials_secret: service-account
+      grace_period: 15s
+      timeout: 40m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kubeadm
+      repo: kubeadm
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/kind
+      repo: kind
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+    name: pull-security-kubernetes-e2e-kind
+    optional: true
+    path_alias: k8s.io/kubernetes
+    rerun_command: /test pull-security-kubernetes-e2e-kind
+    spec:
+      containers:
+      - args:
+        - --ssh=/etc/ssh-security/ssh-security
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=stable
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        command:
+        - runner.sh
+        - kubetest
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /etc/ssh-security
+          name: ssh-security
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - name: ssh-security
+        secret:
+          defaultMode: 256
+          secretName: ssh-security
+    trigger: (?m)^/test( | .* )pull-security-kubernetes-e2e-kind,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
     cluster: security
     context: pull-security-kubernetes-e2e-kind
     decorate: true
@@ -786,6 +867,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     rerun_command: /test pull-security-kubernetes-e2e-kind
     skip_branches:
+    - release-1.16
     - release-1.15
     - release-1.14
     - release-1.13

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -259,6 +259,92 @@ periodics:
         path: /sys/fs/cgroup
         type: Directory
 
+- name: ci-kubernetes-e2e-kubeadm-kind-1-16
+  interval: 12h
+  decorate: true
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.16-informing
+    testgrid-tab-name: kubeadm-kind-1-16
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kind); Uses kubeadm/kind to create a cluster and run the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+      env:
+      # for bazel caching
+      - name: REPO_OWNER
+        value: kubernetes
+      - name: REPO_NAME
+        value: kubernetes
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # kind specific args
+      - --provider=skeleton
+      - --deployment=kind
+      - --kind-binary-version=build
+      - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
+      # generic e2e test args
+      - --build=bazel
+      - --up
+      - --test
+      - --check-version-skew=false
+      - --down
+      # specific e2e test args
+      # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+      - --ginkgo-parallel
+      - --timeout=30m
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      # kind needs /lib/modules and cgroups from the host
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+
 - name: ci-kubernetes-e2e-kubeadm-kind-master
   interval: 2h
   decorate: true
@@ -575,7 +661,81 @@ presubmits:
     optional: true
     always_run: false
     decorate: true
+    branches:
+    - release-1.16
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 40m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubeadm
+      base_ref: master
+      path_alias: k8s.io/kubeadm
+    - org: kubernetes-sigs
+      repo: kind
+      base_ref: master
+      path_alias: sigs.k8s.io/kind
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # kind specific args
+        - --provider=skeleton
+        - --deployment=kind
+        - --kind-binary-version=stable
+        - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
+        # generic e2e test args
+        - --build=bazel
+        - --up
+        - --test
+        - --check-version-skew=false
+        - --down
+        # specific e2e test args
+        # TODO(bentheelder): num-nodes in particular is brittle. it would be better for kubetest to handle this
+        - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\] --num-nodes=3
+        - --ginkgo-parallel
+        - --timeout=30m
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        # kind needs /lib/modules and cgroups from the host
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  - name: pull-kubernetes-e2e-kind
+    optional: true
+    always_run: false
+    decorate: true
     skip_branches:
+    - release-1.16 # per-release job
     - release-1.15 # per-release job
     - release-1.14 # per-release job
     - release-1.13 # per-release job

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -41,6 +41,47 @@ periodics:
           memory: "9000Mi"
           cpu: 2000m
 
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-16
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm
+    testgrid-tab-name: kubeadm-kinder-external-etcd-1-16
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with external etcd and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "external-etcd-1.16"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
 - name: ci-kubernetes-e2e-kubeadm-kinder-external-etcd-1-15
   interval: 12h
   decorate: true

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -1,7 +1,7 @@
 # periodic jobs
 
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-15-master
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-16-master
   interval: 2h
   decorate: true
   labels:
@@ -9,7 +9,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
-    testgrid-tab-name: kubeadm-kinder-upgrade-1-15-master
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-16-master
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
@@ -33,7 +33,47 @@ periodics:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
-      - "upgrade-1.15-master"
+      - "upgrade-1.16-master"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-15-1-16
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.16-informing
+    testgrid-tab-name: kubeadm-kinder-upgrade-1-15-1-16
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "upgrade-1.15-1.16"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -1,7 +1,7 @@
 # periodic jobs
 
 periodics:
-- name: ci-kubernetes-e2e-kubeadm-kinder-master-on-1-15
+- name: ci-kubernetes-e2e-kubeadm-kinder-master-on-1-16
   interval: 2h
   decorate: true
   labels:
@@ -9,12 +9,52 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-master-informing
-    testgrid-tab-name: kubeadm-kinder-master-on-1-15
+    testgrid-tab-name: kubeadm-kinder-master-on-1-16
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "8"
+  decoration_config:
+    timeout: 40m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: kubeadm
+    base_ref: master
+    path_alias: k8s.io/kubeadm
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-514a218-1.16
+      command:
+      - runner.sh
+      - "../kubeadm/kinder/ci/kinder-run.sh"
+      args:
+      - "skew-master-on-1.16"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9000Mi"
+          cpu: 2000m
+
+- name: ci-kubernetes-e2e-kubeadm-kinder-1-16-on-1-15
+  interval: 12h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kubeadm,sig-release-1.16-informing
+    testgrid-tab-name: kubeadm-kinder-1-16-on-1-15
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle@googlegroups.com
+    description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
+    testgrid-num-columns-recent: "20"
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   decoration_config:
     timeout: 40m
   extra_refs:
@@ -33,7 +73,7 @@ periodics:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
-      - "skew-master-on-1.15"
+      - "skew-1.16-on-1.15"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
should merge after:
https://github.com/kubernetes/kubeadm/pull/1744

/sig cluster-lifecycle
/kind cleanup
/priority important-soon
/assign @fabriziopandini 

NOTE: running ./hack/verify-config.sh locally takes ages...