### PR TITLE
Disable beta coreos image in node-e2e

### DIFF
--- a/jobs/e2e_node/image-config-1-12.yaml
+++ b/jobs/e2e_node/image-config-1-12.yaml
@@ -5,10 +5,11 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
-  coreos-beta:
-    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  # see https://github.com/kubernetes/test-infra/issues/14465
+  # coreos-beta:
+  #   image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
+  #   project: coreos-cloud
+  #   metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:
     image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
     project: cos-cloud

--- a/jobs/e2e_node/image-config-1-13.yaml
+++ b/jobs/e2e_node/image-config-1-13.yaml
@@ -5,10 +5,11 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
-  coreos-beta:
-    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  # see https://github.com/kubernetes/test-infra/issues/14465
+  # coreos-beta:
+  #   image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
+  #   project: coreos-cloud
+  #   metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:
     image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
     project: cos-cloud

--- a/jobs/e2e_node/image-config-1-14.yaml
+++ b/jobs/e2e_node/image-config-1-14.yaml
@@ -5,10 +5,11 @@ images:
   ubuntu:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
-  coreos-beta:
-    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  # see https://github.com/kubernetes/test-infra/issues/14465
+  # coreos-beta:
+  #   image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
+  #   project: coreos-cloud
+  #   metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:
     image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
     project: cos-cloud

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -5,10 +5,11 @@ images:
   ubuntu:
     image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
-  coreos-beta:
-    image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  # see https://github.com/kubernetes/test-infra/issues/14465
+  # coreos-beta:
+  #   image: coreos-beta-1911-2-0-v20181024 # docker 18.06.1-ce
+  #   project: coreos-cloud
+  #   metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   cos-stable1:
     image_regex: cos-stable-63-10032-71-0 # docker 17.03.2
     project: cos-cloud


### PR DESCRIPTION
xref https://github.com/kubernetes/test-infra/issues/14465

as discussed in https://kubernetes.slack.com/archives/C0BP8PW9G/p1569374970050800

note that this means we have no coverage of `docker 18.06.1-ce`, so https://github.com/kubernetes/test-infra/issues/14465 should be prioritized to ensure coverage of all desired docker versions

cc @BenTheElder @Random-Liu @yujuhong 