### PR TITLE
Add new testgrid dashboards for osde2e upgrades.

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -4,6 +4,8 @@ test_groups:
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-int-4.1
 - name: osd-int-4.2
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-int-4.2
+- name: osd-upgrade-int-4.1-4.1
+  gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-int-4.1-4.1
 - name: osd-upgrade-int-4.1-4.2
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-int-4.1-4.2
 
@@ -14,6 +16,8 @@ test_groups:
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-stage-4.2
 - name: osd-upgrade-stage-4.1-4.1
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-stage-4.1-4.1
+- name: osd-upgrade-stage-4.1-4.2
+  gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-stage-4.1-4.2
 
 # OpenShift Dedicated production
 - name: osd-prod-4.1
@@ -22,6 +26,8 @@ test_groups:
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-prod-4.2
 - name: osd-upgrade-prod-4.1-4.1
   gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-prod-4.1-4.1
+- name: osd-upgrade-prod-4.1-4.2
+  gcs_prefix: redhat-openshift-osd-e2e/logs/osd-upgrade-prod-4.1-4.2
 
 dashboards:
 # OpenShift Dedicated integration dashboard
@@ -50,6 +56,26 @@ dashboards:
   - name: osd-int-4.2
     description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 integration cluster.
     test_group_name: osd-int-4.2
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/origin/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/origin/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/origin/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: osd-upgrade-int-4.1-4.1
+    description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in integration.
+    test_group_name: osd-upgrade-int-4.1-4.1
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -151,6 +177,26 @@ dashboards:
     code_search_path: github.com/openshift/origin/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: osd-upgrade-stage-4.1-4.2
+    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in staging.
+    test_group_name: osd-upgrade-stage-4.1-4.2
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/origin/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/origin/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/origin/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
 
 # OpenShift Dedicated production dashboard
 - name: redhat-osd-prod
@@ -198,6 +244,26 @@ dashboards:
   - name: osd-upgrade-prod-4.1-4.1
     description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in production.
     test_group_name: osd-upgrade-prod-4.1-4.1
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/origin/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/origin/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/origin/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: osd-upgrade-prod-4.1-4.2
+    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in production.
+    test_group_name: osd-upgrade-prod-4.1-4.2
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
New testgrid upgrade dashboards have been added for osde2e upgrades:

integration 4.1 -> 4.1
staging 4.1 -> 4.2
production 4-1 -> 4.2