### PR TITLE
[WIP] add image-builder jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/OWNERS
+++ b/config/jobs/kubernetes-sigs/image-builder/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - timothysc
+  - justinsb
+  - luxas
+  - moshloop
+  - figo
+  - codenrhoden
+labels:
+  - sig/cluster-lifecycle

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ci.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ci.yaml
@@ -1,0 +1,30 @@
+postsubmits:
+  kubernetes-sigs/image-builder-konfigadm:
+    - name: post-image-builder-konfigadm
+      labels:
+        preset-dind-enabled: "true"
+        preset-image-builder-gcp-creds: "true"
+        preset-image-builder-aws-creds: "true"
+        preset-image-builder-azure-creds: "true"
+        preset-image-builder-vsphere-creds: "true"
+      branches:
+        - ^master$
+      always_run: false
+      run_if_changed: "^images/konfigadm/"
+      decorate: true
+      path_alias: sigs.k8s.io/image-builder
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: google/cloud-sdk:264.0.0
+            resources:
+              requests:
+                cpu: "1000m"
+            command:
+              - ./images/konfigadm/build-all.sh
+            # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+      annotations:
+        testgrid-tab-name: post-deploy
+        description: Builds new images using Nested Virtualization on Google Cloud


### PR DESCRIPTION
As part of the image-builder project, we want to start adding both testing and publishing of jobs, this PR is to start the process off, there will likely be many more jobs and periodics as we progress.

We also need credentials added for all the various clouds - Ideally, these should be new accounts so that they can be used for publishing images as well. e.g. `kubernetes-images`

* GCP
* AWS
* Azure
* VMC - For building and/or testing images.
* Github Key for `https://github.com/kubernetes-sigs/image-builder` to allow uploading artefacts and creating new releases.

/assign @akutz @timothysc @justinsb 

