### PR TITLE
[WIP] Create stable-image-suggester to auto-suggest CIP manifest updates for Prow.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -129,6 +129,7 @@ filegroup(
         "//robots/issue-creator:all-srcs",
         "//robots/pr-creator:all-srcs",
         "//robots/pr-labeler:all-srcs",
+        "//robots/stable-image-suggester:all-srcs",
         "//scenarios:all-srcs",
         "//testgrid:all-srcs",
         "//triage:all-srcs",

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -664,6 +664,37 @@ postsubmits:
       - name: creds
         secret:
           secretName: deployer-service-account
+  - name: post-test-infra-push-stable-image-suggester
+    cluster: test-infra-trusted
+    run_if_changed: '^robots/stable-image-suggester/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "stable-image-suggester"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: builds and pushes the stable-image-suggester image
+    decorate: true
+    branches:
+      - ^master$
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
+          command:
+            - /run.sh
+          args:
+            - --scratch-bucket=gs://k8s-testimages-scratch
+            - --project=k8s-testimages
+            - robots/stable-image-suggester/
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /creds/service-account.json
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: deployer-service-account
   - name: post-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     branches:

--- a/robots/stable-image-suggester/BUILD.bazel
+++ b/robots/stable-image-suggester/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "manifest-types.go",
+    ],
+    importpath = "k8s.io/test-infra/robots/stable-image-suggester",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//experiment/autobumper/bumper:go_default_library",
+        "//prow/config/secret:go_default_library",
+        "//prow/errorutil:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//robots/pr-creator/updater:go_default_library",
+        "@com_github_docker_docker//client:go_default_library",
+        "@com_github_go_yaml_yaml//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_kube_openapi//pkg/util/sets:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "stable-image-suggester",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/stable-image-suggester/Dockerfile
+++ b/robots/stable-image-suggester/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.10.2
+COPY stable-image-suggester /
+CMD ["/stable-image-suggester"]

--- a/robots/stable-image-suggester/cloudbuild.yaml
+++ b/robots/stable-image-suggester/cloudbuild.yaml
@@ -1,0 +1,27 @@
+steps:
+  - name: golang:$_GO_VERSION
+    args:
+    - go
+    - build
+    - -o=./robots/stable-image-suggester/stable-image-suggester
+    - ./robots/stable-image-suggester
+    env:
+    - CGO_ENABLED=0
+    - GOOS=linux
+    - GOARCH=amd64
+    - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
+    - GOSUMDB=sum.golang.org
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/stable-image-suggester:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/stable-image-suggester:latest
+    - .
+    dir: robots/stable-image-suggester
+substitutions:
+  _GIT_TAG: '12345'
+  _GO_VERSION: 1.12.9
+images:
+  - 'gcr.io/$PROJECT_ID/stable-image-suggester:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/stable-image-suggester:latest'

--- a/robots/stable-image-suggester/main.go
+++ b/robots/stable-image-suggester/main.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/docker/docker/client"
+	"github.com/go-yaml/yaml"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/kube-openapi/pkg/util/sets"
+	"k8s.io/test-infra/experiment/autobumper/bumper"
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/robots/pr-creator/updater"
+)
+
+const srcImageRepo = "k8s-prow-edge"
+
+var imageRe = regexp.MustCompile(fmt.Sprintf(`gcr.io/%s/([^:/]+):([^\s"']+)`, srcImageRepo))
+
+type options struct {
+	github  flagutil.GitHubOptions
+	confirm bool
+
+	refPaths        flagutil.Strings
+	cipManifestPath string
+}
+
+func (o options) validate() error {
+	if len(o.refPaths.Strings()) == 0 {
+		return errors.New("--ref-path must be specified at least once in order to find image tags to promote")
+	}
+	if len(o.cipManifestPath) == 0 {
+		return errors.New("--cip-manifest-path must be specified")
+	}
+	return o.github.Validate(!o.confirm)
+}
+
+func optionsFromFlags() options {
+	var o options
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	o.github.AddFlags(fs)
+	fs.BoolVar(&o.confirm, "confirm", false, "Set to mutate github instead of a dry run")
+	fs.Var(&o.refPaths, "ref-path", "Identifies a file or directory in which Prow images are referenced. May be used multiple times.")
+	fs.StringVar(&o.cipManifestPath, "cip-manifest-path", "", "Path to the container image promoter manifest file to update.")
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	logrus.SetLevel(logrus.DebugLevel)
+	o := optionsFromFlags()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid flag.")
+	}
+
+	jamesBond := &secret.Agent{}
+	if err := jamesBond.Start([]string{o.github.TokenPath}); err != nil {
+		logrus.WithError(err).Fatal("Failed to start secrets agent")
+	}
+	stdout := bumper.HideSecretsWriter{Delegate: os.Stdout, Censor: jamesBond}
+	stderr := bumper.HideSecretsWriter{Delegate: os.Stderr, Censor: jamesBond}
+	gc, err := o.github.GitHubClient(jamesBond, !o.confirm)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create github client")
+	}
+
+	user, err := gc.BotUser()
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to get the user data for the provided GH token.")
+	}
+
+	// Checkout repo at yesterday
+	sha, err := yesterdayCommit(stdout, stderr)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to find commit SHA before yesterday.")
+	}
+	if err := gitCheckout(sha, stdout, stderr); err != nil {
+		logrus.WithError(err).Fatal("Failed to checkout commit before yesterday.")
+	}
+
+	// Find all tags for all images
+	images, err := findImages(o.refPaths.Strings())
+	if err != nil {
+		logrus.WithError(err).Fatal("Error looking for images to promote.")
+	}
+	// Pick the tag to promote.
+	// NOTE: We only want to promote Prow images if we can promote all images at the same version so
+	// that users can always use a single tag across all Prow images.
+	tag, err := pickPromotionTag(images)
+	if err != nil {
+		// Not all Prow components were using the same tag.
+		// Give up, but don't fail the Job.
+		logrus.WithError(err).Warn("Failed to determine a single tag to promote for all images. Giving up.")
+		return
+	}
+
+	// Checkout master
+	if err := gitCheckout("master", stdout, stderr); err != nil {
+		logrus.WithError(err).Fatal("Failed to checkout master.")
+	}
+
+	// Convert tags to digests
+	docker, err := client.NewEnvClient()
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create Docker client.")
+	}
+	digests, err := imageDigests(docker, tag, sets.StringKeySet(images))
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to determine image digest(s).")
+	}
+
+	// Update manifest to promote all the tags we found
+	if err := updateCIPManifest(o.cipManifestPath, tag, digests); err != nil {
+		logrus.WithError(err).Fatalf("Failed to update container image promote manifest file %q.", o.cipManifestPath)
+	}
+
+	matchTitle := "Promote edge Prow images to stable: "
+	title := matchTitle + tag
+
+	// Commit and push changes
+	remote := fmt.Sprintf("git@github.com:%s/test-infra.git", user.Login)
+	remoteBranch := "stable-image-suggestion"
+	if err := bumper.GitCommitAndPush(remote, remoteBranch, user.Name, user.Email, title, stdout, stderr); err != nil {
+		logrus.WithError(err).Fatal("Failed to commit and push CIP manifest changes.")
+	}
+
+	// Ensure PR exists and update if needed.
+	body := title // TODO: improve this
+	source := fmt.Sprintf("%s:%s", user.Login, remoteBranch)
+	n, err := updater.EnsurePR("kubernetes", "test-infra", title, body, source, "master", matchTitle, gc)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to ensure PR exists.")
+	}
+
+	logrus.Infof("PR kubernetes/test-infra#%d will merge %s into master: %s", *n, source, title)
+}
+
+func imageDigests(docker *client.Client, tag string, images sets.String) (map[string]string, error) {
+	digests := make(map[string]string, images.Len())
+	for _, image := range images.UnsortedList() {
+		taggedImage := fmt.Sprintf("gcr.io/%s/%s:%s", srcImageRepo, image, tag)
+		di, err := docker.DistributionInspect(context.Background(), taggedImage, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine digest for %q: %v", taggedImage, err)
+		}
+		digests[image] = string(di.Descriptor.Digest)
+	}
+	return digests, nil
+}
+
+func yesterdayCommit(stdout, stderr io.Writer) (string, error) {
+	var buf bytes.Buffer
+	if err := call(&buf, stderr, "git", strings.Split("rev-list -n 1 --first-parent --before=yesterday master", " ")...); err != nil {
+		return "", fmt.Errorf("rev-list failed: %v", err)
+	}
+	sha, err := ioutil.ReadAll(io.TeeReader(&buf, stdout))
+	if err != nil {
+		return "", fmt.Errorf("failed to read SHA from command output buffer: %v", err)
+	}
+	return strings.TrimSpace(string(sha)), nil
+}
+
+func gitCheckout(ref string, stdout, stderr io.Writer) error {
+	if err := call(stdout, stderr, "git", "checkout", string(ref)); err != nil {
+		return fmt.Errorf("failed to checkout ref %q: %v", ref, err)
+	}
+	return nil
+}
+
+func call(stdout, stderr io.Writer, cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	c.Stdout = stdout
+	c.Stderr = stderr
+	logrus.WithField("command", fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))).Info("Running command.")
+	return c.Run()
+}
+
+func findImages(paths []string) (map[string]sets.String, error) {
+	images := map[string]sets.String{}
+	for _, path := range paths {
+		err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
+				return nil // Skip this file or directory.
+			}
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %v", path, err)
+			}
+			for _, match := range imageRe.FindAllStringSubmatch(string(content), -1) {
+				if len(match) != 3 {
+					return fmt.Errorf("impossible regexp match in %q, expected 3 groups, got: %q", path, match)
+				}
+				if _, exists := images[match[1]]; !exists {
+					images[match[1]] = sets.NewString()
+				}
+				images[match[1]].Insert(match[2])
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return images, nil
+}
+
+func pickPromotionTag(images map[string]sets.String) (string, error) {
+	var errs []error
+	candidates := sets.NewString()
+	// First check for images with more than 1 tag.
+	for image, tags := range images {
+		if tags.Len() != 1 {
+			errs = append(errs, fmt.Errorf("did not find 1 tag for %s; tags: %q", image, tags.List()))
+			continue
+		}
+		candidates = candidates.Union(tags)
+	}
+	// Now check that all images had the same tag.
+	switch candidates.Len() {
+	case 0:
+		errs = append(errs, errors.New("failed to find any image tags to promote"))
+	case 1:
+	default:
+		errs = append(errs, fmt.Errorf("found different image tags for different images: %q", candidates.List()))
+	}
+	if err := errorutil.NewAggregate(errs...); err != nil {
+		return "", err
+	}
+	return candidates.List()[0], nil
+}
+
+func updateCIPManifest(path, tag string, digests map[string]string) error {
+	// Load and parse existing manifest file.
+	existingContent, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", path, err)
+	}
+	var manifest Manifest
+	if err := yaml.Unmarshal(existingContent, &manifest); err != nil {
+		return fmt.Errorf("failed to unmarshal existing CIP manifest: %v", err)
+	}
+	// Create or update the entry for each image.
+LOOP:
+	for imageName, digest := range digests {
+		dmap := DigestTags{digest: []string{tag, "latest"}}
+		// First check for an existing entry to update.
+		for i := range manifest.Images {
+			if manifest.Images[i].ImageName == imageName {
+				manifest.Images[i].Dmap = dmap
+				continue LOOP
+			}
+		}
+		// No existing entry to update, make a new one.
+		manifest.Images = append(manifest.Images, Image{ImageName: imageName, Dmap: dmap})
+	}
+	// Marshal and write the updated manifest file back to disk.
+	content, err := yaml.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("error marshaling updated manifest: %v", err)
+	}
+	if err := ioutil.WriteFile(path, content, 0666); err != nil {
+		return fmt.Errorf("error writing updated manifest to disk: %v", err)
+	}
+	return nil
+}

--- a/robots/stable-image-suggester/manifest-types.go
+++ b/robots/stable-image-suggester/manifest-types.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// These types are copied from https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/50e6f45fa9499c9b67c366af3fc33ce328a026dc/lib/dockerregistry/types.go
+
+// Manifest stores the information in a manifest file (describing the
+// desired state of a Docker Registry).
+type Manifest struct {
+	// Registries contains the source and destination (Src/Dest) registry names.
+	// It is possible that in the future, we support promoting to multiple
+	// registries, in which case we would have more than just Src/Dest.
+	Registries []RegistryContext `yaml:"registries,omitempty"`
+	Images     []Image           `yaml:"images,omitempty"`
+
+	// A rename list can contain a list of paths, where each path is a string.
+	//
+	// - A rename entry must have at least 2 paths, one for the source, another
+	// for at least 1 dest registry.
+	//
+	// - Any unknown registry entries in here will be considered a parsing
+	// error.
+	//
+	// - Any redundant entries in here will be considered a parsing error. E.g.,
+	// "gcr.io/louhi-qa/glbc:gcr.io/louhi-gke-k8s/glbc" is redunant as it is
+	// implied already.
+	//
+	// - The names must be valid paths (no errant punctuation, etc.).
+	//
+	// - No self-loops allowed (a registry must not appear more than 1 time).
+	//
+	// - Each name must be the registry+pathname, *without* a trailing slash.
+	//
+	// Just before the promotion, each rename entry is processed, to update the
+	// master inventory entries for the *renamed* images.
+	//
+	// When fetching data from a renamed image's repository, they are
+	// "normalized" to the path as seen in the source registry for that image
+	// --- this is so that the set difference logic can be used as-is. Only when
+	// the promotion itself is performed, do we "denormalize" at the very last
+	// moment by modifying the argument to each destination path.
+	Renames []Rename `yaml:"renames,omitempty"`
+}
+
+// Image holds information about an image. It's like an "Object" in the OOP
+// sense, and holds all the information relating to a particular image that we
+// care about.
+type Image struct {
+	ImageName string     `yaml:"name"`
+	Dmap      DigestTags `yaml:"dmap,omitempty"`
+}
+
+// Rename is list of paths, where each path is full
+// image name (registry + image name, without the tag).
+type Rename []RegistryImagePath
+
+// RegistryImagePath is the registry name and image name, without the tag. E.g.
+// "gcr.io/foo/bar/baz/image".
+type RegistryImagePath string
+
+// DigestTags is a map where each digest is associated with a TagSlice. It is
+// associated with a TagSlice because an image digest can have more than 1 tag
+// pointing to it, even within the same image name's namespace (tags are
+// namespaced by the image name).
+type DigestTags map[string][]string
+
+// RegistryContext holds information about a registry, to be written in a
+// manifest file.
+type RegistryContext struct {
+	Name           string `yaml:"name,omitempty"`
+	ServiceAccount string `yaml:"service-account,omitempty"`
+	Src            bool   `yaml:"src,omitempty"`
+}


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1kBo24FbmeF-h1dk78wi9vnKXU-QkCXI9Ul1XEW9qVls/edit#heading=h.khpbpx7v508u

WIP because I want to make the PR body text more useful and add some unit tests.
/cc @stevekuznetsov @nicoaragon @alvaroaleman @matthyx 

I suspect that we want to import the CIP manifest types instead of copying them, but I started by copying them after the discussion about the pipeline imports and potentially being better off copy/pasting instead of importing. Let me know what you think we should do here.