### PR TITLE
Revert "Stop explicitly setting user info for autobumper"

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -943,7 +943,10 @@ periodics:
       - //experiment/autobumper
       - --
       args:
+      - --github-login=k8s-ci-robot
       - --github-token=/etc/github-token/oauth
+      - --git-name=Kubernetes Prow Robot
+      - --git-email=k8s.ci.robot@gmail.com
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
This reverts commit 986fcd539db53eb329ce584dc76e6ed3952ea789.

The autobump PRs are not passing the CLA check: `cla/linuxfoundation — commit missing GitHub user` [example](https://github.com/kubernetes/test-infra/pull/14459).

/assign @fejta 
/cc @stevekuznetsov @Katharine 