### PR TITLE
Update testgrid tab names for Kops periodics to use CI version markers

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -52,7 +52,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-release-1.16-all, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.16
+    testgrid-tab-name: kops-aws-beta
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
   labels:
@@ -286,7 +286,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.15
+    testgrid-tab-name: kops-aws-stable1
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-stable2
   labels:
@@ -313,7 +313,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-release-1.14-all, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.14
+    testgrid-tab-name: kops-aws-stable2
 - interval: 6h
   name: ci-kubernetes-e2e-kops-aws-stable3
   labels:
@@ -340,7 +340,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.13
+    testgrid-tab-name: kops-aws-stable3
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-updown
   labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -51,8 +51,8 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190903-df3b2f0-master
 
   annotations:
-    testgrid-dashboards: google-aws, sig-release-1.14-all, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.14
+    testgrid-dashboards: google-aws, sig-release-1.16-all, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-1.16
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
   labels:
@@ -286,7 +286,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.13
+    testgrid-tab-name: kops-aws-1.15
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-stable2
   labels:
@@ -312,8 +312,8 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190903-df3b2f0-master
 
   annotations:
-    testgrid-dashboards: google-aws, sig-release-1.13-all, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.12
+    testgrid-dashboards: google-aws, sig-release-1.14-all, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-1.14
 - interval: 6h
   name: ci-kubernetes-e2e-kops-aws-stable3
   labels:
@@ -340,7 +340,7 @@ periodics:
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.11
+    testgrid-tab-name: kops-aws-1.13
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-updown
   labels:


### PR DESCRIPTION
The versions in the tab names are out of date with the version of k8s they actually test.

cc @mikesplain @justinsb 