### PR TITLE
Drop KUBE_BUILD_HYPERKUBE

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -52,8 +52,6 @@ periodics:
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
-      - name: KUBE_BUILD_HYPERKUBE
-        value: "n"
       - name: KUBE_BUILD_CONFORMANCE
         value: "n"
       securityContext:
@@ -120,8 +118,6 @@ periodics:
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
-      - name: KUBE_BUILD_HYPERKUBE
-        value: "n"
       - name: KUBE_BUILD_CONFORMANCE
         value: "n"
       securityContext:

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -120,8 +120,6 @@ def main(args):
         push_build_args.append('--bucket=%s' % args.release)
     if args.registry:
         push_build_args.append('--docker-registry=%s' % args.registry)
-    if args.hyperkube:
-        env['KUBE_BUILD_HYPERKUBE'] = 'y'
     if args.extra_publish_file:
         push_build_args.append('--extra-publish-file=%s' % args.extra_publish_file)
     if args.allow_dup:
@@ -153,8 +151,6 @@ if __name__ == '__main__':
         help='The release kind to push to GCS. Supported values are kubernetes or federation')
     PARSER.add_argument(
         '--registry', help='Push images to the specified docker registry')
-    PARSER.add_argument(
-        '--hyperkube', action='store_true', help='Build hyperkube image')
     PARSER.add_argument(
         '--extra-publish-file', help='Additional version file uploads to')
     PARSER.add_argument(


### PR DESCRIPTION
KUBE_BUILD_HYPERKUBE is [no longer present in k/k](https://github.com/kubernetes/kubernetes/pull/83454). Let's drop it from
test-infra as well.