### PR TITLE
Add function KubernetesClientSet.

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "@com_github_pelletier_go_toml//:go_default_library",
         "@com_github_satori_go_uuid//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@org_golang_x_crypto//ssh:go_default_library",
     ],
 )

--- a/kubetest/eks.go
+++ b/kubetest/eks.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/aws/aws-k8s-tester/eksconfig"
 	"github.com/aws/aws-k8s-tester/ekstester"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/test-infra/kubetest/process"
 	"k8s.io/test-infra/kubetest/util"
 )
@@ -321,5 +322,11 @@ func (dp *eksDeployer) fetchAWSK8sTester() error {
 	if err = util.EnsureExecutable(dp.cfg.AWSK8sTesterPath); err != nil {
 		return err
 	}
+	return nil
+}
+
+// KubernetesClientSet is an empty implement to make eksDeployer meet
+// the definition of interface ekstester.Deployer
+func (dp *eksDeployer) KubernetesClientSet() *kubernetes.Clientset {
 	return nil
 }


### PR DESCRIPTION
Add function KubernetesClientSet to make eksDeployer meet the definition of interface ekstester.Deployer.

Fixes: #14260 