### PR TITLE
Don't consume public IPs in scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -59,6 +59,9 @@ presets:
   # Dump full systemd journal on master and nodes.
   - name: LOG_DUMP_SYSTEMD_JOURNAL
     value: "true"
+  # Use private clusters for scalability tests - https://github.com/kubernetes/kubernetes/issues/76374
+  - name: KUBE_GCE_PRIVATE_CLUSTER
+    value: "true"
 ### kubemark-gce-scale
 - labels:
     preset-e2e-kubemark-gce-scale: "true"
@@ -129,6 +132,9 @@ presets:
     value: "true"
   - name: KUBE_MASTER_NODE_LABELS
     value: "node.kubernetes.io/node-exporter-ready=true"
+  # Use private clusters for scalability tests - https://github.com/kubernetes/kubernetes/issues/76374
+  - name: KUBE_GCE_PRIVATE_CLUSTER
+    value: "true"
 
 ###### Scalability Envs
 ### Common env variables for all scalability-related suites.

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -21,7 +21,6 @@ periodics:
       - --
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      - --env=KUBE_GCE_PRIVATE_CLUSTER=true
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
Private clusters have been already enabled in GCE-5K-correctness test which passed yesterday - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/1179003509022920704 (except for one node test but it's a known issue - https://github.com/kubernetes/kubernetes/issues/83316).

Ref. https://github.com/kubernetes/kubernetes/issues/76374