### PR TITLE
Allow mason destruct.

### DIFF
--- a/boskos/cleaner/cleaner.go
+++ b/boskos/cleaner/cleaner.go
@@ -104,7 +104,7 @@ func (c *Cleaner) recycleOne(res *common.Resource) {
 		return
 	}
 	if leasedResources != nil {
-		resources, err := c.client.AcquireByState(res.Name, common.Cleaning, leasedResources)
+		resources, err := c.client.AcquireByState(res.Name, common.Cleaning, leasedResources.Flatten())
 		if err != nil {
 			logrus.WithError(err).Warningf("could not acquire some leased resources for %s", res.Name)
 		}

--- a/boskos/cleaner/cleaner.go
+++ b/boskos/cleaner/cleaner.go
@@ -104,16 +104,8 @@ func (c *Cleaner) recycleOne(res *common.Resource) {
 		return
 	}
 
-	var legacyLeasedResources common.LegacyLeasedResource
-	switch leasedResources := leasedRes.(type) {
-	case common.LegacyLeasedResource:
-		legacyLeasedResources = leasedResources
-	case common.LeasedResources:
-		legacyLeasedResources = leasedResources.Flatten()
-	}
-
-	if legacyLeasedResources != nil {
-		resources, err := c.client.AcquireByState(res.Name, common.Cleaning, legacyLeasedResources)
+	if leasedRes != nil {
+		resources, err := c.client.AcquireByState(res.Name, common.Cleaning, leasedRes.Flatten())
 		if err != nil {
 			logrus.WithError(err).Warningf("could not acquire some leased resources for %s", res.Name)
 		}

--- a/boskos/cleaner/cleaner_test.go
+++ b/boskos/cleaner/cleaner_test.go
@@ -76,7 +76,7 @@ func (fb *fakeBoskos) ReleaseAll(state string) error {
 	return nil
 }
 
-func testResource(name, rType, state, owner string, leasedResources []string) common.Resource {
+func testResource(name, rType, state, owner string, leasedResources common.LeasedResources) common.Resource {
 	res := common.NewResource(name, rType, state, owner, time.Now())
 	res.UserData.Set(mason.LeasedResources, &leasedResources)
 	return res
@@ -113,7 +113,7 @@ func TestRecycleResources(t *testing.T) {
 				testResource("static_1", "static", "dynamic_1", "", nil),
 				testResource("static_2", "static", "dynamic_1", "", nil),
 				testResource("static_3", "static", common.Free, "", nil),
-				testResource("dynamic_1", "dynamic", common.Free, "", []string{"static_1", "static_2"}),
+				testResource("dynamic_1", "dynamic", common.Free, "", common.LeasedResources{"fakeType": []string{"static_1", "static_2"}}),
 				testResource("dynamic_2", "dynamic", common.ToBeDeleted, "", nil),
 			},
 			drlcs: []common.DynamicResourceLifeCycle{
@@ -137,8 +137,8 @@ func TestRecycleResources(t *testing.T) {
 				testResource("static_1", "static", "dynamic_1", "", nil),
 				testResource("static_2", "static", "dynamic_1", "", nil),
 				testResource("static_3", "static", "dynamic_2", "", nil),
-				testResource("dynamic_1", "dynamic", common.ToBeDeleted, "", []string{"static_1", "static_2"}),
-				testResource("dynamic_2", "dynamic", common.ToBeDeleted, "", []string{"static_3"}),
+				testResource("dynamic_1", "dynamic", common.ToBeDeleted, "", common.LeasedResources{"fakeType": []string{"static_1", "static_2"}}),
+				testResource("dynamic_2", "dynamic", common.ToBeDeleted, "", common.LeasedResources{"fakeType": []string{"static_3"}}),
 			},
 			drlcs: []common.DynamicResourceLifeCycle{
 				{
@@ -161,8 +161,8 @@ func TestRecycleResources(t *testing.T) {
 				testResource("static_1", "static", "dynamic_1", "", nil),
 				testResource("static_2", "static", common.Free, "", nil),
 				testResource("static_3", "static", common.Free, "", nil),
-				testResource("dynamic_1", "dynamic", common.ToBeDeleted, "", []string{"static_1", "static_2"}),
-				testResource("dynamic_2", "dynamic", common.ToBeDeleted, "", []string{"static_3"}),
+				testResource("dynamic_1", "dynamic", common.ToBeDeleted, "", common.LeasedResources{"fakeType": []string{"static_1", "static_2"}}),
+				testResource("dynamic_2", "dynamic", common.ToBeDeleted, "", common.LeasedResources{"fakeType": []string{"static_3"}}),
 			},
 			drlcs: []common.DynamicResourceLifeCycle{
 				{

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -57,6 +57,9 @@ type UserDataMap map[string]string
 // LeasedResources is a map of resource types to list of resource names that are used in order to create another resource by Mason
 type LeasedResources map[string][]string
 
+// LegacyLeasedResources is a list of resources name that used in order to create another resource by Mason
+type LegacyLeasedResource []string
+
 // Flatten returns a slice of all values from the map
 func (r *LeasedResources) Flatten() []string {
 	var resources []string

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -54,9 +54,10 @@ type UserData struct {
 // UserDataMap is the standard Map version of UserMap, it is used to ease UserMap creation.
 type UserDataMap map[string]string
 
-// LeasedResources is a list of resources name that used in order to create another resource by Mason
+// LeasedResources is a map of resource types to list of resource names that are used in order to create another resource by Mason
 type LeasedResources map[string][]string
 
+// Flatten returns a slice of all values from the map
 func (r *LeasedResources) Flatten() []string {
 	var resources []string
 	for _, value := range *r {

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -55,7 +55,15 @@ type UserData struct {
 type UserDataMap map[string]string
 
 // LeasedResources is a list of resources name that used in order to create another resource by Mason
-type LeasedResources []string
+type LeasedResources map[string][]string
+
+func (r *LeasedResources) Flatten() []string {
+	var resources []string
+	for _, value := range *r {
+		resources = append(resources, value...)
+	}
+	return resources
+}
 
 // Item interfaces for resources and configs
 type Item interface {

--- a/boskos/mason/client.go
+++ b/boskos/mason/client.go
@@ -63,7 +63,7 @@ func (c *Client) Acquire(rtype, state, dest string) (*common.Resource, error) {
 		}
 	}
 	resourcesToRelease = append(resourcesToRelease, *res)
-	resources, err := c.basic.AcquireByState(res.Name, dest, leasedResources)
+	resources, err := c.basic.AcquireByState(res.Name, dest, leasedResources.Flatten())
 	if err != nil {
 		releaseOnFailure()
 		return nil, err
@@ -93,7 +93,7 @@ func (c *Client) ReleaseOne(name, dest string) (allErrors error) {
 			return
 		}
 	}
-	resourceNames = append(resourceNames, leasedResources...)
+	resourceNames = append(resourceNames, leasedResources.Flatten()...)
 	for _, n := range resourceNames {
 		if err := c.basic.ReleaseOne(n, dest); err != nil {
 			logrus.WithError(err).Warningf("failed to release resource %s", n)

--- a/boskos/mason/fake-mason/main.go
+++ b/boskos/mason/fake-mason/main.go
@@ -61,6 +61,10 @@ func (m *fakeMasonAgent) Construct(context.Context, common.Resource, common.Type
 	return common.UserDataFromMap(ud), nil
 }
 
+func (m *fakeMasonAgent) Destruct(context.Context, *common.Resource, common.LeasedResources) error {
+	return nil
+}
+
 func main() {
 	kubeClientOptions.AddFlags(flag.CommandLine)
 	flag.Parse()

--- a/boskos/mason/fake-mason/main.go
+++ b/boskos/mason/fake-mason/main.go
@@ -61,7 +61,7 @@ func (m *fakeMasonAgent) Construct(context.Context, common.Resource, common.Type
 	return common.UserDataFromMap(ud), nil
 }
 
-func (m *fakeMasonAgent) Destruct(context.Context, *common.Resource, common.LeasedResources) error {
+func (m *fakeMasonAgent) Destruct(context.Context, *common.Resource, interface{}) error {
 	return nil
 }
 

--- a/boskos/mason/fake-mason/main.go
+++ b/boskos/mason/fake-mason/main.go
@@ -61,7 +61,7 @@ func (m *fakeMasonAgent) Construct(context.Context, common.Resource, common.Type
 	return common.UserDataFromMap(ud), nil
 }
 
-func (m *fakeMasonAgent) Destruct(context.Context, *common.Resource, interface{}) error {
+func (m *fakeMasonAgent) Destruct(context.Context, *common.Resource) error {
 	return nil
 }
 

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -90,6 +90,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
  
+ - *January 23, 2020* The mason interface now adds a `Destruct` phase during resource recycling which enables
+   custom cleanup implementations. `LeasedResources` are now a map from `type->value` instead of just a list of values.
+   During migration, all the previously leased resources will be added to the map with an empty type (`""`) key.
+   Details: https://github.com/kubernetes/test-infra/pull/14295
  - *November 21, 2019* The boskos metrics component replaced the existing prometheus
    metrics with a single, label-qualified metric. Metrics are now served at `/metrics`
    on port 9090. This actually happened August 5th, but is being documented now. 


### PR DESCRIPTION
Currently mason assumes there is nothing to clean while recycling a dynamic resource (apart from just releasing the dependent resources) .

Add a destruct phase before recycling.
Modify leasedResources to be a map from resource type to list of values, instead of just a list of all resources.

/cc @sebastienvas @krzyzacy 