### PR TITLE
CAPV job updates

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -202,10 +202,8 @@ presubmits:
       preset-service-account: "true"
       preset-cluster-api-provider-vsphere-e2e-creds: "true"
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
-    branches:
-    - ^release-0.4$
     always_run: false
-    run_if_changed: '^((cmd|config|pkg|(scripts/e2e)|vendor)/)|Dockerfile'
+    run_if_changed: '^((api|cmd|config|controllers|pkg|(scripts/e2e)|vendor)/)|Dockerfile'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 1

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-verify-fmt
     always_run: false
-    run_if_changed: '^((cmd|pkg|(vendor/github.com/mbenkmann/goformat/goformat)|(vendor/golang.org/x/tools/cmd/goimports))/)|hack/check-format\.sh'
+    run_if_changed: '^((api|cmd|controllers|pkg|(vendor/github.com/mbenkmann/goformat/goformat)|(vendor/golang.org/x/tools/cmd/goimports))/)|hack/check-format\.sh'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -90,7 +90,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-lint
     always_run: false
-    run_if_changed: '^((cmd|pkg|(vendor/golang.org/x/lint/golint))/)|hack/check-lint\.sh'
+    run_if_changed: '^((api|cmd|controllers|pkg|(vendor/golang.org/x/lint/golint))/)|hack/check-lint\.sh'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -106,7 +106,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-vet
     always_run: false
-    run_if_changed: '^((cmd|pkg)/)|hack/check-vet\.sh'
+    run_if_changed: '^((api|cmd|controllers|pkg)/)|hack/check-vet\.sh'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -159,7 +159,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-crds
     always_run: false
-    run_if_changed: '^((config|pkg|vendor)/)|hack/verify-crds\.sh'
+    run_if_changed: '^((api|config|controllers|pkg|vendor)/)|Makefile|hack/verify-crds\.sh'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -175,7 +175,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-test
     always_run: false
-    run_if_changed: '^((cmd|config|hack|pkg|vendor)/)|Makefile|(scripts/(ci-test|fetch_ext_bins)\.sh)'
+    run_if_changed: '^((api|cmd|config|controllers|hack|pkg|vendor)/)|Makefile|(scripts/(ci-test|fetch_ext_bins)\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     labels:
@@ -237,7 +237,7 @@ postsubmits:
     branches:
     - ^master$
     always_run: false
-    run_if_changed: '^(cmd|config|pkg|vendor)/|Dockerfile'
+    run_if_changed: '^(api|cmd|config|controllers|examples|pkg|vendor)/|Dockerfile'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 1


### PR DESCRIPTION
This PR updates the CAPV jobs:

* Reenables e2e for PRs against `master`
* Updates the jobs to support both v1a1 (`release-0.4`) and v1a2 (`master`) branches