### PR TITLE
Use PresubmitsStatic() in all non-test codepaths

### DIFF
--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -76,7 +76,7 @@ func generatePostsubmits(c config.JobConfig, version string) (map[string][]confi
 
 func generatePresubmits(c config.JobConfig, version string) (map[string][]config.Presubmit, error) {
 	newPresubmits := map[string][]config.Presubmit{}
-	for repo, presubmits := range c.Presubmits {
+	for repo, presubmits := range c.PresubmitsStatic() {
 		for _, presubmit := range presubmits {
 			if presubmit.Annotations[forkAnnotation] != "true" {
 				continue

--- a/experiment/config-rotator/main.go
+++ b/experiment/config-rotator/main.go
@@ -85,7 +85,7 @@ func updateJobBase(j *config.JobBase, old, new string) {
 }
 
 func updateEverything(c *config.JobConfig, old, new string) {
-	for _, presubmits := range c.Presubmits {
+	for _, presubmits := range c.PresubmitsStatic() {
 		for i := range presubmits {
 			updateJobBase(&presubmits[i].JobBase, old, new)
 		}
@@ -137,7 +137,7 @@ func main() {
 	updateEverything(&c, o.oldVersion, o.newVersion)
 
 	output, err := yaml.Marshal(map[string]interface{}{
-		"presubmits":  c.Presubmits,
+		"presubmits":  c.PresubmitsStatic(),
 		"postsubmits": c.Postsubmits,
 		"periodics":   c.Periodics,
 	})

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -476,7 +476,7 @@ func getJSONTagName(field reflect.StructField) string {
 
 func validateJobRequirements(c config.JobConfig) error {
 	var validationErrs []error
-	for repo, jobs := range c.Presubmits {
+	for repo, jobs := range c.PresubmitsStatic() {
 		for _, job := range jobs {
 			validationErrs = append(validationErrs, validatePresubmitJob(repo, job))
 		}
@@ -925,7 +925,7 @@ func verifyOwnersPlugin(cfg *plugins.Configuration) error {
 
 func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 	configuredRepos := sets.NewString()
-	for orgRepo := range cfg.JobConfig.Presubmits {
+	for orgRepo := range cfg.JobConfig.PresubmitsStatic() {
 		configuredRepos.Insert(orgRepo)
 	}
 	for orgRepo := range cfg.JobConfig.Postsubmits {

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -55,7 +55,7 @@ type options struct {
 }
 
 func (o *options) genJobSpec(conf *config.Config, name string) (config.JobBase, prowapi.ProwJobSpec) {
-	for fullRepoName, ps := range conf.Presubmits {
+	for fullRepoName, ps := range conf.PresubmitsStatic() {
 		org, repo, err := splitRepoName(fullRepoName)
 		if err != nil {
 			logrus.WithError(err).Warnf("Invalid repo name %s.", fullRepoName)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -162,8 +162,8 @@ type RefGetter = func() (string, error)
 // **Warning:** This does not return dynamic Presubmits configured
 // inside the code repo, hence giving an incomplete view. Use
 // `GetPresubmits` instead if possible.
-func (c *Config) PresubmitsStatic() map[string][]Presubmit {
-	return c.Presubmits
+func (jc *JobConfig) PresubmitsStatic() map[string][]Presubmit {
+	return jc.Presubmits
 }
 
 type refGetterForGitHubPullRequestClient interface {

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -211,8 +211,9 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 			}
 		}
 	case client.New:
-		presubmits := c.config().Presubmits[cloneURI.String()]
-		presubmits = append(presubmits, c.config().Presubmits[cloneURI.Host+"/"+cloneURI.Path]...)
+		// TODO: Do we want to add support for dynamic presubmits?
+		presubmits := c.config().PresubmitsStatic()[cloneURI.String()]
+		presubmits = append(presubmits, c.config().PresubmitsStatic()[cloneURI.Host+"/"+cloneURI.Path]...)
 
 		var filters []pjutil.Filter
 		var latestReport *reporter.JobReport

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -163,21 +163,21 @@ func (c *Controller) Run(ctx context.Context, changes <-chan config.Delta) {
 
 func (c *Controller) reconcile(delta config.Delta) error {
 	var errors []error
-	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.Presubmits, delta.After.Presubmits)); err != nil {
+	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -190,7 +190,7 @@ func applyProwjobAnnotations(c *Config, prowConfigAgent *prowConfig.Agent) error
 		}
 	}
 
-	for repo, js := range jobs.Presubmits {
+	for repo, js := range jobs.PresubmitsStatic() {
 		for _, j := range js {
 			if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PresubmitJob, repo); err != nil {
 				return err


### PR DESCRIPTION
Another step towards #13370, this PR changes all codepaths outside of tests to use `PresubmitsStatic()`. After this got merged, I'll create a follow-up to also move all test code to use `PresubmitsStatic` and unexport the `Presubmits` property so all consumers have to explicitly decide between `PresubmitsStatic` and `GetPresubmits`.

In most of the cases the changes were to CLI tools where we can't use the dynamic presubmit config anyways, except for:
* Status reconciler: We agreed that status reconciliation is a best-effort problem and we can think about how to solve this best after the feature itself is done
* Gerrit adapter: I am now completely sure what an integration with Gerrit entails and can not test it. I hope not supporting it there is okay for now.