### PR TITLE
Explicitly use cookie-secret flag and fix warning.

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -57,6 +57,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
+        - --cookie-secret=/etc/cookie/secret
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -137,7 +137,7 @@ func (o *options) Validate() error {
 	if o.cookieSecretFile == "" && o.oauthURL != "" {
 		if _, err := os.Stat("/etc/cookie/secret"); err == nil {
 			o.cookieSecretFile = "/etc/cookie/secret"
-			logrus.Error("You haven't set --cookie-secret-file, but you're assuming it is set to '/etc/cookie/secret'. Add --cookie-secret-file=/etc/cookie/secret to your deck instance's arguments. Your configuration will stop working at the end of October 2019.")
+			logrus.Error("You haven't set --cookie-secret, but you're assuming it is set to '/etc/cookie/secret'. Add --cookie-secret=/etc/cookie/secret to your deck instance's arguments. Your configuration will stop working at the end of October 2019.")
 		}
 	}
 


### PR DESCRIPTION
```
"You haven't set --cookie-secret-file, but you're assuming it is set to '/etc/cookie/secret'. Add --cookie-secret-file=/etc/cookie/secret to your deck instance's arguments. Your configuration will stop working at the end of October 2019."
```

The flag is actually `--cookie-secret` not `--cookie-secret-file`. https://github.com/kubernetes/test-infra/blob/aa6269e51408145d25e0dc020e52904e42dd7ba3/prow/cmd/deck/main.go#L167

/assign @chases2 @Katharine 