### PR TITLE
Noting that jobs on bootstrap.py are not supported by oncall.

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -1054,10 +1054,14 @@ def bootstrap(args):
     call = lambda *a, **kw: _call(end, *a, **kw)
     gsutil = GSUtil(call)
 
-    logging.warning('bootstrap.py is deprecated!\n'
-                    'Please migrate your job to podutils!\n'
-                    'https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md'
-                    )
+    logging.warning(
+        '**************************************************************************\n'
+        'bootstrap.py is deprecated!\n'
+        'test-infra oncall does not support any job still using bootstrap.py.\n'
+        'Please migrate your job to podutils!\n'
+        'https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md\n'
+        '**************************************************************************'
+    )
 
     if len(sys.argv) > 1:
         logging.info('Args: %s', ' '.join(pipes.quote(a)


### PR DESCRIPTION
Clarifying this to encourage users to migrate to pod-utils.