### PR TITLE
Move boskos config update job to the trusted cluster.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -40,33 +40,3 @@ postsubmits:
       testgrid-dashboards: sig-testing-misc
       testgrid-tab-name: post-bazel
       description: Runs bazel test //... on the test-infra repo on each commit
-
-  - name: maintenance-boskos-config-upload
-    branches:
-    - master
-    labels:
-      preset-service-account: "true"
-    run_if_changed: '^boskos/.*$'
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
-        command:
-        - ./boskos/update_prow_config.sh
-        env:
-        - name: PROW_SERVICE_ACCOUNT
-          value: /etc/prow-build-service/prow-build-service.json
-        volumeMounts:
-        - name: prow-build-service
-          mountPath: /etc/prow-build-service
-          readOnly: true
-      volumes:
-      - name: prow-build-service
-        secret:
-          secretName: prow-build-service
-    annotations:
-      testgrid-dashboards: sig-testing-maintenance
-      testgrid-tab-name: boskos-config-upload
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: Update boskos configmap on test-infra pushes

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -694,6 +694,35 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: Compiles and uploads testgrid config on test-infra pushes
+  - name: post-test-infra-upload-boskos-config
+    cluster: test-infra-trusted
+    branches:
+    - master
+    run_if_changed: '^boskos/.*$'
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
+        command:
+        - ./boskos/update_prow_config.sh
+        env:
+        - name: PROW_SERVICE_ACCOUNT
+          value: /creds/service-account.json
+        volumeMounts:
+        - name: creds
+          mountPath: /creds
+          readOnly: true
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
+    annotations:
+      testgrid-dashboards: sig-testing-maintenance
+      testgrid-tab-name: boskos-config-upload
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: Update boskos configmap on test-infra pushes
+
 
   kubernetes/k8s.io:
   - name: post-k8sio-cip


### PR DESCRIPTION
It isn't safe to have credentials for deploying to the build cluster in the build cluster itself.

This PR moves the job to the trusted cluster, removes the unnecessary credentials added by `preset-service-account`, and switches to using the existing `deployer-service-account` secret that has cluster admin permissions to the build cluster.

Once we've seen this working I'll delete the `prow-build-service` secret from the build cluster and revoke the token.

/cc @fejta @krzyzacy @michelle192837 @Katharine 