### PR TITLE
Adding the triage/deprecated label

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -335,5 +335,6 @@ larger set of contributors to apply/remove them.
 | <a id="language/no" href="#language/no">`language/no`</a> | Issues or PRs related to Norwegian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/pt" href="#language/pt">`language/pt`</a> | Issues or PRs related to Portuguese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="deprecated" href="#triage/deprecated">`docs/deprecated`</a> | Issues or PRs related to deprecated documentation | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1207,6 +1207,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: ffa500
+        description: Issues or PRs related to deprecated documentation
+        name: triage/deprecated
+        target: both
+        prowPlugin: label
+        addedBy: anyone
   kubernetes-sigs/cluster-api:
     labels:
       - color: 0052cc


### PR DESCRIPTION
The purpose of this label is for people to raise issues for sig-docs about documentation which, whether because of old/outdated instructions or policy changes, they suspect should no longer be included.

cc @zacharysarah 