### PR TITLE
[plank] Add logic to allow the decoration configs to co-exist.

### DIFF
--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -221,7 +221,7 @@ func getGCSDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitClient 
 			gcsConfig = presubmit.DecorationConfig.GCSConfiguration
 		} else {
 			// for undecorated jobs assume the default
-			gcsConfig = c.Plank.DefaultDecorationConfig.GCSConfiguration
+			gcsConfig = c.Plank.GetDefaultDecorationConfigs(fullRepo).GCSConfiguration
 		}
 
 		gcsPath, _, _ := gcsupload.PathsForJob(gcsConfig, &downwardapi.JobSpec{

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -364,12 +364,14 @@ func TestGetGCSDirsForPR(t *testing.T) {
 			config: &config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						DefaultDecorationConfig: &prowapi.DecorationConfig{
-							GCSConfiguration: &prowapi.GCSConfiguration{
-								Bucket:       "krusty-krab",
-								PathStrategy: "legacy",
-								DefaultOrg:   "kubernetes",
-								DefaultRepo:  "kubernetes",
+						DefaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
+							"*": {
+								GCSConfiguration: &prowapi.GCSConfiguration{
+									Bucket:       "krusty-krab",
+									PathStrategy: "legacy",
+									DefaultOrg:   "kubernetes",
+									DefaultRepo:  "kubernetes",
+								},
 							},
 						},
 					},

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -913,27 +913,29 @@ func setPeriodicDecorationDefaults(c *Config, ps *Periodic) {
 // finalizeJobConfig mutates and fixes entries for jobspecs
 func (c *Config) finalizeJobConfig() error {
 	if c.decorationRequested() {
-		if c.Plank.DefaultDecorationConfig == nil {
-			return errors.New("no default decoration config provided for plank")
-		}
-		if c.Plank.DefaultDecorationConfig.UtilityImages == nil {
-			return errors.New("no default decoration image pull specs provided for plank")
-		}
-		if c.Plank.DefaultDecorationConfig.GCSConfiguration == nil {
-			return errors.New("no default GCS decoration config provided for plank")
-		}
-		if c.Plank.DefaultDecorationConfig.GCSCredentialsSecret == "" {
-			return errors.New("no default GCS credentials secret provided for plank")
-		}
 
-		if c.Plank.DefaultDecorationConfig != nil && len(c.Plank.DefaultDecorationConfigs) == 0 {
+		if c.Plank.DefaultDecorationConfig != nil {
+			if len(c.Plank.DefaultDecorationConfigs) > 0 {
+				return errors.New("both default_decoration_config and default_decoration_configs are specified")
+			}
+
 			logrus.Warning("default_decoration_config will be deprecated on April 2020, and it will be replaced with default_decoration_configs['*'].")
+			c.Plank.DefaultDecorationConfigs = make(map[string]*prowapi.DecorationConfig)
+			c.Plank.DefaultDecorationConfigs["*"] = c.Plank.DefaultDecorationConfig
 		}
 
 		if len(c.Plank.DefaultDecorationConfigs) == 0 {
-			c.Plank.DefaultDecorationConfigs = make(map[string]*prowapi.DecorationConfig)
+			return errors.New("both default_decoration_config and default_decoration_configs['*'] are missing")
+
 		}
-		c.Plank.DefaultDecorationConfigs["*"] = c.Plank.DefaultDecorationConfig
+
+		if _, ok := c.Plank.DefaultDecorationConfigs["*"]; !ok {
+			return errors.New("default_decoration_configs['*'] is missing")
+		}
+
+		if err := c.Plank.DefaultDecorationConfigs["*"].Validate(); err != nil {
+			return fmt.Errorf("decoration config validation error: %v", err)
+		}
 
 		for repo, vs := range c.Presubmits {
 			for i := range vs {

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -317,10 +317,11 @@ func (s *Spyglass) RunToPR(src string) (string, string, int, error) {
 			// In practice, this shouldn't matter: we only want to read DefaultOrg and DefaultRepo, and overriding those
 			// per job would probably be a bad idea (indeed, not even the tests try to do this).
 			// This decision should probably be revisited if we ever want other information from it.
-			if s.config().Plank.DefaultDecorationConfig == nil || s.config().Plank.DefaultDecorationConfig.GCSConfiguration == nil {
+			// TODO (droslean): we should get the default decoration config depending on the org/repo.
+			if s.config().Plank.DefaultDecorationConfigs["*"] == nil || s.config().Plank.DefaultDecorationConfigs["*"].GCSConfiguration == nil {
 				return "", "", 0, fmt.Errorf("couldn't look up a GCS configuration")
 			}
-			c := s.config().Plank.DefaultDecorationConfig.GCSConfiguration
+			c := s.config().Plank.DefaultDecorationConfigs["*"].GCSConfiguration
 			// Assumption: we can derive the type of URL from how many components it has, without worrying much about
 			// what the actual path configuration is.
 			switch len(split) {

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/test-infra/prow/gcsupload"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/sirupsen/logrus"
@@ -836,12 +837,14 @@ func TestRunToPR(t *testing.T) {
 		fca.Set(&config.Config{
 			ProwConfig: config.ProwConfig{
 				Plank: config.Plank{
-					DefaultDecorationConfig: &prowapi.DecorationConfig{
-						GCSConfiguration: &prowapi.GCSConfiguration{
-							Bucket:       "kubernetes-jenkins",
-							DefaultOrg:   "kubernetes",
-							DefaultRepo:  "kubernetes",
-							PathStrategy: "legacy",
+					DefaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
+						"*": {
+							GCSConfiguration: &prowapi.GCSConfiguration{
+								Bucket:       "kubernetes-jenkins",
+								DefaultOrg:   "kubernetes",
+								DefaultRepo:  "kubernetes",
+								PathStrategy: "legacy",
+							},
 						},
 					},
 				},
@@ -1052,10 +1055,12 @@ func TestGCSPathRoundTrip(t *testing.T) {
 			c: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
-						DefaultDecorationConfig: &prowapi.DecorationConfig{
-							GCSConfiguration: &prowapi.GCSConfiguration{
-								DefaultOrg:  tc.defaultOrg,
-								DefaultRepo: tc.defaultRepo,
+						DefaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
+							"*": {
+								GCSConfiguration: &prowapi.GCSConfiguration{
+									DefaultOrg:  tc.defaultOrg,
+									DefaultRepo: tc.defaultRepo,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds logic for the two decoration configs to co-exist. 

- If not `default_decoration_configs` then use `default_decoration_config` and print a warning for deprecation.
- If `default_decoration_configs` but default key `'*'` is missing and `default_decoration_config` exists use that instead, else return error.

Also, this replace the decoration config validation with [.Validate()](https://github.com/kubernetes/test-infra/blob/master/prow/apis/prowjobs/v1/types.go#L359-L390)

/cc @stevekuznetsov @petr-muller 