### PR TITLE
Be more lenient with server starts in interrupts test

### DIFF
--- a/prow/interrupts/interrupts_test.go
+++ b/prow/interrupts/interrupts_test.go
@@ -43,7 +43,7 @@ var interrupt = make(chan os.Signal, 1)
 // so we can inject our implementation of the interrupt channel
 func init() {
 	signalsLock.Lock()
-	gracePeriod = 0 * time.Second
+	gracePeriod = time.Second
 	signals = func() <-chan os.Signal {
 		return interrupt
 	}
@@ -105,7 +105,9 @@ func TestInterrupts(t *testing.T) {
 		serverCancelled = true
 		lock.Unlock()
 	})
-	ListenAndServe(server, 1*time.Microsecond)
+	ListenAndServe(server, time.Second)
+	// wait for the server to start
+	time.Sleep(100 * time.Millisecond)
 	if _, err := http.Get("http://" + listener.Addr().String()); err != nil {
 		t.Errorf("could not reach server registered with ListenAndServe(): %v", err)
 	}
@@ -133,8 +135,10 @@ func TestInterrupts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not generate cert and key for TLS server: %v", err)
 	}
-	ListenAndServeTLS(tlsServer, cert, key, 1*time.Microsecond)
+	ListenAndServeTLS(tlsServer, cert, key, time.Second)
 	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	// wait for the server to start
+	time.Sleep(100 * time.Millisecond)
 	if _, err := client.Get("https://" + tlsListener.Addr().String()); err != nil {
 		t.Errorf("could not reach server registered with ListenAndServeTLS(): %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta 

```
$ bazel test //prow/interrupts:go_default_test --runs_per_test=100
INFO: Analyzed target //prow/interrupts:go_default_test (1 packages loaded, 7 targets configured).
INFO: Found 1 test target...
Target //prow/interrupts:go_default_test up-to-date:
  bazel-bin/prow/interrupts/linux_amd64_race_stripped/go_default_test
INFO: Elapsed time: 47.153s, Critical Path: 10.79s
INFO: 205 processes: 205 linux-sandbox.
INFO: Build completed successfully, 106 total actions
//prow/interrupts:go_default_test                                        PASSED in 5.5s
  Stats over 100 runs: max = 5.5s, min = 2.4s, avg = 3.1s, dev = 0.5s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 106 total actions
```