### PR TITLE
branchprotector policy for the default branch ref only

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -37,6 +37,8 @@ type Policy struct {
 	Restrictions *Restrictions `json:"restrictions,omitempty"`
 	// RequiredPullRequestReviews specifies github approval/review criteria.
 	RequiredPullRequestReviews *ReviewPolicy `json:"required_pull_request_reviews,omitempty"`
+	// IncludeDefaultBranchOnly will protect the default branch only
+	IncludeDefaultBranchOnly *bool `json:"includeDefaultBranchOnly,omitempty"`
 	// Exclude specifies a set of regular expressions which identify branches
 	// that should be excluded from the protection policy
 	Exclude []string `json:"exclude,omitempty"`
@@ -155,6 +157,7 @@ func (p Policy) Apply(child Policy) Policy {
 		Admins:                     selectBool(p.Admins, child.Admins),
 		Restrictions:               mergeRestrictions(p.Restrictions, child.Restrictions),
 		RequiredPullRequestReviews: mergeReviewPolicy(p.RequiredPullRequestReviews, child.RequiredPullRequestReviews),
+		IncludeDefaultBranchOnly:   selectBool(p.IncludeDefaultBranchOnly, child.IncludeDefaultBranchOnly),
 		Exclude:                    unionStrings(p.Exclude, child.Exclude),
 	}
 }

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -138,6 +138,7 @@ type CommitClient interface {
 type RepositoryClient interface {
 	GetRepo(owner, name string) (Repo, error)
 	GetRepos(org string, isUser bool) ([]Repo, error)
+	GetBranch(org, repo, branch string) (*Branch, error)
 	GetBranches(org, repo string, onlyProtected bool) ([]Branch, error)
 	GetBranchProtection(org, repo, branch string) (*BranchProtection, error)
 	RemoveBranchProtection(org, repo, branch string) error
@@ -1747,6 +1748,20 @@ func (c *client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, er
 		return nil, err
 	}
 	return branches, nil
+}
+
+func (c *client) GetBranch(org, repo, branch string) (*Branch, error) {
+	c.log("GetBranch", org, repo, branch)
+	var b *Branch
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("/repos/%s/%s/branches/%s", org, repo, branch),
+		exitCodes: []int{200},
+	}, &b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GetBranchProtection returns current protection object for the branch


### PR DESCRIPTION
This allows for setting a `branchprotector` policy to protect only a repo's default branch ref.

For https://github.com/kubernetes/test-infra/issues/14519.

* Add `IncludeDefaultBranchOnly` config to branch protector `Policy`
* Add `GetBranch` to the github client
* Apply branch protection policy to only default branch in `UpdateRepo` from the `github.Repo.DefaultBranch`