### PR TITLE
tweak focus / skip for kind presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -603,9 +603,10 @@ presubmits:
         - "cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
         env:
         - name: FOCUS
-          value: ""
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: "\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|In-tree.Volumes.\\[Driver:.nfs\\]|PersistentVolumes.NFS|PodSecurityPolicy|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing.directories.when.readOnly.specified.in.the.volumeSource|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|RuntimeClass.should.run.a.Pod.requesting.a.RuntimeClass.with.a.configured.handler"
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
/cc @amwat @Katharine @aojea 
- focus "" -> "." (match anything, instead of kind defaulting it)
- skip -> clearly skip slow to match pull-kubernetes-e2e-gce, skip loadbalancer tests (both cases) and runtime class tests broadly 

TODO: re-instate runtime class tests when either:
- the tests stop depending on a magical pre-setup runtime class
- kind magically pre-installs the magical pre-setup runtime class ... (probably this one...)