### PR TITLE
Cleanup file situation for pj-on-kind.sh

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,0 @@
-pj.yaml
-pod.yaml

--- a/prow/.gitignore
+++ b/prow/.gitignore
@@ -30,5 +30,3 @@ cmd/tot/tot
 external-plugins/cherrypicker/cherrypicker
 external-plugins/needs-rebase/needs-rebase
 external-plugins/refresh/refresh
-pj.yaml
-pod.yaml


### PR DESCRIPTION
This will create the prowjob, pod, and kind config files to the platform-specific temporary file directory and delete them on script exit (regardless of exit code). 

/assign @cjwagner 