### PR TITLE
Assign a single reviewer to PRs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -169,7 +169,7 @@ blockades:
   explanation: "Changes to certain release tools can affect our ability to test, build, and release Kubernetes. This PR must be explicitly approved by SIG Release repo admins."
 
 blunderbuss:
-  max_request_count: 2
+  max_request_count: 1
   use_status_availability: true
 
 cat:


### PR DESCRIPTION
Having two reviewers means neither feels responsible, and we can't
track responsiveness by reviewer.  PRs are therefore not reviewed in a
timely manner.

Having two reviewers causes a suboptimal experience all round.

Reviewers can mark their status in github when they are on extended
holiday etc.