### PR TITLE
Align label names with the metric prowjob_state_transitions

### DIFF
--- a/prow/cmd/exporter/BUILD.bazel
+++ b/prow/cmd/exporter/BUILD.bazel
@@ -44,7 +44,11 @@ go_test(
     name = "go_default_test",
     srcs = ["collector_test.go"],
     embed = [":go_default_library"],
-    deps = ["@io_k8s_apimachinery//pkg/util/diff:go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/cmd/exporter/README.md
+++ b/prow/cmd/exporter/README.md
@@ -7,10 +7,15 @@ metrics are not directly related to a specific prow-component.
 
 | Metric name          | Metric type | Labels/tags                                                                                                                                                                                           |
 |----------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| prow_job_labels      | Gauge       | `prow_job`=&lt;prow_job-name&gt; <br> `namespace`=&lt;prow_job-namespace&gt; <br> `prow_job_agent`=&lt;prow_job-agent&gt; <br> `label_PROW_JOB_LABEL_KEY`=&lt;PROW_JOB_LABEL_VALUE&gt;                |
-| prow_job_annotations | Gauge       | `prow_job`=&lt;prow_job-name&gt; <br> `namespace`=&lt;prow_job-namespace&gt; <br> `prow_job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt; |
+| prow_job_labels      | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `label_PROW_JOB_LABEL_KEY`=&lt;PROW_JOB_LABEL_VALUE&gt;                 |
+| prow_job_annotations | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt;  |
 
 For example, the metric `prow_job_labels` is similar to `kube_pod_labels` defined
 in [kubernetes/kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/master/docs/pod-metrics.md).
 A typical usage of `prow_job_labels` is to [join](https://github.com/kubernetes/kube-state-metrics/tree/master/docs#join-metrics)
 it with other metrics using a [Prometheus matching operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching).
+
+Note that `job_name` is [`.spec.job`](https://github.com/kubernetes/test-infra/blob/98fac12af0e0b98970606dd7a5c48028a72e7f1d/prow/apis/prowjobs/v1/types.go#L117)
+instead of `.metadata.name` as taken in `kube_pod_labels`.
+The gauge value is always `1` because we have another metric [`prowjobs`](https://github.com/kubernetes/test-infra/tree/master/prow/metrics)
+for the number jobs by name. The metric here shows only the existence of such a job with the label set in the cluster.


### PR DESCRIPTION
This will save the time on `label_replace` in prometheus joining queries.

Another change in this PR is to use `.spec.job` instead of `.metadata.name`
as the value of `job_name` label as explained in readme.

Also fixed the name of the `README.md` file.

/cc @stevekuznetsov 