### PR TITLE
kops: push images to staging in postsubmit

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -1,0 +1,32 @@
+postsubmits:
+  # this is the github repo we'll build from; this block needs to be repeated for each repo.
+  kubernetes/kops:
+    - name: kops-postsubmit-push-to-staging
+      cluster: test-infra-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-kops
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-kops
+              - --scratch-bucket=gs://k8s-staging-kops-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - ci/postsubmit/push-to-staging/
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-service-account


### PR DESCRIPTION
Using GCB to build, because it's in the trusted cluster.