### PR TITLE
Enable finalizer on glbc for ingress e2e test

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -52,6 +52,7 @@ presets:
             - --v=3
             - --logtostderr=false
             - --log_file=/var/log/glbc.log
+            - --enable-finalizer-add
             - --enable-finalizer-remove
             - --default-backend-service=kube-system/default-http-backend
             - --kubeconfig=/etc/srv/kubernetes/l7-lb-controller/kubeconfig


### PR DESCRIPTION
Enable finalizer on glbc for e2e test as the preparation for the upcoming rollout.

/assign @rramkumar1 @skmatti