### PR TITLE
Change Int 4.1 - 4.1 upgrade test to be 4.1 - 4.2 

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -4,8 +4,8 @@ test_groups:
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-int-4.1
 - name: osd-int-4.2
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-int-4.2
-- name: osd-upgrade-int-4.1-4.1
-  gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-int-4.1-4.1
+- name: osd-upgrade-int-4.1-4.2
+  gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-int-4.1-4.2
 
 # OpenShift Dedicated staging
 - name: osd-stage-4.1
@@ -67,9 +67,9 @@ dashboards:
     code_search_path: github.com/openshift/origin/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.1-4.1
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in integration.
-    test_group_name: osd-upgrade-int-4.1-4.1
+  - name: osd-upgrade-int-4.1-4.2
+    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in integration.
+    test_group_name: osd-upgrade-int-4.1-4.2
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
`Int` no longer has 4.1 - 4.1 upgrade testing, however now has a 4.1 - 4.2 upgrade test we should get signal on.

First PR in test-infra so let me know if I did something wrong. :) 