### PR TITLE
Add "watch" / "get" verbs to sinker rbac Role

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -695,6 +695,8 @@ rules:
     verbs:
       - delete
       - list
+      - watch
+      - get
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
This was missing from the `sinker` lister update. See https://github.com/kubernetes/test-infra/issues/14396#issuecomment-533391096 for a full description.

/assign @alvaroaleman @cjwagner 