### PR TITLE
clarketm wants to rerun jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -46,6 +46,7 @@ deck:
   rerun_auth_config:
     github_users:
       - mirandachrist
+      - clarketm
     github_team_ids:
       - 2009231 #test-infra-admins
 


### PR DESCRIPTION
Until I can earn `test-infra-admins`, I would like to be able to rerun jobs for debugging/development purposes.