### PR TITLE
update pull-kubernetes-conformance-image-test job

### DIFF
--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3764,16 +3764,16 @@ presubmits:
         - --ssh=/etc/ssh-security/ssh-security
         - --job=$(JOB_NAME)
         - --root=/go/src
-        - --repo=k8s.io/test-infra=master
         - --repo=github.com/kubernetes-security/kubernetes=$(PULL_REFS)
+        - --repo=sigs.k8s.io/kind=master
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-security-prow/pr-logs
         - --scenario=execute
         - --
-        - bash
-        - --
-        - -c
-        - cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh
+        - ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: PARALLEL
+          value: "true"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190828-850e922-master
         name: ""
         resources:

--- a/config/jobs/kubernetes-security/generated-security-jobs.yaml
+++ b/config/jobs/kubernetes-security/generated-security-jobs.yaml
@@ -3757,7 +3757,7 @@ presubmits:
     name: pull-security-kubernetes-conformance-image-test
     optional: true
     rerun_command: /test pull-security-kubernetes-conformance-image-test
-    run_if_changed: conformance
+    run_if_changed: ^test/
     spec:
       containers:
       - args:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -8,7 +8,7 @@ presubmits:
     skip_report: false
     max_concurrency: 8
     optional: true
-    run_if_changed: 'conformance'
+    run_if_changed: '^test/'
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -45,6 +45,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-misc
+      testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
       description: Runs conformance tests using kind and the conformance image
   - name: pull-kubernetes-conformance-kind-ipv6
     branches:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -18,21 +18,21 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190828-850e922-master
+        env:
+        # skip serial tests and run with --ginkgo-parallel
+        - name: "PARALLEL"
+          value: "true"
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
-        - "--repo=k8s.io/test-infra=master"
         - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--repo=sigs.k8s.io/kind=master"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--scenario=execute"
         - "--"
-            # the script must run from kubernetes, but we're checking out kind
-        - "bash"
-        - "--"
-        - "-c"
-        - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
-          # we need privileged mode in order to do docker in docker
+        - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+        # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
This switches the pull-kubernetes-conformance-image-test to use kind master.
It also uses the kind script to run e2e test because I think it will receive the best support from the kind project.

Fixes #14128