### PR TITLE
Add pull-release-test presubmit

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -38,8 +38,30 @@ presubmits:
       testgrid-tab-name: release-cluster-up
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
-  - name: pull-release-unit
+  - name: pull-release-test
     always_run: true
+    decorate: true
+    path_alias: k8s.io/release
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    spec:
+      containers:
+      - image: launcher.gcr.io/google/bazel:0.29.1
+        command:
+        - ../test-infra/hack/bazel.sh
+        args:
+        - test
+        - //...
+    annotations:
+      testgrid-dashboards: sig-release-misc
+      testgrid-tab-name: release-test
+      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-num-columns-recent: '30'
+  - name: pull-release-unit
+    always_run: true # TODO(fejta): merge with pull-release-test
     decorate: true
     path_alias: k8s.io/release
     spec:
@@ -55,7 +77,7 @@ presubmits:
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-verify
-    always_run: true
+    always_run: true # TODO(fejta): merge with pull-release-test
     optional: true
     decorate: true
     path_alias: k8s.io/release
@@ -69,8 +91,6 @@ presubmits:
         args:
         - make
         - verify
-        securityContext:
-          privileged: true
     annotations:
       testgrid-dashboards: sig-release-misc
       testgrid-tab-name: release-verify


### PR DESCRIPTION
/assign @justaugustus 

This handles both `make verify` and `make test`

```console
fejta@fejta3:~/src/gh/test-infra$ bazel run //config:mkpj -- --job=pull-release-test > ~/pj.yaml
Loading: 
Loading: 0 packages loaded
Analyzing: target //config:mkpj (0 packages loaded, 0 targets configured)
INFO: Analyzed target //config:mkpj (1 packages loaded, 403 targets configured).
INFO: Found 1 target...
[0 / 4] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //config:mkpj up-to-date:
  bazel-bin/prow/cmd/mkpj/linux_amd64_stripped/mkpj
  bazel-bin/config/mkpj
INFO: Elapsed time: 1.495s, Critical Path: 0.21s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/config/mkpj '--config-path=config/prow/config.yaml' '--job-config-path=config/jobs' '--job=pull-release-test'
INFO: Build completed successfully, 1 total action
WARN[0000] default_decoration_config will be deprecated on April 2020, and it will be replaced with default_decoration_configs['*']. 
WARN[0000] empty -github-token-path, will use anonymous github client 
PR Number: 886
INFO[0001] GetPullRequest(kubernetes, release, 886)      client=github

fejta@fejta3:~/src/gh/test-infra$ phaino ~/pj.yaml
INFO[0000] Reading...                                    path=/usr/local/google/home/fejta/pj.yaml
INFO[0000] Converting job into docker run command...     job=pull-release-test
local /path/to/k8s.io/release [/usr/local/google/home/fejta/src/gh/release]: 
local /path/to/k8s.io/test-infra [/usr/local/google/home/fejta/src/gh/test-infra]: 
"docker" "run" "--rm=true" \
 "--name=phaino-194642-1" \
 "--entrypoint=../test-infra/hack/bazel.sh" \
 "-e" \
 "GOPROXY=https://proxy.golang.org" \
 "-v" \
 "/usr/local/google/home/fejta/src/gh/release:/go/src/k8s.io/release" \
 "-v" \
 "/usr/local/google/home/fejta/src/gh/test-infra:/go/src/k8s.io/test-infra" \
 "-v" \
 "/go/src/k8s.io/release" \
 "-w" \
 "/go/src/k8s.io/release" \
 "--label=prow.k8s.io/refs.org=kubernetes" \
 "--label=prow.k8s.io/refs.pull=886" \
 "--label=prow.k8s.io/refs.repo=release" \
 "--label=prow.k8s.io/type=presubmit" \
 "--label=created-by-prow=true" \
 "--label=prow.k8s.io/job=pull-release-test" \
 "--label=phaino=true" \
 "launcher.gcr.io/google/bazel:0.29.1" \
 "test" \
 "//..." 
INFO[0001] Starting job...                               job=pull-release-test
INFO[0001] Waiting for job to finish...                  container=phaino-194642-1 job=pull-release-test
+ bazel test //...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
Loading: 
[598 / 599] 8 / 9 tests; Testing @io_k8s_repo_infra//hack:verify-deps; 12s processwrapper-sandbox
[598 / 599] 8 / 9 tests; Testing @io_k8s_repo_infra//hack:verify-deps; 31s processwrapper-sandbox
INFO: Elapsed time: 150.712s, Critical Path: 47.53s
INFO: 560 processes: 560 processwrapper-sandbox.
INFO: Build completed successfully, 599 total actions
//build/debs:go_default_test                                             PASSED in 0.1s
//lib:common                                                             PASSED in 0.5s
//lib:gitlib                                                             PASSED in 0.6s
//lib:releaselib                                                         PASSED in 0.6s
//pkg/notes:go_default_test                                              PASSED in 0.1s
@io_k8s_repo_infra//hack:verify-bazel                                    PASSED in 0.3s
@io_k8s_repo_infra//hack:verify-boilerplate                              PASSED in 0.5s
@io_k8s_repo_infra//hack:verify-deps                                     PASSED in 31.9s
@io_k8s_repo_infra//hack:verify-gofmt                                    PASSED in 0.1s

Executed 9 out of 9 tests: 9 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Build completed successfully, 599 total actions
+ ../test-infra/hack/coalesce.py
+ exit 0
INFO[0155] PASS                                          duration=2m35.556244773s job=pull-release-test
INFO[0155] SUCCESS
```