### PR TITLE
Add --env-passthrough to image-pusher

### DIFF
--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -44,4 +44,6 @@ bazel run //images/builder -- [options] path/to/image-directory/
 * `--log-dir`: If provided, build logs will be sent to files in this directory instead of to stdout/stderr.
 * `--project`: If specified, use a non-default GCP project.
 * `--scratch-bucket`: If provided, the complete GCS path for Cloud Build to store scratch files (sources, logs). Necessary for upload reuse. If omitted, `gcloud` will create or reuse a bucket of its choosing.
-* `-variant`: If specified, build only the given variant. An error if no variants are defined.
+* `--variant`: If specified, build only the given variant. An error if no variants are defined.
+* `--env-passthrough`: A comma-separated list of environment variables to pass through as substitutions.
+  The substitution names will automatically be prefixed with underscores, as required by GCB.


### PR DESCRIPTION
This lets you pass through a comma-separated list of environment variables as substitutions. This is useful for e.g. passing the ref through from prow to GCB.