### PR TITLE
Fix velodrome deployment (no whitespace b/w resources)

### DIFF
--- a/velodrome/config.py
+++ b/velodrome/config.py
@@ -112,7 +112,7 @@ def print_deployments(components, env):
 
 
 def print_deployment(deployment, env):
-    print(string.Template(deployment).safe_substitute(**env), end=' ')
+    print(string.Template(deployment).safe_substitute(**env), end='')
     print('---')
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was missed in the python `2`->`3` migration.

/assign @michelle192837 @krzyzacy 