### PR TITLE
Return 405 on GET /hook

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -75,6 +75,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *September 24, 2019* Sending an http `GET` request to the `/hook` endpoint now returns a `405` 
+   (Method Not Allowed) instead of a `200` (OK).
  - *September 8, 2019* The deprecated `job_url_prefix` option has been removed from Plank.
  - *May 2, 2019* All components exposing Prometheus metrics will now either push them
    to the Prometheus PushGateway, if configured, or serve them locally on port 9090 at

--- a/prow/github/webhooks.go
+++ b/prow/github/webhooks.go
@@ -31,11 +31,6 @@ import (
 func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) (string, string, []byte, bool, int) {
 	defer r.Body.Close()
 
-	// Our health check uses GET, so just kick back a 200.
-	if r.Method == http.MethodGet {
-		return "", "", nil, false, http.StatusOK
-	}
-
 	// Header checks: It must be a POST with an event type and a signature.
 	if r.Method != http.MethodPost {
 		responseHTTPError(w, http.StatusMethodNotAllowed, "405 Method not allowed")

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -147,7 +147,7 @@ func TestServeHTTPErrors(t *testing.T) {
 				"content-type": "application/json",
 			},
 			Body: body,
-			Code: http.StatusOK,
+			Code: http.StatusMethodNotAllowed,
 		},
 	}
 


### PR DESCRIPTION
Return `405` on webhook `GET`.

/assign @cjwagner @Katharine 