### PR TITLE
Pass PULL_BASE_REF through to cluster-api builds.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -11,13 +11,14 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20190828-ce571c0
+          - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
             command:
               - /run.sh
             args:
               # this is the project GCB will run in, which is the same as the GCR images are pushed to.
               - --project=k8s-staging-cluster-api
               - --scratch-bucket=gs://k8s-staging-cluster-api-scratch
+              - --env-passthrough=PULL_BASE_REF
               - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
This will cause `_PULL_BASE_REF` to be available as a substitution to cluster-api's [cloudbuild.yaml](https://github.com/kubernetes-sigs/cluster-api/blob/master/cloudbuild.yaml).

`_PULL_BASE_REF` will be the name of the ref that was pushed, e.g. `master` or `release-0.2` or `v0.2`.

Due to GCB's strictness, merging this without updating that file to reference `_PULL_BASE_REF` in `substitutions` and `$_PULL_BASE_REF` in `steps` will cause it to fail to build. The strictness can (and probably should) be alleviated by adding this to the cloudbuild.yaml:

```yaml
options:
  substitution_option: ALLOW_LOOSE
```

/cc @detiber @vincepri 
/hold