### PR TITLE
Enable all API groups for alpha-feature tests

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -3931,6 +3931,7 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/k8s-beta
       - --timeout=180m
+      - --runtime-config=api/all=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -625,6 +625,7 @@ jobs:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
       --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
     sigOwners: [sig-gcp]


### PR DESCRIPTION
This aims to emulate the configuration for ci-kubernetes-e2e-gci-gce-alpha-features.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>

For reference, this is the config for the alpha features job in master-blocking: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/sig-gcp-gce-config.yaml#L203