### PR TITLE
ensure janitor is not PID1

### DIFF
--- a/boskos/janitor/BUILD.bazel
+++ b/boskos/janitor/BUILD.bazel
@@ -49,6 +49,14 @@ container_image(
 prow_image(
     name = "image",
     base = ":janitor_image",
+    # the entrypoint must be sh
+    # https://github.com/kubernetes/test-infra/issues/5877
+    entrypoint = [
+        "/bin/sh",
+        "-c",
+        "/bin/echo started && /app/boskos/janitor/app.binary \"$@\"",
+        "--",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
/hold
this is a naive attempt at bringing back https://github.com/kubernetes/test-infra/commit/206236aa6c1121268aad3f4a29c937409f592f20#diff-a0b02602f29a2b75ec8f3634a86877ceR21