### PR TITLE
kubetest: pass the cluster-tag to aws e2e

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -573,6 +573,8 @@ func (k kops) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
 	t.Kubeconfig = k.kubecfg
 	t.Provider = k.provider
 
+	t.ClusterID = k.cluster
+
 	if k.provider == "gce" {
 		t.GCEProject = k.gcpProject
 		if len(k.zones) > 0 {


### PR DESCRIPTION
This enables the correct tagging of volumes, as used by
https://github.com/kubernetes/kubernetes/pull/83301