### PR TITLE
[exporter] Expose Job runtime as prometheus histograms

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -532,7 +532,11 @@ func (g *GCSConfiguration) Validate() error {
 
 // ProwJobStatus provides runtime metadata, such as when it finished, whether it is running, etc.
 type ProwJobStatus struct {
-	StartTime      metav1.Time  `json:"startTime,omitempty"`
+	// StartTime is equal to the creation time of the ProwJob
+	StartTime metav1.Time `json:"startTime,omitempty"`
+	// PendingTime is the timestamp for when the job moved from triggered to pending
+	PendingTime *metav1.Time `json:"pendingTime,omitempty"`
+	// CompletionTime is the timestamp for when the job goes to a final state
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 	State          ProwJobState `json:"state,omitempty"`
 	Description    string       `json:"description,omitempty"`

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -273,6 +273,10 @@ func (in *ProwJobSpec) DeepCopy() *ProwJobSpec {
 func (in *ProwJobStatus) DeepCopyInto(out *ProwJobStatus) {
 	*out = *in
 	in.StartTime.DeepCopyInto(&out.StartTime)
+	if in.PendingTime != nil {
+		in, out := &in.PendingTime, &out.PendingTime
+		*out = (*in).DeepCopy()
+	}
 	if in.CompletionTime != nil {
 		in, out := &in.CompletionTime, &out.CompletionTime
 		*out = (*in).DeepCopy()

--- a/prow/cmd/exporter/BUILD.bazel
+++ b/prow/cmd/exporter/BUILD.bazel
@@ -2,6 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 prow_image(
     name = "image",
@@ -26,6 +27,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/metrics/prowjobs:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -36,6 +38,12 @@ go_library(
 
 go_binary(
     name = "exporter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "exporter_image",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/exporter/README.md
+++ b/prow/cmd/exporter/README.md
@@ -9,6 +9,8 @@ metrics are not directly related to a specific prow-component.
 |----------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | prow_job_labels      | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `label_PROW_JOB_LABEL_KEY`=&lt;PROW_JOB_LABEL_VALUE&gt;                 |
 | prow_job_annotations | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt;  |
+| prow_job_annotations | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt;  |
+| prow_job_runtime_seconds     | Histogram     | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `type`=&lt;prow_job-type&gt; <br> `last_state`=&lt;last-state&gt; <br> `state`=&lt;state&gt; <br> `org`=&lt;org&gt; <br> `repo`=&lt;repo&gt; <br> `base_ref`=&lt;base_ref&gt; <br>  |
 
 For example, the metric `prow_job_labels` is similar to `kube_pod_labels` defined
 in [kubernetes/kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/master/docs/pod-metrics.md).

--- a/prow/cmd/exporter/main.go
+++ b/prow/cmd/exporter/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
+	"k8s.io/test-infra/prow/metrics/prowjobs"
 	"k8s.io/test-infra/prow/pjutil"
 )
 
@@ -90,6 +91,9 @@ func main() {
 	}
 	informerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(pjClientset, 0, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
 	pjLister := informerFactory.Prow().V1().ProwJobs().Lister()
+
+	prometheus.MustRegister(prowjobs.NewProwJobLifecycleHistogramVec(informerFactory.Prow().V1().ProwJobs().Informer()))
+
 	go informerFactory.Start(interrupts.Context().Done())
 
 	registry := mustRegister("exporter", pjLister)

--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -468,6 +468,10 @@ func updateProwJobState(c reconciler, key string, newPipelineRun bool, pj *prowj
 	haveMsg := pj.Status.Description
 	if newPipelineRun || haveState != state || haveMsg != msg {
 		npj := pj.DeepCopy()
+		if haveState != state && state == prowjobv1.PendingState {
+			now := c.now()
+			npj.Status.PendingTime = &now
+		}
 		if npj.Status.StartTime.IsZero() {
 			npj.Status.StartTime = c.now()
 		}

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -258,6 +258,7 @@ func TestReconcile(t *testing.T) {
 			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
 				pj.Status = prowjobv1.ProwJobStatus{
 					StartTime:   now,
+					PendingTime: &now,
 					State:       prowjobv1.PendingState,
 					Description: descScheduling,
 					BuildID:     pipelineID,

--- a/prow/jenkins/BUILD.bazel
+++ b/prow/jenkins/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
     ],
 )
@@ -61,5 +62,6 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
     ],
 )

--- a/prow/metrics/BUILD.bazel
+++ b/prow/metrics/BUILD.bazel
@@ -24,7 +24,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/metrics/prowjobs:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/prow/metrics/prowjobs/BUILD.bazel
+++ b/prow/metrics/prowjobs/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["collector.go"],
+    importpath = "k8s.io/test-infra/prow/metrics/prowjobs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["collector_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_model//go:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
+    ],
+)

--- a/prow/metrics/prowjobs/collector.go
+++ b/prow/metrics/prowjobs/collector.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prowjobs
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/tools/cache"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func update(histogramVec *prometheus.HistogramVec, oldJob *prowapi.ProwJob, newJob *prowapi.ProwJob) {
+	if oldJob == nil || oldJob.Status.State == newJob.Status.State {
+		return
+	}
+
+	var oldTime *metav1.Time
+	var newTime *metav1.Time
+
+	switch oldJob.Status.State {
+	case prowapi.TriggeredState:
+		oldTime = &oldJob.CreationTimestamp
+	case prowapi.PendingState:
+		oldTime = oldJob.Status.PendingTime
+	}
+
+	switch newJob.Status.State {
+	case prowapi.FailureState, prowapi.SuccessState, prowapi.ErrorState, prowapi.AbortedState:
+		newTime = newJob.Status.CompletionTime
+	case prowapi.PendingState:
+		newTime = newJob.Status.PendingTime
+	}
+
+	if oldTime == nil || newTime == nil {
+		return
+	}
+
+	labels := getJobLabel(oldJob, newJob)
+	histogram, err := histogramVec.GetMetricWithLabelValues(labels.values()...)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to get a histogram for a prowjob")
+		return
+	}
+	histogram.Observe(newTime.Sub(oldTime.Time).Seconds())
+}
+
+// NewProwJobLifecycleHistogramVec creates histograms which can track the timespan between ProwJob state transitions.
+// The histograms are based on the job name, the old job state and the new job state.
+// Data is collected by hooking itself into the prowjob informer.
+// The collector will never record the same state transition twice, even if reboots happen.
+func NewProwJobLifecycleHistogramVec(informer cache.SharedIndexInformer) *prometheus.HistogramVec {
+	histogramVec := newHistogramVec()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldJob, newJob interface{}) {
+			update(histogramVec, oldJob.(*prowapi.ProwJob), newJob.(*prowapi.ProwJob))
+		},
+	})
+	return histogramVec
+}
+
+func getJobLabel(oldJob *prowapi.ProwJob, newJob *prowapi.ProwJob) jobLabel {
+	jl := jobLabel{
+		jobNamespace: newJob.Namespace,
+		jobName:      newJob.Spec.Job,
+		jobType:      string(newJob.Spec.Type),
+		state:        string(newJob.Status.State),
+		last_state:   string(oldJob.Status.State),
+	}
+
+	if newJob.Spec.Refs != nil {
+		jl.org = newJob.Spec.Refs.Org
+		jl.repo = newJob.Spec.Refs.Repo
+		jl.baseRef = newJob.Spec.Refs.BaseRef
+	} else if len(newJob.Spec.ExtraRefs) > 0 {
+		jl.org = newJob.Spec.ExtraRefs[0].Org
+		jl.repo = newJob.Spec.ExtraRefs[0].Repo
+		jl.baseRef = newJob.Spec.ExtraRefs[0].BaseRef
+	}
+
+	return jl
+}
+
+type jobLabel struct {
+	jobNamespace string
+	jobName      string
+	jobType      string
+	last_state   string
+	state        string
+	org          string
+	repo         string
+	baseRef      string
+}
+
+func (jl *jobLabel) values() []string {
+	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.last_state, jl.state, jl.org, jl.repo, jl.baseRef}
+}
+
+func newHistogramVec() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "prow_job_runtime_seconds",
+			Buckets: []float64{
+				time.Minute.Seconds() / 2,
+				(1 * time.Minute).Seconds(),
+				(2 * time.Minute).Seconds(),
+				(5 * time.Minute).Seconds(),
+				(10 * time.Minute).Seconds(),
+				(1 * time.Hour).Seconds() / 2,
+				(1 * time.Hour).Seconds(),
+				(2 * time.Hour).Seconds(),
+				(3 * time.Hour).Seconds(),
+				(4 * time.Hour).Seconds(),
+				(5 * time.Hour).Seconds(),
+				(6 * time.Hour).Seconds(),
+				(7 * time.Hour).Seconds(),
+				(8 * time.Hour).Seconds(),
+				(9 * time.Hour).Seconds(),
+				(10 * time.Hour).Seconds(),
+			},
+		},
+		[]string{
+			// namespace of the job
+			"job_namespace",
+			// name of the job
+			"job_name",
+			// type of the prowjob: presubmit, postsubmit, periodic, batch
+			"type",
+			// last state of the prowjob: triggered, pending, success, failure, aborted, error
+			"last_state",
+			// state of the prowjob: triggered, pending, success, failure, aborted, error
+			"state",
+			// the org of the prowjob's repo
+			"org",
+			// the prowjob's repo
+			"repo",
+			// the base_ref of the prowjob's repo
+			"base_ref",
+		},
+	)
+}

--- a/prow/metrics/prowjobs/collector_test.go
+++ b/prow/metrics/prowjobs/collector_test.go
@@ -1,0 +1,251 @@
+package prowjobs
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func TestProwJobLifecycleCollectorUpdate(t *testing.T) {
+	fakeClock := clock.NewFakeClock(time.Now())
+	defaultCompleteTime := v1.NewTime(fakeClock.Now().Add(1 * time.Hour))
+	defaultPendingTime := v1.NewTime(fakeClock.Now().Add(30 * time.Minute))
+	type args struct {
+		oldJob *prowapi.ProwJob
+		newJob *prowapi.ProwJob
+	}
+	type expected struct {
+		collected []dto.Metric
+	}
+	tests := []struct {
+		oldJobStates []prowapi.ProwJobState
+		newJobStates []prowapi.ProwJobState
+		name         string
+		args         args
+		expected     expected
+	}{
+		{name: "should not collect job without history when no state change was observed for state %s to %s",
+			oldJobStates: []prowapi.ProwJobState{
+				prowapi.TriggeredState,
+				prowapi.PendingState,
+				prowapi.SuccessState,
+				prowapi.FailureState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+			},
+			newJobStates: []prowapi.ProwJobState{
+				prowapi.TriggeredState,
+				prowapi.PendingState,
+				prowapi.SuccessState,
+				prowapi.FailureState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+			},
+			args: args{
+				oldJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						CreationTimestamp: v1.NewTime(fakeClock.Now()),
+					},
+					Status: prowapi.ProwJobStatus{
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+					},
+				},
+				newJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						CreationTimestamp: v1.NewTime(fakeClock.Now()),
+					},
+					Status: prowapi.ProwJobStatus{
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+					},
+				},
+			}, expected: expected{
+				collected: nil,
+			}},
+		{name: "should collect job transitions for transitions from %s to  %s",
+			oldJobStates: []prowapi.ProwJobState{
+				prowapi.TriggeredState,
+				prowapi.TriggeredState,
+				prowapi.TriggeredState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+			},
+			newJobStates: []prowapi.ProwJobState{
+				prowapi.PendingState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+				prowapi.SuccessState,
+				prowapi.FailureState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+			},
+			args: args{
+				oldJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						CreationTimestamp: v1.NewTime(fakeClock.Now().Add(-time.Hour)),
+					},
+					Status: prowapi.ProwJobStatus{
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+						State:          prowapi.TriggeredState,
+					},
+				},
+				newJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						Name:              "testjob",
+						Namespace:         "testnamespace",
+						CreationTimestamp: v1.NewTime(fakeClock.Now().Add(-time.Hour)),
+					},
+					Spec: prowapi.ProwJobSpec{
+						Job:  "testjob",
+						Type: prowapi.PeriodicJob,
+						Refs: &prowapi.Refs{
+							Org:     "testorg",
+							Repo:    "testrepo",
+							BaseRef: "master",
+						},
+					},
+					Status: prowapi.ProwJobStatus{
+						State:          prowapi.PendingState,
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+					},
+				},
+			}, expected: expected{
+				collected: []dto.Metric{{Label: []*dto.LabelPair{
+					toLabelPair("base_ref", "master"),
+					toLabelPair("job_name", "testjob"),
+					toLabelPair("job_namespace", "testnamespace"),
+					toLabelPair("last_state", string(prowapi.TriggeredState)),
+					toLabelPair("org", "testorg"),
+					toLabelPair("repo", "testrepo"),
+					toLabelPair("state", string(prowapi.PendingState)),
+					toLabelPair("type", string(prowapi.PeriodicJob)),
+				}}},
+			}},
+		{name: "should collect job transitions for transitions from %s to  %s from extraRefs",
+			oldJobStates: []prowapi.ProwJobState{
+				prowapi.TriggeredState,
+				prowapi.TriggeredState,
+				prowapi.TriggeredState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+				prowapi.PendingState,
+			},
+			newJobStates: []prowapi.ProwJobState{
+				prowapi.PendingState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+				prowapi.SuccessState,
+				prowapi.FailureState,
+				prowapi.ErrorState,
+				prowapi.AbortedState,
+			},
+			args: args{
+				oldJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						CreationTimestamp: v1.NewTime(fakeClock.Now().Add(-time.Hour)),
+					},
+					Status: prowapi.ProwJobStatus{
+						State:          prowapi.TriggeredState,
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+					},
+				},
+				newJob: &prowapi.ProwJob{
+					ObjectMeta: v1.ObjectMeta{
+						UID:               "1234",
+						Name:              "testjob",
+						Namespace:         "testnamespace",
+						CreationTimestamp: v1.NewTime(fakeClock.Now().Add(-time.Hour)),
+					},
+					Spec: prowapi.ProwJobSpec{
+						Job:  "testjob",
+						Type: prowapi.PeriodicJob,
+						ExtraRefs: []prowapi.Refs{{
+							Org:     "testorg",
+							Repo:    "testrepo",
+							BaseRef: "master",
+						}},
+					},
+					Status: prowapi.ProwJobStatus{
+						CompletionTime: &defaultCompleteTime,
+						PendingTime:    &defaultPendingTime,
+						State:          prowapi.PendingState,
+					},
+				},
+			}, expected: expected{
+				collected: []dto.Metric{{Label: []*dto.LabelPair{
+					toLabelPair("base_ref", "master"),
+					toLabelPair("job_name", "testjob"),
+					toLabelPair("job_namespace", "testnamespace"),
+					toLabelPair("last_state", string(prowapi.TriggeredState)),
+					toLabelPair("org", "testorg"),
+					toLabelPair("repo", "testrepo"),
+					toLabelPair("state", string(prowapi.PendingState)),
+					toLabelPair("type", string(prowapi.PeriodicJob)),
+				}}},
+			}},
+	}
+	for _, tt := range tests {
+		for x := 0; x < len(tt.oldJobStates); x++ {
+			t.Run(fmt.Sprintf(tt.name, tt.oldJobStates[x], tt.newJobStates[x]), func(t *testing.T) {
+				histogramVec := newHistogramVec()
+				tt.args.oldJob.Status.State = tt.oldJobStates[x]
+				tt.args.newJob.Status.State = tt.newJobStates[x]
+				update(histogramVec, tt.args.oldJob, tt.args.newJob)
+				assertMetrics(t, collect(histogramVec), tt.expected.collected, tt.oldJobStates[x], tt.newJobStates[x])
+			})
+		}
+	}
+}
+
+func collect(histogram *prometheus.HistogramVec) []dto.Metric {
+	metrics := make(chan prometheus.Metric, 1000)
+	histogram.Collect(metrics)
+	close(metrics)
+	var collected []dto.Metric
+	for metric := range metrics {
+		m := dto.Metric{}
+		metric.Write(&m)
+		collected = append(collected, m)
+	}
+	return collected
+}
+
+func assertMetrics(t *testing.T, actual, expected []dto.Metric, lastState prowapi.ProwJobState, state prowapi.ProwJobState) {
+	if len(actual) != len(expected) {
+		t.Errorf("actual length differs from expected: %v, %v", len(actual), len(expected))
+		return
+	}
+	for x := 0; x < len(actual); x++ {
+		expected[x].Label[3] = toLabelPair("last_state", string(lastState))
+		expected[x].Label[6] = toLabelPair("state", string(state))
+		if !reflect.DeepEqual(actual[x].Label, expected[x].Label) {
+			t.Errorf("actual differs from expected:\n%s", cmp.Diff(expected[x].Label, actual[x].Label))
+		}
+	}
+}
+
+func toLabelPair(name, value string) *dto.LabelPair {
+	return &dto.LabelPair{Name: &name, Value: &value}
+}

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
@@ -49,6 +50,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
     ],
 )

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -32,6 +32,7 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -313,6 +314,7 @@ func TestTerminateDupes(t *testing.T) {
 			buildClients:  map[string]corev1.PodInterface{prowapi.DefaultClusterAlias: fakePodClient.CoreV1().Pods("pods")},
 			log:           log,
 			config:        fca.Config,
+			clock:         clock.RealClock{},
 		}
 
 		if err := c.terminateDupes(tc.pjs, tc.pm); err != nil {
@@ -356,6 +358,9 @@ func handleTot(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSyncTriggeredJobs(t *testing.T) {
+	fakeClock := clock.NewFakeClock(time.Now().Truncate(1 * time.Second))
+	pendingTime := metav1.NewTime(fakeClock.Now())
+
 	var testcases = []struct {
 		name string
 
@@ -375,6 +380,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 		expectedURL           string
 		expectedBuildID       string
 		expectError           bool
+		expectedPendingTime   *metav1.Time
 	}{
 		{
 			name: "start new pod",
@@ -392,11 +398,12 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					State: prowapi.TriggeredState,
 				},
 			},
-			pods:               map[string][]v1.Pod{"default": {}},
-			expectedState:      prowapi.PendingState,
-			expectedPodHasName: true,
-			expectedNumPods:    map[string]int{"default": 1},
-			expectedReport:     true,
+			pods:                map[string][]v1.Pod{"default": {}},
+			expectedState:       prowapi.PendingState,
+			expectedPendingTime: &pendingTime,
+			expectedPodHasName:  true,
+			expectedNumPods:     map[string]int{"default": 1},
+			expectedReport:      true,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
 				reporter.GitHubReporterName: prowapi.PendingState,
 			},
@@ -507,10 +514,11 @@ func TestSyncTriggeredJobs(t *testing.T) {
 				},
 				"trusted": {},
 			},
-			expectedState:      prowapi.PendingState,
-			expectedNumPods:    map[string]int{"default": 1, "trusted": 1},
-			expectedPodHasName: true,
-			expectedReport:     true,
+			expectedState:       prowapi.PendingState,
+			expectedNumPods:     map[string]int{"default": 1, "trusted": 1},
+			expectedPodHasName:  true,
+			expectedReport:      true,
+			expectedPendingTime: &pendingTime,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
 				reporter.GitHubReporterName: prowapi.PendingState,
 			},
@@ -561,7 +569,8 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			expectPrevReportState: map[string]prowapi.ProwJobState{
 				reporter.GitHubReporterName: prowapi.PendingState,
 			},
-			expectedURL: "beer/pending",
+			expectedURL:         "beer/pending",
+			expectedPendingTime: &pendingTime,
 		},
 		{
 			name: "unprocessable prow job",
@@ -677,9 +686,10 @@ func TestSyncTriggeredJobs(t *testing.T) {
 					},
 				},
 			},
-			expectedState:   prowapi.PendingState,
-			expectedNumPods: map[string]int{"default": 1},
-			expectedReport:  true,
+			expectedState:       prowapi.PendingState,
+			expectedNumPods:     map[string]int{"default": 1},
+			expectedReport:      true,
+			expectedPendingTime: &pendingTime,
 			expectPrevReportState: map[string]prowapi.ProwJobState{
 				reporter.GitHubReporterName: prowapi.PendingState,
 			},
@@ -719,6 +729,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			config:        newFakeConfigAgent(t, tc.maxConcurrency).Config,
 			totURL:        totServ.URL,
 			pendingJobs:   make(map[string]int),
+			clock:         fakeClock,
 		}
 		if tc.pendingJobs != nil {
 			c.pendingJobs = tc.pendingJobs
@@ -753,6 +764,9 @@ func TestSyncTriggeredJobs(t *testing.T) {
 		actual := actualProwJobs.Items[0]
 		if actual.Status.State != tc.expectedState {
 			t.Errorf("for case %q got state %v", tc.name, actual.Status.State)
+		}
+		if !reflect.DeepEqual(actual.Status.PendingTime, tc.expectedPendingTime) {
+			t.Errorf("for case %q got pending time %v, expected %v", tc.name, actual.Status.PendingTime, tc.expectedPendingTime)
 		}
 		if (actual.Status.PodName == "") && tc.expectedPodHasName {
 			t.Errorf("for case %q got no pod name, expected one", tc.name)
@@ -1178,6 +1192,7 @@ func TestSyncPendingJob(t *testing.T) {
 			config:        newFakeConfigAgent(t, 0).Config,
 			totURL:        totServ.URL,
 			pendingJobs:   make(map[string]int),
+			clock:         clock.RealClock{},
 		}
 
 		reports := make(chan prowapi.ProwJob, 100)
@@ -1270,6 +1285,7 @@ func TestOrderedJobs(t *testing.T) {
 			totURL:        totServ.URL,
 			pendingJobs:   make(map[string]int),
 			lock:          sync.RWMutex{},
+			clock:         clock.RealClock{},
 		}
 		if err := c.Sync(); err != nil {
 			t.Fatalf("Error on first sync: %v", err)
@@ -1312,6 +1328,7 @@ func TestPeriodic(t *testing.T) {
 		totURL:        totServ.URL,
 		pendingJobs:   make(map[string]int),
 		lock:          sync.RWMutex{},
+		clock:         clock.RealClock{},
 	}
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on first sync: %v", err)
@@ -1516,6 +1533,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 			log:           logrus.NewEntry(logrus.StandardLogger()),
 			config:        newFakeConfigAgent(t, 0).Config,
 			pendingJobs:   test.pendingJobs,
+			clock:         clock.RealClock{},
 		}
 
 		reports := make(chan prowapi.ProwJob, len(test.pjs))
@@ -1653,6 +1671,7 @@ func TestMaxConcurency(t *testing.T) {
 				log:          logrus.NewEntry(logrus.StandardLogger()),
 				config:       newFakeConfigAgent(t, 0).Config,
 				pendingJobs:  tc.pendingJobs,
+				clock:        clock.RealClock{},
 			}
 			logrus.SetLevel(logrus.DebugLevel)
 


### PR DESCRIPTION
Create histograms which track the time between the jobs state transitions. The histogram is pre-configured with buckets. Starting from 30 seconds, up to 10 hours: `30s, 1m, 2m, 5m, 10m, 30m, 1h, 2h, 3h, 4h, 5h, 6h, 7h, 8h, 9h, 10h`.

A resulting histogram for jobs which go from `last_state="pending"` to `state="success"` looks like this:

```
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="30"} 0
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="60"} 0
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="120"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="300"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="600"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="1800"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="3600"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="7200"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="10800"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="14400"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="18000"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="21600"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="25200"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="28800"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="32400"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="36000"} 1
prow_job_runtime_seconds_bucket{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit",le="+Inf"} 1
prow_job_runtime_seconds_sum{base_ref="master",instance="exporter-9d5794677-th4vb",job="exporter",job_name="check-prow-config",job_namespace="kubevirt-prow-jobs",last_state="pending",org="kubevirt",repo="project-infra",state="success",type="presubmit"} 60.108394254
```

In order to properly capture the metrics, the ProwJobStatus was extended with an additional timestamp:

```golang
	// PendingTime is the timestamp for when the job moved from triggered to pending
	PendingTime *metav1.Time `json:"pendingTime,omitempty"`
```

This timestamp makes sense on every agent, thus the `exporter` can export the state metrics for any agent.

Fixes #14672 