### PR TITLE
Fix rpm/deb build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -110,6 +110,8 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-1c5f719-master
       imagePullPolicy: Always
       command:
+      - runner.sh
+      args:
       - make
       - build-debs
       # docker-in-docker needs privileged mode
@@ -140,6 +142,8 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20190822-1c5f719-master
       imagePullPolicy: Always
       command:
+      - runner.sh
+      args:
       - make
       - build-rpms
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
runner.sh looks up the DOCKER_IN_DOCKER_ENABLED env var and starts
docker, then it runs the arguments that it is passed in.

Fix for https://github.com/kubernetes/kubernetes/issues/80715

Change-Id: I19bb6fa6e5e986ea13fa1852d7af5e8a721cd814