### PR TITLE
Change scalability storage suite perfdash type

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -448,7 +448,7 @@ periodics:
 - name: ci-kubernetes-storage-scalability
   tags:
     - "perfDashPrefix: storage"
-    - "perfDashJobType: storage-suite"
+    - "perfDashJobType: storage"
   interval: 6h
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Specified type 'storage-suite' is not supported by perfdash. This causes
it to fail data downloading.

To fix this issue, job type was changed to 'storage', which is
supported.