### PR TITLE
update static ip for "istio-boskos"

### DIFF
--- a/velodrome/config.yaml
+++ b/velodrome/config.yaml
@@ -186,7 +186,7 @@ projects:
             metrics_path: /prometheus
             static_configs:
               - targets:
-                  - 35.233.210.91
+                  - 34.83.176.210
   tensorflow:
     repositories:
       tensorflow/tensorflow:


### PR DESCRIPTION
`Boskos` was migrated to the build cluster in a different region and a new static IP was reassigned.