### PR TITLE
Aggregate errors in branch protector

### DIFF
--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/logrusutil:go_default_library",


### PR DESCRIPTION
Return aggregated errors from `UpdateOrg` and  `UpdateRepo` rather than short circuiting on first error and returning. 

resolve istio/test-infra#1511

---

https://github.com/istio/test-infra/issues/1511#issuecomment-521317775
> ...
BranchProtector should continue to run even when it encounters an error on a single repo. So a single broken repo doesn't mean that all subsequent repos are also broken.