### PR TITLE
Add ci-npd-e2e-test job to run npd e2e tests

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -248,3 +248,42 @@ periodics:
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
+- name: ci-npd-e2e-test
+  interval: 30m
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: node-problem-detector
+    base_ref: master
+    path_alias: k8s.io/node-problem-detector
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190917-d326d2a-master
+      env:
+      - name: ZONE
+        value: us-central1-a
+      - name: VM_IMAGE
+        value: cos-73-11647-217-0
+      - name: IMAGE_PROJECT
+        value: cos-cloud
+      - name: SSH_USER
+        value: $USER
+      - name: SSH_KEY
+        value: $JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+      - name: BOSKOS_PROJECT_TYPE
+        value: gce-project
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - make e2e-test
+  annotations:
+    testgrid-dashboards: sig-node-node-problem-detector
+    testgrid-alert-email: xueweiz@google.com,zhenw@google.com,lantaol@google.com
+    testgrid-num-failures-to-alert: '12'
+    testgrid-alert-stale-results-hours: '24'
+    testgrid-num-columns-recent: '30'


### PR DESCRIPTION
The tests has been running internally for a while.

This PR is part of #14369 and https://github.com/kubernetes/node-problem-detector/issues/296