### PR TITLE
Update github.com/operator-framework/community-operators repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,7 +231,7 @@ go_repositories()
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 new_git_repository(
-    name = "operator_framework_community_operators",
+    name = "com_github_operator_framework_community_operators",
     build_file_content = """
 exports_files([
     "upstream-community-operators/prometheus/alertmanager.crd.yaml",
@@ -240,9 +240,9 @@ exports_files([
     "upstream-community-operators/prometheus/servicemonitor.crd.yaml",
 ])
 """,
-    commit = "42131df7167ec0b264c892c1f3c49ba9a72142da",
+    commit = "efda5dc98fd580ab5f1115a50a28825ae4fe6562",
     remote = "https://github.com/operator-framework/community-operators.git",
-    shallow_since = "1559569397 +0200",
+    shallow_since = "1568320223 +0200",
 )
 
 http_archive(

--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -27,28 +27,28 @@ k8s_object(
     name = "alertmanager_crd",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@operator_framework_community_operators//:upstream-community-operators/prometheus/alertmanager.crd.yaml",
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/alertmanager.crd.yaml",
 )
 
 k8s_object(
     name = "prometheus_crd",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@operator_framework_community_operators//:upstream-community-operators/prometheus/prometheus.crd.yaml",
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheus.crd.yaml",
 )
 
 k8s_object(
     name = "prometheusrule_crd",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@operator_framework_community_operators//:upstream-community-operators/prometheus/prometheusrule.crd.yaml",
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheusrule.crd.yaml",
 )
 
 k8s_object(
     name = "servicemonitor_crd",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@operator_framework_community_operators//:upstream-community-operators/prometheus/servicemonitor.crd.yaml",
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/servicemonitor.crd.yaml",
 )
 
 k8s_object(


### PR DESCRIPTION
/assign @michelle192837 @Katharine 

Addresses the shallow-since error. Ideally this repo will have a release we can use. Or maybe we should just copy the 4 files into this repo?