### PR TITLE
Change path to 'sigs.k8s.io' in K8sSigs function

### DIFF
--- a/kubetest/util/util.go
+++ b/kubetest/util/util.go
@@ -58,7 +58,7 @@ func K8sSigs(projectName string) string {
 	found := false
 	var githubDir string
 	for _, gopath := range gopathList {
-		githubDir = filepath.Join(gopath, "src", "github.com", "kubernetes-sigs")
+		githubDir = filepath.Join(gopath, "src", "sigs.k8s.io")
 		if _, err := os.Stat(githubDir); !os.IsNotExist(err) {
 			found = true
 			break
@@ -66,7 +66,7 @@ func K8sSigs(projectName string) string {
 	}
 	if !found {
 		// Default to the first item in GOPATH list.
-		githubDir = filepath.Join(gopathList[0], "src", "github.com", "kubernetes-sigs")
+		githubDir = filepath.Join(gopathList[0], "src", "sigs.k8s.io")
 		log.Printf(
 			"Warning: Couldn't find directory src/github.com/kubernetes-sigs under any of GOPATH %s, defaulting to %s",
 			build.Default.GOPATH, githubDir)


### PR DESCRIPTION
Follow-up PR for #14650. With `--repo` argument changed to `sigs.k8s.io/$(REPO_NAME)` in [azurefile-csi-driver-config.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml), `K8sSigs` function needs to point to `$GOPATH/src/sigs.k8s.io/projectName` instead of `$GOPATH/src/github.com/kubernetes-sigs/projectName`

/assign @andyzhangx @feiskyer
/area provider/azure