### PR TITLE
Force spyglass logs to soft wrap at end of line.

### DIFF
--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -24,6 +24,8 @@ html {
 }
 .loglines .linetext span {
     white-space: pre-wrap;
+    word-break: break-all;
+    overflow-wrap: break-word;
 }
 .line-highlighted {
     color: rgba(255, 224, 0, 1.0);


### PR DESCRIPTION
Sometimes spyglass log lines fall off the end, and are then totally inaccessible. Instead, force them to wrap at the end of each line.

This PR also disables normal word-wrap, in favour of wrapping at the end of each line regardless of whether that would break a word and whether that could've been avoided. This more closely matches general terminal wrapping behaviour, and avoids giant empty spaces where there was a breaking character before a giant single "word".