### PR TITLE
add more gke project janitor replicas

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 3  # 3 distributed janitor instances for gke
+  replicas: 8  # 8 distributed janitor instances for gke
   selector:
     matchLabels:
       app: boskos-janitor


### PR DESCRIPTION
/cc @krzyzacy @fejta 
xref: https://github.com/kubernetes/test-infra/issues/14697

seems maybe cleaning up routers is a lot slower, adding more replicas to help keep up
http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1&from=now-2d&to=now