### PR TITLE
Adding aws e2e proxy dashboards for 4.2

### DIFF
--- a/config/testgrids/openshift/openshift.yaml
+++ b/config/testgrids/openshift/openshift.yaml
@@ -30,6 +30,10 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-fips-4.2
 - name: canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
   gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+- name: canary-openshift-ocp-installer-e2e-aws-proxy-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-proxy-4.2
+- name: canary-openshift-ocp-installer-e2e-aws-proxy-serial-4.2
+  gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-e2e-aws-proxy-serial-4.2
 - name: canary-openshift-ocp-installer-console-aws-4.2
   gcs_prefix: origin-ci-test/logs/canary-openshift-ocp-installer-console-aws-4.2
 - name: canary-openshift-ocp-installer-e2e-azure-4.2
@@ -300,6 +304,46 @@ dashboards:
   - name: redhat-canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
     description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on AWS with FIPS mode enabled.
     test_group_name: canary-openshift-ocp-installer-e2e-aws-fips-serial-4.2
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/origin/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/origin/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/origin/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: redhat-canary-openshift-ocp-installer-e2e-aws-proxy-4.2
+    description: Runs Kubernetes e2e tests against an OpenShift 4.2 OCP cluster running on AWS with Proxy enabled.
+    test_group_name: canary-openshift-ocp-installer-e2e-aws-proxy-4.2
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/origin/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/origin/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/origin/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: redhat-canary-openshift-ocp-installer-e2e-aws-proxy-serial-4.2
+    description: Runs Kubernetes serial e2e tests against an OpenShift 4.2 OCP cluster running on AWS with Proxy enabled.
+    test_group_name: canary-openshift-ocp-installer-e2e-aws-proxy-serial-4.2
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
Create dashboards to use the aws e2e proxy canary job created here[1]

[1] https://github.com/openshift/release/pull/5098