### PR TITLE
Remove deprecated `data.js` endpoint

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -75,6 +75,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+- *September 16, 2019* `deck` will no longer serve build data via the `/data.js` endpoint. 
+   Instead, `ProwJob` definitions will be served via `/prowjobs.js`.
  - *September 8, 2019* The deprecated `job_url_prefix` option has been removed from Plank.
  - *May 2, 2019* All components exposing Prometheus metrics will now either push them
    to the Prometheus PushGateway, if configured, or serve them locally on port 9090 at

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -493,7 +493,6 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 	cfgGetter := func() *prowapi.RerunAuthConfig { return &cfg().Deck.RerunAuthConfig }
 
 	// setup prod only handlers
-	mux.Handle("/data.js", gziphandler.GzipHandler(handleData(ja)))
 	mux.Handle("/prowjobs.js", gziphandler.GzipHandler(handleProwJobs(ja)))
 	mux.Handle("/badge.svg", gziphandler.GzipHandler(handleBadge(ja)))
 	mux.Handle("/log", gziphandler.GzipHandler(handleLog(ja)))
@@ -742,19 +741,6 @@ func handleProwJobs(ja *jobs.JobAgent) http.HandlerFunc {
 		if err != nil {
 			logrus.WithError(err).Error("Error marshaling jobs.")
 			jd = []byte("{}")
-		}
-		writeJSONResponse(w, r, jd)
-	}
-}
-
-func handleData(ja *jobs.JobAgent) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		setHeadersNoCaching(w)
-		jobs := ja.Jobs()
-		jd, err := json.Marshal(jobs)
-		if err != nil {
-			logrus.WithError(err).Error("Error marshaling jobs.")
-			jd = []byte("[]")
 		}
 		writeJSONResponse(w, r, jd)
 	}


### PR DESCRIPTION
Targets 1 sub-issues of #5216 -> 
1.`"Delete /data.js and associated machinery."`

/hold