### PR TITLE
Add missing release/1.3 verify test for containerd/cri.

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -217,6 +217,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    - release/1.3
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
Add missing verify test in the release/1.3 branch for containerd/cri.

@yujuhong @krzyzacy 
Signed-off-by: Lantao Liu <lantaol@google.com>