### PR TITLE
Make Tide batch size configurable and default to unlimited.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,9 @@
 # Announcements
 
 New features added to each component:
+ - *August 29, 2019* Added a `batch_size_limit` option to the Tide config that
+   allows the batch size limit to be specified globally, per org, or per repo.
+   Values default to 0 indicating no size limit. A value of -1 disables batches.
  - *July 30, 2019* `authorized_users` in `rerun_auth_config` for deck will become `github_users`. 
  - *July 19, 2019* deck will soon remove its default value for `--cookie-secret-file`.
    If you set `--oauth-url` but not `--cookie-secret-file`, add

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -462,6 +462,8 @@ tide:
         dashboard:
           skip-unknown-contexts: true
           from-branch-protection: true
+  batch_size_limit:
+    "kubernetes/kubernetes": 15
 
 push_gateway:
   endpoint: pushgateway

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -132,6 +132,24 @@ type Tide struct {
 	// combined status; otherwise it may apply the branch protection setting or let user
 	// define their own options in case branch protection is not used.
 	ContextOptions TideContextPolicyOptions `json:"context_options,omitempty"`
+
+	// BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
+	// integer batch size limit as the value. The empty string key can be used as
+	// a global default.
+	// Special values:
+	//  0 => unlimited batch size
+	// -1 => batch merging disabled :(
+	BatchSizeLimitMap map[string]int `json:"batch_size_limit,omitempty"`
+}
+
+func (t *Tide) BatchSizeLimit(org, repo string) int {
+	if limit, ok := t.BatchSizeLimitMap[fmt.Sprintf("%s/%s", org, repo)]; ok {
+		return limit
+	}
+	if limit, ok := t.BatchSizeLimitMap[org]; ok {
+		return limit
+	}
+	return t.BatchSizeLimitMap["*"]
 }
 
 // MergeMethod returns the merge method to use for a repo. The default of merge is

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -797,7 +797,13 @@ func TestPickBatch(t *testing.T) {
 		sp.prs = append(sp.prs, pr)
 	}
 	ca := &config.Agent{}
-	ca.Set(&config.Config{})
+	ca.Set(&config.Config{
+		ProwConfig: config.ProwConfig{
+			Tide: config.Tide{
+				BatchSizeLimitMap: map[string]int{"*": 5},
+			},
+		},
+	})
 	c := &Controller{
 		logger: logrus.WithField("component", "tide"),
 		gc:     gc,


### PR DESCRIPTION
Should we set a limit for `k/k` or use unlimited?
Is it reasonable to default to unlimited?
/assign @stevekuznetsov @Katharine @fejta 