### PR TITLE
Assigning the value of acsLocation to aksLocation when it's set.

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -270,9 +270,12 @@ func checkParams() error {
 			return err
 		}
 	} else if *acsLocation == "" {
-		*aksLocation = randomAksEngineLocation()
+		*acsLocation = randomAksEngineLocation()
 	}
 	//TODO: remove acs related lines after baking period
+	if *acsLocation != "" {
+		*aksLocation = *acsLocation
+	}
 	if *acsResourceName != "" {
 		*aksResourceName = *acsResourceName
 	}


### PR DESCRIPTION
Assigning the value of acsLocation to aksLocation when it's set.

Fixes: #14065 

/sig azure
/sig testing
/kind bug