### PR TITLE
kubeflow-periodic-job: Adding extra_refs for project cleanup job

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -127,11 +127,17 @@ periodics:
     description: Periodic testing of Kubeflow kfctl
 - name: kubeflow-periodic-project-cleanup
   interval: 1h
+  decorate: true
   labels:
     preset-service-account: "true"
+  extra_refs:
+  - org: kubeflow
+    repo: pipelines
+    base_ref: master
+    workdir: true
   spec:
     containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-1c5f719-master
         imagePullPolicy: Always
         command:
         - "./test/tools/project-cleaner/project_cleaner.sh"


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/14020 missed adding the extra_refs config for the kubeflow-periodic-project-cleanup periodic job. This changes adds the extra_refs config.

The image for the build is also moved to using kubekins-e2e image so as to use the custom entry point.