### PR TITLE
clonerefs: Add `--fail` flag.

### DIFF
--- a/prow/clonerefs/options.go
+++ b/prow/clonerefs/options.go
@@ -61,6 +61,8 @@ type Options struct {
 	// limit to parallelism
 	MaxParallelWorkers int `json:"max_parallel_workers,omitempty"`
 
+	Fail bool `json:"fail,omitempty"`
+
 	// used to hold flag values
 	refs       gitRefs
 	clonePath  orgRepoFormat
@@ -153,6 +155,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.Var(&o.cloneURI, "uri-prefix", "Format string for the URI prefix to clone from")
 	fs.IntVar(&o.MaxParallelWorkers, "max-workers", 0, "Maximum number of parallel workers, unset for unlimited.")
 	fs.StringVar(&o.CookiePath, "cookiefile", "", "Path to git http.cookiefile")
+	fs.BoolVar(&o.Fail, "fail", false, "Exit with failure if any of the refs can't be fetched.")
 }
 
 type gitRefs struct {

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -82,8 +82,13 @@ func (o Options) Run() error {
 	wg.Wait()
 	close(output)
 
+	var hasFailedRecord bool
 	var results []clone.Record
 	for record := range output {
+		if record.Failed {
+			hasFailedRecord = true
+		}
+
 		results = append(results, record)
 	}
 
@@ -94,6 +99,10 @@ func (o Options) Run() error {
 
 	if err := ioutil.WriteFile(o.Log, logData, 0755); err != nil {
 		return fmt.Errorf("failed to write clone records: %v", err)
+	}
+
+	if o.Fail && hasFailedRecord {
+		return fmt.Errorf("one or more of the records are in failed state")
 	}
 
 	return nil


### PR DESCRIPTION
With this flag, we force `clonerefs` tool to exit with non-zero return code when any of the refs weren't fetched.