### PR TITLE
Trigger Tests on ok-to-test label

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -130,6 +130,20 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 				return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
 			}
 		}
+		if pr.Label.Name == labels.OkToTest {
+			// When the bot adds the label from an /ok-to-test command,
+			// we will trigger tests based on the comment event and do not
+			// need to trigger them here from the label, as well
+			botName, err := c.GitHubClient.BotName()
+			if err != nil {
+				return err
+			}
+			if author == botName {
+				c.Logger.Debug("Label added by the bot, skipping.")
+				return nil
+			}
+			return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
+		}
 	}
 	return nil
 }

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -258,6 +258,30 @@ func TestHandlePullRequest(t *testing.T) {
 			ShouldBuild: false,
 			prAction:    github.PullRequestActionClosed,
 		},
+		{
+			name: "Trusted user labeled PR with ok-to-test should build",
+
+			Author:      "t",
+			ShouldBuild: true,
+			prAction:    github.PullRequestActionLabeled,
+			prLabel:     labels.OkToTest,
+		},
+		{
+			name: "Untrusted user labeled PR with ok-to-test should build",
+
+			Author:      "u",
+			ShouldBuild: true,
+			prAction:    github.PullRequestActionLabeled,
+			prLabel:     labels.OkToTest,
+		},
+		{
+			name: "Label added by a bot. Build should not be triggered in this case.",
+
+			Author:      "k8s-ci-robot",
+			prLabel:     labels.OkToTest,
+			prAction:    github.PullRequestActionLabeled,
+			ShouldBuild: false,
+		},
 	}
 	for _, tc := range testcases {
 		t.Logf("running scenario %q", tc.name)


### PR DESCRIPTION
This PR is about the following task: #13975 
which intends to have the testing triggered the moment somebody issues an ok-to-test label. Right now, it happens via an \ok-to-test comment followed by a test-all comment.