### PR TITLE
capi: Add image pushing job for capz

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -60,6 +60,35 @@ postsubmits:
           - name: creds
             secret:
               secretName: deployer-service-account
+  kubernetes-sigs/cluster-api-provider-azure:
+    - name: post-cluster-api-provider-azure-push-images
+      cluster: test-infra-trusted
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-cluster-lifecycle-cluster-api-provider-azure
+        testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-cluster-api-azure
+              - --scratch-bucket=gs://k8s-staging-cluster-api-azure-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-service-account
   kubernetes-sigs/cluster-api-provider-gcp:
     - name: post-cluster-api-provider-gcp-push-images
       cluster: test-infra-trusted


### PR DESCRIPTION
Dependent on https://github.com/kubernetes/k8s.io/pull/373.
ref: kubernetes-sigs/cluster-api-provider-azure#118

Signed-off-by: Stephen Augustus saugustus@vmware.com

cc: @vincepri @CecileRobertMichon @soggiest
/assign @Katharine @michelle192837 
/sig cluster-lifecycle
/area provider/azure
/hold