### PR TITLE
Consider a corner case in ExpandAliases

### DIFF
--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -311,7 +311,7 @@ func (a RepoAliases) ExpandAliases(logins sets.String) sets.String {
 	// Make logins a copy of the original set to avoid modifying the original.
 	logins = logins.Union(nil)
 	for _, login := range logins.List() {
-		if expanded := a.ExpandAlias(login); len(expanded) > 0 {
+		if expanded, ok := a[github.NormLogin(login)]; ok {
 			logins.Delete(login)
 			logins = logins.Union(expanded)
 		}

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1166,6 +1166,7 @@ func TestExpandAliases(t *testing.T) {
 	testAliases := RepoAliases{
 		"team/t1": sets.NewString("u1", "u2"),
 		"team/t2": sets.NewString("u1", "u3"),
+		"team/t3": sets.NewString(),
 	}
 	tests := []struct {
 		name             string
@@ -1196,6 +1197,11 @@ func TestExpandAliases(t *testing.T) {
 			name:             "Mixed casing in aliases.",
 			unexpanded:       sets.NewString("Team/T1"),
 			expectedExpanded: sets.NewString("u1", "u2"),
+		},
+		{
+			name:             "Empty team.",
+			unexpanded:       sets.NewString("Team/T3"),
+			expectedExpanded: sets.NewString(),
 		},
 	}
 


### PR DESCRIPTION
The corner case: A team has no members (yet) in OWNERS_ALIASES:
Although it is arguable why it introduces a team without
members in the first place, it is still a valid yaml file.

OWNERS
```
reviewers:
  - team-name
```

OWNERS_ALIASES
```
aliases:
  team-name:
```

When expanding, we replace the team by empty set, instead of
ignoring it. Otherwise, the team would be left there as a username,
which leads to a violation of `verify-owners`, saying `team-name`
is not a member of ...

Also added the test for this case.