### PR TITLE
Add image-pushing job for capo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
+++ b/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
@@ -17,7 +17,7 @@ postsubmits:
             args:
               # this is the project GCB will run in, which is the same as the GCR images are pushed to.
               - --project=k8s-staging-capi-openstack
-              - --scratch-bucket=gs://k8s-staging-capi-openstack-scratch
+              - --scratch-bucket=gs://k8s-staging-capi-openstack-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
             env:

--- a/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
+++ b/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
@@ -1,0 +1,31 @@
+postsubmits:
+  # this is the github repo we'll build from; this block needs to be repeated for each repo.
+  kubernetes-sigs/cluster-api-provider-openstack:
+    - name: post-capi-openstack-push-images
+      cluster: test-infra-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20190828-ce571c0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-capi-openstack
+              - --scratch-bucket=gs://k8s-staging-capi-openstack-scratch
+              - .
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-service-account

--- a/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
+++ b/config/jobs/image-pushing/k8s-staging-capi-openstack.yaml
@@ -11,13 +11,14 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20190828-ce571c0
+          - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
             command:
               - /run.sh
             args:
               # this is the project GCB will run in, which is the same as the GCR images are pushed to.
               - --project=k8s-staging-capi-openstack
               - --scratch-bucket=gs://k8s-staging-capi-openstack-scratch
+              - --env-passthrough=PULL_BASE_REF
               - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
This PR adds a job to push CAPO images similar to the CAPI ones: https://github.com/kubernetes/test-infra/pull/14195

Hope this PR is not to wrong. I'mt not sure what the correct process is or if there's anything else to do :)

/cc @Katharine @detiber 