### PR TITLE
Remove unneeded gazelle statement

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,6 @@
 # gazelle:exclude vendor/k8s.io/code-generator/_examples/
 # gazelle:exclude hack
 # gazelle:exclude node_modules
-# gazelle:repository_macro repos.bzl%go_repositories
 
 load("@io_k8s_repo_infra//defs:run_in_workspace.bzl", "workspace_binary")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")


### PR DESCRIPTION
This statement is only needed in the WORKSPACE file, but not the BUILD file.
https://github.com/kubernetes/test-infra/blob/63b8ee7f034fd5917eba0bf8a107689cd77315c4/WORKSPACE#L1

Fixes the warning:
```
gazelle: /go/src/k8s.io/test-infra/BUILD.bazel: unknown directive: gazelle:repository_macro
```

/assign @stevekuznetsov @fejta 