### PR TITLE
Update bazelbuild jobs to use new 0.29.1 image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -50,7 +50,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
         command:
         - ./boskos/update_prow_config.sh
         env:
@@ -81,7 +81,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
         command:
         - ./testgrid/config-upload.sh
         resources:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -93,7 +93,7 @@ postsubmits:
     branches:
     - master
     spec:
-      containers: # https://github.com/bazelbuild/rules_k8s make -C images/gcloud-bazel push PROJECT=k8s-testimages
+      containers:
       - image: gcr.io/k8s-testimages/gcloud-bazel:v20190823-v0.1-129-gb799dd0
         command:
         - prow/deploy.sh
@@ -122,7 +122,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1 # whatever image you use here must have bash 4.4+
         command:
         - prow/push.sh
         env:
@@ -186,7 +186,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1 # whatever image you use here must have bash 4.4+
         command:
         - boskos/push.sh
         env:
@@ -802,7 +802,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
       command:
       - hack/autodeps.sh
       args:
@@ -839,7 +839,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
       command:
       - hack/autodeps.sh
       args:
@@ -876,7 +876,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20190628-265d81f-0.27.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
       command:
       - bazel
       - run


### PR DESCRIPTION
/assign @BenTheElder @Katharine 

Katharine any idea why we don't auto-bump these? Because of the variants?