### PR TITLE
Use more obvious URL construction for redirects

### DIFF
--- a/prow/githuboauth/githuboauth_test.go
+++ b/prow/githuboauth/githuboauth_test.go
@@ -373,7 +373,7 @@ func TestHandleRedirectWithValidState(t *testing.T) {
 		t.Errorf("Mismatch github login. Got %v, expected %v", loginCookie.Value, mockLogin)
 	}
 	path := mockResponse.Header().Get("Location")
-	if path != "/"+dest+"?rerun="+rerunStatus {
+	if path != "http://example.com/"+dest+"?rerun="+rerunStatus {
 		t.Errorf("Incorrect final redirect URL. Actual path: %s, Expected path: /%s", path, dest+"?rerun="+rerunStatus)
 	}
 }


### PR DESCRIPTION
The previous approach did not always behave in the way you would expect.

/cc @BenTheElder 