### PR TITLE
Revert listed Boskos version(s) to deployed images

### DIFF
--- a/boskos/deployment.yaml
+++ b/boskos/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-testimages/boskos:v20190621-ff01381
+        image: gcr.io/k8s-testimages/boskos:v20190326-21e7f896f
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/boskos/metrics/deployment.yaml
+++ b/boskos/metrics/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-testimages/metrics:v20190621-ff01381
+        image: gcr.io/k8s-testimages/metrics:v20180604-ea866c2e8
         args:
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account
         ports:

--- a/boskos/reaper/deployment.yaml
+++ b/boskos/reaper/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-testimages/reaper:v20190621-ff01381
+        image: gcr.io/k8s-testimages/reaper:v20190319-1a5a7d7fb
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-project,aws-account


### PR DESCRIPTION
Bump #14249 changed the listed Boskos version in these configs, but because #14267 hasn't been fully resolved, the listed image doesn't match reality.

Rather than deploy this version of Boskos immediately, we are changing these files to match reality.

/assign @Katharine @cjwagner @michelle192837 