### PR TITLE
Tide: Use a lister for ProwJobs

### DIFF
--- a/prow/apis/prowjobs/v1/BUILD.bazel
+++ b/prow/apis/prowjobs/v1/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
     ],
 )
 

--- a/prow/apis/prowjobs/v1/register.go
+++ b/prow/apis/prowjobs/v1/register.go
@@ -17,12 +17,21 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"k8s.io/test-infra/prow/apis/prowjobs"
 )
+
+func init() {
+	if err := AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add prowjob api to scheme: %v", err))
+	}
+}
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: prowjobs.GroupName, Version: "v1"}

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -17,6 +17,8 @@ rules:
     verbs:
       - create
       - list
+      - get
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
-        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -132,9 +132,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating manager")
 	}
-	if err := prowapi.AddToScheme(mgr.GetScheme()); err != nil {
-		logrus.WithError(err).Fatal("Error adding prow api to scheme")
-	}
 
 	buildClusterClients, err := o.kubernetes.BuildClusterClients(cfg().PodNamespace, o.dryRun.Value)
 	if err != nil {

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1fake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -385,10 +384,6 @@ func TestClean(t *testing.T) {
 		},
 	}
 	deletedPodsTrusted := sets.NewString("old-failed-trusted")
-
-	if err := prowv1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to add prowv1 to scheme: %v", err)
-	}
 
 	fpjc := fakectrlruntimeclient.NewFakeClient(prowJobs...)
 	fkc := []*corev1fake.Clientset{corev1fake.NewSimpleClientset(pods...), corev1fake.NewSimpleClientset(podsTrusted...)}

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/flagutil:go_default_library",
         "//pkg/io:go_default_library",
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
@@ -24,6 +25,9 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/tide:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/runtime/signals:go_default_library",
     ],
 )
 

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/tide:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/runtime/signals:go_default_library",
     ],

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//prow/tide:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/runtime/signals:go_default_library",
     ],
 )
 

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/test-infra/prow/interrupts"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -163,9 +162,6 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
 
-	if err := prowjobsv1.AddToScheme(scheme.Scheme); err != nil {
-		logrus.WithError(err).Fatal("failed to add ProwJobs to scheme.")
-	}
 	kubeCfg, err := o.kubernetes.InfrastructureClusterConfig(o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kubeconfig.")

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/errorutil:go_default_library",
         "//prow/git:go_default_library",
@@ -25,6 +24,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )
@@ -57,7 +57,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/git:go_default_library",
         "//prow/git/localgit:go_default_library",
@@ -70,6 +69,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -33,12 +33,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/test-infra/pkg/io"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/errorutil"
 	"k8s.io/test-infra/prow/git"
@@ -50,11 +49,6 @@ import (
 
 // For mocking out sleep during unit tests.
 var sleep = time.Sleep
-
-type prowJobClient interface {
-	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
-	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
-}
 
 type githubClient interface {
 	CreateStatus(string, string, string, github.Status) error
@@ -74,10 +68,11 @@ type contextChecker interface {
 
 // Controller knows how to sync PRs and PJs.
 type Controller struct {
+	ctx           context.Context
 	logger        *logrus.Entry
 	config        config.Getter
 	ghc           githubClient
-	prowJobClient prowJobClient
+	prowJobClient ctrlruntimeclient.Client
 	gc            *git.Client
 
 	sc *statusController
@@ -199,7 +194,7 @@ func init() {
 }
 
 // NewController makes a Controller out of the given clients.
-func NewController(ghcSync, ghcStatus github.Client, prowJobClient prowv1.ProwJobInterface, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*Controller, error) {
+func NewController(ghcSync, ghcStatus github.Client, prowJobClient ctrlruntimeclient.Client, cfg config.Getter, gc *git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}
@@ -219,6 +214,7 @@ func NewController(ghcSync, ghcStatus github.Client, prowJobClient prowv1.ProwJo
 	}
 	go sc.run()
 	return &Controller{
+		ctx:           context.Background(),
 		logger:        logger.WithField("controller", "sync"),
 		ghc:           ghcSync,
 		prowJobClient: prowJobClient,
@@ -307,8 +303,8 @@ func (c *Controller) Sync() error {
 	var err error
 	if len(prs) > 0 {
 		start := time.Now()
-		pjList, err := c.prowJobClient.List(metav1.ListOptions{})
-		if err != nil {
+		pjList := &prowapi.ProwJobList{}
+		if err := c.prowJobClient.List(c.ctx, pjList, ctrlruntimeclient.InNamespace(c.config().ProwJobNamespace)); err != nil {
 			c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to list ProwJobs from the cluster.")
 			return err
 		}
@@ -1043,7 +1039,7 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 		pj := pjutil.NewProwJob(spec, ps.Labels, ps.Annotations)
 		log := c.logger.WithFields(pjutil.ProwJobFields(&pj))
 		start := time.Now()
-		if _, err := c.prowJobClient.Create(&pj); err != nil {
+		if err := c.prowJobClient.Create(c.ctx, &pj); err != nil {
 			log.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
 			return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
 		}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -34,16 +34,22 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/tide/history"
 )
+
+func init() {
+	if err := prowapi.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to register scheme: %v", err))
+	}
+}
 
 func testPullsMatchList(t *testing.T, test string, actual []PullRequest, expected []int) {
 	if len(actual) != len(expected) {
@@ -1357,13 +1363,13 @@ func TestTakeAction(t *testing.T) {
 			return prs
 		}
 		fgc := fgc{mergeErrs: tc.mergeErrs}
-		fakeProwJobClient := fake.NewSimpleClientset()
+		client := fakectrlruntimeclient.NewFakeClient()
 		c := &Controller{
 			logger:        logrus.WithField("controller", "tide"),
 			gc:            gc,
 			config:        ca.Config,
 			ghc:           &fgc,
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: client,
 			changedFiles: &changedFilesAgent{
 				ghc:             &fgc,
 				nextChangeCache: make(map[changeCacheKey][]string),
@@ -1383,17 +1389,19 @@ func TestTakeAction(t *testing.T) {
 			t.Errorf("Wrong action. Got %v, wanted %v.", act, tc.action)
 		}
 
-		numCreated := 0
+		prowJobs := &prowapi.ProwJobList{}
+		if err := client.List(context.Background(), prowJobs); err != nil {
+			t.Fatalf("failed to list ProwJobs: %v", err)
+		}
+		numCreated := len(prowJobs.Items)
+
 		var batchJobs []*prowapi.ProwJob
-		for _, action := range fakeProwJobClient.Actions() {
-			switch action := action.(type) {
-			case clienttesting.CreateActionImpl:
-				numCreated++
-				if prowJob, ok := action.Object.(*prowapi.ProwJob); ok && prowJob.Spec.Type == prowapi.BatchJob {
-					batchJobs = append(batchJobs, prowJob)
-				}
+		for _, pj := range prowJobs.Items {
+			if pj.Spec.Type == prowapi.BatchJob {
+				batchJobs = append(batchJobs, &pj)
 			}
 		}
+
 		if tc.triggered != numCreated {
 			t.Errorf("Wrong number of jobs triggered. Got %d, expected %d.", numCreated, tc.triggered)
 		}
@@ -1646,7 +1654,6 @@ func TestSync(t *testing.T) {
 				"org/repo B":       "SHA",
 			},
 		}
-		fakeProwJobClient := fake.NewSimpleClientset()
 		ca := &config.Agent{}
 		ca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
@@ -1675,7 +1682,7 @@ func TestSync(t *testing.T) {
 			config:        ca.Config,
 			ghc:           fgc,
 			gc:            &git.Client{},
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: fakectrlruntimeclient.NewFakeClient(),
 			logger:        logrus.WithField("controller", "sync"),
 			sc:            sc,
 			changedFiles: &changedFilesAgent{

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -34,7 +34,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/client-go/kubernetes/scheme"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -44,12 +43,6 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/tide/history"
 )
-
-func init() {
-	if err := prowapi.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		panic(fmt.Sprintf("failed to register scheme: %v", err))
-	}
-}
 
 func testPullsMatchList(t *testing.T, test string, actual []PullRequest, expected []int) {
 	if len(actual) != len(expected) {


### PR DESCRIPTION
This PR updates Tide to use a lister for Prowjobs. This is done to significantly reduce the cost of LIST operations against the kube api which we need in order to fix https://github.com/kubernetes/test-infra/issues/14233