### PR TITLE
Build and publish an image for the pr-creator

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -118,7 +118,7 @@ postsubmits:
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(prow|ghproxy|label_sync|robots/commenter|robots/issue-creator)/'
+    run_if_changed: '^(prow|ghproxy|label_sync|robots/commenter|robots/pr-creator|robots/issue-creator)/'
     decorate: true
     spec:
       containers:

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -45,6 +45,7 @@ prow_push(
             "ghproxy": "//ghproxy:image",
             "label_sync": "//label_sync:image",
             "commenter": "//robots/commenter:image",
+            "pr-creator": "//robots/pr-creator:image",
             "issue-creator": "//robots/issue-creator:image",
         },
     ),

--- a/robots/pr-creator/BUILD.bazel
+++ b/robots/pr-creator/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image", "prow_push")
 
 go_library(
     name = "go_default_library",
@@ -16,6 +17,12 @@ go_library(
 go_binary(
     name = "pr-creator",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+prow_image(
+    name = "image",
+    base = "@git-base//image",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
We base the image off of `git` since it will likely need to be in the
image in the first place to generate the commits that the pr-creator
uses for the PR.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 
/cc @hongkailiu 