### PR TITLE
Remove the use of dev-push-hyperkube.sh in Azure deployer

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -723,11 +723,16 @@ func (c *Cluster) buildHyperKube() error {
 	if err := c.dockerLogin(); err != nil {
 		return err
 	}
-	log.Println("Building and pushing hyperkube.")
-	pushHyperkube := util.K8s("kubernetes", "hack", "dev-push-hyperkube.sh")
-	cmd := exec.Command(pushHyperkube)
+	log.Println("Building hyperkube.")
+	cmd := exec.Command("make", "-C", util.K8s("kubernetes"), "WHAT=cmd/hyperkube")
 	// dev-push-hyperkube will produce a lot of output to stdout. We should capture the output here.
 	cmd.Stdout = ioutil.Discard
+	if err := control.FinishRunning(cmd); err != nil {
+		return err
+	}
+	log.Println("Pushing hyperkube.")
+	hyperkube_bin := util.K8s("kubernetes", "_output", "bin", "hyperkube")
+	cmd = exec.Command("make", "-C", util.K8s("kubernetes", "cluster", "images", "hyperkube"), "push", fmt.Sprintf("HYPERKUBE_BIN=%s", hyperkube_bin))
 	if err := control.FinishRunning(cmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
The script hack/dev-push-hyperkube.sh was removed from Kubernetes
recently in a general effort of moving Hyperkube away from the
k/k repo (see https://github.com/kubernetes/kubernetes/issues/81760).

Until hyperkube gets an official home and it is completely removed
from k/k, we will need to build it manually from within the k8s
repo.

This affects the upstream Windows 1.17 jobs (
https://testgrid.k8s.io/sig-windows#aks-engine-azure-windows-master-staging
and
https://testgrid.k8s.io/sig-windows#aks-engine-azure-windows-master)