### PR TITLE
Bump CI image version

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -29,7 +29,7 @@ presubmits:
 
   - name: pull-cloud-provider-vsphere-verify-fmt
     always_run: false
-    run_if_changed: '^((cmd|pkg)/)|hack/check-format\.sh'
+    run_if_changed: '\.go$|hack/check-format\.sh'
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
@@ -47,7 +47,7 @@ presubmits:
 
   - name: pull-cloud-provider-vsphere-verify-lint
     always_run: false
-    run_if_changed: '^((cmd|pkg)/)|hack/check-lint\.sh'
+    run_if_changed: '\.go$|hack/check-lint\.sh'
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
@@ -65,7 +65,7 @@ presubmits:
 
   - name: pull-cloud-provider-vsphere-verify-vet
     always_run: false
-    run_if_changed: '^((cmd|pkg)/)|hack/check-vet\.sh'
+    run_if_changed: '\.go$|hack/check-vet\.sh'
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
@@ -122,7 +122,7 @@ presubmits:
 
   - name: pull-cloud-provider-vsphere-verify-staticcheck
     always_run: false
-    run_if_changed: '^((cmd|pkg)/)|hack/check-staticcheck\.sh'
+    run_if_changed: '\.go$|hack/check-staticcheck\.sh'
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
@@ -145,7 +145,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: true
+    always_run: false
+    run_if_changed: '\.go$|go.mod'
     skip_report: false
     spec:
       containers:
@@ -165,7 +166,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: true
+    always_run: false
+    run_if_changed: '\.go$|go.mod'
     skip_report: false
     spec:
       containers:
@@ -188,7 +190,8 @@ presubmits:
     - ^master$
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
-    always_run: true
+    always_run: false
+    run_if_changed: '\.go$|go.mod'
     skip_report: false
     spec:
       containers:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -149,7 +149,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:05583732
+      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
         command:
         - "make"
         args:
@@ -169,7 +169,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:05583732
+      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
         command:
         - "make"
         args:
@@ -192,7 +192,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:05583732
+      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
         command:
         - "make"
         args:
@@ -223,7 +223,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:05583732
+      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
         resources:
           requests:
             cpu: "1000m"
@@ -254,7 +254,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:05583732
+      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
         resources:
           requests:
             cpu: "1000m"
@@ -291,7 +291,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -329,7 +329,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -367,7 +367,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -405,7 +405,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -446,7 +446,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -482,7 +482,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -518,7 +518,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:
@@ -554,7 +554,7 @@ periodics:
   skip_submodules: true
   spec:
     containers:
-    - image: gcr.io/cloud-provider-vsphere/ci:05583732
+    - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
       command:
       - "make"
       args:


### PR DESCRIPTION
This is a two-fer (separated into two commits).

The first bumps the version on the CI Image. I built and pushed a new one today to pick up a more up to date package cache and make sure everything is re-built with Go 1.12.10.

The second is to only only run Go-related tests when something actually Go-related changes. For example, we run all unit tests and integration tests when the PR is only a doc change. This changes that.

/assign @yastij @frapposelli 