### PR TITLE
Refactor some functions in repoowners

### DIFF
--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )


### PR DESCRIPTION
* Reuse ParseAliasesConfig function in loadAliasesFrom.
* Open APIs for loading Configs from bytes
* Open APIs for saving Config to file
* Publicize normLogins function

The APIs are useful for downstream to handle OWNERS and OWNERS_ALIASES
related objects.

/cc @stevekuznetsov 