### PR TITLE
Stop explicitly setting user info for autobumper

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -943,10 +943,7 @@ periodics:
       - //experiment/autobumper
       - --
       args:
-      - --github-login=k8s-ci-robot
       - --github-token=/etc/github-token/oauth
-      - --git-name=Kubernetes Prow Robot
-      - --git-email=k8s.ci.robot@gmail.com
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
We can get all of this information from the GitHub client we create
using the token provided.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @Katharine @cjwagner 