### PR TITLE
Update to oldest available coreos-beta image - take #2

### DIFF
--- a/jobs/e2e_node/image-config-1-12.yaml
+++ b/jobs/e2e_node/image-config-1-12.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
+    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-13.yaml
+++ b/jobs/e2e_node/image-config-1-13.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
+    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config-1-14.yaml
+++ b/jobs/e2e_node/image-config-1-14.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
+    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
   coreos-beta:
-    image: coreos-beta-1911-1-1-v20181011 # docker 18.06.1-ce
+    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:


### PR DESCRIPTION
coreos-beta-1911-1-1-v20181011 is gone! All hail coreos-beta-1911-2-0-v20181024

Deja Vu! https://github.com/kubernetes/test-infra/pull/14203

Change-Id: I292029e5fc51397e4ec09c4978984d1d4782feb3