### PR TITLE
prow/pod-utils/clone: TrimSace before head-timestamp Atoi

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -165,7 +165,7 @@ func (g *gitCtx) gitHeadTimestamp() (int, error) {
 		logrus.WithError(err).Debug("Could not obtain timestamp of git HEAD")
 		return 0, err
 	}
-	timestamp, convErr := strconv.Atoi(string(gitOutput))
+	timestamp, convErr := strconv.Atoi(strings.TrimSpace(string(gitOutput)))
 	if convErr != nil {
 		logrus.WithError(convErr).Errorf("Failed to parse timestamp %q", gitOutput)
 		return 0, convErr


### PR DESCRIPTION
Avoid issues with trailing whitespace [like][1]:

```
{"component":"clonerefs","error":"strconv.Atoi: parsing \"1570291151\\n\": invalid syntax","file":"prow/pod-utils/clone/clone.go:170","func":"k8s.io/test-infra/prow/pod-utils/clone.(*gitCtx).gitHeadTimestamp","level":"error","msg":"Failed to parse timestamp \"1570291151\\n\"","time":"2019-10-05T18:30:15Z"}
```

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1146/pull-ci-openshift-machine-config-operator-master-e2e-aws-upgrade/1950