### PR TITLE
Enable NodeLocalDNS feature in the benchmark

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -423,6 +423,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --cluster=node-local-dns-benchmark
+      - --env="KUBE_ENABLE_NODELOCAL_DNS=true"
       - --extract=ci/latest
       - --gcp-nodes=3
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
The benchmark should run queries against node-local-dns pods. Enabling this feature on the cluster that runs the tests.

/assign @krzysied @wojtek-t 