### PR TITLE
branchprotector: explicit protect:false should result in bp removal

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -254,7 +254,9 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch) (*Policy, error) 
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies {
 				logrus.Warnf("%s/%s=%s has required jobs but has protect: false", org, repo, branch)
-				return nil, nil
+				return &Policy{
+					Protect: policy.Protect,
+				}, nil
 			} else {
 				return nil, fmt.Errorf("required prow jobs require branch protection")
 			}

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -805,7 +805,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			expected: &Policy{Protect: no},
 		},
 	}
 


### PR DESCRIPTION
We had a user reporting that BP is still enabled on his repo branches even after `protect: false` was [explicitly set](https://github.com/openshift/release/commit/dfd2beadbd400ce3ac680b2e3a430f58bcc5e63d#diff-d7cf2e1205c1d56c2443e189d97904d3R775-R780) on them.

The [log](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-branch-protector/4905#0:build-log.txt%3A241) said the following about that repo (pruned for clarity):
```
{"client":"github","component":"branchprotector","level":"info","msg":"GetRepo(openshift, tektoncd-catalog)"}
{"client":"github","component":"branchprotector","level":"info","msg":"GetBranches(openshift, tektoncd-catalog)"}
{"client":"github","component":"branchprotector","level":"info","msg":"GetBranches(openshift, tektoncd-catalog)"}
{"component":"branchprotector","level":"warning","msg":"openshift/tektoncd-catalog=release-next-ci has required jobs but has protect: false"}
{"component":"branchprotector","level":"warning","msg":"openshift/tektoncd-catalog=release-next has required jobs but has protect: false"}
```

This message is only emitted when `AllowDisabledJobPolicies` is true, allowing branches to not have BP even when required presubmits are configured for them. Previously, `GetPolicy` did not return a `&Policy{Protect: false}` in this case, but `nil`, which the branchprotector callsite (`UpdateBranches`) interprets as _"no policy is set, do not do anything"_. I believe a policy to disable BP should be returned instead.