### PR TITLE
Add a ProwJob's .Status.BuildID as a Label on resources

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -33,6 +33,9 @@ const (
 	// this allows for multiple resources to be linked to one
 	// ProwJob.
 	ProwJobIDLabel = "prow.k8s.io/id"
+	// ProwBuildIDLabel is added in resources created by prow and
+	// carries the BuildID from a Prow Job's Status.
+	ProwBuildIDLabel = "prow.k8s.io/build-id"
 	// ProwJobAnnotation is added in resources created by prow and
 	// carries the name of the job that the pod is running. Since
 	// job names can be arbitrarily long, this is added as

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -144,6 +144,7 @@ func LabelsAndAnnotationsForJob(pj prowapi.ProwJob) (map[string]string, map[stri
 		extraAnnotations = map[string]string{}
 	}
 	extraLabels[kube.ProwJobIDLabel] = pj.ObjectMeta.Name
+	extraLabels[kube.ProwBuildIDLabel] = pj.Status.BuildID
 	return LabelsAndAnnotationsForSpec(pj.Spec, extraLabels, extraAnnotations)
 }
 

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -365,10 +365,11 @@ func TestProwJobToPod(t *testing.T) {
 	falseth := false
 	var sshKeyMode int32 = 0400
 	tests := []struct {
-		podName string
-		buildID string
-		labels  map[string]string
-		pjSpec  prowapi.ProwJobSpec
+		podName  string
+		buildID  string
+		labels   map[string]string
+		pjSpec   prowapi.ProwJobSpec
+		pjStatus prowapi.ProwJobStatus
 
 		expected *coreapi.Pod
 	}{
@@ -402,6 +403,9 @@ func TestProwJobToPod(t *testing.T) {
 					},
 				},
 			},
+			pjStatus: prowapi.ProwJobStatus{
+				BuildID: "blabla",
+			},
 
 			expected: &coreapi.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -415,6 +419,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "blabla",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -513,6 +518,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -734,6 +740,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -956,6 +963,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -1202,6 +1210,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -1432,6 +1441,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.ProwJobIDLabel:    "pod",
 						"needstobe":            "inherited",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -1617,6 +1627,7 @@ func TestProwJobToPod(t *testing.T) {
 						kube.RepoLabel:         "repo-name",
 						kube.PullLabel:         "1",
 						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
 					},
 					Annotations: map[string]string{
 						kube.ProwJobAnnotation: "job-name",
@@ -1787,7 +1798,7 @@ func TestProwJobToPod(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			pj := prowapi.ProwJob{ObjectMeta: metav1.ObjectMeta{Name: test.podName, Labels: test.labels}, Spec: test.pjSpec}
+			pj := prowapi.ProwJob{ObjectMeta: metav1.ObjectMeta{Name: test.podName, Labels: test.labels}, Spec: test.pjSpec, Status: test.pjStatus}
 			got, err := ProwJobToPod(pj, test.buildID)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
Prior to this commit Pods created by a prow job would receive the job's BuildID as an environment variable but not as a kubernetes label. Some logging systems, such as Stackdriver, pull in resource labels and allow them to form part of search queries. The BuildID proves useful in such queries as it allows the user to find the log output of all pods created as part of a job.

This commit adds the BuildID as a label on any resource modified using the `LabelsAndAnnotationsForJob` func. This includes Pods and Tekton PipelineRuns.