### PR TITLE
ci-npd-e2e-test: install libs required for compiling NPD

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -280,7 +280,9 @@ periodics:
       args:
       - bash
       - -c
-      - make e2e-test
+      - >-
+        ./test/build.sh install-lib &&
+        make e2e-test
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
     testgrid-alert-email: xueweiz@google.com,zhenw@google.com,lantaol@google.com


### PR DESCRIPTION
This PR is part of #14369 

To fix this test failure:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-npd-e2e-test/1174112341168492547