### PR TITLE
Turn on go modules

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -55,6 +55,9 @@ periodics:
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - --pass-on-error
       - ./experiment/dummybenchmarks/...
+      env:
+      - name: GO111MODULE
+        value: "on"
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: benchmark-demo

--- a/pkg/benchmarkjunit/prowjob_example.yaml
+++ b/pkg/benchmarkjunit/prowjob_example.yaml
@@ -19,3 +19,6 @@ periodics:
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - --pass-on-error
       - ./experiment/dummybenchmarks/...
+      env:
+      - name: GO111MODULE
+        value: "on"


### PR DESCRIPTION
/assign @michelle192837 @cjwagner 

We deleted vendor so anything in test-infra needs to run in module mode.