### PR TITLE
Don't try loading the remote config for runlocal

### DIFF
--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -25,7 +25,5 @@ curl "${HOST}/tide.js?var=tideData" > tide.js
 curl "${HOST}/tide-history.js?var=tideHistory" > tide-history.js
 curl "${HOST}/plugin-help.js?var=allHelp" > plugin-help.js
 curl "${HOST}/pr-data.js" > pr-data.js
-# Use config that matches the data instead of whatever is checked out locally.
-curl "${HOST}/config" > config.yaml
-curl "${HOST}/plugin-config" > plugins.yaml
-bazel run //prow/cmd/deck:deck -- --pregenerated-data=${DIR}/localdata --static-files-location=./prow/cmd/deck/static --template-files-location=./prow/cmd/deck/template --spyglass-files-location=./prow/spyglass/lenses --config-path ${DIR}/localdata/config.yaml --spyglass --plugin-config ${DIR}/localdata/plugins.yaml
+
+bazel run //prow/cmd/deck:deck -- --pregenerated-data=${DIR}/localdata --static-files-location=./prow/cmd/deck/static --template-files-location=./prow/cmd/deck/template --spyglass-files-location=./prow/spyglass/lenses --config-path "${DIR}/../../../config/prow/config.yaml" --spyglass


### PR DESCRIPTION
This can't possibly work - prow can't parse config prow has already parsed. Also, the `/plugin-config` endpoint [is busted anyway](https://prow.k8s.io/plugin-config).