### PR TITLE
controller-runtime: bump test to go 1.13

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
@@ -1,16 +1,15 @@
 presubmits:
   kubernetes-sigs/controller-runtime:
-  - name: pull-controller-runtime-test
+  - name: pull-controller-runtime-test-master
     decorate: true
     always_run: true
     path_alias: sigs.k8s.io/controller-runtime
     branches:
     # The script this job runs is not in all branches.
     - ^master$
-    - ^release-0.2$
     spec:
       containers:
-      - image: golang:1.12
+      - image: golang:1.13
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -18,4 +17,4 @@ presubmits:
             cpu: 4000m
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: controller-runtime
+      testgrid-tab-name: controller-runtime-master

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.2.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.2.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  kubernetes-sigs/controller-runtime:
+  - name: pull-controller-runtime-test-release-0-2
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/controller-runtime
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.2$
+    spec:
+      containers:
+      - image: golang:1.12
+        command:
+        - ./hack/ci-check-everything.sh
+        resources:
+          requests:
+            cpu: 4000m
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-runtime-release-0.2

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.3.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  kubernetes-sigs/controller-runtime:
+  - name: pull-controller-runtime-test-release-0-3
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/controller-runtime
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: golang:1.12
+        command:
+        - ./hack/ci-check-everything.sh
+        resources:
+          requests:
+            cpu: 4000m
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-runtime-release-0.3


### PR DESCRIPTION
Needed to make https://github.com/kubernetes-sigs/controller-runtime/pull/606 work

/cc @DirectXMan12 