### PR TITLE
sig-release: Fix typo in deb package build job

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -105,7 +105,7 @@ periodics:
       - ./deb-builder
       args:
       - -distros
-      - -bionic
+      - bionic
       resources:
         requests:
           cpu: 4


### PR DESCRIPTION
So close! Had a typo in one of the args.
[Test failure](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-release-build-packages-debs/1167349063008391169):
```shell
2019/08/30 08:11:37 err: lstat -bionic: no such file or directory
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/kubernetes/issues/80715

/assign @tpepper @calebamiles @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 
/priority important-soon
/milestone v1.16
/kind bug