### PR TITLE
Use --extract=ci/latest in ci-kubernetes-e2e-autoscaling-hpa-cpu test

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -377,7 +377,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest
       - --timeout=100m
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8


### PR DESCRIPTION
This is addressing https://github.com/kubernetes/kubernetes/issues/81491#issuecomment-526190559.