### PR TITLE
Refactor kubekins-e2e to build with modules

### DIFF
--- a/images/kubekins-e2e/Makefile
+++ b/images/kubekins-e2e/Makefile
@@ -20,7 +20,7 @@ ifneq ($(K8S), everything)
 endif
 
 push-prod:
-  bazel run //images/builder -- $(EXTRA_ARG) --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/kubekins-e2e
+	bazel run //images/builder -- $(EXTRA_ARG) --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/kubekins-e2e
 
 push:
 	bazel run //images/builder -- $(EXTRA_ARG) --allow-dirty images/kubekins-e2e

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -1,19 +1,34 @@
 steps:
-  - name: gcr.io/cloud-builders/go
-    args: ['build', '-o', '/workspace/images/kubekins-e2e/kubetest', './kubetest/']
-    env: ['PROJECT_ROOT=k8s.io/test-infra', 'CGO_ENABLED=0', 'GOOS=linux', 'GOARCH=amd64']
+  - name: golang:$_GO_VERSION
+    args:
+    - go
+    - build
+    - -o=/workspace/images/kubekins-e2e/kubetest
+    - ./kubetest/
+    env:
+    - CGO_ENABLED=0
+    - GOOS=linux
+    - GOARCH=amd64
+    - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
+    - GOSUMDB=sum.golang.org
   - name: gcr.io/cloud-builders/docker
-    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG',
-            '--build-arg', 'GO_VERSION=$_GO_VERSION',
-            '--build-arg', 'K8S_RELEASE=$_K8S_RELEASE',
-            '--build-arg', 'BAZEL_VERSION_ARG=$_BAZEL_VERSION',
-            '--build-arg', 'CFSSL_VERSION=$_CFSSL_VERSION',
-            '--build-arg', 'UPGRADE_DOCKER_ARG=$_UPGRADE_DOCKER',
-            '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG',
-            '.' ]
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - --build-arg=GO_VERSION=$_GO_VERSION
+    - --build-arg=K8S_RELEASE=$_K8S_RELEASE
+    - --build-arg=BAZEL_VERSION_ARG=$_BAZEL_VERSION
+    - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
+    - --build-arg=UPGRADE_DOCKER_ARG=$_UPGRADE_DOCKER
+    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - .
     dir: images/kubekins-e2e
   - name: gcr.io/cloud-builders/docker
-    args: [ 'tag', 'gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG', 'gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG']
+    args:
+    - tag
+    - gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG
     dir: images/kubekins-e2e
 substitutions:
   _GIT_TAG: '12345'


### PR DESCRIPTION
/assign @Katharine @feiskyer 

Tested with `make push`, images exist at `gcr.io/fejta-prod/kubekins-e2e:v20190827-82fc8fcd5-dirty-1.14` (not sure if those are publicly accessible)