### PR TITLE
add prow bump auto-revert script

### DIFF
--- a/experiment/revert-bump.sh
+++ b/experiment/revert-bump.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+bold_blue() {
+  echo -e "\x1B[1;34m${*}\x1B[0m"
+}
+
+bold_yellow() {
+  echo -e "\x1B[1;33m${*}\x1B[0m"
+}
+
+main() {
+  bold_blue "Checking out latest upstream ..."
+  git fetch https://github.com/kubernetes/test-infra master
+  git checkout FETCH_HEAD
+
+  bold_blue "Finding most recent bump commit ..."
+  local most_recent_bump
+  local most_recent_bump_commmit
+  most_recent_bump="$(git log --no-merges --extended-regexp \
+    --grep='Update prow to v[a-f0-9]+-[a-f0-9]+, and other images as necessary\.' \
+    --pretty=oneline -n 1)"
+  bold_yellow "Matching Commit: ${most_recent_bump}"
+  most_recent_bump_commmit=$(cut -f1 -d ' ' <<< "${most_recent_bump}")
+  echo "Commit SHA: ${most_recent_bump_commmit}"
+
+  bold_blue "Creating revert ..."
+  local revert_branch
+  revert_branch="revert-$(date +'%s')-${most_recent_bump_commmit}"
+  git checkout -b "${revert_branch}"
+  git revert --no-edit "${most_recent_bump_commmit}"
+
+  bold_blue "Pushing branch ..."
+  git -c push.default=current push
+
+  bold_yellow "You should now file a pull request from your ${revert_branch} branch."
+}
+
+main "$@"


### PR DESCRIPTION
Adds a script that automatically:
- obtains the latest upstream sources
- locates the most recent Prow bump commit
- creates a `revert-${unix_time}-${bump_commit}` branch
- reverts the bump commit
- pushes the branch

usage: `experiment/revert-bump.sh`

<img width="1401" alt="Screen Shot 2019-09-25 at 10 14 02 PM" src="https://user-images.githubusercontent.com/917931/65659835-ce1aa880-dfe1-11e9-8e84-0caaf2c8ca77.png">


We could _also_ automate filing the PR if we're ok with a dependency on `hub`, but that doesn't seem terribly more helpful seeing as after you push github will already have a button you can click to file the PR at the top of https://github.com/kubernetes/test-infra. 

<img width="1011" alt="Screen Shot 2019-09-25 at 10 12 53 PM" src="https://user-images.githubusercontent.com/917931/65659789-a9becc00-dfe1-11e9-8bde-5abdd23bf6d7.png">


Currently this just depends on `git`, `bash`, `cut`, and `date`.

Hopefully this makes it slightly faster and lower effort to "push the rollback button".

/cc @fejta @clarketm @Katharine 