### PR TITLE
Fix failures when no update of image is made

### DIFF
--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -159,6 +159,11 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to update references.")
 	}
 
+	if len(images) == 0 {
+		logrus.Info("no images updated, exiting ...")
+		return
+	}
+
 	remoteBranch := "autobump"
 
 	if err := bumper.MakeGitCommit(fmt.Sprintf("git@github.com:%s/test-infra.git", o.githubLogin), remoteBranch, o.gitName, o.gitEmail, images, stdout, stderr); err != nil {


### PR DESCRIPTION
The failed `git-commit` would lead to job failures.

This is an example of log from a failed job:

```
time="2019-10-06T11:36:40Z" level=info msg="Making git commit..."
nothing to commit, working directory clean
time="2019-10-06T11:36:41Z" level=fatal msg="Failed to push changes." error="failed to git commit: exit status 1"
```

/cc @stevekuznetsov 