### PR TITLE
Revert "Addition of Testgrid Service Account"

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -70,3 +70,26 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: Update boskos configmap on test-infra pushes
+
+  - name: maintenance-ci-testgrid-config-upload
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+    run_if_changed: '^config/(jobs|testgrids)/.*$'
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
+        command:
+        - ./testgrid/config-upload.sh
+        resources:
+          requests:
+            memory: "1Gi"
+    annotations:
+      testgrid-dashboards: sig-testing-maintenance
+      testgrid-tab-name: testgrid-config-upload
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: Compiles and uploads testgrid config on test-infra pushes

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -664,40 +664,6 @@ postsubmits:
       - name: creds
         secret:
           secretName: deployer-service-account
-  - name: post-test-infra-upload-testgrid-config
-    cluster: test-infra-trusted
-    branches:
-    - master
-    labels:
-      preset-bazel-scratch-dir: "true"
-    env:
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/service-account.json
-    run_if_changed: '^config/(jobs|testgrids)/.*$'
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
-        command:
-        - ./testgrid/config-upload.sh
-        volumeMounts:
-        - name: testgrid-service-account
-          mountPath: /etc/service-account
-          readOnly: true
-        resources:
-          requests:
-            memory: "1Gi"
-      volumes:
-      - name: testgrid-service-account
-        secret:
-          secretName: testgrid-config-updater-service-account
-    annotations:
-      testgrid-dashboards: sig-testing-maintenance
-      testgrid-tab-name: testgrid-config-upload
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: Compiles and uploads testgrid config on test-infra pushes
-
   kubernetes/k8s.io:
   - name: post-k8sio-cip
     cluster: test-infra-trusted

--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -23,7 +23,6 @@ TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
 for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
   dir="$(dirname "${BASH_SOURCE}")"
   bazel run //testgrid/cmd/configurator -- \
-    --gcp-service-account="/etc/service-account" \
     --yaml="${TESTINFRA_ROOT}/config/testgrids" \
     --default="${TESTINFRA_ROOT}/config/testgrids/default.yaml" \
     --prow-config="${TESTINFRA_ROOT}/prow/config.yaml" \


### PR DESCRIPTION
Reverts kubernetes/test-infra#14364

This segfaults and panics (likely because the client doesn't have permissions?), see https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-testgrid-config-upload/1174063397352771585.