### PR TITLE
Set up heapster node in private cluster correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -19,6 +19,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=private-gce-test
+      - --env=HEAPSTER_MACHINE_TYPE=n1-standard-1
       - --env=KUBE_GCE_PRIVATE_CLUSTER=true
       - --extract=ci/latest
       - --gcp-master-image=gci


### PR DESCRIPTION
The heapster node has a public IP address, which should fix one test (the one exercising firewalls) that IIUC requires only one node with public IP.

Ref. https://github.com/kubernetes/kubernetes/issues/76374