### PR TITLE
use kubekins-e2e image for build and release

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -121,7 +121,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/csi-ci:v0.2.1-57-gc586855
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
         command:
         - "make"
         args:
@@ -140,7 +140,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/csi-ci:v0.2.1-57-gc586855
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
         command:
         - "make"
         args:
@@ -166,7 +166,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/csi-ci:v0.2.1-57-gc586855
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
         command:
         - "make"
         args:
@@ -191,7 +191,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/csi-ci:v0.2.1-57-gc586855
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
         command:
         - "make"
         args:


### PR DESCRIPTION
This patch replaces the use of the "csi-ci" image, as it is not well
maintained and the latest version of it fails to start up DinD. Rather
than fix/maintain that, use kubekins-e2e. While the original motivation
for "csi-ci" was to speed up the builds by caching pre-compiled packages
and pre-downloading the go module dependencies, the recent usage of
GOPROXY has made most of the time spent downloading deps a non-issue.

