### PR TITLE
Add a container image promoter manifest and postsubmit job for Prow.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -722,7 +722,38 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: Update boskos configmap on test-infra pushes
-
+  - name: post-test-infra-cip-prow
+    cluster: test-infra-trusted
+    decorate: true
+    run_if_changed: "^prow/cip-manifest.yaml$"
+    # Never run more than 1 job at a time. This is because we don't want to run
+    # into a case where an older manifest PR merge gets run last (after a newer
+    # one).
+    max_concurrency: 1
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-artifact-promoter/cip:20190821-v2.2.1-2-gc29e4fc
+        command:
+        - cip
+        args:
+        - -manifest=prow/cip-manifest.yaml
+        - -key-files=/etc/service-account/service-account.json
+        - -dry-run=false
+        volumeMounts:
+        - name: service-account
+          mountPath: /etc/service-account
+      volumes:
+      - name: service-account
+        secret:
+          secretName: pusher-service-account
+    annotations:
+      testgrid-dashboards: sig-testing-prow
+      testgrid-tab-name: cip-prow
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: Uses the Container Image Promoter to promote images from gcr.io/k8s-prow-edge to gcr.io/k8s-prow.
 
   kubernetes/k8s.io:
   - name: post-k8sio-cip

--- a/prow/cip-manifest.yaml
+++ b/prow/cip-manifest.yaml
@@ -1,0 +1,8 @@
+# Container Image Promoter manifest file for promoting images from gcr.io/k8s-prow-edge to gcr.io/k8s-prow
+# https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master
+registries:
+- name: gcr.io/k8s-prow-edge # publicly readable, does not need a service account for access
+  src: true # mark it as the source registry (required)
+- name: gcr.io/k8s-prow
+  service-account: pusher@k8s-prow.iam.gserviceaccount.com
+images:


### PR DESCRIPTION
This won't do anything until we start updating `prow/cip-manifest.yaml` with the stable-image-suggester. 
Container image promoter: https://github.com/kubernetes-sigs/k8s-container-image-promoter
Existing CIP prowjob for reference: https://github.com/kubernetes/test-infra/blob/b778d6be921dc495139c9a4d3dabf753551c048f/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L727-L756

ref: https://github.com/kubernetes/test-infra/issues/14582
/cc @stevekuznetsov @listx @fejta 