### PR TITLE
Allow configuring the Prow URL for command help

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -104,6 +104,9 @@ type ProwConfig struct {
 	// Defaults to "default".
 	PodNamespace string `json:"pod_namespace,omitempty"`
 
+	// ProwURL is the URL to use in help messages when referring to this deployment
+	ProwURL string `json:"prow_url"`
+
 	// LogLevel enables dynamically updating the log level of the
 	// standard logger that is used by all prow components.
 	//

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -19,9 +19,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -54,8 +52,8 @@ func (o *options) Validate() error {
 		}
 	}
 
-	if _, err := url.ParseRequestURI(o.prowURL); err != nil {
-		return fmt.Errorf("invalid -prow-url URI: %q", o.prowURL)
+	if len(o.prowURL) > 0 {
+		logrus.Warn("--prow-url is deprecated, set prow_url in config.yaml instead")
 	}
 
 	return nil
@@ -109,7 +107,6 @@ func main() {
 
 	serv := &server{
 		tokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
-		prowURL:        o.prowURL,
 		configAgent:    configAgent,
 		ghc:            githubClient,
 		log:            log,

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -54,7 +54,6 @@ func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 
 type server struct {
 	tokenGenerator func() []byte
-	prowURL        string
 	configAgent    *config.Agent
 	ghc            github.Client
 	log            *logrus.Entry
@@ -118,7 +117,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 	s.log.WithFields(l.Data).Info("Requested a status refresh.")
 
 	// TODO: Retries
-	resp, err := http.Get(s.prowURL + "/prowjobs.js")
+	resp, err := http.Get(s.configAgent.Config().ProwURL + "/prowjobs.js")
 	if err != nil {
 		return err
 	}
@@ -182,7 +181,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 
 		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		if err := report.Report(s.ghc, reportTemplate, pj, reportTypes); err != nil {
+		if err := report.Report(s.ghc, reportTemplate, pj, reportTypes, s.configAgent.Config().ProwURL); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
 		}
 	}

--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -128,7 +128,7 @@ func ShouldReport(pj prowapi.ProwJob, validTypes []prowapi.ProwJobType) bool {
 
 // Report is creating/updating/removing reports in GitHub based on the state of
 // the provided ProwJob.
-func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.ProwJob, validTypes []prowapi.ProwJobType) error {
+func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.ProwJob, validTypes []prowapi.ProwJobType, prowURL string) error {
 	if ghc == nil {
 		return fmt.Errorf("trying to report pj %s, but found empty github client", pj.ObjectMeta.Name)
 	}
@@ -172,7 +172,7 @@ func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.Prow
 		}
 	}
 	if len(entries) > 0 {
-		comment, err := createComment(reportTemplate, pj, entries)
+		comment, err := createComment(reportTemplate, pj, entries, prowURL)
 		if err != nil {
 			return fmt.Errorf("generating comment: %v", err)
 		}
@@ -275,7 +275,7 @@ func createEntry(pj prowapi.ProwJob) string {
 // createComment take a ProwJob and a list of entries generated with
 // createEntry and returns a nicely formatted comment. It may fail if template
 // execution fails.
-func createComment(reportTemplate *template.Template, pj prowapi.ProwJob, entries []string) (string, error) {
+func createComment(reportTemplate *template.Template, pj prowapi.ProwJob, entries []string, prowURL string) (string, error) {
 	plural := ""
 	if len(entries) > 1 {
 		plural = "s"
@@ -300,7 +300,7 @@ func createComment(reportTemplate *template.Template, pj prowapi.ProwJob, entrie
 		"",
 		"<details>",
 		"",
-		plugins.AboutThisBot,
+		plugins.AboutThisBot(pj.Spec.Refs.Org, pj.Spec.Refs.Repo, prowURL),
 		"</details>",
 		commentTag,
 	}...)

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -19,7 +19,7 @@ limitations under the License.
 package reporter
 
 import (
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github/report"
 )
@@ -74,5 +74,5 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 // Report will report via reportlib
 func (c *Client) Report(pj *v1.ProwJob) ([]*v1.ProwJob, error) {
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	return []*v1.ProwJob{pj}, report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GitHubReporter.JobTypesToReport)
+	return []*v1.ProwJob{pj}, report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GitHubReporter.JobTypesToReport, c.config().ProwURL)
 }

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -217,7 +217,7 @@ func (c *Controller) Sync() error {
 	reportTemplate := c.config().ReportTemplate
 	reportTypes := c.cfg().GitHubReporter.JobTypesToReport
 	for report := range reportCh {
-		if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
+		if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes, c.cfg().ProwURL); err != nil {
 			reportErrs = append(reportErrs, err)
 			c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 		}

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -265,7 +265,7 @@ func (c *Controller) Sync() error {
 		reportTemplate := c.config().Plank.ReportTemplate
 		reportTypes := c.config().GitHubReporter.JobTypesToReport
 		for report := range reportCh {
-			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
+			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes, c.config().ProwURL); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 			}

--- a/prow/plugins/approve/BUILD.bazel
+++ b/prow/plugins/approve/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//prow/plugins/approve/approvers:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -210,7 +211,6 @@ func TestHandle(t *testing.T) {
 		expectedComment string
 		expectToggle    bool
 	}{
-
 		// breaking cases
 		// case: /approve in PR body
 		{
@@ -232,7 +232,7 @@ func TestHandle(t *testing.T) {
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -267,7 +267,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -300,7 +300,7 @@ This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
 Associated issue requirement bypassed by: *<a href="" title="Approved">Alice</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -336,7 +336,7 @@ This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
 Associated issue: *#42*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -382,7 +382,7 @@ This pull-request has been approved by: *<a href="" title="Approved">ALIcE</a>*,
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with `+"`/approve no-issue`"+`
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -435,7 +435,7 @@ You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -520,7 +520,7 @@ This pull-request has been approved by: *<a href="" title="Approved">alice</a>*
 
 Associated issue: *#1*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -589,7 +589,7 @@ Approval requirements bypassed by manually added approval.
 
 This pull-request has been approved by:
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -635,7 +635,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**
 You can assign the PR to them by writing `+"`/assign @alice`"+` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -678,7 +678,7 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 
 This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -713,7 +713,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -744,7 +744,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -783,7 +783,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -821,7 +821,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -857,7 +857,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -897,7 +897,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -932,7 +932,7 @@ This pull-request has been approved by:
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -963,7 +963,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 This pull-request has been approved by: *<a href="" title="Approved">Alice</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -997,7 +997,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -1031,7 +1031,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 This pull-request has been approved by: *<a href="#" title="Author self-approved">cjwagner</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -1098,6 +1098,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 				author:    "cjwagner",
 				assignees: []github.User{{Login: "spxtr"}},
 			},
+			"http.com",
 		); err != nil {
 			t.Errorf("[%s] Unexpected error handling event: %v.", test.name, err)
 		}
@@ -1128,10 +1129,9 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 				)
 			} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fghc.IssueCommentsAdded[0]; test.expectedComment != "" && got != expect {
 				t.Errorf(
-					"[%s] Expected the created notification to be:\n%s\n\nbut got:\n%s\n\n",
+					"[%s] Expected a different created notification: %v",
 					test.name,
-					expect,
-					got,
+					diff.StringDiff(expect, got),
 				)
 			}
 		} else {
@@ -1328,7 +1328,7 @@ func TestHandleGenericComment(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state, prowURL string) error {
 		gotState = pr
 		handled = true
 		return nil
@@ -1543,7 +1543,7 @@ func TestHandleReview(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, config config.GitHubOptions, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, config config.GitHubOptions, opts *plugins.Approve, pr *state, prowURL string) error {
 		gotState = pr
 		handled = true
 		return nil
@@ -1708,7 +1708,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 	var handled bool
 	var gotState *state
-	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state) error {
+	handleFunc = func(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConfig config.GitHubOptions, opts *plugins.Approve, pr *state, prowURL string) error {
 		gotState = pr
 		handled = true
 		return nil

--- a/prow/plugins/approve/approvers/BUILD.bazel
+++ b/prow/plugins/approve/approvers/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
 
 	"net/url"
 	"reflect"
@@ -714,7 +715,7 @@ You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -726,10 +727,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "dev"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "dev", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -754,7 +755,7 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Al
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -768,10 +769,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -796,7 +797,7 @@ You can assign the PR to them by writing ` + "`/assign @alice @bill`" + ` in a c
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -808,10 +809,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -838,7 +839,7 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Al
 
 Associated issue: *#12345*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -852,10 +853,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -881,7 +882,7 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Al
 
 Associated issue requirement bypassed by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="Approved">Bill</a>*
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
 
@@ -895,10 +896,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -924,7 +925,7 @@ You can assign the PR to them by writing ` + "`/assign @alice @doctor`" + ` in a
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -936,10 +937,10 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }
 
@@ -965,7 +966,7 @@ You can assign the PR to them by writing ` + "`/assign @alice @doctor`" + ` in a
 
 *No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+The full list of commands accepted by this bot can be found [here](http.com/bot-commands?repo=org%2Frepo).
 
 <details open>
 Needs approval from an approver in each of these files:
@@ -977,9 +978,9 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "org", "repo", "master", "http.com"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
-		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+		t.Errorf("incorrect message: %v", diff.StringDiff(*got, want))
 	}
 }

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -598,7 +598,7 @@ func GenerateTemplate(templ, name string, data interface{}) (string, error) {
 // 	- a suggested list of people from each OWNERS files that can fully approve the PR
 // 	- how an approver can indicate their approval
 // 	- how an approver can cancel their approval
-func GetMessage(ap Approvers, linkURL *url.URL, org, repo, branch string) *string {
+func GetMessage(ap Approvers, linkURL *url.URL, org, repo, branch, prowURL string) *string {
 	linkURL.Path = org + "/" + repo
 	message, err := GenerateTemplate(`{{if (and (not .ap.RequirementsMet) (call .ap.ManuallyApproved )) }}
 Approval requirements bypassed by manually added approval.
@@ -626,7 +626,7 @@ Associated issue requirement bypassed by:{{range $index, $approval := .ap.ListNo
 
 {{ end -}}
 
-The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo={{ .org }}%2F{{ .repo }}).
+The full list of commands accepted by this bot can be found [here]({{ .prowURL }}/bot-commands?repo={{ .org }}%2F{{ .repo }}).
 
 {{ if (or .ap.AreFilesApproved (call .ap.ManuallyApproved)) -}}
 The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
@@ -638,7 +638,7 @@ Needs approval from an approver in each of these files:
 {{range .ap.GetFiles .baseURL .branch}}{{.}}{{end}}
 Approvers can indicate their approval by writing `+"`/approve`"+` in a comment
 Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
-</details>`, "message", map[string]interface{}{"ap": ap, "baseURL": linkURL, "org": org, "repo": repo, "branch": branch})
+</details>`, "message", map[string]interface{}{"ap": ap, "baseURL": linkURL, "org": org, "repo": repo, "branch": branch, "prowURL": prowURL})
 	if err != nil {
 		ap.owners.log.WithError(err).Errorf("Error generating message.")
 		return nil

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -162,7 +162,7 @@ func TestCLALabels(t *testing.T) {
 			SHA:     tc.statusSHA,
 			State:   tc.state,
 		}
-		if err := handle(fc, logrus.WithField("plugin", pluginName), se); err != nil {
+		if err := handle(fc, logrus.WithField("plugin", pluginName), se, "http.com"); err != nil {
 			t.Errorf("For case %s, didn't expect error from cla plugin: %v", tc.name, err)
 			continue
 		}

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -51,6 +51,9 @@ type Configuration struct {
 	// Owners contains configuration related to handling OWNERS files.
 	Owners Owners `json:"owners,omitempty"`
 
+	// ProwURL is the URL to use in help messages when referring to this deployment
+	ProwURL string `json:"prow_url"`
+
 	// Built-in plugins specific configuration.
 	Approve                    []Approve                    `json:"approve,omitempty"`
 	UseDeprecatedSelfApprove   bool                         `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`

--- a/prow/plugins/dco/BUILD.bazel
+++ b/prow/plugins/dco/BUILD.bazel
@@ -41,5 +41,6 @@ go_test(
         "//prow/github/fakegithub:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
     ],
 )

--- a/prow/plugins/invalidcommitmsg/BUILD.bazel
+++ b/prow/plugins/invalidcommitmsg/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
     ],
 )
 

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -83,10 +83,10 @@ func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 	if err != nil {
 		return err
 	}
-	return handle(pc.GitHubClient, pc.Logger, pr, cp)
+	return handle(pc.GitHubClient, pc.Logger, pr, cp, pc.PluginConfig.ProwURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp commentPruner) error {
+func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp commentPruner, prowURL string) error {
 	// Only consider actions indicating that the code diffs may have changed.
 	if !hasPRChanged(pr) {
 		return nil
@@ -146,7 +146,7 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 		})
 
 		log.Debugf("Commenting on PR to advise users of invalid commit messages")
-		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(commentBody, dco.MarkdownSHAList(org, repo, invalidCommits), plugins.AboutThisBot)); err != nil {
+		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(commentBody, dco.MarkdownSHAList(org, repo, invalidCommits), plugins.AboutThisBot(prowURL, org, repo))); err != nil {
 			log.WithError(err).Errorf("Could not create comment for invalid commit messages")
 		}
 	}

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/diff"
 
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -104,7 +105,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 <details>
 
-Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](http.com/bot-commands?repo=k%2Fk).
 </details>
 `,
 		},
@@ -134,7 +135,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			if tc.hasInvalidCommitMessageLabel {
 				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel))
 			}
-			if err := handle(fc, logrus.WithField("plugin", pluginName), event, &fakePruner{}); err != nil {
+			if err := handle(fc, logrus.WithField("plugin", pluginName), event, &fakePruner{}, "http.com"); err != nil {
 				t.Errorf("For case %s, didn't expect error from invalidcommitmsg plugin: %v", tc.name, err)
 			}
 
@@ -173,7 +174,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				t.Errorf("did not expect more than one comment to be created")
 			}
 			if len(comments) != 0 && comments[0] != tc.addedComment {
-				t.Errorf("expected comment to be \n%q\n but it was \n%q\n", tc.addedComment, comments[0])
+				t.Errorf("expected different comment: %v", diff.StringDiff(tc.addedComment, comments[0]))
 			}
 		})
 	}

--- a/prow/plugins/respond.go
+++ b/prow/plugins/respond.go
@@ -26,11 +26,13 @@ import (
 // AboutThisBotWithoutCommands contains the message that explains how to interact with the bot.
 const AboutThisBotWithoutCommands = "Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository."
 
-// AboutThisBotCommands contains the message that links to the commands the bot understand.
-const AboutThisBotCommands = "I understand the commands that are listed [here](https://go.k8s.io/bot-commands)."
+// aboutThisBotCommands contains the message that links to the commands the bot understand.
+const aboutThisBotCommands = "I understand the commands that are listed [here](%s/bot-commands?repo=%s%%2F%s)."
 
-// AboutThisBot contains the text of both AboutThisBotWithoutCommands and AboutThisBotCommands.
-const AboutThisBot = AboutThisBotWithoutCommands + " " + AboutThisBotCommands
+// AboutThisBot contains the text of both AboutThisBotWithoutCommands and aboutThisBotCommands.
+func AboutThisBot(prowURL, org, repo string) string {
+	return AboutThisBotWithoutCommands + " " + fmt.Sprintf(aboutThisBotCommands, prowURL, org, repo)
+}
 
 // FormatResponse nicely formats a response to a generic reason.
 func FormatResponse(to, message, reason string) string {


### PR DESCRIPTION
Not all Prow deployments will use the configurations that prow.k8s.io
does, and it is best to link to the direct help page for the repo in
question for the deployment that is used to run it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @spiffxp @cblecker @nikhita 