### PR TITLE
Set the TEST_NGINX_LB_TIMEOUT to 2h in gce-5k-correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -21,6 +21,7 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
+      - --env=TEST_NGINX_LB_TIMEOUT=2h # TODO(82416): Clean up once we figure out a proper timeout
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
Ref. https://github.com/kubernetes/kubernetes/issues/82695