### PR TITLE
sig-cloud-provider: Add justaugustus as approver

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - andrewsykim
 - cheftako
 - hogepodge
-reviewers:
 - justaugustus
 
 labels:

--- a/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - andrewsykim
 - cheftako
 - hogepodge
+- justaugustus
 
 labels:
 - sig/cloud-provider


### PR DESCRIPTION
I've been poking at test jobs in a few areas (Release, capz, provider-azure), as well as reviewing/removing GCP tests where possible/necessary, so it might be useful for me to help out with approvals here to spread the load e.g., https://github.com/kubernetes/test-infra/pull/14701

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @andrewsykim 