### PR TITLE
Revert "branchprotector: explicit protect:false should result in bp removal"

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -254,9 +254,7 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Pres
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies {
 				logrus.Warnf("%s/%s=%s has required jobs but has protect: false", org, repo, branch)
-				return &Policy{
-					Protect: policy.Protect,
-				}, nil
+				return nil, nil
 			} else {
 				return nil, fmt.Errorf("required prow jobs require branch protection")
 			}

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -805,7 +805,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 			},
-			expected: &Policy{Protect: no},
+			expected: nil,
 		},
 	}
 


### PR DESCRIPTION
Reverts kubernetes/test-infra#14495

Apparently different people have different expectations about what `protect: false` should mean. I made the PR after I received a report by users who expected the BP to be off with this config (which is consistent with e.g. with [this doc](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector#scope)). With new version, we are receiving reports by users who were expecting this config to have "do not touch my BP settings" semantics. Given this is not clearly documented and possibly confusing, lets revert the change and make branchprotector less problematic (not removing BP when people expect to is smaller bug than removing it when people do not expect it) until we resolve these use cases properly. I'll file an issue for it.

/cc @stevekuznetsov 