### PR TITLE
AWS janitor: Make klog flags available

### DIFF
--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_klog//:go_default_library",
     ],
 )
 

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/main.go
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 	"k8s.io/test-infra/boskos/client"
 	"k8s.io/test-infra/boskos/common"
 	awsboskos "k8s.io/test-infra/boskos/common/aws"
@@ -44,6 +45,7 @@ const (
 )
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 	if d, err := time.ParseDuration(*sweepSleep); err != nil {
 		sweepSleepDuration = time.Second * 30


### PR DESCRIPTION
The AWS janitor does quite a bit of logging via klog, however its not possible to set up klog to log to log to stderr, as its flags are not initialized, effectively making the klog logs inaccessible.

/assign @liztio 