### PR TITLE
Cleverer k8s unit coverage.

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -148,9 +148,11 @@ periodics:
       args:
       - -c
       - |
-        go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum
-        make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}"
-        cp "${ARTIFACTS}/combined-coverage.out" "${ARTIFACTS}/filtered.cov"
-        cp "${ARTIFACTS}/combined-coverage.html" "${ARTIFACTS}/filtered.html"
+        local result=0
+        go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum || result=$?
+        make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" || result=$?
+        grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+        go tool cover -html="${ARTIFACTS}/filtered.cov" -o "${ARTIFACTS}/filtered.html" || result=$?
+        exit $result
       securityContext:
         privileged: true


### PR DESCRIPTION
Fail the job if the tests fail; filter out generated code.

/cc @BenTheElder 