### PR TITLE
Make elide_skipped_contexts default to true and add deprecation warning.

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -346,8 +346,9 @@ type Trigger struct {
 	// This is a security mitigation to only allow testing from trusted users.
 	IgnoreOkToTest bool `json:"ignore_ok_to_test,omitempty"`
 	// ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs
-	// that could run but do not run.
-	ElideSkippedContexts bool `json:"elide_skipped_contexts,omitempty"`
+	// that could run but do not run. Defaults to true.
+	// THIS FIELD IS DEPRECATED AND WILL BE REMOVED AFTER OCTOBER 2019.
+	ElideSkippedContexts *bool `json:"elide_skipped_contexts,omitempty"`
 }
 
 // Heart contains the configuration for the heart plugin.
@@ -648,6 +649,21 @@ func (c *Configuration) TriggerFor(org, repo string) Trigger {
 	return Trigger{}
 }
 
+var warnElideSkippedContexts time.Time
+
+func (t *Trigger) SetDefaults() {
+	truth := true
+	if t.ElideSkippedContexts == nil {
+		t.ElideSkippedContexts = &truth
+	} else if !*t.ElideSkippedContexts {
+		warnDeprecated(&warnElideSkippedContexts, 5*time.Minute, "elide_skipped_contexts is deprecated and will be removed after Oct. 2019. Skipped contexts are now elided by default.")
+	}
+
+	if t.TrustedOrg != "" && t.JoinOrgURL == "" {
+		t.JoinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", t.TrustedOrg)
+	}
+}
+
 // DcoFor finds the Dco for a repo, if one exists
 // a Dco can be listed for the repo itself or for the
 // owning organization
@@ -753,11 +769,8 @@ func (c *Configuration) setDefaults() {
 		c.Blunderbuss.ReviewerCount = new(int)
 		*c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
 	}
-	for i, trigger := range c.Triggers {
-		if trigger.TrustedOrg == "" || trigger.JoinOrgURL != "" {
-			continue
-		}
-		c.Triggers[i].JoinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", trigger.TrustedOrg)
+	for i := range c.Triggers {
+		c.Triggers[i].SetDefaults()
 	}
 	if c.SigMention.Regexp == "" {
 		c.SigMention.Regexp = `(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -126,7 +126,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	if err != nil {
 		return err
 	}
-	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
+	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, *trigger.ElideSkippedContexts)
 }
 
 func HonorOkToTest(trigger plugins.Trigger) bool {

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -62,10 +62,12 @@ type testcase struct {
 	Presubmits           map[string][]config.Presubmit
 	IssueLabels          []string
 	IgnoreOkToTest       bool
-	ElideSkippedContexts bool
+	ElideSkippedContexts *bool
 }
 
 func TestHandleGenericComment(t *testing.T) {
+	truth := true
+	lies := false
 	var testcases = []testcase{
 		{
 			name: "Not a PR.",
@@ -200,7 +202,7 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldBuild: true,
 		},
 		{
-			name: "Wrong branch.",
+			name: "Wrong branch. Skipped statuses elided (by default).",
 
 			Author:       "trusted-member",
 			Body:         "/test all",
@@ -208,7 +210,19 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:         true,
 			Branch:       "other",
 			ShouldBuild:  false,
-			ShouldReport: true,
+			ShouldReport: false,
+		},
+		{
+			name: "Wrong branch. Skipped statuses not elided.",
+
+			Author:               "trusted-member",
+			Body:                 "/test all",
+			State:                "open",
+			IsPR:                 true,
+			Branch:               "other",
+			ShouldBuild:          false,
+			ElideSkippedContexts: &lies,
+			ShouldReport:         true,
 		},
 		{
 			name: "Wrong branch. Skipped statuses elided.",
@@ -219,7 +233,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:                 true,
 			Branch:               "other",
 			ShouldBuild:          false,
-			ElideSkippedContexts: true,
+			ElideSkippedContexts: &truth,
 			ShouldReport:         false,
 		},
 		{
@@ -431,8 +445,9 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldBuild:  false,
-			ShouldReport: true,
+			ShouldBuild:          false,
+			ElideSkippedContexts: &lies,
+			ShouldReport:         true,
 		},
 		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job. Skipped statuses elided.",
@@ -458,7 +473,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:          false,
-			ElideSkippedContexts: true,
+			ElideSkippedContexts: &truth,
 			ShouldReport:         false,
 		},
 		{
@@ -558,7 +573,8 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldReport: true,
+			ElideSkippedContexts: &lies,
+			ShouldReport:         true,
 		},
 		{
 			name:   "branch-sharded job. no shard matches base branch. Skipped statuses elided.",
@@ -593,7 +609,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: true,
+			ElideSkippedContexts: &truth,
 			ShouldReport:         false,
 		},
 		{
@@ -620,7 +636,8 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldReport: true,
+			ElideSkippedContexts: &lies,
+			ShouldReport:         true,
 		},
 		{
 			name: "/retest of RunIfChanged job that doesn't need to run and hasn't run. Skipped statuses elided.",
@@ -646,7 +663,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: true,
+			ElideSkippedContexts: &truth,
 			ShouldReport:         false,
 		},
 		{
@@ -702,7 +719,7 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
-			name:   "/test all of run_if_changed job that has passed and doesn't need to run",
+			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses elided (by default)",
 			Author: "trusted-member",
 			Body:   "/test all",
 			State:  "open",
@@ -724,7 +741,33 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldReport: true,
+			ShouldReport: false,
+		},
+		{
+			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses not elided",
+			Author: "trusted-member",
+			Body:   "/test all",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jub",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							RunIfChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
+						RerunCommand: `/test jub`,
+					},
+				},
+			},
+			ElideSkippedContexts: &lies,
+			ShouldReport:         true,
 		},
 		{
 			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses elided.",
@@ -749,7 +792,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: true,
+			ElideSkippedContexts: &truth,
 			ShouldReport:         false,
 		},
 		{
@@ -869,6 +912,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IgnoreOkToTest:       tc.IgnoreOkToTest,
 			ElideSkippedContexts: tc.ElideSkippedContexts,
 		}
+		trigger.SetDefaults()
 
 		log.Printf("running case %s", tc.name)
 		// In some cases handleGenericComment can be called twice for the same event.

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -72,7 +72,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		}
 		if member {
 			c.Logger.Info("Starting all jobs for new PR.")
-			return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
+			return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
 		}
 		c.Logger.Infof("Welcome message to PR author %q.", author)
 		if err := welcomeMsg(c.GitHubClient, trigger, pr.PullRequest); err != nil {
@@ -93,7 +93,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 				}
 			}
 			c.Logger.Info("Starting all jobs for updated PR.")
-			return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
+			return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
 		}
 	case github.PullRequestActionEdited:
 		// if someone changes the base of their PR, we will get this
@@ -127,7 +127,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 				return fmt.Errorf("could not validate PR: %s", err)
 			} else if !trusted {
 				c.Logger.Info("Starting all jobs for untrusted PR with LGTM.")
-				return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
+				return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
 			}
 		}
 	}
@@ -162,7 +162,7 @@ func buildAllIfTrusted(c Client, trigger plugins.Trigger, pr github.PullRequestE
 			}
 		}
 		c.Logger.Info("Starting all jobs for updated PR.")
-		return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
+		return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
 	}
 	return nil
 }

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -329,6 +329,7 @@ func TestHandlePullRequest(t *testing.T) {
 			TrustedOrg:     "org",
 			OnlyOrgMembers: true,
 		}
+		trigger.SetDefaults()
 		if err := handlePR(c, trigger, pr); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -106,7 +106,7 @@ func (t *kubeProwJobTriggerer) runAndSkip(pr *github.PullRequest, requestedJobs,
 			Config:        t.configAgent.Config(),
 			Logger:        logrus.WithField("client", "trigger"),
 		},
-		pr, baseSHA, requestedJobs, skippedJobs, "none", t.pluginAgent.Config().TriggerFor(org, repo).ElideSkippedContexts,
+		pr, baseSHA, requestedJobs, skippedJobs, "none", *t.pluginAgent.Config().TriggerFor(org, repo).ElideSkippedContexts,
 	)
 }
 


### PR DESCRIPTION
Changes the default of `elide_skipped_contexts` and enters a deprecation period so that we can remove the field entirely in a little while. FWIW I can't think of any reason that someone would want to use `elide_skipped_contexts: false` unless they use branchprotector and haven't updated it since February and even in that case the failure mode is soft so this deprecation period shouldn't really be necessary in practice (which is why I made it short). I'm happy to increase the deprecation period duration if that is desired though.

refs: https://github.com/kubernetes/test-infra/issues/12047#issuecomment-532903026 https://github.com/kubernetes/test-infra/pull/14394#discussion_r325933016
/assign @fejta 
/cc @stevekuznetsov @alvaroaleman 