### PR TITLE
properly move sig-cluster-lifecycle-upgrade-skew jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -394,7 +394,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
@@ -421,7 +421,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
@@ -448,7 +448,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
@@ -474,7 +474,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew-serial
 - interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
@@ -751,7 +751,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gke-1.13-1.12-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
@@ -781,7 +781,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gke-1.13-1.12-gci-kubectl-skew-serial
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
@@ -812,7 +812,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gke-1.12-1.13-gci-kubectl-skew
 - interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
@@ -841,5 +841,5 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all
     testgrid-tab-name: gke-1.12-1.13-gci-kubectl-skew-serial

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
@@ -27,7 +27,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.12-1.13-cluster-upgrade
 - cron: "0 5-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable2-stable1-master-upgrade
@@ -57,7 +57,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.12-1.13-master-upgrade
 - cron: "0 1-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-cluster-upgrade
@@ -87,7 +87,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.13-1.14-cluster-upgrade
 - cron: "0 7-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-beta-master-upgrade
@@ -117,7 +117,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.13-1.14-master-upgrade
 - cron: "0 3-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-cluster-upgrade
@@ -147,7 +147,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.13-master-cluster-upgrade
 - cron: "0 9-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-stable1-master-master-upgrade
@@ -177,7 +177,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.13-master-master-upgrade
 - cron: "0 10-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-beta-stable1-cluster-downgrade
@@ -208,7 +208,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
 
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-1.14-1.13-cluster-downgrade
 - cron: "0 11-23/12 * * *"
   name: ci-kubernetes-e2e-gce-gpu-master-stable1-cluster-downgrade
@@ -238,5 +238,5 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-master-1.13-cluster-downgrade

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
@@ -199,7 +199,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster
 
 - interval: 12h
@@ -229,7 +229,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster-parallel
 
 - interval: 12h
@@ -257,7 +257,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all, google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster
 
 - interval: 12h
@@ -285,7 +285,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all, google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster-new
 
 - interval: 12h
@@ -313,7 +313,7 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
   annotations:
-    testgrid-dashboards: sig-release-1.13-all, sig-cluster-lifecycle-upgrade-skew
+    testgrid-dashboards: sig-release-1.13-all, google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-master
 
 - interval: 2h

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -552,6 +552,7 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable1-slow
 - name: google-gke-stackdriver
 - name: google-gke-upgrade
+- name: google-gce-upgrade
 - name: google-soak
 - name: google-unit
 - name: google-windows
@@ -898,6 +899,7 @@ dashboard_groups:
   - google-gke
   - google-gke-stackdriver
   - google-gke-upgrade
+  - google-gce-upgrade
   - google-kops-gce
   - google-rules_k8s
   - google-soak

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -3,7 +3,6 @@ dashboard_groups:
   dashboard_names:
     - sig-cluster-lifecycle-all
     - sig-cluster-lifecycle-kubeadm
-    - sig-cluster-lifecycle-upgrade-skew
     - sig-cluster-lifecycle-multi-platform
     - sig-cluster-lifecycle-cluster-api
     - sig-cluster-lifecycle-cluster-api-provider-aws
@@ -22,7 +21,6 @@ dashboard_groups:
 dashboards:
 - name: sig-cluster-lifecycle-all
 - name: sig-cluster-lifecycle-kubeadm
-- name: sig-cluster-lifecycle-upgrade-skew
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:
     - name: periodic-kubeadm-gce-amd64


### PR DESCRIPTION
- remove all reference of sig-cluster-lifecycle-upgrade-skew.
- create a new dashboard google-gce-upgrade and use it in place
of sig-cluster-lifecycle-upgrade-skew for some upgrade jobs.
- remove the sig-cluster-lifecycle-upgrade-skew dashboard
from testgrids/kubernetes/sig-cluster-lifecycle/config.yaml

my last PR did incomplete move/cleanup

/kind cleanup
/priority important-longterm

cc @andrewsykim @justaugustus @timothysc 
/assign @fejta @krzyzacy 
/sig cluster-lifecycle release testing cloud-provider cli
