### PR TITLE
Add test runtime handler for containerd 1.3 test.

### DIFF
--- a/jobs/e2e_node/containerd/containerd-release-1.3/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/env
@@ -2,3 +2,7 @@ CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
 CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.3'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"


### PR DESCRIPTION
Add test runtime handler for containerd 1.3 test.

The runtime class test is failing because of this.

/assign @yujuhong 
Signed-off-by: Lantao Liu <lantaol@google.com>