### PR TITLE
Remove comments in BUILD.bazel in prometheus folder

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
@@ -15,8 +15,6 @@ jsonnet_to_json(
     name = "prow_prometheusrule",
     src = "prow_prometheusrule.jsonnet",
     outs = ["prow_prometheusrule.yaml"],
-    #uncomment the following line when https://github.com/bazelbuild/rules_jsonnet/issues/114 has a fix.
-    #yaml_stream = True,
     visibility = ["//visibility:public"],
     deps = [":prom_lib"],
 )


### PR DESCRIPTION
https://github.com/bazelbuild/rules_jsonnet/issues/114 is closed.
`yaml_stream = True` does not convert the file to standard yaml as I expected.

See https://github.com/bazelbuild/rules_jsonnet/issues/114#issuecomment-528060474.

When we do the `kubectl apply`, the input file is with json format.