### PR TITLE
Fix reference to replaced shurcool/go/ctxhttp module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module k8s.io/test-infra
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f
 
+replace github.com/shurcooL/go/ctxhttp => golang.org/x/net/context/ctxhttp v0.0.0-20190926025831-c00fd9afed17
+
 // Pin all k8s.io staging repositories to kubernetes-1.15.3.
 // When bumping Kubernetes dependencies, you should update each of these lines
 // to point to the same kubernetes-1.x.y release branch before running update-deps.sh.


### PR DESCRIPTION
Ref: https://github.com/shurcooL/go/commit/914043390fc61e853638b3b18e1fdc33f01832ec
Should fix errors like this:
```
Installing mkpj...
go: finding k8s.io/test-infra latest
go: downloading k8s.io/test-infra v0.0.0-20190926150909-eccc24f74c5a
go: extracting k8s.io/test-infra v0.0.0-20190926150909-eccc24f74c5a
go: finding github.com/shurcooL/go latest
build k8s.io/test-infra/prow/cmd/mkpj: cannot load github.com/shurcooL/go/ctxhttp: module github.com/shurcooL/go@latest (v0.0.0-20190704215121-7189cc372560) found, but does not contain package github.com/shurcooL/go/ctxhttp
```
/assign @michelle192837 @fejta