### PR TITLE
Remove myself from top-level owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- amwat # oncall
 - cjwagner # oncall
 - fejta # lead
-- ixdy # oncall
 - Katharine # oncall
-- krzyzacy # oncall
 - michelle192837 # oncall
 - spiffxp # lead
 - stevekuznetsov # lead
 emeritus_approvers:
+- amwat
 - BenTheElder
+- ixdy
+- krzyzacy
 
 labels:
 - sig/testing

--- a/prow/cmd/gerrit/OWNERS
+++ b/prow/cmd/gerrit/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+- amwat
+- krzyzacy
 labels:
- - area/prow/gerrit
+- area/prow/gerrit

--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- amwat
 - krzyzacy
 labels:
 - area/prow/gerrit


### PR DESCRIPTION
I'm refocusing onto non-OSS facing areas, so I'll step down from the top-level test-infra owners for now. (As currently only leads & oncalls should have top-level approve rights)

I checked subdir ownership, I still owns:
- boskos
- config
- jenkins
- kubetest/kubetest2
- prow/gerrit
- prow/crier

Also removed @ixdy and @amwat, added @amwat to co-own gerrit controller.  

/assign @fejta @spiffxp @stevekuznetsov 
/cc @amwat @ixdy 