### PR TITLE
testgrid: add cert-manager master branch jobs

### DIFF
--- a/config/testgrids/cert-manager/OWNERS
+++ b/config/testgrids/cert-manager/OWNERS
@@ -1,6 +1,4 @@
 approvers:
 - munnerz
-- JoshVanL
 reviewers:
 - munnerz
-- JoshVanL

--- a/config/testgrids/cert-manager/OWNERS
+++ b/config/testgrids/cert-manager/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- munnerz
+- JoshVanL
+reviewers:
+- munnerz
+- JoshVanL

--- a/config/testgrids/cert-manager/groups.yaml
+++ b/config/testgrids/cert-manager/groups.yaml
@@ -1,0 +1,4 @@
+dashboard_groups:
+- dashboard_names:
+  - jetstack-cert-manager-master
+  name: jetstack

--- a/config/testgrids/cert-manager/jetstack-cert-manager-master.yaml
+++ b/config/testgrids/cert-manager/jetstack-cert-manager-master.yaml
@@ -1,0 +1,182 @@
+dashboards:
+- name: jetstack-cert-manager-master
+  dashboard_tab:
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'Bazel: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-bazel
+    description: Bazel verify results
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-bazel
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'Bazel (experimental): <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-bazel-experimental
+    description: Bazel verify results using newest/unreleased Bazel version
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-bazel-experimental
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-11
+    description: End-to-end tests using Kubernetes 1.11
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-11
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-12
+    description: End-to-end tests using Kubernetes 1.12
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-12
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-13
+    description: End-to-end tests using Kubernetes 1.13
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-13
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-14
+    description: End-to-end tests using Kubernetes 1.14
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-14
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-15
+    description: End-to-end tests using Kubernetes 1.15
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-15
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-16
+    description: End-to-end tests using Kubernetes 1.16
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-16
+
+# These are periodic jobs that target the master branch of cert-manager
+test_groups:
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-bazel
+  name: ci-cert-manager-bazel
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-bazel-experimental
+  name: ci-cert-manager-bazel-experimental
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-11
+  name: ci-cert-manager-e2e-v1-11
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-12
+  name: ci-cert-manager-e2e-v1-12
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-13
+  name: ci-cert-manager-e2e-v1-13
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-14
+  name: ci-cert-manager-e2e-v1-14
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-15
+  name: ci-cert-manager-e2e-v1-15
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-16
+  name: ci-cert-manager-e2e-v1-16

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -49,6 +49,7 @@ var (
 		"redhat",
 		"vmware",
 		"gardener",
+		"jetstack",
 	}
 	orgs = []string{
 		"conformance",


### PR DESCRIPTION
:wave: I'm PRing in to add some of cert-manager's periodic jobs to `testgrid.k8s.io` after @michelle192837 mentioned it may be okay to get these visualised here 😄 

This PR only adds jobs that target the `master` branch, but once this is set up and we can see it works, we may add an additional dashboard for the latest/current release so we can get a signal on test failures ahead of releasing patch/bugfix releases.

I've not configured testgrid before, so I copied/borrowed what seemed to make sense in the openshift and gardener configs.

I also tried to follow conventions of including the company name at the top level dashboard group to make it easy to navigate/discover jobs correctly 😄 

/cc @michelle192837 
