### PR TITLE
Increase the histogram bucket sizes for deck

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -200,7 +200,7 @@ var (
 			prometheus.HistogramOpts{
 				Name:    "deck_http_request_duration_seconds",
 				Help:    "http request duration in seconds",
-				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20},
 			},
 			[]string{"path", "method", "status"},
 		),
@@ -208,7 +208,7 @@ var (
 			prometheus.HistogramOpts{
 				Name:    "deck_http_response_size_bytes",
 				Help:    "http response size in bytes",
-				Buckets: []float64{16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216},
+				Buckets: []float64{16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432},
 			},
 			[]string{"path", "method", "status"},
 		),


### PR DESCRIPTION
We routinely hit the time and size maximums here, so we need to support
larger ones as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @Katharine @cjwagner 