### PR TITLE
Allow enabling inrepoconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	k8s.io/code-generator v0.0.0-20190831074504-732c9ca86353
 	k8s.io/klog v0.4.0
 	k8s.io/repo-infra v0.0.0-20190921032325-1fedfadec8ce
+	k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5
 	mvdan.cc/xurls/v2 v2.0.0
 	sigs.k8s.io/controller-runtime v0.2.1
 	sigs.k8s.io/yaml v1.1.0

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
More work towards https://github.com/kubernetes/test-infra/issues/13370, this PR adds a basic config struct for `inrepoconfig` that allows enabling it.

I deliberately choose not to use a `map[string]ConfigStruct` but instead a struct that wraps a `map[string]*bool` because this is likely to get more setting than just enable/disable in the future and those settings may be scoped differently, i.E. prow.k8s.io would enable this for a subset of repos but will set globally that only the `default` build cluster may be used.