### PR TITLE
Add a directory for image pushing jobs.

### DIFF
--- a/config/jobs/image-pushing/OWNERS
+++ b/config/jobs/image-pushing/OWNERS
@@ -1,0 +1,10 @@
+# Only oncall gets approval here because it provides access to magic secrets.
+options:
+  no_parent_owners: true
+
+approvers:
+- chases2
+- cjwagner
+- fejta
+- Katharine
+- michelle192837

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -313,6 +313,7 @@ func TestTrustedJobs(t *testing.T) {
 	// that uses a foo-trusted cluster
 	const trusted = "test-infra-trusted"
 	trustedPath := path.Join(*jobConfigPath, "kubernetes", "test-infra", "test-infra-trusted.yaml")
+	trustedDir := path.Join(*jobConfigPath, "image-pushing") + "/"
 
 	// Presubmits may not use trusted clusters.
 	for _, pre := range c.AllPresubmits(nil) {
@@ -326,7 +327,7 @@ func TestTrustedJobs(t *testing.T) {
 		if post.Cluster != trusted {
 			continue
 		}
-		if post.SourcePath != trustedPath {
+		if post.SourcePath != trustedPath && !strings.HasPrefix(post.SourcePath, trustedDir) {
 			t.Errorf("%s defined in %s may not run in trusted cluster", post.Name, post.SourcePath)
 		}
 	}
@@ -336,7 +337,7 @@ func TestTrustedJobs(t *testing.T) {
 		if per.Cluster != trusted {
 			continue
 		}
-		if per.SourcePath != trustedPath {
+		if per.SourcePath != trustedPath && !strings.HasPrefix(per.SourcePath, trustedDir) {
 			t.Errorf("%s defined in %s may not run in trusted cluster", per.Name, per.SourcePath)
 		}
 	}


### PR DESCRIPTION
These jobs run in the trusted cluster, don't have anything to do with test-infra, and should only be approved by the set of people who would otherwise have access to them.

(We can clean this up / move the directory / whatever, but I need this for a PoC nowish.)

/cc @fejta 