### PR TITLE
Make staticcheck test required

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -96,7 +96,6 @@ presubmits:
   - name: pull-vsphere-csi-driver-verify-staticcheck
     always_run: false
     run_if_changed: '\.go$|hack\/check-staticcheck\.sh'
-    optional: true
     decorate: true
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:


### PR DESCRIPTION
This patch no longer sets "optional: true" for the staticcheck presubmit
test. This was always a temporary setting as some major code refactoring
was happening, and that perioid has passed.

/assign @dvonthenen 