### PR TITLE
only welcome users

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -159,7 +159,15 @@ type User struct {
 	ID          int             `json:"id"`
 	HTMLURL     string          `json:"html_url"`
 	Permissions RepoPermissions `json:"permissions"`
+	Type        string          `json:"type"`
 }
+
+const (
+	// UserTypeUser identifies an actual user account in the User.Type field
+	UserTypeUser = "User"
+	// UserTypeBot identifies a github app bot user in the User.Type field
+	UserTypeBot = "Bot"
+)
 
 // NormLogin normalizes GitHub login strings
 func NormLogin(login string) string {

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -99,6 +99,11 @@ func handlePR(c client, pre github.PullRequestEvent, welcomeTemplate string) err
 		return nil
 	}
 
+	// ignore bots, we can't query their PRs
+	if pre.PullRequest.User.Type != github.UserTypeUser {
+		return nil
+	}
+
 	// search for PRs from the author in this repo
 	org := pre.PullRequest.Base.Repo.Owner.Login
 	repo := pre.PullRequest.Base.Repo.Name


### PR DESCRIPTION
... as we can't query bot users and welcoming them probably isn't helpful

https://developer.github.com/v3/users/ has a `"type"` field that will be `"Bot"` for a bot and `"User"` for a user.

I've confirmed this with the event data from the example in #14565 

/cc @cjwagner @fejta 