### PR TITLE
Make 2 more functions in autobumper public

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -51,10 +51,12 @@ func Call(cmd string, args ...string) error {
 // "images" contains the tag replacements that have been made which is returned from "UpdateReferences([]string{"."}, extraFiles)"
 // "images" and "extraLineInPRBody" are used to generate commit summary and body of the PR
 func UpdatePR(gc github.Client, org, repo string, images map[string]string, extraLineInPRBody string, matchTitle, source, branch string) error {
-	return updatePR(gc, org, repo, makeCommitSummary(images), generatePRBody(images, extraLineInPRBody), matchTitle, source, branch)
+	return UpdatePullRequest(gc, org, repo, makeCommitSummary(images), generatePRBody(images, extraLineInPRBody), matchTitle, source, branch)
 }
 
-func updatePR(gc github.Client, org, repo, title, body, matchTitle, source, branch string) error {
+// UpdatePullRequest updates with github client "gc" the PR of github repo org/repo
+// with "title" and "body" of PR matching "matchTitle" from "source" to "branch"
+func UpdatePullRequest(gc github.Client, org, repo, title, body, matchTitle, source, branch string) error {
 	logrus.Info("Creating PR...")
 	n, err := updater.UpdatePR(org, repo, title, body, matchTitle, gc)
 	if err != nil {
@@ -115,11 +117,17 @@ func makeCommitSummary(images map[string]string) string {
 // "images" contains the tag replacements that have been made which is returned from "UpdateReferences([]string{"."}, extraFiles)"
 // "images" is used to generate commit message
 func MakeGitCommit(remote, remoteBranch, name, email string, images map[string]string) error {
+	return GitCommitAndPush(remote, remoteBranch, name, email, makeCommitSummary(images))
+}
+
+// GitCommitAndPush runs a sequence of git commands to
+// commit and push the changes the "remote" on "remoteBranch"
+// "name", "email", and "message" are used for git-commit command
+func GitCommitAndPush(remote, remoteBranch, name, email, message string) error {
 	logrus.Info("Making git commit...")
 	if err := Call("git", "add", "-A"); err != nil {
 		return fmt.Errorf("failed to git add: %v", err)
 	}
-	message := makeCommitSummary(images)
 	commitArgs := []string{"commit", "-m", message}
 	if name != "" && email != "" {
 		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", name, email))


### PR DESCRIPTION
Those 2 functions can be used for more general cases by removing
the dependency of `images` which is obtained from `UpdateReferences`.