### PR TITLE
Fix nil panic in hook

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -646,7 +646,9 @@ func (c *Configuration) TriggerFor(org, repo string) Trigger {
 			}
 		}
 	}
-	return Trigger{}
+	t := Trigger{}
+	t.SetDefaults()
+	return t
 }
 
 var warnElideSkippedContexts time.Time


### PR DESCRIPTION
Since we upgrade hook to [1] this morning, hook panicked serveral
times (see the bottom for an instance).

 It might be this PR [2] introducing the problem.

[1] gcr.io/k8s-prow/hook:v20190924-6dd4ce833
[2] https://github.com/kubernetes/test-infra/pull/14447

---tl;tr---
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12c017e]

goroutine 1507 [running]:
k8s.io/test-infra/prow/plugins/trigger.buildAllIfTrusted(0x7efc4161afc0, 0xc0026eb3b0, 0x7efc4161b048, 0xc001444620, 0xc0043b2000, 0xc00315a1c0, 0xc000aa0480, 0x0, 0x0, 0x0, ...)
	prow/plugins/trigger/pull-request.go:165 +0x33e
k8s.io/test-infra/prow/plugins/trigger.handlePR(0x7efc4161afc0, 0xc0026eb3b0, 0x7efc4161b048, 0xc001444620, 0xc0043b2000, 0xc00315a1c0, 0xc000aa0480, 0x0, 0x0, 0x0, ...)
	prow/plugins/trigger/pull-request.go:121 +0xe71
k8s.io/test-infra/prow/plugins/trigger.handlePullRequest(0x1a171a0, 0xc0026eb3b0, 0x19ebe80, 0xc001444620, 0x1a09e40, 0xc002d98000, 0xc000aa0480, 0xc001444660, 0x19d4c60, 0xc001adac90, ...)
	prow/plugins/trigger/trigger.go:151 +0x32a
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1(0xc002ca3340, 0xc0002620f8, 0xc003fcc900, 0xc0009d5937, 0x7, 0x17fbcb8)
	prow/hook/events.go:177 +0x294
created by k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent
```

/assign @cjwagner @fejta 
/cc @stevekuznetsov @petr-muller 