### PR TITLE
Make Prow images that might be used by hand or as PJs put their binary at root.

### DIFF
--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -16,6 +16,8 @@ k8s_object(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    directory = "/",
+    files = [":branchprotector"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/config-bootstrapper/BUILD.bazel
+++ b/prow/cmd/config-bootstrapper/BUILD.bazel
@@ -41,5 +41,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    directory = "/",
+    files = [":config-bootstrapper"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -10,6 +10,8 @@ load("//prow:def.bzl", "prow_image")
 
 prow_image(
     name = "image",
+    directory = "/",
+    files = [":mkpj"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/mkpod/BUILD.bazel
+++ b/prow/cmd/mkpod/BUILD.bazel
@@ -3,6 +3,8 @@ load("//prow:def.bzl", "prow_image")
 
 prow_image(
     name = "image",
+    directory = "/",
+    files = [":mkpod"],
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -124,5 +124,7 @@ k8s_objects(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    directory = "/",
+    files = [":peribolos"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This will let us specify entrypoints like `/branchprotector` instead of the following: https://github.com/kubernetes/test-infra/blob/86fbc418c31dcb5084a89a41d67a59fbbd423369/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L952-L953

/assign @fejta @stevekuznetsov 