### PR TITLE
Always use relative URLs in frontend assets

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -54,14 +54,14 @@
     <nav class="mdl-navigation">
       <a class="mdl-navigation__link{{if eq .PageName "index"}} mdl-navigation__link--current{{end}}" href="/">Prow Status</a>
       {{ if sections.PR }}
-        <a class="mdl-navigation__link{{if eq .PageName "pr"}} mdl-navigation__link--current{{end}}" href="/pr">PR Status</a>
+        <a class="mdl-navigation__link{{if eq .PageName "pr"}} mdl-navigation__link--current{{end}}" href="pr">PR Status</a>
       {{ end }}
-      <a class="mdl-navigation__link{{if eq .PageName "command-help"}} mdl-navigation__link--current{{end}}" href="/command-help">Command Help</a>
+      <a class="mdl-navigation__link{{if eq .PageName "command-help"}} mdl-navigation__link--current{{end}}" href="command-help">Command Help</a>
       {{ if sections.Tide }}
-        <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="/tide">Tide Status</a>
-        <a class="mdl-navigation__link{{if eq .PageName "tide-history"}} mdl-navigation__link--current{{end}}" href="/tide-history">Tide History</a>
+        <a class="mdl-navigation__link{{if eq .PageName "tide"}} mdl-navigation__link--current{{end}}" href="tide">Tide Status</a>
+        <a class="mdl-navigation__link{{if eq .PageName "tide-history"}} mdl-navigation__link--current{{end}}" href="tide-history">Tide History</a>
       {{ end }}
-      <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="/plugins">Plugins</a>
+      <a class="mdl-navigation__link{{if eq .PageName "plugins"}} mdl-navigation__link--current{{end}}" href="plugins">Plugins</a>
       <a class="mdl-navigation__link" href="https://github.com/kubernetes/test-infra/blob/master/prow/README.md" target="_blank">Documentation <span class="material-icons">open_in_new</span></a>
     </nav>
     <footer>

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -26,12 +26,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   {{end}}
   <title>{{block "title" .Arguments}}Prow{{ end }}</title>
-  <link rel="stylesheet" type="text/css" href="/static/style.css">
-  <link rel="stylesheet" type="text/css" href="/static/extensions/style.css">
+  <link rel="stylesheet" type="text/css" href="static/style.css">
+  <link rel="stylesheet" type="text/css" href="static/extensions/style.css">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-  <script type="text/javascript" src="/static/extensions/script.js"></script>
+  <script type="text/javascript" src="static/extensions/script.js"></script>
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   {{block "scripts" .Arguments}}{{end}}
 </head>

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -35,9 +35,9 @@
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   {{block "scripts" .Arguments}}{{end}}
 </head>
-{{$defaultLogo := "/static/logo-light.png"}}
+{{$defaultLogo := "static/logo-light.png"}}
 {{- if .DarkMode -}}
-{{- $defaultLogo = "/static/logo-dark.png" -}}
+{{- $defaultLogo = "static/logo-dark.png" -}}
 {{- end -}}
 <body id="{{.PageName}}"{{if branding.BackgroundColor}} style="background-color: {{branding.BackgroundColor}};"{{end}}>
 <div id="alert-container"></div>

--- a/prow/cmd/deck/template/command-help.html
+++ b/prow/cmd/deck/template/command-help.html
@@ -1,7 +1,7 @@
 {{define "title"}}Command Help{{end}}
 {{define "scripts"}}
-<link rel="stylesheet" href="/static/dialog-polyfill.css">
-<script type="text/javascript" src="/static/command_help_bundle.min.js"></script>
+<link rel="stylesheet" href="static/dialog-polyfill.css">
+<script type="text/javascript" src="static/command_help_bundle.min.js"></script>
 <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
 {{end}}
 {{define "content"}}

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -1,7 +1,7 @@
 {{define "title"}}Prow Status{{end}}
 
 {{define "scripts"}}
-<script type="text/javascript" src="/static/prow_bundle.min.js"></script>
+<script type="text/javascript" src="static/prow_bundle.min.js"></script>
 <script type="text/javascript" src="prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec"></script>
 <script type="text/javascript">
   var spyglass = {{.SpyglassEnabled}};

--- a/prow/cmd/deck/template/plugins.html
+++ b/prow/cmd/deck/template/plugins.html
@@ -1,8 +1,8 @@
 {{define "title"}}Prow Plugin Catalog{{end}}
 
 {{define "scripts"}}
-<link rel="stylesheet" href="/static/dialog-polyfill.css">
-<script type="text/javascript" src="/static/plugin_help_bundle.min.js"></script>
+<link rel="stylesheet" href="static/dialog-polyfill.css">
+<script type="text/javascript" src="static/plugin_help_bundle.min.js"></script>
 <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
 {{end}}
 

--- a/prow/cmd/deck/template/pr.html
+++ b/prow/cmd/deck/template/pr.html
@@ -1,8 +1,8 @@
 {{define "title"}}PR Status{{end}}
 {{define "scripts"}}
-    <link rel="stylesheet" href="/static/labels.css">
-    <link rel="stylesheet" href="/static/dialog-polyfill.css">
-    <script type="text/javascript" src="/static/pr_bundle.min.js"></script>
+    <link rel="stylesheet" href="static/labels.css">
+    <link rel="stylesheet" href="static/dialog-polyfill.css">
+    <script type="text/javascript" src="static/pr_bundle.min.js"></script>
     <script type="text/javascript" src="prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec"></script>
     <script type="text/javascript" src="tide.js?var=tideData"></script>
 {{end}}
@@ -71,7 +71,7 @@
     <p>To meet merge requirements, all PR's labels need to satisfy at least one of queries configured for the repo that the PR belongs to.</p>
     <p>The table below shows all queries for the PR's repo. Each row of the table below shows 2 parts of a query: <strong>required</strong> labels <strong>missing</strong> from the PR and <strong>forbidden</strong> labels that the PR <strong>has</strong>.</p>
     <p>The PR would be considered as meeting merge requirements once it <strong>obtains all required labels</strong> and <strong>removes all forbidden labels</strong> for at least one row.</p>
-    <p>For more information, see: <a href="https://github.com/kubernetes/community/tree/master/contributors/guide">Kubernetes Contributor Guide</a> & <a href="/command-help">Command Help Page</a></p>
+    <p>For more information, see: <a href="https://github.com/kubernetes/community/tree/master/contributors/guide">Kubernetes Contributor Guide</a> & <a href="command-help">Command Help Page</a></p>
   </div>
   <div class="mdl-dialog__actions">
     <button type="button" class="mdl-button close">Close</button>

--- a/prow/cmd/deck/template/spyglass-lens.html
+++ b/prow/cmd/deck/template/spyglass-lens.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="/static/spyglass/lens.css">
-  <script src="/static/spyglass_lens_bundle.min.js"></script>
+  <script src="static/spyglass_lens_bundle.min.js"></script>
   {{.Head}}
 </head>
 <body class="lens-body">

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -6,7 +6,7 @@
   var lensArtifacts = {{.LensArtifacts}};
   var lensIndexes = {{.LensIndexes}};
 </script>
-<script type="text/javascript" src="/static/spyglass_bundle.min.js"></script>
+<script type="text/javascript" src="static/spyglass_bundle.min.js"></script>
 <link rel="stylesheet" type="text/css" href="/static/spyglass/spyglass.css">
 {{end}}
 
@@ -38,7 +38,7 @@
   <div class="mdl-card mdl-shadow--2dp lens-card">
     <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
     <div id="{{$config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
-      <img src="/static/kubernetes-wheel.svg" alt="loading spinner" class="loading-spinner is-active lens-card-loading" id="{{$config.Name}}-loading">
+      <img src="static/kubernetes-wheel.svg" alt="loading spinner" class="loading-spinner is-active lens-card-loading" id="{{$config.Name}}-loading">
       <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="allow-scripts allow-top-navigation allow-popups" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
     </div>
   </div>

--- a/prow/cmd/deck/template/tide-history.html
+++ b/prow/cmd/deck/template/tide-history.html
@@ -1,7 +1,7 @@
 {{define "title"}}Tide History{{end}}
 
 {{define "scripts"}}
-<script type="text/javascript" src="/static/tide_history_bundle.min.js"></script>
+<script type="text/javascript" src="static/tide_history_bundle.min.js"></script>
 <script type="text/javascript" src="tide-history.js?var=tideHistory"></script>
 {{end}}
 

--- a/prow/cmd/deck/template/tide.html
+++ b/prow/cmd/deck/template/tide.html
@@ -1,8 +1,8 @@
 {{define "title"}}Tide Status{{end}}
 
 {{define "scripts"}}
-<link rel="stylesheet" type="text/css" href="/static/labels.css">
-<script type="text/javascript" src="/static/tide_bundle.min.js"></script>
+<link rel="stylesheet" type="text/css" href="static/labels.css">
+<script type="text/javascript" src="static/tide_bundle.min.js"></script>
 <script type="text/javascript" src="tide.js?var=tideData"></script>
 {{end}}
 


### PR DESCRIPTION
I am trying to use deck UI on a custom path and the UI is broken due to usage of absolute paths for frontend assets such as `css` and `js` files