### PR TITLE
move oncall approvers to alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- BenTheElder #oncall
-- chases2 # oncall
-- cjwagner # oncall
 - fejta # lead
-- Katharine # oncall
-- michelle192837 # oncall
 - spiffxp # lead
 - stevekuznetsov # lead
+- test-infra-oncall # oncall
 emeritus_approvers:
 - amwat
 - ixdy

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+aliases:
+  # business hours oncall for prow etc
+  test-infra-oncall:
+  - BenTheElder
+  - chases2
+  - cjwagner
+  - fejta
+  - Katharine
+  - michelle192837

--- a/config/jobs/image-pushing/OWNERS
+++ b/config/jobs/image-pushing/OWNERS
@@ -8,8 +8,4 @@ reviewers:
 
 # All oncallers
 approvers:
-- chases2
-- cjwagner
-- fejta
-- Katharine
-- michelle192837
+- test-infra-oncall # oncall

--- a/config/testgrids/kubernetes/sig-testing/OWNERS
+++ b/config/testgrids/kubernetes/sig-testing/OWNERS
@@ -1,13 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- amwat # oncall
-- cjwagner # oncall
+- test-infra-oncall # oncall
 - fejta # lead
-- ixdy # oncall
-- Katharine # oncall
-- krzyzacy # oncall
-- michelle192837 # oncall
 - spiffxp # lead
 - stevekuznetsov # lead
 


### PR DESCRIPTION
some of these were stale, also adding people required finding and updating all files like `config/jobs/image-pushing/OWNERS`, now it just requires updating the alias in OWNERS_ALIASES and possibly the slack oncall bot.

/cc @Katharine