### PR TITLE
Remove lgtm_acts_as_approve option for ip-masq-agent

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -58,7 +58,6 @@ approve:
   - kubernetes/examples
   - kubernetes/federation
   - kubernetes/gengo
-  - kubernetes-incubator/ip-masq-agent
   - kubernetes/ingress-gce
   - kubernetes/ingress-nginx
   - kubernetes/klog


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1154

@bowei @dnardo @MrHohn @varunmar @grayluck want to double check...do you still need `/lgtm` to automatically act as `/approve` in the repo? If not, we can remove this line entirely.

/sig network
/assign @cblecker 