### PR TITLE
capz: Update repo configurations

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -10,7 +10,6 @@ approvers:
 - khenidak
 - soggiest
 reviewers:
-- awesomenix
 - CecileRobertMichon
 - juan-lee
 - serbrech

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -83,10 +83,8 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    extra_refs:
-    - base_ref: release-0.2
-      org: kubernetes-sigs
-      repo: cluster-api-provider-azure
+    branches:
+      - ^release-0.2$
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
@@ -102,10 +100,8 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    extra_refs:
-    - base_ref: release-0.2
-      org: kubernetes-sigs
-      repo: cluster-api-provider-azure
+    branches:
+      - ^release-0.2$
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
@@ -121,10 +117,8 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    extra_refs:
-    - base_ref: release-0.2
-      org: kubernetes-sigs
-      repo: cluster-api-provider-azure
+    branches:
+      - ^release-0.2$
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
@@ -140,10 +134,8 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    extra_refs:
-    - base_ref: release-0.2
-      org: kubernetes-sigs
-      repo: cluster-api-provider-azure
+    branches:
+      - ^release-0.2$
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -434,7 +434,6 @@ tide:
     kubeflow: squash
     kubernetes-client/csharp: squash
     kubernetes-client/gen: squash
-    kubernetes-sigs/cluster-api-provider-azure: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/cluster-api-provider-openstack: squash
@@ -453,11 +452,11 @@ tide:
   merge_label: tide/merge-method-merge
   context_options:
     orgs:
-     kubernetes:
-      repos:
-        dashboard:
-          skip-unknown-contexts: true
-          from-branch-protection: true
+      kubernetes:
+        repos:
+          dashboard:
+            skip-unknown-contexts: true
+            from-branch-protection: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
 


### PR DESCRIPTION
- Remove v1alpha1 presubmits
- Set merge method to merge commit instead of squash (to follow capa)
- Dedupe awesomenix in OWNERS

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/283
/assign @vincepri @CecileRobertMichon 