### PR TITLE
vsphere-csi: Add codenrhoden to rerun_auth_config

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -198,6 +198,9 @@ postsubmits:
         - "push-images"
         securityContext:
           privileged: true
+    rerun_auth_config:
+      github_users:
+      - codenrhoden
     annotations:
       testgrid-dashboards: vmware-postsubmits-vsphere-csi-driver
       testgrid-num-columns-recent: '20'


### PR DESCRIPTION
/assign @dvonthenen 

I've got an odd one for you. The most recent "release" job failed -- for reasons I don't think are related to our process, but something went wrong in the Prow cluster. Since it's a post-submit job, I can't restart it with `/test`.

I found this config option when searching #sig-testing on Slack, and I think it will allow me to restart the job via prow.k8s.io. Right now if I try to restart using that UI, it says I'm not allowed. But I think this is what turns it on. Would be an awesome help for us if it works.

If it does, we can expand the user list and use it on other projects as well.