### PR TITLE
Support links to line by line coverage

### DIFF
--- a/gopherage/cmd/html/static/browser_bundle.es2015.js
+++ b/gopherage/cmd/html/static/browser_bundle.es2015.js
@@ -149,6 +149,22 @@
         if (modeLabel !== 'mode') {
             throw new Error('Expected to start with mode line.');
         }
+        // Well-formed coverage files are already sorted alphabetically, but Kubernetes'
+        // `make test` produces ill-formed coverage files. This does actually matter, so
+        // sort it ourselves.
+        lines.sort((a, b) => {
+            a = a.split(':', 2)[0];
+            b = b.split(':', 2)[0];
+            if (a < b) {
+                return -1;
+            }
+            else if (a > b) {
+                return 1;
+            }
+            else {
+                return 0;
+            }
+        });
         const coverage = new Coverage(mode);
         let fileCounter = 0;
         for (const line of lines) {

--- a/gopherage/cmd/html/static/parser.ts
+++ b/gopherage/cmd/html/static/parser.ts
@@ -126,6 +126,21 @@ export function parseCoverage(content: string): Coverage {
     throw new Error('Expected to start with mode line.');
   }
 
+  // Well-formed coverage files are already sorted alphabetically, but Kubernetes'
+  // `make test` produces ill-formed coverage files. This does actually matter, so
+  // sort it ourselves.
+  lines.sort((a, b) => {
+    a = a.split(':', 2)[0];
+    b = b.split(':', 2)[0];
+    if (a < b) {
+      return -1;
+    } else if (a > b) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
   const coverage = new Coverage(mode);
   let fileCounter = 0;
   for (const line of lines) {

--- a/prow/spyglass/lenses/coverage/coverage.css
+++ b/prow/spyglass/lenses/coverage/coverage.css
@@ -22,3 +22,7 @@ body {
   border: 0.5px solid #303030;
   box-sizing: border-box;
 }
+
+#treemap.interactive {
+  cursor: pointer;
+}

--- a/prow/spyglass/lenses/coverage/template.html
+++ b/prow/spyglass/lenses/coverage/template.html
@@ -6,6 +6,7 @@
 {{define "body"}}
   <script type="text/javascript">
     var COVERAGE_FILE = {{ .CoverageContent }};
+    var RENDERED_COVERAGE_URL = {{ .RenderedCoverage }};
   </script>
   <div id="treemap" style="width: 100%; height: 300px; position: relative;">
 


### PR DESCRIPTION
The coverage lens can now link to files produced by `go tool cover -html` from the same coverage files, if it receives one as an artifact. In a subsequent PR I will update the prow configuration to actually provide them where possible.

/cc @BenTheElder 
