### PR TITLE
Revert "Use boskos for k8s.io/perf-tests presubmits"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -309,7 +309,7 @@ presubmits:
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -371,7 +371,7 @@ presubmits:
             - --gcp-master-size=n1-standard-2
             - --gcp-node-size=n1-standard-4
             - --gcp-nodes=4
-            - --gcp-project-type=scalability-presubmit-project
+            - --gcp-project=k8s-presubmit-scale
             - --gcp-zone=us-east1-b
             - --kubemark
             - --kubemark-nodes=100


### PR DESCRIPTION
This reverts commit edc776c08afaab33642e096040860a69c57378a1.

Boskos is broken due to https://github.com/kubernetes/test-infra/issues/14697

Will re-enable once it gets fixed.

Ref. https://github.com/kubernetes/perf-tests/issues/650