### PR TITLE
kops pr e2e: Run the master jobs against master

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -56,9 +56,10 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: bazel-test
-  - name: pull-kops-e2e-kubernetes-aws
+
+  - name: pull-kops-e2e-kubernetes-aws-k115
     branches:
-    - master
+    - release-1.15
     always_run: true
     labels:
       preset-service-account: "true"
@@ -95,10 +96,53 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      testgrid-tab-name: e2e-k115
 
+  - name: pull-kops-e2e-kubernetes-aws
+    branches:
+    - master
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+      preset-dind-enabled: "true"
+      preset-e2e-platform-aws: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190920-5a67b1f-experimental
+        args:
+        - --root=/go/src
+        - --job=$(JOB_NAME)
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - --
+        - --aws
+        - --aws-cluster-domain=test-cncf-aws.k8s.io
+        - --check-leaked-resources=false
+        - --cluster=
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
+        - --extract=ci/latest
+        - --ginkgo-parallel
+        - --kops-build
+        - --provider=aws
+        - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+        - --timeout=55m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: e2e
+
   - name: pull-kops-verify-bazel
     branches:
     - master


### PR DESCRIPTION
Also keep the 1.15 configuration around and use it for the
release-1.15 branch.