### PR TITLE
K8s 1.12 is gone, let's test 1.13.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -163,7 +163,7 @@ periodics:
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.12
+      - --extract=ci/latest-1.13
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
@@ -171,7 +171,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.1
@@ -193,7 +193,7 @@ periodics:
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.12
+      - --extract=ci/latest-1.13
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
@@ -201,7 +201,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.2
@@ -303,10 +303,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.12
+      - --repo=k8s.io/kubernetes=release-1.13
       - --repo=github.com/containerd/cri=release/1.0
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -333,10 +333,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.12
+      - --repo=k8s.io/kubernetes=release-1.13
       - --repo=github.com/containerd/cri=release/1.2
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -423,10 +423,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.12
+      - --repo=k8s.io/kubernetes=release-1.13
       - --repo=github.com/containerd/cri=release/1.0
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -453,10 +453,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.13
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.12
+      - --repo=k8s.io/kubernetes=release-1.13
       - --repo=github.com/containerd/cri=release/1.2
       - --timeout=90
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Containerd 1.1 test will be removed when it is not supported in the future.

Currently, it is in extended support for security patches only.

/assign @yujuhong 
Signed-off-by: Lantao Liu <lantaol@google.com>