### PR TITLE
Add chases2 to Testgrid OWNERS

### DIFF
--- a/testgrid/OWNERS
+++ b/testgrid/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - spiffxp
 - wojtek-t
 - shyamjvs
-reviewers:
 - chases2
 labels:
 - area/testgrid


### PR DESCRIPTION
I've worked on several issues and components of TestGrid (primarily Configurator and Entomologist) and plan to continue working on TestGrid as it moves towards open source.

Being added as an OWNER to this subdirectory may help streamline this process.

/cc @fejta 
/assign @spiffxp 
/assign @michelle192837 
/assign @wojtek-t 
/assign @shyamjvs 