### PR TITLE
re-enable stubdomains test with node-cache

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -389,6 +389,31 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190903-df3b2f0-master
 
 - interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=520
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=NODE_LOCAL_SSDS_EXT=1,scsi,fs
+      - --env=CLUSTER_DNS_CORE_DNS=false,
+      - --env=KUBE_ENABLE_NODELOCAL_DNS=true
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=500m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190903-df3b2f0-master
+
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
   labels:
     preset-service-account: "true"

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -87,6 +87,12 @@ dashboards:
       description: network gci-gce with kube-dns serial e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
+    - name: gci-gce-serial-kube-dns-nodecache
+      test_group_name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
+      base_options: include-filter-by-regex=\[sig-network\]
+      description: network gci-gce with kube-dns and nodelocaldns cache serial e2e tests for master branch
+      alert_options:
+        alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-alpha-features
       test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
       base_options: include-filter-by-regex=\[sig-network\]


### PR DESCRIPTION
Revert of https://github.com/kubernetes/test-infra/pull/10936/files
To be merged after support for stubdomains is added here - https://github.com/kubernetes/dns/pull/322