### PR TITLE
update kind presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -252,6 +252,8 @@ presubmits:
           value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
+        - name: BUILD_TYPE
+          value: bazel
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -301,7 +301,7 @@ presubmits:
           value: "."
         # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -269,3 +269,55 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+
+
+  - name: pull-kubernetes-e2e-kind-canary
+    optional: true
+    always_run: false # manual for testing new configurations
+    decorate: true
+    skip_branches:
+    - release-1.16 # per-release job
+    - release-1.15 # per-release job
+    - release-1.14 # per-release job
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 40m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191001-33df843-master
+        command:
+        - runner.sh
+        - bash
+        - -c
+        # TODO(bentheelder): remove the mkdir after the next image bump
+        - mkdir -p "${PATH%%:*}" && gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -221,7 +221,7 @@ presubmits:
 
   - name: pull-kubernetes-e2e-kind
     optional: true
-    always_run: false
+    always_run: true
     decorate: true
     skip_branches:
     - release-1.16 # per-release job

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -732,6 +732,11 @@ dashboards:
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: bentheelder+alerts@google.com
+  - name: pull-kubernetes-e2e-kind-canary
+    test_group_name: pull-kubernetes-e2e-kind-canary
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: bentheelder+alerts@google.com
   - name: pull-kubernetes-e2e-aks-engine-azure
     test_group_name: pull-kubernetes-e2e-aks-engine-azure
     base_options: width=10


### PR DESCRIPTION
This now runs ~560 tests in ~20 - 22m (including build, up, test, down, etc...), it's pretty reliable and we've optimized away unnecessary compute (eg building kind) and thoroughly skipped tests that are flaky / known to not work.

This PR changes the job to always run. Note that it is NOT blocking still (for now).

We're also:
- explicitly setting the build type option now to avoid depending on any defaults.
- adding a canary job for experimenting with tweaking the configuration
- experimenting in the canary job with enabling even more tests after https://github.com/kubernetes/kubernetes/pull/82424

/cc @fejta 