### PR TITLE
fixup kind presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
         # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
         # and then pull-kubernetes-e2e-kind
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Dynamic.PV|LocalVolumeType:.block|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -224,9 +224,7 @@ presubmits:
     always_run: true
     decorate: true
     skip_branches:
-    - release-1.16 # per-release job
-    - release-1.15 # per-release job
-    - release-1.14 # per-release job
+    - release-\d+\.\d+ # per-release settings
     labels:
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -249,7 +247,7 @@ presubmits:
           value: "."
         # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Mount.propagation.should.propagate.mounts.to.the.host|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Dynamic.PV|LocalVolumeType:.block|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE
@@ -276,9 +274,7 @@ presubmits:
     always_run: false # manual for testing new configurations
     decorate: true
     skip_branches:
-    - release-1.16 # per-release job
-    - release-1.15 # per-release job
-    - release-1.14 # per-release job
+    - release-\d+\.\d+ # per-release settings
     labels:
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -294,14 +290,13 @@ presubmits:
         - runner.sh
         - bash
         - -c
-        # TODO(bentheelder): remove the mkdir after the next image bump
-        - mkdir -p "${PATH%%:*}" && gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
         # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|RuntimeClass|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|\[NodeFeature:PodReadinessGate\]|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Dynamic.PV|LocalVolumeType:.block|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE


### PR DESCRIPTION
- skip all release branches instead of specific ones
- skip block volume type specifically
- don't skip runtimeclass tests (we fixed this in kind)
- don't skip mount propagation tests (this was fixed in the e2e tests to not use ssh)
- move podreadiness gates to the end (should work I think, but flaky)

skip ordering is roughly:
- standard presubmit skips | things we know not to work on kind currently (PodSecurityPolicy for example) | specific tests that are too flaky on kind (possibly in general...)