### PR TITLE
Configure presubmit prow job for kubernetes-sigs/multi-tenancy HNC project

### DIFF
--- a/config/jobs/kubernetes-sigs/multi-tenancy/hnc-presubmit.yml
+++ b/config/jobs/kubernetes-sigs/multi-tenancy/hnc-presubmit.yml
@@ -1,0 +1,14 @@
+presubmits:
+  kubernetes-sigs/multi-tenancy:
+  - name: pull-hnc-test
+    annotations:
+      testgrid-dashboards: wg-multi-tenancy-hnc
+      testgrid-tab-name: pull-test
+    decorate: true
+    path_alias: sigs.k8s.io/multi-tenancy
+    run_if_changed: "./incubator/hnc/.*"
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - ./incubator/hnc/hack/ci-test.sh


### PR DESCRIPTION
Hey there delilah,

At https://github.com/kubernetes-sigs/multi-tenancy, the HNC (Hierarchical Namespace Controller) is in need of its CI. This PR configures a Prow job to run our unit tests and check some conditions before.

This job will run the following file https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/hack/ci-test.sh

I tested this prow job locally with `pj-on-kind.sh` and everything worked just as fine.