### PR TITLE
Handle GCS Error in Configurator

### DIFF
--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -324,11 +324,14 @@ func main() {
 		return
 	}
 
-	// Setup GCS client
+	// Set up GCS client if output is to GCS
 	var client *storage.Client
-	if opt.output != "" {
-		// Error returned if outputting to file; ignore for now
-		client, _ = gcs.ClientWithCreds(ctx, opt.creds)
+	if strings.HasPrefix(opt.output, "gs://") {
+		var err error
+		client, err = gcs.ClientWithCreds(ctx, opt.creds)
+		if err != nil {
+			log.Fatalf("failed to create gcs client: %v", err)
+		}
 	}
 
 	// Oneshot mode, write config and exit


### PR DESCRIPTION
When there is a credential error in GCS, the program should terminate.
Instead, it was leading to a dereferencing a nil pointer.

See #14366 and [its result](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-testgrid-config-upload/1174063397352771585)

/cc @Katharine @michelle192837 