### PR TITLE
kubekins-e2e: updated `K8S_RELEASE` for 1.16

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -13,7 +13,7 @@ variants:
   '1.16':
     CONFIG: '1.16'
     GO_VERSION: 1.12.9
-    K8S_RELEASE: latest-1.16
+    K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'


### PR DESCRIPTION
... as 1.16.0 is now released.

ref: https://github.com/kubernetes/test-infra/pull/13870#discussion_r313628808

/sig release
/area release-eng

/cc @kubernetes/release-engineering @kubernetes/sig-release-admins
/assign @spiffxp @BenTheElder @cblecker