### PR TITLE
kind repo presubmit: remove stray pipe character

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
         # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
         # and then pull-kubernetes-e2e-kind
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Dynamic.PV||Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Dynamic.PV|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE


### PR DESCRIPTION
... causing all tests to match the skip 🤦‍♂ 

thankfully we haven't merged much since this occurred.