### PR TITLE
Gate kind on IPv6

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -41,8 +41,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    always_run: false
-    optional: true
+    always_run: true
     spec:
       # run on the ubuntu node pool, which has ipv6 modules
       tolerations:


### PR DESCRIPTION
Kind ipv6 job currently is running as a release blocker on kubernetes
and as an optional job in kubernetes presubmits.

We should gate on this job in kind to avoid breaking changes that can
affect the jobs that run in kubernetes