### PR TITLE
prow/cluster/starter: plank needs to patch prowjobs.

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -633,6 +633,7 @@ rules:
       - create
       - list
       - update
+      - patch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
I just stood up prow using the "tackle" utility.  The plank Role
created was not sufficient.  The "echo-test" job was not running.
This was because plank was emitting errors in its log about not being
able to patch the prowjob.  Manually adding this to the Role fixed the
problem for me.