### PR TITLE
Pull-controller-runtime-test: Request 4 CPUs

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits.yaml
@@ -9,6 +9,9 @@ presubmits:
       - image: golang:1.12
         command:
         - ./hack/ci-check-everything.sh
+        resources:
+          requests:
+            cpu: 4000m
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/581 had a 50% flakerate with the first try failing due to timeout: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-runtime/581/pull-controller-runtime-test/1169003158895071232

I followed the standard approach of "wild guessing"[0] and gave it 4 CPUs in the hope that this will make things better.

/assign @DirectXMan12 

[0] https://kubernetes.slack.com/archives/C09QZ4DQB/p1567548138026200