### PR TITLE
Retire planks deprecated job_url_prefix option

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -4,7 +4,7 @@ New features added to each component:
  - *August 29, 2019* Added a `batch_size_limit` option to the Tide config that
    allows the batch size limit to be specified globally, per org, or per repo.
    Values default to 0 indicating no size limit. A value of -1 disables batches.
- - *July 30, 2019* `authorized_users` in `rerun_auth_config` for deck will become `github_users`. 
+ - *July 30, 2019* `authorized_users` in `rerun_auth_config` for deck will become `github_users`.
  - *July 19, 2019* deck will soon remove its default value for `--cookie-secret-file`.
    If you set `--oauth-url` but not `--cookie-secret-file`, add
    `--cookie-secret-file=/etc/cookie-secret` to your deck instance. The default value
@@ -75,6 +75,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *September 8, 2019* The deprecated `job_url_prefix` option has been removed from Plank.
  - *May 2, 2019* All components exposing Prometheus metrics will now either push them
    to the Prometheus PushGateway, if configured, or serve them locally on port 9090 at
    `/metrics`, if not configured (the default).

--- a/prow/cmd/plank/README.md
+++ b/prow/cmd/plank/README.md
@@ -16,7 +16,8 @@ Only GCS is supported as the job log storage at the moment.
 plank:
   allow_cancellations: true # whether to delete ProwJobs' pod (true) or not (false) when new instances are triggered for the same PR
   # used to link to job results for decorated jobs (with pod utilities)
-  job_url_prefix: 'https://<domain>/view/gcs'
+  job_url_prefix_config:
+    '*': https://<domain>/view/gcs
   # used to link to job results for non decorated jobs (without pod utilities)
   job_url_template: 'https://<domain>/view/gcs/<bucket-name>/pr-logs/pull/{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
   report_template: '[Full PR test history](https://<domain>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,7 +1,8 @@
 plank:
   job_url_template: '{{if .Spec.Refs}}{{if eq .Spec.Refs.Org "kubernetes-security"}}https://console.cloud.google.com/storage/browser/kubernetes-security-prow/{{else}}https://prow.k8s.io/view/gcs/kubernetes-jenkins/{{end}}{{else}}https://prow.k8s.io/view/gcs/kubernetes-jenkins/{{end}}{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{if and (eq .Spec.Refs.Org "kubernetes-sigs") (ne .Spec.Refs.Repo "poseidon")}}sigs.k8s.io{{else}}{{.Spec.Refs.Org}}{{end}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.k8s.io/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
-  job_url_prefix: https://prow.k8s.io/view/gcs/
+  job_url_prefix_config:
+    '*': https://prow.k8s.io/view/gcs/
   pod_pending_timeout: 60m
   default_decoration_config:
     timeout: 2h

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -377,11 +377,6 @@ type Plank struct {
 	// DefaultDecorationConfig are defaults for shared fields for ProwJobs
 	// that request to have their PodSpecs decorated
 	DefaultDecorationConfig *prowapi.DecorationConfig `json:"default_decoration_config,omitempty"`
-	// Deprecated, use JobURLPrefixConfig instead
-	// JobURLPrefix is the host and path prefix under
-	// which job details will be viewable
-	// TODO @alvaroaleman: Remove in September 2019
-	JobURLPrefix string `json:"job_url_prefix,omitempty"`
 	// JobURLPrefixConfig is the host and path prefix under which job details
 	// will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
 	JobURLPrefixConfig map[string]string `json:"job_url_prefix_config,omitempty"`
@@ -957,9 +952,6 @@ func (c *Config) finalizeJobConfig() error {
 
 // validateComponentConfig validates the infrastructure component configuration
 func (c *Config) validateComponentConfig() error {
-	if c.Plank.JobURLPrefix != "" && c.Plank.JobURLPrefixConfig["*"] != "" {
-		return errors.New(`Planks job_url_prefix must be unset when job_url_prefix_config["*"] is set. The former is deprecated, use the latter`)
-	}
 	for k, v := range c.Plank.JobURLPrefixConfig {
 		if _, err := url.Parse(v); err != nil {
 			return fmt.Errorf(`Invalid value for Planks job_url_prefix_config["%s"]: %v`, k, err)
@@ -1315,13 +1307,6 @@ func parseProwConfig(c *Config) error {
 
 	if c.Plank.JobURLPrefixConfig == nil {
 		c.Plank.JobURLPrefixConfig = map[string]string{}
-	}
-	if c.Plank.JobURLPrefix != "" && c.Plank.JobURLPrefixConfig["*"] == "" {
-		c.Plank.JobURLPrefixConfig["*"] = c.Plank.JobURLPrefix
-		// Set JobURLPrefix to an empty string to indicate we've moved
-		// it to JobURLPrefixConfig["*"] without overwriting the latter
-		// so validation succeeds
-		c.Plank.JobURLPrefix = ""
 	}
 
 	if c.GitHubOptions.LinkURLFromConfig == "" {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2349,26 +2349,6 @@ func TestValidateComponentConfig(t *testing.T) {
 		errExpected bool
 	}{
 		{
-			name: `JobURLPrefix and JobURLPrefixConfig["*"].URL set, err`,
-			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefix: "https://my-default-prow",
-				JobURLPrefixConfig: map[string]string{
-					"*": "https://my-alternate-prow",
-				},
-			}}},
-			errExpected: true,
-		},
-		{
-			name: `JobURLPrefix and JobURLPrefixConfig["*"].URL unset, no err`,
-			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefix: "https://my-default-prow",
-				JobURLPrefixConfig: map[string]string{
-					"my-other-org": "https://my-alternate-prow",
-				},
-			}}},
-			errExpected: false,
-		},
-		{
 			name: "Valid default URL, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
 				JobURLPrefixConfig: map[string]string{"*": "https://my-prow"}}}},

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -21,7 +21,7 @@ To enable spyglass, just pass the `--spyglass` flag to your `deck` instance. Onc
 it will expose itself under `/view/` on your `deck` instance.
 
 In order to make Spyglass useful, you may want to set your job URLs to point at it. You can do so by
-setting `plank.job_url_prefix` to `https://your.deck/view/gcs/`, and possibly `plank.job_url_template`
+setting `plank.job_url_prefix_config['*']` to `https://your.deck/view/gcs/`, and possibly `plank.job_url_template`
 to reference something similar depending on your setup.
 
 If you are not using the images we provide, you may also need to provide `--spyglass-files-location`,


### PR DESCRIPTION
Removes the deprecated `job_url_prefix` option from Plank.

Fixes #13270