### PR TITLE
Update to oldest available coreos-beta image

### DIFF
--- a/jobs/e2e_node/image-config-1-12.yaml
+++ b/jobs/e2e_node/image-config-1-12.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce
+    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-13.yaml
+++ b/jobs/e2e_node/image-config-1-13.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce
+    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-14.yaml
+++ b/jobs/e2e_node/image-config-1-14.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce
+    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1883-1-0-v20180911 # docker 18.06.1-ce
+    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:


### PR DESCRIPTION
coreos-beta-1883-1-0-v20180911 is gone! All hail coreos-beta-1911-1-1-v20181011

Also reported in https://github.com/kubernetes/kubernetes/issues/82358

```
dims@coreos-beta-1 ~ $ docker version
Client:
 Version:           18.06.1-ce
 API version:       1.38
 Go version:        go1.10.4
 Git commit:        e68fc7a
 Built:             Tue Aug 21 17:16:31 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.1-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.4
  Git commit:       e68fc7a
  Built:            Tue Aug 21 17:16:31 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```