### PR TITLE
unfreeze k/website after release

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -390,8 +390,6 @@ tide:
     - kubernetes/sample-apiserver
     - kubernetes/sample-cli-plugin
     - kubernetes/sample-controller
-    # https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/docs#release-week-week-12
-    - kubernetes/website
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The PR is to unfreeze k/website after 1.16 release in contrast to https://github.com/kubernetes/test-infra/pull/14339

🛑 This needs to be merged after 1.16 release on Sep 18th 🛑