### PR TITLE
update container to use for rules_k8s

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/rules-k8s/gcloud-bazel:v20190507-v0.1-58-g37b9460
+      - image: gcr.io/rules-k8s/gcloud-bazel:v20191007-v0.1-141-gf150cbe
         args:
         - bash
         - -c


### PR DESCRIPTION
New container has Bazel 0.29.1 which is required for rules_docker update https://github.com/bazelbuild/rules_k8s/pull/428