### PR TITLE
add pull-kubeadm-operator-verify presubmit job to k/kubeadm

### DIFF
--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -10,3 +10,12 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
         command:
         - "./kinder/hack/verify-all.sh"
+  - name: pull-kubeadm-operator-verify
+    path_alias: "k8s.io/kubeadm"
+    decorate: true
+    run_if_changed: '^operator\/.*$'
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191008-b83b3fe-master
+        command:
+        - "./operator/hack/verify-all.sh"


### PR DESCRIPTION
As per https://github.com/kubernetes/enhancements/pull/1239 enhancement, we are starting to prototype the kubeadm operator into k/kubeadm repository.

This PR adds the `pull-kubeadm-operator-verify` presubmit job so we can ensure a core set of checks is performed (spell check, go fmt, go vet, unit tests, etc.)  before any changes merge.

/sig cluster-lifecycle
/area kubeadm

/assign @neolit123 
/cc @ereslibre @yagonobre @yastij 

/hold
until https://github.com/kubernetes/kubeadm/pull/1824 is merged