### PR TITLE
Revert "Fix reference to replaced shurcool/go/ctxhttp module. https:/…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module k8s.io/test-infra
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f
 
-replace github.com/shurcooL/go/ctxhttp => golang.org/x/net/context/ctxhttp v0.0.0-20190926025831-c00fd9afed17
-
 // Pin all k8s.io staging repositories to kubernetes-1.15.3.
 // When bumping Kubernetes dependencies, you should update each of these lines
 // to point to the same kubernetes-1.x.y release branch before running update-deps.sh.


### PR DESCRIPTION
…/github.com/shurcooL/go/commit/914043390fc61e853638b3b18e1fdc33f01832ec"

This reverts commit fcaaa3ac0980dc450f1fa2bfd8aaec907d70cce5.

I don't think this is the right fix:
* It does appear to fix the problem you're experiencing
* This problem is not reproduced on presubmits
* Replace clauses as technical deb to the repo -- replace is ignored downstream, and makes it less obvious what version is being used.

/assign @cjwagner 