### PR TITLE
prow/gcsupload: Log options

### DIFF
--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -40,6 +40,8 @@ import (
 // to their destination in GCS, so the caller can
 // operate relative to the base of the GCS dir.
 func (o Options) Run(spec *downwardapi.JobSpec, extra map[string]gcs.UploadFunc) error {
+	logrus.WithField("options", o).Debug("Uploading to GCS")
+
 	for extension, mediaType := range o.GCSConfiguration.MediaTypes {
 		mime.AddExtensionType("."+extension, mediaType)
 	}


### PR DESCRIPTION
Sometimes the Prow stack leading to the `gcsupload` call is long and complicated.  Log our options to help folks managing the stack distinguish between "`gcsupload` isn't doing what I'm telling it to do" and "I'm telling `gcsupload` the wrong thing".  Log lines will look like:

    {"component":"gcsupload","file":".../src/k8s.io/test-infra/prow/cmd/gcsupload/main.go:48","func":"main.main","level":"info","msg":"gcsupload called with: \u0026gcsupload.Options{Items:[]string(nil), ...},"time":"2019-09-09T11:28:13-07:00"}