### PR TITLE
Let janitor update all resources it's holding

### DIFF
--- a/boskos/janitor/janitor_test.go
+++ b/boskos/janitor/janitor_test.go
@@ -82,18 +82,8 @@ func (fb *fakeBoskos) ReleaseOne(name string, dest string) error {
 	return fmt.Errorf("no resource %v", name)
 }
 
-func (fb *fakeBoskos) UpdateOne(name string, state string, userdata *common.UserData) error {
-	fb.lock.Lock()
-	defer fb.lock.Unlock()
-
-	for idx := range fb.resources {
-		r := &fb.resources[idx]
-		if r.Name == name && r.State == state {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("no resource %v", name)
+func (fb *fakeBoskos) SyncAll() error {
+	return nil
 }
 
 // waitTimeout waits for the waitgroup for the specified max timeout.


### PR DESCRIPTION
So, the existing behavior is that each janitor goroutine will update the resources, however we exit the goroutine, and we kept updating resources that the goroutine no longer owns.

`SyncAll` will allow the janitor server periodically update the resource it's owning, since the client tracks the owner of the resources.

/assign @fejta @BenTheElder @sebastienvas 