### PR TITLE
Changed GitHub team permission struct

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -821,7 +821,7 @@ type Team struct {
 	Privacy      string         `json:"privacy,omitempty"`
 	Parent       *Team          `json:"parent,omitempty"`         // Only present in responses
 	ParentTeamID *int           `json:"parent_team_id,omitempty"` // Only valid in creates/edits
-	Permission   TeamPermission `json:"permission"`
+	Permission   TeamPermission `json:"permission,omitempty"`
 }
 
 // TeamMember is a member of an organizational team


### PR DESCRIPTION
Validation error occurs from GitHub when attempting to create a team using peribolos. Removing requirement to include Permission field when not provided as this field is currently deprecated per [API documentation](https://developer.github.com/v3/teams/#create-team)