### PR TITLE
Automate windows jobs landing on SIG Release informing board

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -329,6 +329,43 @@ periodics:
   tags:
   - 'perfDashPrefix: gce-100Nodes-stable2'
   - 'perfDashJobType: performance'
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: google-windows, sig-release-1.14-informing, sig-windows
+    testgrid-tab-name: gce-windows-stable2
+    description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE
+  name: ci-kubernetes-e2e-windows-gce-k8s-stable2
+  decorate: true
+  extra_refs:
+  - org: yujuhong
+    repo: gce-k8s-windows-testing
+    base_ref: master
+    path_alias: k8s.io/gce-k8s-windows-testing
+  interval: 2h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-e2e-gce-windows: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-stable2
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
+
 postsubmits:
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build-1-14

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -334,7 +334,7 @@ periodics:
     testgrid-dashboards: google-windows, sig-release-1.14-informing, sig-windows
     testgrid-tab-name: gce-windows-stable2
     description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE
-  name: ci-kubernetes-e2e-windows-gce-k8s-stable2
+  name: ci-kubernetes-e2e-windows-gce-stable2
   decorate: true
   extra_refs:
   - org: yujuhong

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -348,7 +348,7 @@ periodics:
     testgrid-dashboards: google-windows, sig-release-1.15-informing, sig-windows
     testgrid-tab-name: gce-windows-stable1
     description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE
-  name: ci-kubernetes-e2e-windows-gce-k8s-stable1
+  name: ci-kubernetes-e2e-windows-gce-stable1
   decorate: true
   extra_refs:
   - org: yujuhong

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -343,6 +343,43 @@ periodics:
           cpu: "4"
       securityContext:
         privileged: true
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: google-windows, sig-release-1.15-informing, sig-windows
+    testgrid-tab-name: gce-windows-stable1
+    description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE
+  name: ci-kubernetes-e2e-windows-gce-k8s-stable1
+  decorate: true
+  extra_refs:
+  - org: yujuhong
+    repo: gce-k8s-windows-testing
+    base_ref: master
+    path_alias: k8s.io/gce-k8s-windows-testing
+  interval: 2h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-e2e-gce-windows: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-stable1
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
+
 postsubmits:
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build-1-15

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -364,7 +364,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
     preset-e2e-gce-windows: "true"
-  name: ci-kubernetes-e2e-windows-gce-k8s-beta
+  name: ci-kubernetes-e2e-windows-gce-beta
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -348,6 +348,43 @@ periodics:
           cpu: "4"
       securityContext:
         privileged: true
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: google-windows, sig-release-1.16-informing, sig-windows
+    testgrid-tab-name: gce-windows-beta
+    description: Runs tests on a Kubernetes 1.16 cluster with Windows nodes on GCE
+  decorate: true
+  extra_refs:
+  - org: yujuhong
+    repo: gce-k8s-windows-testing
+    base_ref: master
+    path_alias: k8s.io/gce-k8s-windows-testing
+  interval: 2h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-e2e-gce-windows: "true"
+  name: ci-kubernetes-e2e-windows-gce-k8s-beta
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-beta
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
+
 postsubmits:
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build-1-16

--- a/config/jobs/kubernetes/sig-windows/OWNERS
+++ b/config/jobs/kubernetes/sig-windows/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- pjh
+- PatrickLang
+- michmike
+- benmoss
+- ddebroy
+
+labels:
+- sig/windows

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -99,117 +99,11 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
   annotations:
-    testgrid-dashboards: google-windows, sig-windows
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing
     testgrid-tab-name: gce-windows-master
-    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE"
-
-- name: ci-kubernetes-e2e-windows-gce-k8sbeta
-  decorate: true
-  extra_refs:
-  - org: yujuhong
-    repo: gce-k8s-windows-testing
-    base_ref: master
-    path_alias: k8s.io/gce-k8s-windows-testing
-  interval: 2h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-    preset-e2e-gce-windows: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/k8s-beta
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
-      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
-      - --test-cmd-args=--node-os-distro=windows
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
-  annotations:
-    testgrid-dashboards: google-windows, sig-windows
-    testgrid-tab-name: gce-windows-1.16
-    description: Runs tests on a Kubernetes 1.16 cluster with Windows nodes on GCE"
-
-- name: ci-kubernetes-e2e-windows-gce-k8sstable1
-  decorate: true
-  extra_refs:
-  - org: yujuhong
-    repo: gce-k8s-windows-testing
-    base_ref: master
-    path_alias: k8s.io/gce-k8s-windows-testing
-  interval: 2h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-    preset-e2e-gce-windows: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/k8s-stable1
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
-      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
-      - --test-cmd-args=--node-os-distro=windows
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
-  annotations:
-    testgrid-dashboards: google-windows, sig-windows
-    testgrid-tab-name: gce-windows-1.15
-    description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE"
-
-- name: ci-kubernetes-e2e-windows-gce-k8sstable2
-  decorate: true
-  extra_refs:
-  - org: yujuhong
-    repo: gce-k8s-windows-testing
-    base_ref: master
-    path_alias: k8s.io/gce-k8s-windows-testing
-  interval: 2h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-    preset-e2e-gce-windows: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/k8s-stable2
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/run-e2e.sh
-      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
-      - --test-cmd-args=--node-os-distro=windows
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-master
-  annotations:
-    testgrid-dashboards: google-windows, sig-release-1.14-all, sig-windows
-    testgrid-tab-name: gce-windows-1.14
-    description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE"
+    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE
 
 - name: ci-kubernetes-e2e-windows-gce-alpha-features
   decorate: true
@@ -248,7 +142,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-windows, sig-windows
     testgrid-tab-name: gce-windows-master-alpha-features
-    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled"
+    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled
 
 - name: ci-kubernetes-e2e-windows-gce-serial
   decorate: true


### PR DESCRIPTION
1. Thanks @justaugustus, as he suggested in [comment](https://github.com/kubernetes/test-infra/pull/14278#pullrequestreview-287176185) and referred this [doc](https://github.com/kubernetes/test-infra/tree/master/experiment/config-forker) to config job forker on release
2. Added OWNERS file following this [guide](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md) 