### PR TITLE
Revert "Make elide_skipped_contexts default to true and add deprecati…

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -346,9 +346,8 @@ type Trigger struct {
 	// This is a security mitigation to only allow testing from trusted users.
 	IgnoreOkToTest bool `json:"ignore_ok_to_test,omitempty"`
 	// ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs
-	// that could run but do not run. Defaults to true.
-	// THIS FIELD IS DEPRECATED AND WILL BE REMOVED AFTER OCTOBER 2019.
-	ElideSkippedContexts *bool `json:"elide_skipped_contexts,omitempty"`
+	// that could run but do not run.
+	ElideSkippedContexts bool `json:"elide_skipped_contexts,omitempty"`
 }
 
 // Heart contains the configuration for the heart plugin.
@@ -649,21 +648,6 @@ func (c *Configuration) TriggerFor(org, repo string) Trigger {
 	return Trigger{}
 }
 
-var warnElideSkippedContexts time.Time
-
-func (t *Trigger) SetDefaults() {
-	truth := true
-	if t.ElideSkippedContexts == nil {
-		t.ElideSkippedContexts = &truth
-	} else if !*t.ElideSkippedContexts {
-		warnDeprecated(&warnElideSkippedContexts, 5*time.Minute, "elide_skipped_contexts is deprecated and will be removed after Oct. 2019. Skipped contexts are now elided by default.")
-	}
-
-	if t.TrustedOrg != "" && t.JoinOrgURL == "" {
-		t.JoinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", t.TrustedOrg)
-	}
-}
-
 // DcoFor finds the Dco for a repo, if one exists
 // a Dco can be listed for the repo itself or for the
 // owning organization
@@ -769,8 +753,11 @@ func (c *Configuration) setDefaults() {
 		c.Blunderbuss.ReviewerCount = new(int)
 		*c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
 	}
-	for i := range c.Triggers {
-		c.Triggers[i].SetDefaults()
+	for i, trigger := range c.Triggers {
+		if trigger.TrustedOrg == "" || trigger.JoinOrgURL != "" {
+			continue
+		}
+		c.Triggers[i].JoinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", trigger.TrustedOrg)
 	}
 	if c.SigMention.Regexp == "" {
 		c.SigMention.Regexp = `(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -126,7 +126,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	if err != nil {
 		return err
 	}
-	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, *trigger.ElideSkippedContexts)
+	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
 }
 
 func HonorOkToTest(trigger plugins.Trigger) bool {

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -62,12 +62,10 @@ type testcase struct {
 	Presubmits           map[string][]config.Presubmit
 	IssueLabels          []string
 	IgnoreOkToTest       bool
-	ElideSkippedContexts *bool
+	ElideSkippedContexts bool
 }
 
 func TestHandleGenericComment(t *testing.T) {
-	truth := true
-	lies := false
 	var testcases = []testcase{
 		{
 			name: "Not a PR.",
@@ -202,7 +200,7 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldBuild: true,
 		},
 		{
-			name: "Wrong branch. Skipped statuses elided (by default).",
+			name: "Wrong branch.",
 
 			Author:       "trusted-member",
 			Body:         "/test all",
@@ -210,19 +208,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:         true,
 			Branch:       "other",
 			ShouldBuild:  false,
-			ShouldReport: false,
-		},
-		{
-			name: "Wrong branch. Skipped statuses not elided.",
-
-			Author:               "trusted-member",
-			Body:                 "/test all",
-			State:                "open",
-			IsPR:                 true,
-			Branch:               "other",
-			ShouldBuild:          false,
-			ElideSkippedContexts: &lies,
-			ShouldReport:         true,
+			ShouldReport: true,
 		},
 		{
 			name: "Wrong branch. Skipped statuses elided.",
@@ -233,7 +219,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:                 true,
 			Branch:               "other",
 			ShouldBuild:          false,
-			ElideSkippedContexts: &truth,
+			ElideSkippedContexts: true,
 			ShouldReport:         false,
 		},
 		{
@@ -445,9 +431,8 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldBuild:          false,
-			ElideSkippedContexts: &lies,
-			ShouldReport:         true,
+			ShouldBuild:  false,
+			ShouldReport: true,
 		},
 		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job. Skipped statuses elided.",
@@ -473,7 +458,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:          false,
-			ElideSkippedContexts: &truth,
+			ElideSkippedContexts: true,
 			ShouldReport:         false,
 		},
 		{
@@ -573,8 +558,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: &lies,
-			ShouldReport:         true,
+			ShouldReport: true,
 		},
 		{
 			name:   "branch-sharded job. no shard matches base branch. Skipped statuses elided.",
@@ -609,7 +593,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: &truth,
+			ElideSkippedContexts: true,
 			ShouldReport:         false,
 		},
 		{
@@ -636,8 +620,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: &lies,
-			ShouldReport:         true,
+			ShouldReport: true,
 		},
 		{
 			name: "/retest of RunIfChanged job that doesn't need to run and hasn't run. Skipped statuses elided.",
@@ -663,7 +646,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: &truth,
+			ElideSkippedContexts: true,
 			ShouldReport:         false,
 		},
 		{
@@ -719,7 +702,7 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
-			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses elided (by default)",
+			name:   "/test all of run_if_changed job that has passed and doesn't need to run",
 			Author: "trusted-member",
 			Body:   "/test all",
 			State:  "open",
@@ -741,33 +724,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldReport: false,
-		},
-		{
-			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses not elided",
-			Author: "trusted-member",
-			Body:   "/test all",
-			State:  "open",
-			IsPR:   true,
-			Presubmits: map[string][]config.Presubmit{
-				"org/repo": {
-					{
-						JobBase: config.JobBase{
-							Name: "jub",
-						},
-						RegexpChangeMatcher: config.RegexpChangeMatcher{
-							RunIfChanged: "CHANGED2",
-						},
-						Reporter: config.Reporter{
-							Context: "pull-jub",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
-						RerunCommand: `/test jub`,
-					},
-				},
-			},
-			ElideSkippedContexts: &lies,
-			ShouldReport:         true,
+			ShouldReport: true,
 		},
 		{
 			name:   "/test all of run_if_changed job that has passed and doesn't need to run. Skipped statuses elided.",
@@ -792,7 +749,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ElideSkippedContexts: &truth,
+			ElideSkippedContexts: true,
 			ShouldReport:         false,
 		},
 		{
@@ -912,7 +869,6 @@ func TestHandleGenericComment(t *testing.T) {
 			IgnoreOkToTest:       tc.IgnoreOkToTest,
 			ElideSkippedContexts: tc.ElideSkippedContexts,
 		}
-		trigger.SetDefaults()
 
 		log.Printf("running case %s", tc.name)
 		// In some cases handleGenericComment can be called twice for the same event.

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -72,7 +72,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		}
 		if member {
 			c.Logger.Info("Starting all jobs for new PR.")
-			return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
+			return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
 		}
 		c.Logger.Infof("Welcome message to PR author %q.", author)
 		if err := welcomeMsg(c.GitHubClient, trigger, pr.PullRequest); err != nil {
@@ -93,7 +93,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 				}
 			}
 			c.Logger.Info("Starting all jobs for updated PR.")
-			return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
+			return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
 		}
 	case github.PullRequestActionEdited:
 		// if someone changes the base of their PR, we will get this
@@ -127,7 +127,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 				return fmt.Errorf("could not validate PR: %s", err)
 			} else if !trusted {
 				c.Logger.Info("Starting all jobs for untrusted PR with LGTM.")
-				return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
+				return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
 			}
 		}
 	}
@@ -162,7 +162,7 @@ func buildAllIfTrusted(c Client, trigger plugins.Trigger, pr github.PullRequestE
 			}
 		}
 		c.Logger.Info("Starting all jobs for updated PR.")
-		return buildAll(c, &pr.PullRequest, pr.GUID, *trigger.ElideSkippedContexts, baseSHA, presubmits)
+		return buildAll(c, &pr.PullRequest, pr.GUID, trigger.ElideSkippedContexts, baseSHA, presubmits)
 	}
 	return nil
 }

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -329,7 +329,6 @@ func TestHandlePullRequest(t *testing.T) {
 			TrustedOrg:     "org",
 			OnlyOrgMembers: true,
 		}
-		trigger.SetDefaults()
 		if err := handlePR(c, trigger, pr); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -106,7 +106,7 @@ func (t *kubeProwJobTriggerer) runAndSkip(pr *github.PullRequest, requestedJobs,
 			Config:        t.configAgent.Config(),
 			Logger:        logrus.WithField("client", "trigger"),
 		},
-		pr, baseSHA, requestedJobs, skippedJobs, "none", *t.pluginAgent.Config().TriggerFor(org, repo).ElideSkippedContexts,
+		pr, baseSHA, requestedJobs, skippedJobs, "none", t.pluginAgent.Config().TriggerFor(org, repo).ElideSkippedContexts,
 	)
 }
 


### PR DESCRIPTION
…on warning."

This reverts commit 7090938084d2017bcb2d76fd7662789486dfb672.

Since we upgrade hook to [1] this morning, hook panicked serveral
times (see the bottom for an instance).

 It might be this PR [2] introducing the problem.

[1] gcr.io/k8s-prow/hook:v20190924-6dd4ce833
[2] https://github.com/kubernetes/test-infra/pull/14447

---tl;tr---
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12c017e]

goroutine 1507 [running]:
k8s.io/test-infra/prow/plugins/trigger.buildAllIfTrusted(0x7efc4161afc0, 0xc0026eb3b0, 0x7efc4161b048, 0xc001444620, 0xc0043b2000, 0xc00315a1c0, 0xc000aa0480, 0x0, 0x0, 0x0, ...)
	prow/plugins/trigger/pull-request.go:165 +0x33e
k8s.io/test-infra/prow/plugins/trigger.handlePR(0x7efc4161afc0, 0xc0026eb3b0, 0x7efc4161b048, 0xc001444620, 0xc0043b2000, 0xc00315a1c0, 0xc000aa0480, 0x0, 0x0, 0x0, ...)
	prow/plugins/trigger/pull-request.go:121 +0xe71
k8s.io/test-infra/prow/plugins/trigger.handlePullRequest(0x1a171a0, 0xc0026eb3b0, 0x19ebe80, 0xc001444620, 0x1a09e40, 0xc002d98000, 0xc000aa0480, 0xc001444660, 0x19d4c60, 0xc001adac90, ...)
	prow/plugins/trigger/trigger.go:151 +0x32a
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1(0xc002ca3340, 0xc0002620f8, 0xc003fcc900, 0xc0009d5937, 0x7, 0x17fbcb8)
	prow/hook/events.go:177 +0x294
created by k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent
```

/assign @cjwagner @fejta 
/cc @stevekuznetsov @petr-muller 