### PR TITLE
Add alerts for sinker doing nothing

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
@@ -1,0 +1,37 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'sinker-missing',
+        rules: [
+          {
+            alert: 'SinkerNotRemovingPods',
+            expr: |||
+              absent(sum(rate(sinker_pods_removed[1h]))) == 1
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Sinker has not removed any Pods in the last hour, likely indicating an outage in the service.',
+            },
+          },
+          {
+            alert: 'SinkerNotRemovingProwJobs',
+            expr: |||
+              absent(sum(rate(sinker_prow_jobs_cleaned[1h]))) == 1
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Sinker has not removed any Prow jobs in the last hour, likely indicating an outage in the service.',
+            },
+          }
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
From my queries, there is no point in time where sinker has legitimately
had nothing to do for an hour straight. The alert queries here should
only fire when sinker is down. Sinker not being active for an hour is a
very soft failure mode so there's not a pressing need to find a smaller
time window for which we can alert with high signal-to-noise ratio.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner @fejta @hongkailiu @Katharine 