### PR TITLE
[ Plank ] add the ability to hold different default decoration config by repository

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,10 @@
 # Announcements
 
 New features added to each component:
+ - *October 07, 2010* Added a `default_decoration_configs` option to the Plank config
+    that allows to specify different plank's default configuration for each organization 
+    or a specific repository. `default_decoration_config` will be deprecated on April, 2020
+    and it will be replaced with the `*` value in `default_decoration_configs`.
  - *August 29, 2019* Added a `batch_size_limit` option to the Tide config that
    allows the batch size limit to be specified globally, per org, or per repo.
    Values default to 0 indicating no size limit. A value of -1 disables batches.


### PR DESCRIPTION
Currently `plank` holds the default decoration config, and this can be overridden by the job's config. 
This patch allows `plank` to holds multiple default decoration configs mapped by a repository. This can be used to inject the config to multiple jobs without the need to update the job itself.

Also, if the repository's config has missing fields, those will be merged with plank's decoration config, since it is already validated. 