### PR TITLE
ci-npd-e2e-test: pick up test VM image using image family

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -265,8 +265,8 @@ periodics:
       env:
       - name: ZONE
         value: us-central1-a
-      - name: VM_IMAGE
-        value: cos-73-11647-217-0
+      - name: IMAGE_FAMILY
+        value: cos-73-lts
       - name: IMAGE_PROJECT
         value: cos-cloud
       - name: BOSKOS_PROJECT_TYPE


### PR DESCRIPTION
This PR is to pickup the change at https://github.com/kubernetes/node-problem-detector/pull/353

This PR makes the CI test pick up test image by image family, so that it will keep testing on the latest stable (product quality) images.