### PR TITLE
Peribolos skip team repo if permissions invalid

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2613,7 +2613,11 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 			return &[]Repo{}
 		},
 		func(obj interface{}) {
-			repos = append(repos, *(obj.(*[]Repo))...)
+			for _, repo := range *obj.(*[]Repo) {
+				if LevelFromPermissions(repo.Permissions) != None {
+					repos = append(repos, repo)
+				}
+			}
 		},
 	)
 	if err != nil {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1970,3 +1970,27 @@ func TestCombinedStatus(t *testing.T) {
 		t.Errorf("Wrong review IDs: %v", combined.Statuses)
 	}
 }
+
+func TestListTeamRepos(t *testing.T) {
+	ts := simpleTestServer(t, "/teams/1/repos",
+		[]Repo{
+			{
+				Name:        "repo-bar",
+				Permissions: RepoPermissions{Pull: true},
+			},
+			{
+				Name: "repo-invalid-permission-level",
+			},
+		},
+	)
+	defer ts.Close()
+	c := getClient(ts.URL)
+	repos, err := c.ListTeamRepos(1)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if len(repos) != 1 {
+		t.Errorf("Expected one repo, found %d: %v", len(repos), repos)
+	} else if repos[0].Name != "repo-bar" {
+		t.Errorf("Wrong repos: %v", repos)
+	}
+}


### PR DESCRIPTION
See #14325 

Peribolos will now skip updating a repo for a team if the
existing permission level for the team on the repo is 'none'.
This is to avoid overwriting any of the team's repos if the existing
permission level cannot be parsed, e.g. with new 'Triage' and 'Maintain'
levels not yet exposed by GitHub API v3.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>