### PR TITLE
triage: bypass unknown keys rather than runtime error 

### DIFF
--- a/triage/summarize.py
+++ b/triage/summarize.py
@@ -516,7 +516,10 @@ def annotate_owners(data, builds, owners):
                     continue
                 job_path = job_paths[job['name']]
                 for build in job['builds']:
-                    if builds['%s/%s' % (job_path, build)]['started'] > yesterday:
+                    bucket_key = '%s/%s' % (job_path, build)
+                    if bucket_key not in builds:
+                        continue
+                    elif builds[bucket_key]['started'] > yesterday:
                         counts[0] += 1
                     else:
                         counts[1] += 1

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -119,7 +119,7 @@ class ClusterTest(unittest.TestCase):
                     'cols': {'started': [now]}
                 },
                 'clustered': [
-                    {'tests': [{'name': test, 'jobs': [{'name': 'somejob', 'builds': ['123']}]}]}
+                    {'tests': [{'name': test, 'jobs': [{'name': 'somejob', 'builds': ['123', '125']}]}]}
                 ],
             }
             summarize.annotate_owners(


### PR DESCRIPTION
A series of builds for the `pull-kubernetes-conformance-kind-ipv6` job pull # `81856` (kubernetes/kubernetes#81856) do not exist in [GCS](https://pantheon.corp.google.com/storage/browser/kubernetes-jenkins/logs/pull/81856/?project=kubernetes-jenkins&organizationId=433637338589) and this is causing triage to fail.

**e.g. GCS objects that do not exist**
`gs://kubernetes-jenkins/logs/pull/81856/pull-kubernetes-conformance-kind-ipv6/1165011996727316480`
`gs://kubernetes-jenkins/logs/pull/81856/pull-kubernetes-conformance-kind-ipv6/1165008467442798592`
...

> This issue applies only to pull `81856` job `pull-kubernetes-conformance-kind-ipv6`.

The cause of the missing GCS object is uncertain. It may be to a job misconfiguration, a bad build, or the fact that the upload location changed in the job definition (4461ade) on an *active* PR. Regardless, runtime errors for a subset of builds *should not be fatal*, rather they *should be skipped*.

fix #14186