### PR TITLE
freeze k/website before release

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -390,6 +390,7 @@ tide:
     - kubernetes/sample-apiserver
     - kubernetes/sample-cli-plugin
     - kubernetes/sample-controller
+    # https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/docs#release-week-week-12
     - kubernetes/website
     labels:
     - lgtm

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -390,6 +390,7 @@ tide:
     - kubernetes/sample-apiserver
     - kubernetes/sample-cli-plugin
     - kubernetes/sample-controller
+    - kubernetes/website
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/docs#release-week-week-12

The goal is to freeze k/website 24hrs before release.
🛑 This needs to be merged exactly on Tuesday Sep 17th 4pm PT 🛑