### PR TITLE
update azure deployer for dual-stack phase2

### DIFF
--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -115,6 +115,11 @@ type KubernetesConfig struct {
 	KubernetesImageBase          string            `json:"kubernetesImageBase,omitempty"`
 	ControllerManagerConfig      map[string]string `json:"controllerManagerConfig,omitempty"`
 	KubeletConfig                map[string]string `json:"kubeletConfig,omitempty"`
+	KubeProxyMode                string            `json:"kubeProxyMode,omitempty"`
+	LoadBalancerSku              string            `json:"loadBalancerSku,omitempty"`
+	ExcludeMasterFromStandardLB  *bool             `json:"excludeMasterFromStandardLB,omitempty"`
+	ServiceCidr                  string            `json:"serviceCidr,omitempty"`
+	DNSServiceIP                 string            `json:"dnsServiceIP,omitempty"`
 }
 
 type OrchestratorProfile struct {


### PR DESCRIPTION
The api model for dual-stack phase 2 defines the following fields in the JSON which are missing. This PR fixes that by adding the fields.

Reference api model - https://github.com/Azure/aks-engine/blob/master/examples/dualstack/kubernetes.json

**NOTE**: requires new kubekins-e2e to be built after this PR is merged

/cc @ritazh